### PR TITLE
Update PXF URI and Pipelines

### DIFF
--- a/concourse/README.md
+++ b/concourse/README.md
@@ -1,47 +1,48 @@
 # Deploy pxf-docker-images pipeline
 ```
-fly -t ud set-pipeline -p gpdb_pxf_docker-images \
-    -c docker-images.yml -l ~/workspace/continuous-integration/secrets/gpdb-release-secrets.dev.yml
+fly -t ud set-pipeline \
+    -c ~/workspace/pxf/concourse/docker-images.yml \
+    -l ~/workspace/continuous-integration/secrets/gpdb-release-secrets.dev.yml \
+    -v pxf-git-remote=https://github.com/greenplum-db/pxf.git \
+    -p gpdb_pxf_docker-images
 ```
 
 # Deploy production PXF pipelines
 The following commands would create two PXF pipelines - one for **gpdb_master** and the other for **5X_STABLE**
 ```
-fly -t ud set-pipeline -p pxf_master -c ./pxf_pipeline.yml \
+fly -t ud set-pipeline \
+    -c ~/workspace/pxf/concourse/pxf_pipeline.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml \
-    -v folder-prefix=prod/gpdb_branch \
-    -v test-env= \
-    -l pxf-multinode-params.yml \
+    -l ~/workspace/pxf/concourse/pxf-multinode-params.yml \
     -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_ud.yml \
-    -v gpdb-branch=master -v icw_green_bucket=gpdb5-assert-concourse-builds
-
+    -v folder-prefix=prod/gpdb_branch -v test-env= \
+    -v gpdb-branch=master -v icw_green_bucket=gpdb5-assert-concourse-builds \
+    -p pxf_master
 ```
 
 ```
-fly -t ud set-pipeline -p pxf_5X_STABLE -c ./pxf_pipeline.yml \
+fly -t ud set-pipeline \
+    -c ~/workspace/pxf/concourse/pxf_pipeline.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_5X_STABLE-ci-secrets.yml \
-    -v folder-prefix=prod/gpdb_branch \
-    -v test-env= \
-    -l pxf-multinode-params.yml \
+    -l ~/workspace/pxf/concourse/pxf-multinode-params.yml \
     -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_ud.yml \
-    -v gpdb-branch=5X_STABLE -v icw_green_bucket=gpdb5-stable-concourse-builds
+    -v folder-prefix=prod/gpdb_branch -v test-env= \
+    -v gpdb-branch=5X_STABLE -v icw_green_bucket=gpdb5-stable-concourse-builds \
+    -p pxf_5X_STABLE 
 ```
 
 # Deploy the pull-request pipeline
 
 ```
-fly -t ud set-pipeline -p pxf_pr \
-    -c ./pxf_pr_pipeline.yml \
+fly -t ud set-pipeline \
+    -c ~/workspace/pxf/concourse/pxf_pr_pipeline.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+    -l ~/workspace/continuous-integration/secrets/gpdb-release-secrets.dev.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml \
-    -l pxf-multinode-params.yml \
     -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_ud.yml \
-    -v folder-prefix=dev/pivotal-default \
-    -v test-env=dev \
-    -v gpdb-branch=master \
-    -v icw_green_bucket=gpdb5-assert-concourse-builds
+    -v folder-prefix=dev/pivotal-default -v test-env=dev -v gpdb-branch=master \
+    -v icw_green_bucket=gpdb5-assert-concourse-builds \
+    -p pxf_pr
 ```
 
 # Deploy the release pipeline
@@ -51,11 +52,11 @@ https://github.com/pivotal/gp-continuous-integration/blob/master/README.md#pxf_r
 # Deploy the performance pipeline
 
 ```
-fly -t ud set-pipeline -c ./perf_pipeline.yml \
+fly -t ud set-pipeline \
+    -c ~/workspace/pxf/concourse/perf_pipeline.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml \
     -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_ud.yml \
-    -l ./perf-settings.yml \
+    -l ~/workspace/pxf/concourse/perf-settings.yml \
     -v gpdb-branch=master -v icw_green_bucket=gpdb5-assert-concourse-builds \
     -v pxf-git-branch=master -p pxf_perf
 ```

--- a/concourse/README.md
+++ b/concourse/README.md
@@ -13,8 +13,8 @@ The following commands would create two PXF pipelines - one for **gpdb_master** 
 fly -t ud set-pipeline \
     -c ~/workspace/pxf/concourse/pxf_pipeline.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/pxf/concourse/pxf-multinode-params.yml \
     -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_ud.yml \
+    -l ~/workspace/pxf/concourse/pxf-multinode-params.yml \
     -v folder-prefix=prod/gpdb_branch -v test-env= \
     -v gpdb-branch=master -v icw_green_bucket=gpdb5-assert-concourse-builds \
     -p pxf_master
@@ -24,8 +24,8 @@ fly -t ud set-pipeline \
 fly -t ud set-pipeline \
     -c ~/workspace/pxf/concourse/pxf_pipeline.yml \
     -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-    -l ~/workspace/pxf/concourse/pxf-multinode-params.yml \
     -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_ud.yml \
