### PR TITLE
Column projection support changes

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/testplugin/ColumnProjectionVerifyAccessor.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/testplugin/ColumnProjectionVerifyAccessor.java
@@ -11,8 +11,7 @@ import org.greenplum.pxf.api.model.BasePlugin;
  * The returned data has 4 columns delimited with DELIMITER property value.
  * First column - text, second column - int (counter), third column - bool, fourth column - text.
  */
-public class UserDataVerifyAccessor extends BasePlugin implements Accessor
-{
+public class ColumnProjectionVerifyAccessor extends BasePlugin implements Accessor {
     private String userData;
     private String userDelimiter;
 
@@ -38,13 +37,58 @@ public class UserDataVerifyAccessor extends BasePlugin implements Accessor
         }
 
         // Generate tuple with user data value as last column.
-        String data = firstColumn + userDelimiter + counter + userDelimiter +  (counter % 2 == 0) + userDelimiter +  userData;
+        String data = getData();
         String key = Integer.toString(counter);
 
         counter++;
         firstColumn++;
 
         return new OneRow(key, data);
+    }
+
+    private String getData() {
+        StringBuilder sb = new StringBuilder();
+
+        if (context.getTupleDescription().get(0).isProjected()) {
+            sb.append(firstColumn);
+        } else {
+            // Specifies the string that represents a NULL value.
+            // The default is \N (backslash-N) in TEXT mode, and
+            // an empty value with no quotations in CSV mode.
+            sb.append("\\N");
+        }
+        sb.append(userDelimiter);
+
+        if (context.getTupleDescription().get(1).isProjected()) {
+            sb.append(counter);
+        } else {
+            // Specifies the string that represents a NULL value.
+            // The default is \N (backslash-N) in TEXT mode, and
+            // an empty value with no quotations in CSV mode.
+            sb.append("\\N");
+        }
+        sb.append(userDelimiter);
+
+        if (context.getTupleDescription().get(2).isProjected()) {
+            sb.append(counter % 2 == 0);
+        } else {
+            // Specifies the string that represents a NULL value.
+            // The default is \N (backslash-N) in TEXT mode, and
+            // an empty value with no quotations in CSV mode.
+            sb.append("\\N");
+        }
+        sb.append(userDelimiter);
+
+        if (context.getTupleDescription().get(3).isProjected()) {
+            sb.append(userData);
+        } else {
+            // Specifies the string that represents a NULL value.
+            // The default is \N (backslash-N) in TEXT mode, and
+            // an empty value with no quotations in CSV mode.
+            sb.append("\\N");
+        }
+
+        return sb.toString();
     }
 
     @Override

--- a/automation/src/main/java/org/greenplum/pxf/automation/testplugin/ColumnProjectionVerifyFragmenter.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/testplugin/ColumnProjectionVerifyFragmenter.java
@@ -1,0 +1,46 @@
+package org.greenplum.pxf.automation.testplugin;
+
+import org.greenplum.pxf.api.model.BaseFragmenter;
+import org.greenplum.pxf.api.model.Fragment;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Test class for regression tests.
+ * Stringify column projection information when available as a comma separated list of column names.
+ * Return it as UserData
+ */
+public class ColumnProjectionVerifyFragmenter extends BaseFragmenter {
+    /**
+     * Returns one fragment with incoming column projection column names as CSV in the user data.
+     * If no incoming column projection info available, then return "No Column Projection" as user data.
+     *
+     * @return one data fragment
+     * @throws Exception
+     */
+    @Override
+    public List<Fragment> getFragments() throws Exception {
+
+        String columnProjection = "No Column Projection";
+
+        if (context.getNumAttrsProjected() > 0) {
+            columnProjection = context.getTupleDescription().stream()
+                    .filter(ColumnDescriptor::isProjected)
+                    .map(ColumnDescriptor::columnName)
+                    .collect(Collectors.joining("|"));
+        }
+
+        String[] hosts = {"localhost", "localhost", "localhost"};
+        // Set filter value as returned user data.
+        Fragment fragment = new Fragment(
+                "dummy_file_path",
+                hosts,
+                "".getBytes(),
+                columnProjection.getBytes());
+        fragments.add(fragment);
+
+        return fragments;
+    }
+}

