### PR TITLE
Use loginUser to access HiveMetaStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,45 @@ $PXF_HOME/bin/pxf start
 no JDK set for Gradle. Just cancel and retry. It goes away the second time.
 - Restart IntelliJ
 - Check that it worked by running a test (Cmd+O)
+
+## To run a Kerberized Hadoop Cluster
+
+# Requirements
+
+- Download bin_gpdb (from any of the pipelines)
+- Download pxf_tarball (from any of the pipelines)
+
+These instructions allow you to run a Kerberized cluster
+
+```bash
+docker run --rm -it \
+  --privileged \
+  --hostname c6401.ambari.apache.org \
+  -p 5432:5432 \
+  -p 5888:5888 \
+  -p 8000:8000 \
+  -p 8080:8080 \
+  -p 8020:8020 \
+  -p 9090:9090 \
+  -p 50070:50070 \
+  -w /home/gpadmin/workspace \
+  -v ~/workspace/gpdb:/home/gpadmin/workspace/gpdb_src \
+  -v ~/workspace/pxf:/home/gpadmin/workspace/pxf_src \
+  -v ~/workspace/singlecluster-HDP:/home/gpadmin/workspace/singlecluster \
+  -v ~/Downloads/bin_gpdb:/home/gpadmin/workspace/bin_gpdb \
+  -v ~/Downloads/pxf_tarball:/home/gpadmin/workspace/pxf_tarball \
+  -e CLUSTER_NAME=hdp \
+  -e NODE=c6401.ambari.apache.org \
+  -e REALM=AMBARI.APACHE.ORG \
+  pivotaldata/gpdb-pxf-dev:centos6-hdp-secure /bin/bash
+
+# Inside the container run the following command:
+pxf_src/concourse/scripts/test_pxf_secure.bash
+
+echo "+----------------------------------------------+"
+echo "| Kerberos admin principal: admin/admin@${REALM} |"
+echo "| Kerberos admin password : admin              |"
+echo "+----------------------------------------------+"
+
+su - gpadmin
+```

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -235,6 +235,7 @@ project('pxf-hdfs') {
 project('pxf-hive') {
     dependencies {
         compile(project(':pxf-hdfs'))
+        compile(project(':pxf-service'))
         compile("org.apache.hive:hive-exec:$hiveVersion") {
             exclude module: 'calcite-core'
             exclude module: 'calcite-avatica'

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/SecureLogin.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/SecureLogin.java
@@ -65,11 +65,6 @@ public class SecureLogin {
 
             LOG.info("Kerberos Security is enabled");
 
-            if (!isUserImpersonationEnabled) {
-                throw new RuntimeException("User Impersonation is required when Kerberos Security is enabled. " +
-                        "Set PXF_USER_IMPERSONATION=true in $PXF_HOME/conf/pxf-env.sh");
-            }
-
             String principal = System.getProperty(CONFIG_KEY_SERVICE_PRINCIPAL);
             String keytabFilename = System.getProperty(CONFIG_KEY_SERVICE_KEYTAB);
 


### PR DESCRIPTION
When Kerberos is enabled we need to access the HiveMetaStore as the loginUser instead of the proxyUser.

Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>
Co-authored-by: Lav Jain <ljain@pivotal.io>