### PR TITLE
Add descriptive message when JAVA_HOME is not set

### DIFF
--- a/server/pxf-service/src/scripts/pxf-service
+++ b/server/pxf-service/src/scripts/pxf-service
@@ -103,7 +103,7 @@ function get_environment()
 
     # validate JAVA_HOME
     if [[ ! -x ${JAVA_HOME}/bin/java ]]; then
-        fail "\$JAVA_HOME is invalid"
+        fail "\$JAVA_HOME=$JAVA_HOME is invalid. Set \$JAVA_HOME in ~/.bashrc or ${default_env_script} on all Greenplum hosts."
     fi
 }
 
@@ -344,7 +344,7 @@ function doInit()
 	instanceExists
     if (( $? == 0 )); then
 		echo Instance already exists. Cleanup ${instance_root}/pxf-service if you wish to re-initialize.
-		return 0
+		return 1
 	fi
 
 	update_pxf_conf


### PR DESCRIPTION
JAVA_HOME needs to be set in the interactive non-login shell file (i.e.
~/.bashrc) or in the default environment script on all greenplum hosts.
Also, init function should fail when re-init fails because
${instance_root}/pxf-service file exists

#163201852