### PR TITLE
Gitignore out and tmp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 *.log
 *.out
+server/*/out
+server/tmp


### PR DESCRIPTION
I noticed that we had a bunch of untracked files on our workstation. This change ensures we don't accidentally add them to Git.