### PR TITLE
Upgrade to hadoop 2.8.5 libraries

### DIFF
--- a/concourse/README.md
+++ b/concourse/README.md
@@ -85,7 +85,7 @@ fly -t ud expose-pipeline -p pxf_5X_STABLE
 
 ### Visual VM Debugging
 
-To perform memory profiling add the following line to PXF's enviroment settings (`pxf/conf/pxf-env.sh`) on the machine where we want to debug:
+To perform memory profiling add the following line to PXF's environment settings (`pxf/conf/pxf-env.sh`) on the machine where we want to debug:
 
 ```
 export CATALINA_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.rmi.port=9090 -Dcom.sun.management.jmxremote.port=9090 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Djava.rmi.server.hostname=127.0.0.1"

--- a/concourse/scripts/pxf-perf-multi-node.bash
+++ b/concourse/scripts/pxf-perf-multi-node.bash
@@ -325,7 +325,7 @@ EOF
 
     # Restore core-site
     gpssh -u gpadmin -f /tmp/segment_hosts -v -s -e \
-      'source /usr/local/greenplum-db-devel/greenplum_path.sh && mv $GPHOME/pxf/conf/core-site.xml $GPHOME/pxf/conf/core-site.xml.s3 && cp $GPHOME/pxf/conf/core-site.xml.back $GPHOME/pxf/conf/core-site.xml && $GPHOME/pxf/bin/pxf restart'
+      'source /usr/local/greenplum-db-devel/greenplum_path.sh && mv $GPHOME/pxf/conf/core-site.xml $GPHOME/pxf/conf/core-site.xml.s3 && cp $GPHOME/pxf/conf/core-site.xml.back $GPHOME/pxf/conf/core-site.xml'
 }
 
 function main {
@@ -344,7 +344,7 @@ function main {
     echo -e "Data loading and validation complete\n"
     LINEITEM_COUNT=$(psql -t -c "SELECT COUNT(*) FROM lineitem" | tr -d ' ')
 
-#    run_s3_extension_benchmark
+    run_s3_extension_benchmark
 
     if [ "${BENCHMARK_GPHDFS}" == "true" ]; then
         run_gphdfs_benchmark

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -223,6 +223,7 @@ project('pxf-hdfs') {
         compile(project(':pxf-api'))
         compile "org.apache.avro:avro-mapred:1.7.4"
         compile "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoopVersion"
+        compile "org.apache.hadoop:hadoop-yarn-api:$hadoopVersion" // Kerberos dependency
         compile "org.apache.hadoop:hadoop-common:$hadoopVersion"
         compile "org.apache.htrace:htrace-core4:$htraceVersion"
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -140,17 +140,17 @@ subprojects { subProject ->
 
 project('pxf') {
     jar.enabled = false
-//    dependencies {
-//        // AWS S3 support jars
-////        bundleJars "com.fasterxml.jackson.core:jackson-core:2.6.7"
-////        bundleJars "com.fasterxml.jackson.core:jackson-databind:2.6.7.1"
-////        bundleJars "com.fasterxml.jackson.core:jackson-annotations:2.6.0"
-////        bundleJars "org.apache.httpcomponents:httpclient:4.5.2"
-////        bundleJars "org.apache.httpcomponents:httpcore:4.4.4"
-////        bundleJars "org.apache.hadoop:hadoop-aws:2.8.5"
-////        bundleJars "com.amazonaws:aws-java-sdk-core:$awsJavaSdk"
-////        bundleJars "com.amazonaws:aws-java-sdk-kms:$awsJavaSdk"
-////        bundleJars "com.amazonaws:aws-java-sdk-s3:$awsJavaSdk"
+    dependencies {
+        // AWS S3 support jars
+        bundleJars "com.fasterxml.jackson.core:jackson-core:2.6.7"
+        bundleJars "com.fasterxml.jackson.core:jackson-databind:2.6.7.1"
+        bundleJars "com.fasterxml.jackson.core:jackson-annotations:2.6.0"
+        bundleJars "org.apache.httpcomponents:httpclient:4.5.2"
+        bundleJars "org.apache.httpcomponents:httpcore:4.4.4"
+        bundleJars "org.apache.hadoop:hadoop-aws:2.8.5"
+        bundleJars "com.amazonaws:aws-java-sdk-core:$awsJavaSdk"
+        bundleJars "com.amazonaws:aws-java-sdk-kms:$awsJavaSdk"
+        bundleJars "com.amazonaws:aws-java-sdk-s3:$awsJavaSdk"
 //        // Azure Datalake jars
 ////        bundleJars "org.apache.hadoop:hadoop-azure-datalake:3.0.0-alpha2"
 ////        bundleJars "com.microsoft.azure:azure-data-lake-store-sdk:2.0.11"
@@ -160,7 +160,7 @@ project('pxf') {
 ////        bundleJars "com.google.flogger:flogger:0.3.1"
 ////        bundleJars "com.google.flogger:flogger-system-backend:0.3.1"
 ////        bundleJars "com.google.flogger:google-extensions:0.3.1"
-//    }
+    }
 }
 
 project('pxf-api') {
@@ -199,8 +199,11 @@ project('pxf-service') {
     dependencies {
         providedCompile(project(':pxf-api'))
         providedCompile "org.apache.hadoop:hadoop-common:$hadoopVersion"
+        providedCompile "org.apache.htrace:htrace-core4:$htraceVersion"
         providedCompile "org.apache.hadoop:hadoop-hdfs:$hadoopVersion"
+        providedCompile "org.apache.hadoop:hadoop-hdfs-client:$hadoopVersion"
         providedCompile "org.apache.tomcat:tomcat-catalina:$tomcatVersion"
+
 
         bundleJars "org.apache.hadoop:hadoop-auth:$hadoopVersion"
         bundleJars "commons-cli:commons-cli:1.2"
@@ -221,7 +224,10 @@ project('pxf-hdfs') {
         compile "org.apache.avro:avro-mapred:1.7.4"
         compile "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoopVersion"
         compile "org.apache.hadoop:hadoop-common:$hadoopVersion"
+        compile "org.apache.htrace:htrace-core4:$htraceVersion"
+
         compile "org.apache.hadoop:hadoop-hdfs:$hadoopVersion"
+        compile "org.apache.hadoop:hadoop-hdfs-client:$hadoopVersion"
         compile "org.apache.parquet:parquet-hadoop-bundle:$parquetVersion"
 
         bundleJars "org.apache.avro:avro:1.7.4"

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -17,7 +17,8 @@
 
 version=4.0.0
 license=ASL 2.0
-hadoopVersion=2.7.3
+hadoopVersion=2.8.5
+htraceVersion=4.0.1-incubating
 hiveVersion=1.2.1
 hbaseVersionJar=1.1.2
 hbaseVersionRPM=1.1.2


### PR DESCRIPTION
- Upgrading to hadoop 2.8.5 libraries to support S3.
- Restore S3 tests in perf pipeline
- Add dependencies required by hadoop 2.8.5