--- a/automation/src/main/java/org/greenplum/pxf/automation/testplugin/FilterPrinterAccessor.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/testplugin/FilterPrinterAccessor.java
@@ -10,7 +10,7 @@ import org.greenplum.pxf.api.model.BasePlugin;
 /**
  * Test class for regression tests.
  * The only thing this class does is to throw an exception
- * containing the received filter from GPDB (HAS-FILTER & FILTER).
+ * containing the received filter from GPDB (FILTER).
  */
 public class FilterPrinterAccessor extends BasePlugin implements Accessor
 {

--- a/automation/src/main/java/org/greenplum/pxf/automation/testplugin/FilterVerifyFragmenter.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/testplugin/FilterVerifyFragmenter.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 /**
  * Test class for regression tests.
- * The only thing this class does is to take received filter string from GPDB (HAS-FILTER & FILTER).
+ * The only thing this class does is to take received filter string from GPDB (FILTER).
  * And return it in UserData back to gpdb for later validation in Resolver/Accessor
  */
 public class FilterVerifyFragmenter extends BaseFragmenter

--- a/automation/src/main/java/org/greenplum/pxf/automation/testplugin/HiveDataFragmenterWithFilter.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/testplugin/HiveDataFragmenterWithFilter.java
@@ -30,7 +30,6 @@ public class HiveDataFragmenterWithFilter extends HiveDataFragmenter {
         context.setFilterString(filterStr);
         LOG.debug("User defined filter: " + context.getFilterString());
 
-        context.setFilterStringValid(true);
         LOG.debug("User defined filter: " + context.hasFilter());
     }
 }

--- a/automation/src/main/java/org/greenplum/pxf/automation/testplugin/HiveInputFormatFragmenterWithFilter.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/testplugin/HiveInputFormatFragmenterWithFilter.java
@@ -30,7 +30,6 @@ public class HiveInputFormatFragmenterWithFilter extends HiveInputFormatFragment
             context.setFilterString(filterStr);
             LOG.debug("User defined filter: " + context.getFilterString());
 
-            context.setFilterStringValid(true);
             LOG.debug("User defined filter: " + context.hasFilter());
     }
 }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -1,0 +1,56 @@