+    -l ~/workspace/pxf/concourse/pxf-multinode-params.yml \
     -v folder-prefix=prod/gpdb_branch -v test-env= \
     -v gpdb-branch=5X_STABLE -v icw_green_bucket=gpdb5-stable-concourse-builds \
     -p pxf_5X_STABLE 

--- a/concourse/default.yml
+++ b/concourse/default.yml
@@ -3,5 +3,5 @@
 gpdb-git-remote: https://github.com/greenplum-db/gpdb.git
 gpdb-git-branch: master
 
-pxf-git-remote: git@github.com:/greenplum-db/pxf.git
+pxf-git-remote: https://github.com/greenplum-db/pxf.git
 pxf-git-branch: master

--- a/concourse/deploy
+++ b/concourse/deploy
@@ -53,13 +53,15 @@ fi
 
 echo "Deploying ${PIPELINE_NAME} pipeline with custom values from ${YML_FILE} ..."
 
-cmd="fly -t ${TARGET} set-pipeline -p ${PIPELINE_NAME} -c ./pxf_pipeline.yml \
-  -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-  -l ~/workspace/continuous-integration/secrets/gpdb_${BRANCH}-ci-secrets.yml \
-  -l ${YML_FILE} -v folder-prefix=${PREFIX} -v test-env=${TEST_ENV} \
-  -l pxf-multinode-params.yml \
-  -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_ud.yml \
-  -v gpdb-branch=${BRANCH} -v icw_green_bucket=${ICW_GREEN_BUCKET}"
+cmd="fly -t ${TARGET} set-pipeline \
+    -c ~/workspace/pxf/concourse/pxf_pipeline.yml \
+    -l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+    -l ~/workspace/continuous-integration/secrets/ccp_ci_secrets_ud.yml \
+    -l ~/workspace/pxf/concourse/pxf-multinode-params.yml \
+    -l ${YML_FILE} \
+    -v folder-prefix=${PREFIX} -v test-env=${TEST_ENV} \
+    -v gpdb-branch=${BRANCH} -v icw_green_bucket=${ICW_GREEN_BUCKET} \
+    -p ${PIPELINE_NAME}"
 
 
 echo "${cmd}"

--- a/concourse/docker-images.yml
+++ b/concourse/docker-images.yml
@@ -26,7 +26,6 @@ resources:
     type: git
     source:
       branch: {{pxf-git-branch}}
-      private_key: {{pxf-git-key}}
       uri: {{pxf-git-remote}}
 
   - name: hdp_tars_tarball
@@ -87,7 +86,6 @@ resources:
     type: git
     source:
       branch: {{pxf-git-branch}}
-      private_key: {{pxf-git-key}}
       uri: {{pxf-git-remote}}
       paths: [singlecluster/*]
 
@@ -133,7 +131,6 @@ resources:
     type: git
     source:
       branch: {{pxf-git-branch}}
-      private_key: {{pxf-git-key}}
       uri: {{pxf-git-remote}}
       paths: [concourse/docker/centos6-hdp-secure/Dockerfile]
 
@@ -171,7 +168,6 @@ resources:
     type: git
     source:
       branch: {{pxf-git-branch}}
-      private_key: {{pxf-git-key}}
       uri: {{pxf-git-remote}}
       paths: [concourse/docker/pxf-dev-base]
 
@@ -195,7 +191,6 @@ resources:
     type: git
     source:
       branch: {{pxf-git-branch}}
-      private_key: {{pxf-git-key}}
       uri: {{pxf-git-remote}}
       paths: [concourse/docker/centos6-pxf-server]
 
@@ -203,7 +198,6 @@ resources:
     type: git
     source:
       branch: {{pxf-git-branch}}
-      private_key: {{pxf-git-key}}
       uri: {{pxf-git-remote}}
       paths: [concourse/docker/ubuntu16-pxf-server]
 

--- a/concourse/perf-settings.yml
+++ b/concourse/perf-settings.yml
@@ -1,3 +1,4 @@
+gpdb-git-branch: master
 tf-bucket-path: clusters-google/
 tf-cloud-provider: google
 folder-prefix: perf

--- a/concourse/perf_pipeline.yml
+++ b/concourse/perf_pipeline.yml
@@ -99,7 +99,6 @@ resources:
   type: git
   source:
     branch: {{pxf-git-branch}}
-    private_key: {{pxf-git-key}}
     uri: {{pxf-git-remote}}
 
 - name: pxf_build_number

--- a/concourse/pxf_pipeline.yml
+++ b/concourse/pxf_pipeline.yml
@@ -42,7 +42,6 @@ resources:
   type: git
   source:
     branch: {{pxf-git-branch}}
-    private_key: {{pxf-git-key}}
     uri: {{pxf-git-remote}}
 
 - name: pxf_build_number


### PR DESCRIPTION
PXF is a public repo and it doesn't need a deploy key to access the repo
    
- Only PR pipeline requires a deploy key
- Updated README.md
- Updated concourse deploy script