### PR TITLE
Upgrade to hadoop version 2.9.2

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -17,7 +17,7 @@
         <java.version>1.8</java.version>
         <gphd.home>${GPHD_ROOT}</gphd.home>
         <pxf.lib>${PXF_TMP_LIB}</pxf.lib>
-        <hdp.hadoop.version>2.8.5</hdp.hadoop.version>
+        <hdp.hadoop.version>2.9.2</hdp.hadoop.version>
         <hdp.hbase.version>1.1.2</hdp.hbase.version>
         <hdp.hive.version>1.1.0</hdp.hive.version>
         <snappy.java.version>1.1.1.7</snappy.java.version>
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.7.1</version>
+            <version>2.6.7.2</version>
         </dependency>
 
         <dependency>
@@ -231,20 +231,20 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.4</version>
+            <version>4.4.9</version>
         </dependency>
 
         <!--Google Dependencies-->
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcs-connector</artifactId>
-            <version>1.9.0-hadoop2</version>
+            <version>1.9.2-hadoop2</version>
             <classifier>shaded</classifier>
             <!--The block below excludes all transitive dependencies for the gcs-connector jar-->
             <exclusions>
@@ -265,7 +265,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>2.2.0</version>
+            <version>5.4.0</version>
         </dependency>
 
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -169,6 +169,7 @@ project('pxf-hdfs') {
         compile "org.apache.avro:avro-mapred:1.7.7"
         compile "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}"
         compile "org.apache.hadoop:hadoop-yarn-api:${hadoopVersion}" // Kerberos dependency
+        compile "org.apache.hadoop:hadoop-yarn-client:${hadoopVersion}" // Kerberos dependency
         compile "org.apache.hadoop:hadoop-common:${hadoopVersion}"
         compile "org.apache.htrace:htrace-core4:${htraceVersion}"
         compile "org.apache.hadoop:hadoop-hdfs:${hadoopVersion}"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -183,6 +183,8 @@ project('pxf-hdfs') {
         bundleJars "org.apache.avro:avro:1.7.7"
         // Dependency in hadoop 2.9.2
         bundleJars "com.fasterxml.woodstox:woodstox-core:5.0.3"
+        bundleJars "org.codehaus.woodstox:stax2-api:3.1.4"
+
     }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -181,6 +181,8 @@ project('pxf-hdfs') {
         compile "org.apache.parquet:parquet-hadoop:${parquetVersion}"
 
         bundleJars "org.apache.avro:avro:1.7.7"
+        // Dependency in hadoop 2.9.2
+        bundleJars "com.fasterxml.woodstox:woodstox-core:5.0.3"
     }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -129,7 +129,7 @@ project('pxf') {
         bundleJars "org.apache.hadoop:hadoop-azure-datalake:${hadoopVersion}"
         bundleJars "com.microsoft.azure:azure-data-lake-store-sdk:2.2.3"
         // GCS jars and dependencies
-        bundleJars "com.google.cloud.bigdataoss:gcs-connector:1.9.0-hadoop2:shaded"
+        bundleJars "com.google.cloud.bigdataoss:gcs-connector:1.9.2-hadoop2:shaded"
     }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -114,17 +114,17 @@ project('pxf') {
     dependencies {
         // AWS S3 support jars
         bundleJars "com.fasterxml.jackson.core:jackson-core:2.6.7"
-        bundleJars "com.fasterxml.jackson.core:jackson-databind:2.6.7.1"
+        bundleJars "com.fasterxml.jackson.core:jackson-databind:2.6.7.2"
         bundleJars "com.fasterxml.jackson.core:jackson-annotations:2.6.0"
-        bundleJars "org.apache.httpcomponents:httpclient:4.5.2"
-        bundleJars "org.apache.httpcomponents:httpcore:4.4.4"
+        bundleJars "org.apache.httpcomponents:httpclient:4.5.5"
+        bundleJars "org.apache.httpcomponents:httpcore:4.4.9"
         bundleJars "org.apache.hadoop:hadoop-aws:${hadoopVersion}"
         bundleJars "com.amazonaws:aws-java-sdk-core:${awsJavaSdk}"
         bundleJars "com.amazonaws:aws-java-sdk-kms:${awsJavaSdk}"
         bundleJars "com.amazonaws:aws-java-sdk-s3:${awsJavaSdk}"
         // Azure Data Blob
         bundleJars "org.apache.hadoop:hadoop-azure:${hadoopVersion}"
-        bundleJars "com.microsoft.azure:azure-storage:2.2.0"
+        bundleJars "com.microsoft.azure:azure-storage:5.4.0"
         // Azure Datalake jars
         bundleJars "org.apache.hadoop:hadoop-azure-datalake:${hadoopVersion}"
         bundleJars "com.microsoft.azure:azure-data-lake-store-sdk:2.2.3"

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -17,7 +17,7 @@
 
 version=4.1.0
 license=ASL 2.0
-hadoopVersion=2.8.5
+hadoopVersion=2.9.2
 htraceVersion=4.0.1-incubating
 hiveVersion=1.2.1
 hbaseVersion=1.1.2


### PR DESCRIPTION
By upgrading to hadoop version 2.9.2, we are seeing reduced warn messages for parquet files (i.e)

WARN tomcat-http--32 com.amazonaws.services.s3.internal.S3AbortableInputStream - Not all bytes were read from the S3ObjectInputStream, aborting HTTP connection. This is likely an error and may result in sub-optimal behavior. Request only the bytes you need via a ranged GET or drain the input stream after use.

This introduces new dependencies for Hadoop.

- [ ] Request approval for new jars