### PR TITLE
PXF-Ignite: Use Ignite thin client for Java

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -78,7 +78,6 @@ allprojects {
             force "org.codehaus.jackson:jackson-mapper-asl:1.9.13"
             force "junit:junit:${junitVersion}"
             force "com.google.guava:guava:11.0.2" // because this version ships with HDP-2.5.3
-            force "com.google.code.gson:gson:2.8.2" // because HDP ships with an older version, but Ignite expects 2.8.2
         }
     }
 
@@ -207,8 +206,8 @@ project('pxf-hive') {
 project('pxf-ignite') {
     dependencies {
         compile(project(':pxf-api'))
-        compile "com.google.code.gson:gson:2.8.2"
         compile "org.apache.commons:commons-compress:1.16.1"
+        compile "org.apache.ignite:ignite-core:2.6.0"
     }
 }
 

--- a/server/pxf-ignite/src/main/java/org/greenplum/pxf/plugins/ignite/IgniteAccessor.java
+++ b/server/pxf-ignite/src/main/java/org/greenplum/pxf/plugins/ignite/IgniteAccessor.java
@@ -19,62 +19,171 @@ package org.greenplum.pxf.plugins.ignite;
  * under the License.
  */
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.greenplum.pxf.api.OneRow;
 import org.greenplum.pxf.api.model.Accessor;
 import org.greenplum.pxf.api.utilities.ColumnDescriptor;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.ClientConfiguration;
+import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.cache.query.FieldsQueryCursor;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
 
 /**
  * PXF-Ignite accessor class
  */
 public class IgniteAccessor extends IgniteBasePlugin implements Accessor {
-
-    private static final Log LOG = LogFactory.getLog(IgniteAccessor.class);
-    // A pattern to cut extra parameters from 'RequestContext.dataSource' when write operation is performed. See {@link openForWrite()} for the details
-    private static final Pattern writeAddressPattern = Pattern.compile("/(.*)/[0-9]*-[0-9]*_[0-9]*");
-    // Prepared URLs to send to Ignite when reading data
-    private String urlReadStart = null;
-    private String urlReadFetch = null;
-    private String urlReadClose = null;
-    // Set to true when Ignite reported all the data for the SELECT query was retreived
-    private boolean isLastReadFinished = false;
-    // A buffer to store the SELECT query results (without Ignite metadata)
-    private LinkedList<JsonArray> bufferRead = new LinkedList<JsonArray>();
-    // A template for the INSERT
-    private String queryWrite = null;
-    // Set to true when the INSERT operation is in progress
-    private boolean isWriteActive = false;
-    // A buffer to store prepared values for the INSERT query
-    private LinkedList<OneRow> bufferWrite = new LinkedList<OneRow>();
-
     /**
      * openForRead() implementation
      */
     @Override
     public boolean openForRead() throws Exception {
-        if (bufferSize == 0) {
-            bufferSize = 1;
+        ClientConfiguration cfg = new ClientConfiguration();
+        cfg.setAddresses(hosts);
+        if (user != null) {
+            cfg.setUserName(user);
+        }
+        if (password != null) {
+            cfg.setUserPassword(password);
+        }
+        if (bufferSize > 0) {
+            cfg.setReceiveBufferSize(bufferSize);
+        }
+        cfg.setTcpNoDelay(tcpNodelay);
+
+        SqlFieldsQuery query = buildSelectQuery();
+        if (igniteCache != null) {
+            query.setSchema(igniteCache);
+        }
+        query.setLazy(lazy);
+        query.setReplicatedOnly(replicatedOnly);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("openForRead(): making a request to Ignite. Query: '" + query.getSql() + "'");
         }
 
+        igniteClient = Ignition.startClient(cfg);
+        readIgniteCursor = igniteClient.query(query);
+        readIterator = readIgniteCursor.iterator();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("openForRead() finished successfully");
+        }
+
+        return true;
+    }
+
+    /**
+     * readNextObject() implementation
+     */
+    @Override
+    public OneRow readNextObject() throws Exception {
+        return readIterator.hasNext() ? new OneRow(readIterator.next()) : null;
+    }
+
+    /**
+     * closeForRead() implementation
+     *
+     * Any number of resources, each of which are to be closed, can be closed by this procedure. Only one exception will be thrown - the last that happened
+     */
+    @Override
+    public void closeForRead() throws Exception {
+        Exception exception = null;
+
+        if (readIgniteCursor != null) {
+            try {
+                readIgniteCursor.close();
+                readIgniteCursor = null;
+            }
+            catch(Exception e) {
+                exception = e;
+            }
+        }
+        if (igniteClient != null) {
+            try {
+                igniteClient.close();
+                igniteClient = null;
+            }
+            catch(Exception e) {
+                exception = e;
+            }
+        }
+
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    /**
+     * openForWrite() implementation
+     */
+    @Override
+    public boolean openForWrite() throws IllegalArgumentException {
+        ClientConfiguration cfg = new ClientConfiguration();
+        cfg.setAddresses(hosts);
+        if (user != null) {
+            cfg.setUserName(user);
+        }
+        if (password != null) {
+            cfg.setUserPassword(password);
+        }
+        if (bufferSize > 0) {
+            cfg.setSendBufferSize(bufferSize);
+        }
+
+        writeQuery = buildInsertQuery();
+        writeQuery.setSchema(igniteCache);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("openForWrite(): connecting to Ignite");
+        }
+
+        igniteClient = Ignition.startClient(cfg);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("openForWrite() finished successfully");
+        }
+
+        return true;
+    }
+
+    /**
+     * writeNextObject() implementation
+     */
+    @Override
+    public boolean writeNextObject(OneRow currentRow) throws Exception {
+        Object[] args = (Object[])currentRow.getData();
+        writeQuery.setArgs(args);
+
+        igniteClient.query(writeQuery).getAll();
+
+        return true;
+    }
+
+    /**
+     * closeForWrite() implementation
+     */
+    @Override
+    public void closeForWrite() throws Exception {
+        if (igniteClient != null) {
+            igniteClient.close();
+            igniteClient = null;
+        }
+    }
+
+    /**
+     * Build a SELECT query using the existing plugin parameters
+     * @return a {@link SqlFieldsQuery} (with default settings) containing a SQL query
+     * @throws Exception in case plugin parameters are incorrect or {@link WhereSQLBuilder} failed
+     */
+    private SqlFieldsQuery buildSelectQuery() throws Exception {
         StringBuilder sb = new StringBuilder();
 
         // Insert a list of fields to be selected
@@ -88,7 +197,11 @@ public class IgniteAccessor extends IgniteBasePlugin implements Accessor {
             if (i > 0) {
                 sb.append(", ");
             }
-            sb.append(column.columnName());
+            sb.append(
+                quoteColumns ?
+                QUOTE + column.columnName() + QUOTE
+                : column.columnName()
+            );
         }
 
         // Insert the name of the table to select values from
@@ -100,10 +213,8 @@ public class IgniteAccessor extends IgniteBasePlugin implements Accessor {
         sb.append(tableName);
 
         // Insert query constraints
-        // Note: Filter constants may be passed to Ignite separately from the WHERE expression, primarily for the safety of the SQL queries. However, at the moment they are passed in the query.
-        ArrayList<String> filterConstants = null;
         if (context.hasFilter()) {
-            WhereSQLBuilder filterBuilder = new WhereSQLBuilder(context);
+            WhereSQLBuilder filterBuilder = new WhereSQLBuilder(context, quoteColumns ? QUOTE : null);
             String whereSql = filterBuilder.buildWhereSQL();
 
             if (whereSql != null) {
@@ -114,95 +225,21 @@ public class IgniteAccessor extends IgniteBasePlugin implements Accessor {
         // Insert partition constraints
         IgnitePartitionFragmenter.buildFragmenterSql(context, sb);
 
-        // Format URL
-        urlReadStart = buildQueryFldexe(sb.toString(), filterConstants);
+        sb.append(";");
 
-        // Send the first REST request that opens the connection
-        JsonElement response = sendRestRequest(urlReadStart);
-
-        // Build 'urlReadFetch' and 'urlReadClose'
-        isLastReadFinished = response.getAsJsonObject().get("last").getAsBoolean();
-        urlReadFetch = buildQueryFetch(response.getAsJsonObject().get("queryId").getAsInt());
-        urlReadClose = buildQueryCls(response.getAsJsonObject().get("queryId").getAsInt());
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Ignite read request. URL: '" + urlReadStart + "'");
-        }
-        return true;
+        return new SqlFieldsQuery(sb.toString());
     }
 
     /**
-     * readNextObject() implementation
+     * Build an INSERT query using the existing plugin parameters
+     * @return a {@link SqlFieldsQuery} (with default settings) containing a SQL query with placeholders
+     * @throws IllegalArgumentException in case plugin parameters are incorrect
+     *
+     * This function also checks the external data source (target table name) against a regexp. At the moment there is no other way (except for the usage of user-defined parameters) to get correct name of that table: GPDB inserts extra data into the address, because it is required required by Hadoop.
+     * If no extra data is present, the source is left unchanged
      */
-    @Override
-    public OneRow readNextObject() throws Exception {
-        if (urlReadFetch == null) {
-            LOG.error("readNextObject(): urlReadFetch is null. This means the Ignite qryfldexe query was not executed properly");
-            throw new ProtocolException("readNextObject(): urlReadFetch is null. This means the Ignite qryfldexe query was not executed properly");
-        }
-
-        if (bufferRead.isEmpty()) {
-            // Refill buffer
-            if (isLastReadFinished) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("readNextObject(): All the data received from Ignite");
-                }
-                return null;
-            }
-
-            JsonElement response = sendRestRequest(urlReadFetch);
-            isLastReadFinished = response.getAsJsonObject().get("last").getAsBoolean();
-
-            // Parse 'items'
-            Iterator<JsonElement> itemsIterator = response.getAsJsonObject().get("items").getAsJsonArray().iterator();
-            while (itemsIterator.hasNext()) {
-                if (!bufferRead.add(itemsIterator.next().getAsJsonArray())) {
-                    throw new IOException("readNextObject(): not enough memory in 'bufferRead'");
-                }
-            }
-
-            // Check again in case "response" contains no elements
-            if (bufferRead.isEmpty()) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("readNextObject(): Buffer refill failed");
-                    LOG.debug("readNextObject(): All the data received from Ignite");
-                }
-                return null;
-            }
-        }
-
-        return new OneRow(bufferRead.pollFirst());
-    }
-
-    /**
-     * closeForRead() implementation
-     */
-    @Override
-    public void closeForRead() {
-        if (urlReadClose != null) {
-            try {
-                sendRestRequest(urlReadClose);
-            } catch (Exception e) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("closeForRead() Exception: " + e.getClass().getSimpleName());
-                }
-            }
-        }
-        isLastReadFinished = false;
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Ignite read request finished. URL: '" + urlReadClose + "'");
-        }
-    }
-
-    /**
-     * openForWrite() implementation.
-     * No queries are sent to Ignite by this procedure, so if there are some problems (for example, with connection), they will be revealed only during the execution of 'writeNextObject()'
-     */
-    @Override
-    public boolean openForWrite() throws Exception {
-        // This is a temporary solution. At the moment there is no other way (except for the usage of user-defined parameters) to get the correct name of Ignite table: GPDB inserts extra data into the address, as required by Hadoop.
-        // Note that if no extra data is present, the 'definedSource' will be left unchanged
+    private SqlFieldsQuery buildInsertQuery() throws IllegalArgumentException {
+        // Check data source
         String definedSource = context.getDataSource();
         Matcher matcher = writeAddressPattern.matcher(definedSource);
         if (matcher.find()) {
@@ -212,14 +249,14 @@ public class IgniteAccessor extends IgniteBasePlugin implements Accessor {
         StringBuilder sb = new StringBuilder();
         sb.append("INSERT INTO ");
 
-        // Insert the table name
+        // Insert table name
         String tableName = context.getDataSource();
         if (tableName == null) {
             throw new IllegalArgumentException("Table name must be set as DataSource.");
         }
         sb.append(tableName);
 
-        // Insert the column names
+        // Insert column names
         sb.append("(");
         List<ColumnDescriptor> columns = context.getTupleDescription();
         if (columns == null) {
@@ -229,255 +266,42 @@ public class IgniteAccessor extends IgniteBasePlugin implements Accessor {
         for (int i = 0; i < columns.size(); i++) {
             sb.append(fieldDivisor);
             fieldDivisor = ", ";
-            sb.append(columns.get(i).columnName());
+            sb.append(
+                quoteColumns ?
+                QUOTE + columns.get(i).columnName() + QUOTE
+                : columns.get(i).columnName()
+            );
         }
         sb.append(")");
 
         sb.append(" VALUES ");
 
-        queryWrite = sb.toString();
-        return true;
-    }
-
-    /**
-     * writeNextObject() implementation
-     */
-    @Override
-    public boolean writeNextObject(OneRow currentRow) throws Exception {
-        boolean currentRowInBuffer = bufferWrite.add(currentRow);
-
-        if (!isWriteActive) {
-            if (!currentRowInBuffer) {
-                LOG.error("writeNextObject(): Failed (not enough memory in 'bufferWrite')");
-                throw new IOException("writeNextObject(): not enough memory in 'bufferWrite'");
-            }
-            LOG.info("Ignite write request. Query: '" + queryWrite + "'");
-            sendInsertRestRequest(queryWrite);
-            isWriteActive = true;
-            return true;
-        }
-
-        if ((bufferWrite.size() >= bufferSize) || (!currentRowInBuffer)) {
-            sendInsertRestRequest(queryWrite);
-        }
-
-        if (!currentRowInBuffer) {
-            if (!bufferWrite.add(currentRow)) {
-                LOG.error("writeNextObject(): Failed (not enough memory in 'bufferSend')");
-                throw new IOException("writeNextObject(): not enough memory in 'bufferSend'");
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * closeForWrite() implementation
-     */
-    @Override
-    public void closeForWrite() throws Exception {
-        isWriteActive = false;
-        if (!bufferWrite.isEmpty()) {
-            sendInsertRestRequest(queryWrite);
-        }
-        if (isWriteActive) {
-            // At this point, the request must have finished successfully
-            LOG.info("Ignite write request finished successfully. Query: '" + queryWrite + "'");
-        }
-    }
-
-    /**
-     * Build HTTP GET query for Ignite REST API with command 'qryfldexe'
-     *
-     * @param querySql        SQL query
-     * @param filterConstants A list of Constraints' constants. Must be null in this version.
-     * @return Prepared HTTP query. The query will be properly encoded with {@link java.net.URLEncoder}
-     * @throws UnsupportedEncodingException from {@link java.net.URLEncoder#encode(String, String)}
-     */
-    private String buildQueryFldexe(String querySql, List<String> filterConstants) throws UnsupportedEncodingException {
-        StringBuilder sb = new StringBuilder();
-        sb.append("http://");
-        sb.append(igniteHost);
-        sb.append("/ignite");
-        sb.append("?");
-        sb.append("cmd=qryfldexe");
-        sb.append("&");
-        sb.append("pageSize=0");
-        sb.append("&");
-        if (cacheName != null) {
-            sb.append("cacheName=");
-            // Note that Ignite supports only "good" cache names (those that will be left unchanged by the URLEncoder.encode())
-            sb.append(URLEncoder.encode(cacheName, "UTF-8"));
-            sb.append("&");
-        }
-        /*
-        'filterConstants' must always be null in the current version.
-        This code allows to pass filters' constants separately from the filters' expressions. This feature is supported by Ignite database; however, it is not implemented in PXF Ignite plugin at the moment.
-        To implement this, changes should be made in {@link WhereSQLBuilder} (form SQL query without filter constants) and {@link IgnitePartitionFragmenter} (form partition constraints the similar way).
-        */
-        int counter = 1;
-        if (filterConstants != null) {
-            for (String constant : filterConstants) {
-                sb.append("arg");
-                sb.append(counter);
-                sb.append("=");
-                sb.append(URLEncoder.encode(constant, "UTF-8"));
-                sb.append("&");
-                counter += 1;
-            }
-        }
-        sb.append("qry=");
-        sb.append(URLEncoder.encode(querySql, "UTF-8"));
-
-        return sb.toString();
-    }
-
-    /**
-     * Build HTTP GET query for Ignite REST API with command 'qryfetch'
-     * This query is used to retrieve data after the 'qryfldexe' command started
-     *
-     * @param queryId ID of the query assigned by Ignite when the query started
-     * @return Prepared HTTP query
-     */
-    private String buildQueryFetch(int queryId) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("http://");
-        sb.append(igniteHost);
-        sb.append("/ignite");
-        sb.append("?");
-        sb.append("cmd=qryfetch");
-        sb.append("&");
-        sb.append("pageSize=");
-        sb.append(bufferSize);
-        sb.append("&");
-        sb.append("qryId=");
-        sb.append(queryId);
-
-        return sb.toString();
-    }
-
-    /**
-     * Build HTTP GET query for Ignite REST API with command 'qrycls'
-     * This query is used to close query resources on Ignite side
-     *
-     * @param queryId ID of the query assigned by Ignite when the query started
-     * @return Prepared HTTP query
-     */
-    private String buildQueryCls(int queryId) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("http://");
-        sb.append(igniteHost);
-        sb.append("/ignite");
-        sb.append("?");
-        sb.append("cmd=qrycls");
-        sb.append("&");
-        sb.append("qryId=");
-        sb.append(queryId);
-
-        return sb.toString();
-    }
-
-    /**
-     * Send a REST request to the Ignite server
-     *
-     * @param query A prepared and properly encoded HTTP GET request
-     * @return "response" field from the received JSON object
-     * (See Ignite REST API documentation for details)
-     * @throws ProtocolException     if Ignite reports error in it's JSON response
-     * @throws MalformedURLException if URL is malformed
-     * @throws IOException           in case of connection failure
-     */
-    private JsonElement sendRestRequest(String query) throws ProtocolException, MalformedURLException, IOException {
-        // Create URL object. This operation may throw 'MalformedURLException'
-        URL url = new URL(query);
-
-        // Connect to the Ignite server, send query and get raw response
-        BufferedReader reader = null;
-        String responseRaw = null;
-        try {
-            StringBuilder sb = new StringBuilder();
-            reader = new BufferedReader(new InputStreamReader(url.openStream()));
-            String responseLine;
-            while ((responseLine = reader.readLine()) != null) {
-                sb.append(responseLine);
-            }
-            responseRaw = sb.toString();
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("sendRestRequest(): URL: '" + query + "'; Result: '" + responseRaw + "'");
-            }
-        } catch (Exception e) {
-            LOG.error("sendRestRequest(): Failed (connection failure). URL is '" + query + "'");
-            throw e;
-        } finally {
-            if (reader != null) {
-                reader.close();
-            }
-            // if 'reader' is null, an exception must have been thrown
-        }
-
-        // Parse raw Ignite server response
-        JsonElement response = null;
-        String error = null;
-        int successStatus;
-        try {
-            response = new JsonParser().parse(responseRaw);
-
-            if (!response.getAsJsonObject().get("error").isJsonNull()) {
-                error = response.getAsJsonObject().get("error").getAsString();
-            }
-            successStatus = response.getAsJsonObject().get("successStatus").getAsInt();
-        } catch (Exception e) {
-            LOG.error("sendRestRequest(): Failed (JSON parsing failure). URL is '" + query + "'");
-            throw e;
-        }
-
-        // Check errors reported by Ignite
-        if ((error != null) || (successStatus != 0)) {
-            LOG.error("sendRestRequest(): Failed (failure on Ignite side: '" + error + "'). URL is '" + query + "'");
-            throw new ProtocolException("Ignite failure: status " + successStatus + ", '" + error + "'");
-        }
-
-        // Return response without metadata
-        try {
-            return response.getAsJsonObject().get("response");
-        } catch (Exception e) {
-            LOG.error("sendRestRequest(): Failed (JSON parsing failure). URL is '" + query + "'");
-            throw e;
-        }
-    }
-
-    /**
-     * Send an INSERT REST request to the Ignite server.
-     * <p>
-     * Note that
-     * <p>
-     * The {@link #sendRestRequest(String)} is used to handle network operations, thus all its exceptions may be thrown. They are:
-     *
-     * @throws ProtocolException     if Ignite reports error in it's JSON response
-     * @throws MalformedURLException if URL is malformed
-     * @throws IOException           in case of connection failure
-     */
-    private void sendInsertRestRequest(String query) throws ProtocolException, MalformedURLException, IOException {
-        if (query == null) {
-            LOG.error("sendInsertRestRequest(): Failed (malformed URL). URL is null");
-            throw new MalformedURLException("sendInsertRestRequest(): query is null");
-        }
-        if (bufferWrite.isEmpty()) {
-            return;
-        }
-
-        StringBuilder sb = new StringBuilder(query);
-        String fieldDivisor = "";
-        for (OneRow row : bufferWrite) {
+        sb.append("(");
+        fieldDivisor = "";
+        for (int i = 0; i < columns.size(); i++) {
             sb.append(fieldDivisor);
             fieldDivisor = ", ";
-            sb.append((String) row.getData());
+            sb.append("?");
         }
-        bufferWrite.clear();
+        sb.append(")");
 
-        // Send REST request 'qryfldexe' to Ignite
-        JsonElement response = sendRestRequest(buildQueryFldexe(sb.toString(), null));
-        // Close the request immediately
-        sendRestRequest(buildQueryCls(response.getAsJsonObject().get("queryId").getAsInt()));
+        sb.append(";");
+
+        return new SqlFieldsQuery(sb.toString());
     }
+
+    private static final Log LOG = LogFactory.getLog(IgniteAccessor.class);
+
+    // A pattern to cut extra parameters from 'InputData.dataSource' when write operation is performed. See {@link openForWrite()} for the details
+    private static final Pattern writeAddressPattern = Pattern.compile("/(.*)/[0-9]*-[0-9]*_[0-9]*");
+
+    // An instance of Ignite thin client, used by both read and write pipelines
+    private IgniteClient igniteClient = null;
+
+    // Read pipeline objects
+    private FieldsQueryCursor<List<?>> readIgniteCursor = null;
+    private Iterator<List<?>> readIterator = null;
+
+    // Write pipeline objects
+    private SqlFieldsQuery writeQuery = null;
 }

--- a/server/pxf-ignite/src/main/java/org/greenplum/pxf/plugins/ignite/WhereSQLBuilder.java
+++ b/server/pxf-ignite/src/main/java/org/greenplum/pxf/plugins/ignite/WhereSQLBuilder.java
@@ -37,10 +37,13 @@ import java.util.List;
 public class WhereSQLBuilder extends IgniteFilterBuilder {
     /**
      * Class constructor
-     * @param input Input
+     *
+     * @param input
+     * @param quoteMark quote string to use. `null` is allowed
      */
-    public WhereSQLBuilder(RequestContext input) {
+    public WhereSQLBuilder(RequestContext input, String quoteMark) {
         requestContext = input;
+        QUOTE = quoteMark != null ? quoteMark : new String("");
     }
 
     /**
@@ -68,12 +71,9 @@ public class WhereSQLBuilder extends IgniteFilterBuilder {
 
                 sb.append(andDivisor);
                 andDivisor = " AND ";
-
                 ColumnDescriptor column = requestContext.getColumn(filter.getColumn().index());
-                //the column name of filter
-                sb.append(column.columnName());
+                sb.append(QUOTE + column.columnName() + QUOTE);
 
-                //the operation of filter
                 FilterParser.Operation op = filter.getOperation();
                 switch (op) {
                     case HDOP_LT:
@@ -125,19 +125,6 @@ public class WhereSQLBuilder extends IgniteFilterBuilder {
 
 
     /**
-     * Unsupported filter exception class.
-     * Thrown when the filter string passed to constructor cannot be parsed
-     */
-    private static class UnsupportedFilterException extends Exception {
-        UnsupportedFilterException(String message) {
-            super(message);
-        }
-    }
-
-    // PXF RequestContext
-    private RequestContext requestContext;
-
-    /**
      * Parses PXF {@link RequestContext} 'FilterObject'
      * Only 'HDOP_AND' is supported as a 'LogicalOperation' at the moment
      *
@@ -167,4 +154,20 @@ public class WhereSQLBuilder extends IgniteFilterBuilder {
 
         return returnList;
     }
+
+    /**
+     * Unsupported filter exception class.
+     * Thrown when the filter string passed to constructor cannot be parsed
+     */
+    private static class UnsupportedFilterException extends Exception {
+        UnsupportedFilterException(String message) {
+            super(message);
+        }
+    }
+
+    // PXF RequestContext
+    private RequestContext requestContext;
+
+    // Quotation mark (provided by IgniteAccessor)
+    private final String QUOTE;
 }

--- a/server/pxf-ignite/src/test/java/org/greenplum/pxf/plugins/ignite/IgniteFilterBuilderTest.java
+++ b/server/pxf-ignite/src/test/java/org/greenplum/pxf/plugins/ignite/IgniteFilterBuilderTest.java
@@ -8,9 +8,9 @@ package org.greenplum.pxf.plugins.ignite;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -65,7 +65,7 @@ public class IgniteFilterBuilderTest {
 
     @Test
     public void parseFilterWithLogicalOperation() throws Exception {
-        WhereSQLBuilder builder = new WhereSQLBuilder(null);
+        WhereSQLBuilder builder = new WhereSQLBuilder(null, null);
         LogicalFilter filter = (LogicalFilter) builder.getFilterObject("a1c25s5dfirsto5a2c20s1d2o2l0");
         assertEquals(LogicalOperation.HDOP_AND, filter.getOperator());
         assertEquals(2, filter.getFilterList().size());
@@ -73,7 +73,7 @@ public class IgniteFilterBuilderTest {
 
     @Test
     public void parseNestedExpressionWithLogicalOperation() throws Exception {
-        WhereSQLBuilder builder = new WhereSQLBuilder(null);
+        WhereSQLBuilder builder = new WhereSQLBuilder(null, null);
         LogicalFilter filter = (LogicalFilter) builder.getFilterObject("a1c25s5dfirsto5a2c20s1d2o2l0a1c20s1d1o1l1");
         assertEquals(LogicalOperation.HDOP_OR, filter.getOperator());
         assertEquals(LogicalOperation.HDOP_AND, ((LogicalFilter) filter.getFilterList().get(0)).getOperator());
@@ -82,7 +82,7 @@ public class IgniteFilterBuilderTest {
 
     @Test
     public void parseIsNullExpression() throws Exception {
-        WhereSQLBuilder builder = new WhereSQLBuilder(null);
+        WhereSQLBuilder builder = new WhereSQLBuilder(null, null);
         BasicFilter filter = (BasicFilter) builder.getFilterObject("a1o8");
         assertEquals(FilterParser.Operation.HDOP_IS_NULL, filter.getOperation());
         assertEquals(1, filter.getColumn().index());
@@ -91,7 +91,7 @@ public class IgniteFilterBuilderTest {
 
     @Test
     public void parseIsNotNullExpression() throws Exception {
-        WhereSQLBuilder builder = new WhereSQLBuilder(null);
+        WhereSQLBuilder builder = new WhereSQLBuilder(null, null);
         BasicFilter filter = (BasicFilter) builder.getFilterObject("a1o9");
         assertEquals(FilterParser.Operation.HDOP_IS_NOT_NULL, filter.getOperation());
         assertEquals(1, filter.getColumn().index());

--- a/server/pxf-ignite/src/test/java/org/greenplum/pxf/plugins/ignite/SqlBuilderTest.java
+++ b/server/pxf-ignite/src/test/java/org/greenplum/pxf/plugins/ignite/SqlBuilderTest.java
@@ -45,8 +45,18 @@ public class SqlBuilderTest {
         when(context.hasFilter()).thenReturn(true);
         when(context.getFilterString()).thenReturn("a0c20s1d1o5");  // id=1
 
-        WhereSQLBuilder builder = new WhereSQLBuilder(context);
+        WhereSQLBuilder builder = new WhereSQLBuilder(context, null);
         assertEquals("id=1", builder.buildWhereSQL());
+    }
+
+    @Test
+    public void testIdFilterQuoted() throws Exception {
+        prepareConstruction();
+        when(context.hasFilter()).thenReturn(true);
+        when(context.getFilterString()).thenReturn("a0c20s1d1o5");  // id=1
+
+        WhereSQLBuilder builder = new WhereSQLBuilder(context, "\"");
+        assertEquals("\"id\"=1", builder.buildWhereSQL());
     }
 
     @Test
@@ -56,7 +66,7 @@ public class SqlBuilderTest {
         // cdate>'2008-02-01' and cdate<'2008-12-01' and amt > 1200
         when(context.getFilterString()).thenReturn("a1c25s10d2008-02-01o2a1c25s10d2008-12-01o1l0a2c20s4d1200o2l0");
 
-        WhereSQLBuilder builder = new WhereSQLBuilder(context);
+        WhereSQLBuilder builder = new WhereSQLBuilder(context, null);
         assertEquals("cdate>'2008-02-01' AND cdate<'2008-12-01' AND amt>1200"
                 , builder.buildWhereSQL());
     }
@@ -68,7 +78,7 @@ public class SqlBuilderTest {
         // grade like 'bad'
         when(context.getFilterString()).thenReturn("a3c25s3dbado7");
 
-        WhereSQLBuilder builder = new WhereSQLBuilder(context);
+        WhereSQLBuilder builder = new WhereSQLBuilder(context, null);
         assertEquals(null, builder.buildWhereSQL());
     }
 
@@ -79,7 +89,7 @@ public class SqlBuilderTest {
         // cdate>'2008-02-01' or amt < 1200
         when(context.getFilterString()).thenReturn("a1c25s10d2008-02-01o2a2c20s4d1200o2l1");
 
-        WhereSQLBuilder builder = new WhereSQLBuilder(context);
+        WhereSQLBuilder builder = new WhereSQLBuilder(context, null);
         assertEquals(null, builder.buildWhereSQL());
     }
 
@@ -110,7 +120,7 @@ public class SqlBuilderTest {
         when(context.getOption("PARTITION_BY")).thenReturn("grade:enum");
         when(context.getOption("RANGE")).thenReturn("excellent:good:general:bad");
 
-        WhereSQLBuilder builder = new WhereSQLBuilder(context);
+        WhereSQLBuilder builder = new WhereSQLBuilder(context, null);
         String whereSql = builder.buildWhereSQL();
         assertEquals("id>5", whereSql);
 


### PR DESCRIPTION
Use Ignite thin client for Java instead of REST in PXF-Ignite plugin. Ignite thin client uses custom Ignite binary protocol and is much faster than REST in most cases.

There are a few new parameters (passed in `LOCATION` clause of external table DDL) that Ignite thin connector supports. User can now set `lazy`, `replicated_only`, `tcp_nodelay` flags for Ignite thin connector. This can speed up queries' execution. `IGNITE_HOSTS` parameter allows to pass multiple hosts so that if one host failed, Ignite thin connector would try to use other ones.

Complete description of new parameters is given in README.

Changes:
* Introduce multiple new `LOCATION` clause parameters
* Remove `gson 2.8.2` dependency; introduce `ignite-core 2.6.0` dependency instead. Note this is not the only version of `ignite-core` supported.
* Update unit tests
* Update README.md