+package org.greenplum.pxf.automation.features.columnprojection;
+
+import org.greenplum.pxf.automation.components.cluster.PhdCluster;
+import org.greenplum.pxf.automation.features.BaseFeature;
+import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+/** Functional PXF column projection cases */
+public class ColumnProjectionTest extends BaseFeature {
+
+    String testPackageLocation = "/org/greenplum/pxf/automation/testplugin/";
+    String testPackage = "org.greenplum.pxf.automation.testplugin.";
+
+    @Override
+    protected void beforeClass() throws Exception {
+        String newPath = "/tmp/publicstage/pxf";
+        // copy additional plugins classes to cluster nodes, used for filter pushdown cases
+        cluster.copyFileToNodes(new File("target/classes/" + testPackageLocation + "ColumnProjectionVerifyFragmenter.class").getAbsolutePath(), newPath + testPackageLocation, true, false);
+        cluster.copyFileToNodes(new File("target/classes/" + testPackageLocation + "ColumnProjectionVerifyAccessor.class").getAbsolutePath(), newPath + testPackageLocation, true, false);
+        // add new path to classpath file and restart PXF service
+        cluster.addPathToPxfClassPath(newPath);
+        cluster.restart(PhdCluster.EnumClusterServices.pxf);
+    }
+
+    /**
+     * Check PXF receive the expected column projection string from GPDB.
+     * Column delimiter is ",".
+     *
+     * @throws Exception
+     */
+    @Test(groups = {"features", "gpdb"})
+    public void checkColumnProjection() throws Exception {
+
+        // Create PXF external table for column projection testing
+        ReadableExternalTable pxfExternalTable = new ReadableExternalTable("test_column_projection", new String[] {
+                "t0    text",
+                "a1    integer",
+                "b2    boolean",
+                "colprojValue  text"
+        }, "dummy_path","TEXT");
+
+        pxfExternalTable.setFragmenter(testPackage + "ColumnProjectionVerifyFragmenter");
+        pxfExternalTable.setAccessor(testPackage + "ColumnProjectionVerifyAccessor");
+        pxfExternalTable.setResolver("org.greenplum.pxf.plugins.hdfs.StringPassResolver");
+        pxfExternalTable.setDelimiter(",");
+        pxfExternalTable.setUserParameters(new String[] { "delimiter=," });
+        pxfExternalTable.setHost(pxfHost);
+        pxfExternalTable.setPort(pxfPort);
+
+        gpdb.createTableAndVerify(pxfExternalTable);
+
+        runTincTest("pxf.features.columnprojection.checkColumnProjection.runTest");
+    }
+}

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/filterpushdown/FilterPushDownTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/filterpushdown/FilterPushDownTest.java
@@ -32,7 +32,7 @@ public class FilterPushDownTest extends BaseFeature {
     }
 
     /**
-     * Check PXF receive the expected filter string from gpdb/gpdb.
+     * Check PXF receive the expected filter string from GPDB.
      * Column delimiter is ",".
      *
      * @throws Exception

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/expected/query01.ans
@@ -1,0 +1,296 @@
+-- start_ignore
+-- end_ignore
+-- start_ignore
+DROP TABLE IF EXISTS t0_values;
+DROP TABLE
+CREATE TABLE t0_values(key char(1), value int) DISTRIBUTED BY (key);
+CREATE TABLE
+INSERT INTO t0_values VALUES('A', 50);
+INSERT 0 1
+-- end_ignore
+-- @description query01 for PXF Column Projection Support
+SET optimizer = off;
+SET
+SELECT * FROM test_column_projection ORDER BY t0;
+ t0 | a1 | b2 |     colprojvalue
+----+----+----+----------------------
+ A  |  0 | t  | No Column Projection
+ B  |  1 | f  | No Column Projection
+ C  |  2 | t  | No Column Projection
+ D  |  3 | f  | No Column Projection
+ E  |  4 | t  | No Column Projection
+ F  |  5 | f  | No Column Projection
+ G  |  6 | t  | No Column Projection
+ H  |  7 | f  | No Column Projection
+ I  |  8 | t  | No Column Projection
+ J  |  9 | f  | No Column Projection
+(10 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
+ t0 |  colprojvalue
+----+-----------------
+ A  | t0|colprojvalue
+ B  | t0|colprojvalue
+ C  | t0|colprojvalue
+ D  | t0|colprojvalue
+ E  | t0|colprojvalue
+ F  | t0|colprojvalue
+ G  | t0|colprojvalue
+ H  | t0|colprojvalue
+ I  | t0|colprojvalue
+ J  | t0|colprojvalue
+(10 rows)
+
+SELECT colprojvalue FROM test_column_projection ORDER BY t0;
+  colprojvalue
+-----------------
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+(10 rows)
+
+-- Column Projection is not supported for boolean?
+-- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+--
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+(5 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+ F  | t0|a1|colprojvalue
+(6 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+(5 rows)
+
+SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+ value |  colprojvalue
+-------+-----------------
+    50 | t0|colprojvalue
+(1 row)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ I  | t0|a1|colprojvalue
+ J  | t0|a1|colprojvalue
+(4 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+ F  | t0|a1|colprojvalue
+ G  | t0|a1|colprojvalue
+ H  | t0|a1|colprojvalue
+ I  | t0|a1|colprojvalue
+ J  | t0|a1|colprojvalue
+(8 rows)
+
+SELECT t0, colprojvalue, sqrt(a1) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    |       sqrt
+----+--------------------+------------------
+ A  | t0|a1|colprojvalue |                0
+ B  | t0|a1|colprojvalue |                1
+ C  | t0|a1|colprojvalue |  1.4142135623731
+ D  | t0|a1|colprojvalue | 1.73205080756888
+ E  | t0|a1|colprojvalue |                2
+ F  | t0|a1|colprojvalue | 2.23606797749979
+ G  | t0|a1|colprojvalue | 2.44948974278318
+ H  | t0|a1|colprojvalue | 2.64575131106459
+ I  | t0|a1|colprojvalue | 2.82842712474619
+ J  | t0|a1|colprojvalue |                3
+(10 rows)
+
+-- Casting boolean column to int
+SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    | sqrt
+----+--------------------+------
+ A  | t0|b2|colprojvalue |    1
+ B  | t0|b2|colprojvalue |    0
+ C  | t0|b2|colprojvalue |    1
+ D  | t0|b2|colprojvalue |    0
+ E  | t0|b2|colprojvalue |    1
+ F  | t0|b2|colprojvalue |    0
+ G  | t0|b2|colprojvalue |    1
+ H  | t0|b2|colprojvalue |    0
+ I  | t0|b2|colprojvalue |    1
+ J  | t0|b2|colprojvalue |    0
+(10 rows)
+
+SET optimizer = on;
+SET
+SELECT * FROM test_column_projection ORDER BY t0;
+ t0 | a1 | b2 |     colprojvalue
+----+----+----+----------------------
+ A  |  0 | t  | No Column Projection
+ B  |  1 | f  | No Column Projection
+ C  |  2 | t  | No Column Projection
+ D  |  3 | f  | No Column Projection
+ E  |  4 | t  | No Column Projection
+ F  |  5 | f  | No Column Projection
+ G  |  6 | t  | No Column Projection
+ H  |  7 | f  | No Column Projection
+ I  |  8 | t  | No Column Projection
+ J  |  9 | f  | No Column Projection
+(10 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
+ t0 |  colprojvalue
+----+-----------------
+ A  | t0|colprojvalue
+ B  | t0|colprojvalue
+ C  | t0|colprojvalue
+ D  | t0|colprojvalue
+ E  | t0|colprojvalue
+ F  | t0|colprojvalue
+ G  | t0|colprojvalue
+ H  | t0|colprojvalue
+ I  | t0|colprojvalue
+ J  | t0|colprojvalue
+(10 rows)
+
+SELECT colprojvalue FROM test_column_projection ORDER BY t0;
+  colprojvalue
+-----------------
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+(10 rows)
+
+-- Column Projection is not supported for boolean?
+-- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+--
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+(5 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+ F  | t0|a1|colprojvalue
+(6 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+(5 rows)
+
+SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+ value |  colprojvalue
+-------+-----------------
+    50 | t0|colprojvalue
+(1 row)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ I  | t0|a1|colprojvalue
+ J  | t0|a1|colprojvalue
+(4 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+ F  | t0|a1|colprojvalue
+ G  | t0|a1|colprojvalue
+ H  | t0|a1|colprojvalue
+ I  | t0|a1|colprojvalue
+ J  | t0|a1|colprojvalue
+(8 rows)
+
+SELECT t0, colprojvalue, sqrt(a1) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    |       sqrt
+----+--------------------+------------------
+ A  | t0|a1|colprojvalue |                0
+ B  | t0|a1|colprojvalue |                1
+ C  | t0|a1|colprojvalue |  1.4142135623731
+ D  | t0|a1|colprojvalue | 1.73205080756888
+ E  | t0|a1|colprojvalue |                2
+ F  | t0|a1|colprojvalue | 2.23606797749979
+ G  | t0|a1|colprojvalue | 2.44948974278318
+ H  | t0|a1|colprojvalue | 2.64575131106459
+ I  | t0|a1|colprojvalue | 2.82842712474619
+ J  | t0|a1|colprojvalue |                3
+(10 rows)
+
+-- Casting boolean column to int
+SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    | sqrt
+----+--------------------+------
+ A  | t0|b2|colprojvalue |    1
+ B  | t0|b2|colprojvalue |    0
+ C  | t0|b2|colprojvalue |    1
+ D  | t0|b2|colprojvalue |    0
+ E  | t0|b2|colprojvalue |    1
+ F  | t0|b2|colprojvalue |    0
+ G  | t0|b2|colprojvalue |    1
+ H  | t0|b2|colprojvalue |    0
+ I  | t0|b2|colprojvalue |    1
+ J  | t0|b2|colprojvalue |    0
+(10 rows)
+
+-- cleanup
+-- start_ignore
+DROP TABLE IF EXISTS t0_values;
+DROP TABLE
+-- end_ignore

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/runTest.py
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLTestCase
+from mpp.models import SQLConcurrencyTestCase
+
+class PxfColumnProjection(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/sql/query01.sql
@@ -1,0 +1,67 @@
+-- start_ignore
+DROP TABLE IF EXISTS t0_values;
+CREATE TABLE t0_values(key char(1), value int) DISTRIBUTED BY (key);
+INSERT INTO t0_values VALUES('A', 50);
+-- end_ignore
+-- @description query01 for PXF Column Projection Support
+
+SET optimizer = off;
+
+SELECT * FROM test_column_projection ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
+
+SELECT colprojvalue FROM test_column_projection ORDER BY t0;
+
+-- Column Projection is not supported for boolean?
+-- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+--
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
+
+SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
+
+SELECT t0, colprojvalue, sqrt(a1) FROM test_column_projection ORDER BY t0;
+
+-- Casting boolean column to int
+SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;
+
+SET optimizer = on;
+
+SELECT * FROM test_column_projection ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
+
+SELECT colprojvalue FROM test_column_projection ORDER BY t0;
+
+-- Column Projection is not supported for boolean?
+-- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+--
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
+
+SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
+
+SELECT t0, colprojvalue, sqrt(a1) FROM test_column_projection ORDER BY t0;
+
+-- Casting boolean column to int
+SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;
+
+-- cleanup
+-- start_ignore
+DROP TABLE IF EXISTS t0_values;
+-- end_ignore

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/FilterParser.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/FilterParser.java
@@ -8,9 +8,9 @@ package org.greenplum.pxf.api;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -116,7 +116,7 @@ public class FilterParser {
          * @return the built filter
          * @throws Exception if building the filter failed
          */
