### PR TITLE
Allow PXF_USER_IMPERSONATION to be overridden by env

### DIFF
--- a/server/pxf-service/src/configs/templates/pxf-private.classpath.template
+++ b/server/pxf-service/src/configs/templates/pxf-private.classpath.template
@@ -22,10 +22,9 @@
 ##################################################################
 
 # Hadoop/Hive/HBase Configurations
-# Uncomment the lines below to use the configuration files that hadoop client is using
-# /etc/hadoop/conf
-# /etc/hive/conf
-# /etc/hbase/conf
+/etc/hadoop/conf
+/etc/hive/conf
+/etc/hbase/conf
 
 # PXF Configuration
 PXF_HOME/conf

--- a/server/pxf-service/src/scripts/pxf-env.sh
+++ b/server/pxf-service/src/scripts/pxf-env.sh
@@ -45,13 +45,13 @@ export PXF_PORT=${PXF_PORT:=@pxfPortNum@}
 export PXF_JVM_OPTS=${PXF_JVM_OPTS:="-Xmx2g -Xms1g"}
 
 # Kerberos path to keytab file owned by pxf service with permissions 0400
-export PXF_KEYTAB="${PXF_HOME}/conf/pxf.service.keytab"
+export PXF_KEYTAB=${PXF_KEYTAB:="${PXF_HOME}/conf/pxf.service.keytab"}
 
 # Kerberos principal pxf service should use. _HOST is replaced automatically with hostnames FQDN
-export PXF_PRINCIPAL="gpadmin/_HOST@EXAMPLE.COM"
+export PXF_PRINCIPAL=${PXF_PRINCIPAL:="gpadmin/_HOST@EXAMPLE.COM"}
 
 # End-user identity impersonation, set to true to enable
-export PXF_USER_IMPERSONATION=@pxfDefaultUserImpersonation@
+export PXF_USER_IMPERSONATION=${PXF_USER_IMPERSONATION:=@pxfDefaultUserImpersonation@}
 
 # Set to true to enable Remote debug via port 8000
-export PXF_DEBUG=${PXF_DEBUG:-false}
+export PXF_DEBUG=${PXF_DEBUG:=false}


### PR DESCRIPTION
Also, let the default hadoop configurations override pxf confs