### PR TITLE
Add help and version commands to PXF CLI

### DIFF
--- a/concourse/scripts/package_pxf_rc.bash
+++ b/concourse/scripts/package_pxf_rc.bash
@@ -15,7 +15,7 @@ EOF
 cat > smoke_test_gpdb_component <<EOF
 #!/bin/bash
 set -x
-\$GPHOME/pxf/bin/pxf 2>&1 | grep "pxf {start|stop|restart|init|status}" || exit 1
+\$GPHOME/pxf/bin/pxf version 2>&1 | grep "PXF version ${VERSION}" || exit 1
 EOF
 chmod +x install_gpdb_component smoke_test_gpdb_component
 cp pxf_tarball/pxf.tar.gz .

--- a/concourse/scripts/test_pxf_multinode.bash
+++ b/concourse/scripts/test_pxf_multinode.bash
@@ -10,8 +10,9 @@ GPHD_ROOT="/singlecluster"
 
 function configure_local_hdfs() {
 
-    sed -i -e 's|hdfs://0.0.0.0:8020|hdfs://hadoop:8020|' ${PXF_CONF_DIR}/servers/default/core-site.xml ${PXF_CONF_DIR}/servers/default/hbase-site.xml
-    sed -i -e "s/>tez/>mr/g" ${PXF_CONF_DIR}/servers/default/hive-site.xml
+    sed -i -e 's|hdfs://0.0.0.0:8020|hdfs://hadoop:8020|' \
+    ${GPHD_ROOT}/hadoop/etc/hadoop/core-site.xml ${GPHD_ROOT}/hbase/conf/hbase-site.xml
+    sed -i -e "s/>tez/>mr/g" ${GPHD_ROOT}/hive/conf/hive-site.xml
 }
 
 function run_multinode_smoke_test() {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -264,13 +264,13 @@ project('pxf-hive') {
 
 project('pxf-json') {
     dependencies {
-      compile(project(':pxf-hdfs'))
-      compile(project(':pxf-api'))
-      testCompile 'pl.pragmatists:JUnitParams:1.0.2'
+        compile(project(':pxf-hdfs'))
+        compile(project(':pxf-api'))
+        testCompile 'pl.pragmatists:JUnitParams:1.0.2'
     }
 
-    task create_tweets_tgz(type: Exec){
-      commandLine 'tar', '-zcf', 'src/test/resources/tweets.tar.gz', '-C', 'src/test/resources', 'tweets-pp.json'
+    task create_tweets_tgz(type: Exec) {
+        commandLine 'tar', '-zcf', 'src/test/resources/tweets.tar.gz', '-C', 'src/test/resources', 'tweets-pp.json'
     }
 
     tasks['test'].dependsOn('create_tweets_tgz')
@@ -358,7 +358,7 @@ task buildCli(type: Exec) {
     commandLine('make', '-C', 'pxf-cli/go/src/pxf-cluster', 'depend', 'build')
 }
 
-task assemble(type: Copy, dependsOn: [subprojects.jar, project(':pxf-service').war, subprojects.copyRuntimeDependencies, tomcatGet, buildCli])  {
+task assemble(type: Copy, dependsOn: [subprojects.jar, project(':pxf-service').war, subprojects.copyRuntimeDependencies, tomcatGet, buildCli]) {
     into "build/stage"
     subprojects { project ->
         from("${project.name}/build/libs") { into 'lib' }
@@ -369,6 +369,9 @@ task assemble(type: Copy, dependsOn: [subprojects.jar, project(':pxf-service').w
         into 'bin'
         fileMode 0755
         rename('pxf-service', 'pxf')
+        filter {
+            String line -> line.replaceAll("GRADLE_PRINT_PXF_VERSION", "echo PXF version ${version}")
+        }
     }
     from("pxf-cli/go/src/pxf-cluster/pxf-cluster") {
         into 'bin'
@@ -394,7 +397,7 @@ task tar(type: Tar, dependsOn: [assemble]) {
     from assemble.outputs.files
 }
 
-task install (type: Copy, dependsOn: [assemble]) {
+task install(type: Copy, dependsOn: [assemble]) {
     from assemble.outputs.files
     into System.properties['deployPath']
 }

--- a/server/pxf-cli/go/src/pxf-cluster/pxf/pxf.go
+++ b/server/pxf-cli/go/src/pxf-cluster/pxf/pxf.go
@@ -6,32 +6,56 @@ import (
 )
 
 type CliInputs struct {
-	Gphome string
-	Args   []string
+	Gphome  string
+	PxfConf string
+	Args    []string
 }
+
+type EnvVar string
+
+const (
+	Gphome  EnvVar = "GPHOME"
+	PxfConf EnvVar = "PXF_CONF"
+)
 
 func MakeValidCliInputs(args []string) (*CliInputs, error) {
 	usageMessage := "usage: pxf cluster {start|stop|restart|init|status}"
-	gphome, isGphomeSet := os.LookupEnv("GPHOME")
-	if !isGphomeSet {
-		return nil, errors.New("GPHOME is not set")
-	}
-	if gphome == "" {
-		return nil, errors.New("GPHOME is blank")
+	gphome, error := ValidateEnvVar(Gphome)
+	if error != nil {
+		return nil, error
 	}
 	if len(args) != 2 {
 		return nil, errors.New(usageMessage)
 	}
 	switch args[1] {
-	case "init", "start", "stop", "restart", "status":
-		return &CliInputs{
-			Gphome: os.Getenv("GPHOME"),
-			Args:   args[1:],
-		}, nil
+	case "start", "stop", "restart", "status":
+		return &CliInputs{Gphome: gphome, PxfConf: "", Args: args[1:]}, nil
+	case "init":
+		pxfConf, error := ValidateEnvVar(PxfConf)
+		if error != nil {
+			return nil, error
+		}
+		return &CliInputs{Gphome: gphome, PxfConf: pxfConf, Args: args[1:]}, nil
 	}
 	return nil, errors.New(usageMessage)
 }
 
+func ValidateEnvVar(envVar EnvVar) (string, error) {
+	envVarValue, isEnvVarSet := os.LookupEnv(string(envVar))
+	if !isEnvVarSet {
+		return "", errors.New(string(envVar) + " must be set.")
+	}
+	if envVarValue == "" {
+		return "", errors.New(string(envVar) + " cannot be blank.")
+	}
+	return envVarValue, nil
+}
+
 func RemoteCommandToRunOnSegments(inputs *CliInputs) []string {
-	return []string{inputs.Gphome + "/pxf/bin/pxf", inputs.Args[0]}
+	pxfCommand := ""
+	if inputs.PxfConf != "" {
+		pxfCommand += "PXF_CONF=" + inputs.PxfConf + " "
+	}
+	pxfCommand += inputs.Gphome + "/pxf/bin/pxf"
+	return []string{pxfCommand, inputs.Args[0]}
 }

--- a/server/pxf-service/src/scripts/pxf-service
+++ b/server/pxf-service/src/scripts/pxf-service
@@ -335,7 +335,7 @@ function setup_conf_directory()
 
 function printUsage()
 {
-    echo $"Usage: $0 {start|stop|restart|init|status} [-y]"
+    echo $"Usage: $0 {start|stop|restart|init|status|version|cluster} [subcommands] [-y]"
 }
 
 function validate_system()
@@ -351,6 +351,50 @@ function validate_system()
     if [ $? -ne 0 ]; then
         fail "unzip is not installed, please install"
     fi
+}
+
+# doVersion handles the version command
+# the string below will be replaced with 'echo <correct-version>' during the build process
+doVersion() {
+	GRADLE_PRINT_PXF_VERSION
+	exit 0
+}
+
+# doHelp handles the help command
+doHelp() {
+	local normal=$(tput sgr0)
+	local bold=$(tput bold)
+	local tab=$(printf '\t')
+	printUsage
+	cat <<-EOF
+
+	${bold}start${normal}:
+	${tab}Start the local instance of pxf
+
+	${bold}stop${normal}:
+	${tab}Stop the local instance of pxf
+
+	${bold}restart${normal}:
+	${tab}Restart the local instance of pxf
+
+	${bold}init${normal}:
+	${tab}Initialize the local instance of pxf
+
+	${bold}status${normal}:
+	${tab}Query the status of the local instance of pxf
+
+	${bold}version${normal}:
+	${tab}Print the version of pxf
+
+	${bold}cluster {start|stop|restart|init|status}${normal}:
+	${tab}Issue a command for the entire cluster, takes a subcommand
+
+	${bold}Bypass ${bold}PXF_CONF${normal} verification during init${normal}:
+	${tab}When ${bold}PXF_CONF${normal} is not set, avoid confirmation of using \$HOME/pxf as ${bold}PXF_CONF${normal} with ${bold}-y${normal}
+	${tab}Note: ${bold}cluster init${normal} does not take this flag, ${bold}PXF_CONF${normal} must be set
+
+	EOF
+	exit 0
 }
 
 # doInit handles the init command
@@ -427,27 +471,33 @@ validate_user
 validate_system
 
 case "${pxf_script_command}" in
-	"init" )
-		if [ "$2" == "-y" ] || [ "$2" == "-Y" ]; then
+	'init' )
+		if [[ $2 == -y ]] || [[ $2 == -Y ]]; then
 			silent=true
 		fi
 		doInit
 		;;
-	"start" )
+	'start' )
 		doStart
 		;;
-	"stop" )
+	'stop' )
 		doStop
 		;;
-	"restart" )
+	'restart' )
 		doStop
 		sleep 1s
 		doStart
 		;;
-	"status" )
+	'status' )
 		doStatus
 		;;
-	"cluster" )
+	'help' )
+		doHelp
+		;;
+	'version' )
+		doVersion
+		;;
+	'cluster' )
 		doCluster "$@"
 		;;
 	* )


### PR DESCRIPTION
- Add help and version commands to pxf cli the version is pulled into the script during the gradle build. This felt like the right place to put that, since the information is in gradle, and gradle is already doing things like chmod and cp of the script to the install location.
- Fix PXF performance pipeline. Uses new CLI commands in the perf pipeline. Copy the config files to the new persistent location.

Co-authored-by: Oliver Albertini <oalbertini@pivotal.io>
Co-authored-by: Lav Jain <ljain@pivotal.io>
Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>