-        public Object build(Operation operation, Object left, Object right) throws Exception;
+        Object build(Operation operation, Object left, Object right) throws Exception;
 
         /**
          * Builds the filter for an operation with one operand
@@ -126,7 +126,7 @@ public class FilterParser {
          * @return the built filter
          * @throws Exception if building the filter failed
          */
-        public Object build(Operation operation, Object operand) throws Exception;
+        Object build(Operation operation, Object operand) throws Exception;
 
         /**
          * Builds the filter for a logical operation and two operands
@@ -137,7 +137,7 @@ public class FilterParser {
          * @return the built filter
          * @throws Exception if building the filter failed
          */
-        public Object build(LogicalOperation operation, Object left, Object right) throws Exception;
+        Object build(LogicalOperation operation, Object left, Object right) throws Exception;
 
         /**
          * Builds the filter for a logical operation and one operand
@@ -147,7 +147,7 @@ public class FilterParser {
          * @return the built filter
          * @throws Exception if building the filter failed
          */
-        public Object build(LogicalOperation operation, Object filter) throws Exception;
+        Object build(LogicalOperation operation, Object filter) throws Exception;
     }
 
     /** Represents a column index. */
@@ -192,7 +192,7 @@ public class FilterParser {
      * @param eval the filter builder
      */
     public FilterParser(FilterBuilder eval) {
-        operandsStack = new Stack<Object>();
+        operandsStack = new Stack<>();
         filterBuilder = eval;
     }
 

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
@@ -49,7 +49,6 @@ public class RequestContext {
     private int fragmentIndex;
     private byte[] fragmentMetadata = null;
     private String filterString;
-    private boolean filterStringValid;
     // Profile-centric metadata
     private Object metadata;
 
@@ -128,14 +127,6 @@ public class RequestContext {
 
     public Map<String, String> getOptions() {
         return Collections.unmodifiableMap(options);
-    }
-
-    public boolean isFilterStringValid() {
-        return filterStringValid;
-    }
-
-    public void setFilterStringValid(boolean filterStringValid) {
-        this.filterStringValid = filterStringValid;
     }
 
     public String getRemoteLogin() {
@@ -232,7 +223,7 @@ public class RequestContext {
      * @return whether there is a filter string
      */
     public boolean hasFilter() {
-        return filterStringValid;
+        return filterString != null;
     }
 
     /**

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/ColumnDescriptor.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/ColumnDescriptor.java
@@ -50,17 +50,16 @@ public class ColumnDescriptor {
      * @param isProj does the column need to be projected
      */
     public ColumnDescriptor(String name, int typecode, int index, String typename, Integer[] typemods, boolean isProj) {
-        this(name, typecode, index, typename, typemods);
-        isProjected = isProj;
-    }
-
-    public ColumnDescriptor(String name, int typecode, int index, String typename, Integer[] typemods) {
         dbColumnTypeCode = typecode;
         dbColumnTypeName = typename;
         dbColumnName = name;
         dbColumnIndex = index;
         dbColumnTypeModifiers = typemods;
-        isProjected = true;
+        isProjected = isProj;
+    }
+
+    public ColumnDescriptor(String name, int typecode, int index, String typename, Integer[] typemods) {
+        this(name, typecode, index, typename, typemods, true);
     }
 
     /**

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
@@ -257,7 +257,6 @@ public abstract class PxfUnit {
 //
 ////		paramsMap.put("X-GP-ALIGNMENT", "what");
 ////		paramsMap.put("X-GP-SEGMENT-ID", "1");
-////		paramsMap.put("X-GP-HAS-FILTER", "0");
 ////		paramsMap.put("X-GP-SEGMENT-COUNT", "1");
 //
 ////		paramsMap.put("X-GP-FORMAT", "GPDBWritable");

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
@@ -350,7 +350,6 @@ public abstract class PxfUnit {
         context.setUser("who");
         System.setProperty("greenplum.alignment", "what");
         context.setSegmentId(1);
-        context.setFilterStringValid(false);
         context.setTotalSegments(1);
         context.setOutputFormat(OutputFormat.GPDBWritable);
         context.setHost("localhost");

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
@@ -95,7 +95,6 @@ public class HttpRequestParser implements RequestParser<HttpHeaders> {
         String hasFilter = params.removeProperty("HAS-FILTER");
         if (filterString != null) {
             context.setFilterString(filterString);
-            context.setFilterStringValid(true);
         } else if ("1".equals(hasFilter)) {
             LOG.info("Original query has filter, but it was not propagated to PXF");
         }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
@@ -250,16 +250,12 @@ public class HttpRequestParser implements RequestParser<HttpHeaders> {
      * Attribute Projection information is optional
      */
     private void parseFilterAndProjectionInformationAndTupleDescription(RequestMap params, RequestContext context) {
-        Set<Integer> attrsProjected;
+        Set<Integer> attrsProjected = new HashSet<>();
 
         String filterString = params.removeOptionalProperty("FILTER");
         if (filterString != null) {
             context.setFilterString(filterString);
             context.setFilterStringValid(true);
-
-            attrsProjected = extractProjectedAttrsFromFilter(filterString);
-        } else {
-            attrsProjected = new HashSet<>();
         }
 
         /* Process column projection info */
@@ -300,59 +296,6 @@ public class HttpRequestParser implements RequestParser<HttpHeaders> {
                 context.setRecordkeyColumn(column);
             }
         }
-    }
-
-
-    /**
-     * Returns a set of attribute indexes from the filter string
-     *
-     * @param filterString the filter string
-     * @return a set of distinct attribute indexes
-     */
-    private Set<Integer> extractProjectedAttrsFromFilter(String filterString) {
-        final Set<Integer> attrsProjected = new HashSet<>();
-        // Parse filterString and add attrs to attrsProjected set
-        FilterParser parser = new FilterParser(new FilterParser.FilterBuilder() {
-            @Override
-            public Object build(FilterParser.Operation operation, Object left, Object right) {
-                addAttributes(left);
-                addAttributes(right);
-                return null;
-            }
-
-            @Override
-            public Object build(FilterParser.Operation operation, Object operand) {
-                addAttributes(operand);
-                return null;
-            }
-
-            @Override
-            public Object build(FilterParser.LogicalOperation operation, Object left, Object right) {
-                addAttributes(left);
-                addAttributes(right);
-                return null;
-            }
-
-            @Override
-            public Object build(FilterParser.LogicalOperation operation, Object filter) {
-                addAttributes(filter);
-                return null;
-            }
-
-            private void addAttributes(Object operand) {
-                if (operand instanceof FilterParser.ColumnIndex) {
-                    attrsProjected.add(((FilterParser.ColumnIndex) operand).index());
-                }
-            }
-        });
-
-        try {
-            parser.parse(filterString.getBytes(FilterParser.DEFAULT_CHARSET));
-        } catch (Exception e) {
-            LOG.error(String.format("Unable to parse filter string %s", filterString), e);
-        }
-
-        return attrsProjected;
     }
 
     private Integer[] parseTypeMods(RequestMap params, int columnIndex) {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
@@ -56,7 +56,6 @@ import java.io.InputStream;
   	--header "X-GP-ALIGNMENT: 4" \
  	--header "X-GP-SEGMENT-ID: 0" \
  	--header "X-GP-SEGMENT-COUNT: 3" \
- 	--header "X-GP-HAS-FILTER: 0" \
  	--header "X-GP-FORMAT: TEXT" \
  	--header "X-GP-URI: pxf://localhost:51200/data/curl/?Accessor=TextFileWAccessor&Resolver=TextWResolver" \
  	--header "X-GP-URL-HOST: localhost" \

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/BridgeOutputBuilderTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/BridgeOutputBuilderTest.java
@@ -368,7 +368,6 @@ public class BridgeOutputBuilderTest {
 
         context.setSegmentId(-44);
         context.setTotalSegments(2);
-        context.setFilterStringValid(false);
         context.setOutputFormat(OutputFormat.TEXT);
         context.setHost("my://bags");
         context.setPort(-8020);

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
@@ -68,7 +68,6 @@ public class HttpRequestParserTest {
         parameters.putSingle("X-GP-ALIGNMENT", "all");
         parameters.putSingle("X-GP-SEGMENT-ID", "-44");
         parameters.putSingle("X-GP-SEGMENT-COUNT", "2");
-        parameters.putSingle("X-GP-HAS-FILTER", "0");
         parameters.putSingle("X-GP-FORMAT", "TEXT");
         parameters.putSingle("X-GP-URL-HOST", "my://bags");
         parameters.putSingle("X-GP-URL-PORT", "-8020");
@@ -305,8 +304,6 @@ public class HttpRequestParserTest {
 
     @Test
     public void filterUtf8() {
-        parameters.remove("X-GP-HAS-FILTER");
-        parameters.putSingle("X-GP-HAS-FILTER", "1");
         String isoString = new String("UTF8_計算機用語_00000000".getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
         parameters.putSingle("X-GP-FILTER", isoString);
         RequestContext context = parser.parseRequest(mockRequestHeaders);

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
@@ -68,6 +68,7 @@ public class HttpRequestParserTest {
         parameters.putSingle("X-GP-ALIGNMENT", "all");
         parameters.putSingle("X-GP-SEGMENT-ID", "-44");
         parameters.putSingle("X-GP-SEGMENT-COUNT", "2");
+        parameters.putSingle("X-GP-HAS-FILTER", "0");
         parameters.putSingle("X-GP-FORMAT", "TEXT");
         parameters.putSingle("X-GP-URL-HOST", "my://bags");
         parameters.putSingle("X-GP-URL-PORT", "-8020");
@@ -304,6 +305,8 @@ public class HttpRequestParserTest {
 
     @Test
     public void filterUtf8() {
+        parameters.remove("X-GP-HAS-FILTER");
+        parameters.putSingle("X-GP-HAS-FILTER", "1");
         String isoString = new String("UTF8_計算機用語_00000000".getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
         parameters.putSingle("X-GP-FILTER", isoString);
         RequestContext context = parser.parseRequest(mockRequestHeaders);


### PR DESCRIPTION
We remove "HAS-FILTER" header for the moment because it didn't add any additional information that cannot be induced from the "FILTER" header. 
Column projection information will not be available for queries with filters that pxf doesn't support.

Pending:
1. Will be updating the FilterPushDownTest to test for column projection information

Co-authored: Francisco Guerrero [aguerrero@pivotal.io](mailto:aguerrero@pivotal.io)
Co-authored: Shivram Mani [smani@pivotal.io](mailto:smani@pivotal.io)