### PR TITLE
Add commented out dfs.client.use.datanode.hostname option in core-site

### DIFF
--- a/server/pxf-service/src/templates/user/templates/core-site.xml
+++ b/server/pxf-service/src/templates/user/templates/core-site.xml
@@ -4,4 +4,30 @@
         <name>fs.defaultFS</name>
         <value>hdfs://0.0.0.0:8020</value>
     </property>
+
+
+    <!--
+
+    The following properties are optional and can be
+    used depending on your Hadoop configuration:
+
+
+
+    dfs.client.use.datanode.hostname: By default HDFS
+    clients connect to DataNodes using the IP address
+    provided by the NameNode. Depending on the network
+    configuration this IP address may be unreachable by
+    the clients. The fix is letting clients perform
+    their own DNS resolution of the DataNode hostname.
+    The following setting enables this behavior.
+    <property>
+        <name>dfs.client.use.datanode.hostname</name>
+        <value>true</value>
+        <description>Whether clients should use datanode hostnames when
+            connecting to datanodes.
+        </description>
+    </property>
+
+    -->
+
 </configuration>


### PR DESCRIPTION
We add the commented out option dfs.client.use.datanode.hostname in
template for core-site.xml for datanodes where the IP address is not
reachable by the client, and a domain name is provided instead, letting
clients perform their own DNS resolution. This was useful when setting
up a dataproc cluster and attempting to access it from a different
network.

[#164339537]