### PR TITLE
Throw IOException when fs.mkdirs() returns false

### DIFF
--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -95,7 +95,9 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
 
         Path parent = file.getParent();
         if (!fs.exists(parent)) {
-            fs.mkdirs(parent);
+            if (!fs.mkdirs(parent)) {
+                throw new IOException("Creation of dir '" + parent.toString() + "' failed");
+            }
             LOG.debug("Created new dir {}", parent);
         }
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessor.java
@@ -198,7 +198,9 @@ public class ParquetFileAccessor extends BasePlugin implements Accessor {
         }
         Path parent = file.getParent();
         if (!fs.exists(parent)) {
-            fs.mkdirs(parent);
+            if (!fs.mkdirs(parent)) {
+                throw new IOException("Creation of dir '" + parent.toString() + "' failed");
+            }
             LOG.debug("Created new dir {}", parent);
         }
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/SequenceFileAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/SequenceFileAccessor.java
@@ -98,7 +98,9 @@ public class SequenceFileAccessor extends HdfsSplittableDataAccessor {
 
         Path parent = file.getParent();
         if (!fs.exists(parent)) {
-            fs.mkdirs(parent);
+            if (!fs.mkdirs(parent)) {
+                throw new IOException("Creation of dir '" + parent.toString() + "' failed");
+            }
             LOG.debug("Created new dir {}", parent);
         } else {
             LOG.debug("Directory {} already exists. Skip creating", parent);

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/SequenceFileAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/SequenceFileAccessorTest.java
@@ -95,6 +95,7 @@ public class SequenceFileAccessorTest {
 
         when(mockConfigurationFactory.initConfiguration("default", map)).thenReturn(mockConfiguration);
         when(file.getFileSystem(mockConfiguration)).thenReturn(fs);
+        when(fs.mkdirs(Mockito.any(Path.class))).thenReturn(true);
         when(requestContext.getDataSource()).thenReturn("deep.throat");
         when(requestContext.getSegmentId()).thenReturn(0);
 


### PR DESCRIPTION
`org.apache.hadoop.fs.FileSystem.mkdirs()` is used by PXF-HDFS connector classes `LineBreakAccessor`, `ParquetFileAccessor` and `SequenceFileAccessor` to create directory containing files written to HDFS.

This call may return `false` (e.g. when a user has no permission to create requested directory), which is not processed properly.

This PR adds handling of this case: throw an `IOException` with appropriate message.