### PR TITLE
Update PR status for each job in the pipeline

### DIFF
--- a/concourse/pxf_pr_pipeline.yml
+++ b/concourse/pxf_pr_pipeline.yml
@@ -55,23 +55,52 @@ resources:
 jobs:
 
 - name: compile_pxf
+  on_failure:
+    put: pxf_src
+    params:
+      path: pxf_src
+      status: failure
+      context: $BUILD_JOB_NAME
+  on_success:
+    put: pxf_src
+    params:
+      path: pxf_src
+      status: success
+      context: $BUILD_JOB_NAME
   plan:
-  - aggregate:
-    - get: gpdb_src
-    - get: pxf_src
-      trigger: true
-    - get: gpdb-pxf-dev-centos6
   - put: pxf_src
     params:
       path: pxf_src
       status: pending
       context: $BUILD_JOB_NAME
+  - aggregate:
+    - get: gpdb_src
+    - get: pxf_src
+      trigger: true
+    - get: gpdb-pxf-dev-centos6
   - task: compile_pxf
     image: gpdb-pxf-dev-centos6
     file: pxf_src/concourse/tasks/compile_pxf.yml
 
-- name: test_pxf_hdp
+- name: test_pxf
+  on_failure:
+    put: pxf_src
+    params:
+      path: pxf_src
+      status: failure
+      context: $BUILD_JOB_NAME
+  on_success:
+    put: pxf_src
+    params:
+      path: pxf_src
+      status: success
+      context: $BUILD_JOB_NAME
   plan:
+  - put: pxf_src
+    params:
+      path: pxf_src
+      status: pending
+      context: $BUILD_JOB_NAME
   - aggregate:
     - get: gpdb_src
       passed:
@@ -130,16 +159,5 @@ jobs:
         GROUP: smoke,proxy
       run:
         path: pxf_src/concourse/scripts/test_pxf.bash
-    on_success:
-      put: pxf_src
-      params:
-        path: pxf_src
-        status: success
-        context: $BUILD_JOB_NAME
-    on_failure:
-      put: pxf_src
-      params:
-        path: pxf_src
-        status: failure
-        context: $BUILD_JOB_NAME
+
     timeout: 2h


### PR DESCRIPTION
- Set the status to "pending" before starting to fetch resources
- Set the status to "success" or "failure" in job-level success/failure
  hooks

Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>