### PR TITLE
Remove unused constructors from InputData and subclasses

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/InputData.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/InputData.java
@@ -94,34 +94,6 @@ public class InputData {
     }
 
     /**
-     * Constructs an InputData from a copy. Used to create from an extending
-     * class.
-     *
-     * @param copy the input data to copy
-     */
-    public InputData(InputData copy) {
-
-        this.requestParametersMap = copy.requestParametersMap;
-        this.segmentId = copy.segmentId;
-        this.totalSegments = copy.totalSegments;
-        this.fragmentMetadata = copy.fragmentMetadata;
-        this.userData = copy.userData;
-        this.tupleDescription = copy.tupleDescription;
-        this.recordkeyColumn = copy.recordkeyColumn;
-        this.filterStringValid = copy.filterStringValid;
-        this.filterString = copy.filterString;
-        this.dataSource = copy.dataSource;
-        this.profile = copy.profile;
-        this.accessor = copy.accessor;
-        this.resolver = copy.resolver;
-        this.fragmenter = copy.fragmenter;
-        this.metadata = copy.metadata;
-        this.remoteLogin = copy.remoteLogin;
-        this.remoteSecret = copy.remoteSecret;
-        this.threadSafe = copy.threadSafe;
-    }
-
-    /**
      * Returns a user defined property.
      *
      * @param userProp the lookup user property

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/ProtocolData.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/ProtocolData.java
@@ -20,19 +20,15 @@ package org.greenplum.pxf.api.utilities;
  */
 
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.greenplum.pxf.api.OutputFormat;
-import org.greenplum.pxf.api.utilities.ColumnDescriptor;
-import org.greenplum.pxf.api.utilities.EnumAggregationType;
-import org.greenplum.pxf.api.utilities.InputData;
-import org.greenplum.pxf.api.utilities.ProfilesConf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Common configuration of all MetaData classes. Provides read-only access to
@@ -133,38 +129,6 @@ public class ProtocolData extends InputData {
         if (fragmentIndexStr != null) {
             this.setFragmentIndex(Integer.parseInt(fragmentIndexStr));
         }
-    }
-
-    /**
-     * Constructs an InputDataBuilder from a copy. Used to create from an
-     * extending class.
-     *
-     * @param copy the input data to copy
-     */
-    public ProtocolData(ProtocolData copy) {
-        this.requestParametersMap = copy.requestParametersMap;
-        this.segmentId = copy.segmentId;
-        this.totalSegments = copy.totalSegments;
-        this.outputFormat = copy.outputFormat;
-        this.host = copy.host;
-        this.port = copy.port;
-        this.fragmentMetadata = copy.fragmentMetadata;
-        this.userData = copy.userData;
-        this.tupleDescription = copy.tupleDescription;
-        this.recordkeyColumn = copy.recordkeyColumn;
-        this.filterStringValid = copy.filterStringValid;
-        this.filterString = copy.filterString;
-        this.dataSource = copy.dataSource;
-        this.accessor = copy.accessor;
-        this.resolver = copy.resolver;
-        this.fragmenter = copy.fragmenter;
-        this.threadSafe = copy.threadSafe;
-        this.remoteLogin = copy.remoteLogin;
-        this.remoteSecret = copy.remoteSecret;
-        this.token = copy.token;
-        this.user = copy.user;
-        this.statsMaxFragments = copy.statsMaxFragments;
-        this.statsSampleRatio = copy.statsSampleRatio;
     }
 
     /**

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/utilities/ProtocolDataTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/utilities/ProtocolDataTest.java
@@ -73,13 +73,6 @@ public class ProtocolDataTest {
     }
 
     @Test
-    public void ProtocolDataCopied() throws Exception {
-        ProtocolData protocolData = new ProtocolData(parameters);
-        ProtocolData copy = new ProtocolData(protocolData);
-        assertEquals(copy.getParametersMap(), protocolData.getParametersMap());
-    }
-
-    @Test
     public void profileWithDuplicateProperty() throws Exception {
         PowerMockito.mockStatic(ProfilesConf.class);
 

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
@@ -365,7 +365,7 @@ public abstract class PxfUnit {
 			}
 		}
 
-		LocalInputData fragmentInputData = new LocalInputData(paramsMap);
+		ProtocolData fragmentInputData = new ProtocolData(paramsMap);
 
 		List<Fragment> fragments = getFragmenter(fragmentInputData).getFragments();
 
@@ -392,7 +392,7 @@ public abstract class PxfUnit {
 			paramsMap.put("X-GP-DATA-DIR", sourceData);
 			paramsMap.put("X-GP-FRAGMENT-METADATA", fragNode.get("metadata").getTextValue());
 			paramsMap.put("X-GP-DATA-FRAGMENT", Integer.toString(i++));
-			inputs.add(new LocalInputData(paramsMap));
+			inputs.add(new ProtocolData(paramsMap));
 		}
 	}
 
@@ -643,22 +643,6 @@ public abstract class PxfUnit {
 		public Pair(FIRST f, SECOND s) {
 			this.first = f;
 			this.second = s;
-		}
-	}
-
-	/**
-	 * An extension of InputData for the local file system instead of HDFS. Leveraged by the PXFUnit framework. Do not
-	 * concern yourself with such a simple piece of code.
-	 */
-	public static class LocalInputData extends ProtocolData {
-
-		public LocalInputData(ProtocolData copy) {
-			super(copy);
-			super.setDataSource(super.getDataSource().substring(1));
-		}
-
-		public LocalInputData(Map<String, String> paramsMap) {
-			super(paramsMap);
 		}
 	}
 }


### PR DESCRIPTION
This removes some dead code that was getting in the way of some refactoring I wanted to do as part of the spike @shivzone and I were doing.

After removing the unique constructor from LocalInputData, it was just a wrapper that called
the super constructor from ProtocolData, so I deleted LocalInputData and replaced its usages
with ProtocolData.
