### PR TITLE
Enable Integration sanity tests to run on CentOS 7

### DIFF
--- a/concourse/scripts/install_hadoop.bash
+++ b/concourse/scripts/install_hadoop.bash
@@ -17,7 +17,7 @@ function install_hadoop_single_cluster() {
     ssh ${SSH_OPTS} centos@edw0 "sudo mkdir -p /root/.ssh &&
         sudo cp /home/centos/.ssh/authorized_keys /root/.ssh &&
         sudo sed -i 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config &&
-        sudo cat /var/run/sshd.pid | xargs kill -9 &&
+        sudo cat /var/run/sshd.pid | xargs kill -9 ;
         { sudo /usr/sbin/sshd -D & }"
 
     tar -xzf pxf_tarball/pxf.tar.gz -C /tmp

--- a/concourse/scripts/install_hadoop.bash
+++ b/concourse/scripts/install_hadoop.bash
@@ -10,15 +10,10 @@ GPHD_ROOT="/singlecluster"
 
 function install_hadoop_single_cluster() {
     local hadoop_ip=${1}
-    # We can't use service sshd restart as service is not installed on CentOS 7.
-    # Also, we got "Operation not permitted" errors even running service in a
-    # privileged container.
-    # So we have to kill and start the sshd process directly.
     ssh ${SSH_OPTS} centos@edw0 "sudo mkdir -p /root/.ssh &&
         sudo cp /home/centos/.ssh/authorized_keys /root/.ssh &&
         sudo sed -i 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config &&
-        sudo cat /var/run/sshd.pid | xargs kill -9 ;
-        { sudo /usr/sbin/sshd -D & }"
+        sudo service sshd restart"
 
     tar -xzf pxf_tarball/pxf.tar.gz -C /tmp
     cp /tmp/pxf/lib/pxf-hbase-*.jar /singlecluster/hbase/lib

--- a/concourse/scripts/pxf-perf-multi-node.bash
+++ b/concourse/scripts/pxf-perf-multi-node.bash
@@ -58,7 +58,7 @@ function writable_external_table_parquet_query() {
 ###########################################
 
 function setup_sshd() {
-    /usr/sbin/sshd -D &
+    service sshd start
     passwd -u root
 
     if [[ -d cluster_env_files ]]; then

--- a/concourse/scripts/pxf-perf-multi-node.bash
+++ b/concourse/scripts/pxf-perf-multi-node.bash
@@ -58,7 +58,7 @@ function writable_external_table_parquet_query() {
 ###########################################
 
 function setup_sshd() {
-    service sshd start
+    /usr/sbin/sshd -D &
     passwd -u root
 
     if [[ -d cluster_env_files ]]; then

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -50,7 +50,7 @@ function install_gpdb_binary() {
 	fi
 
 	if [[ ${TARGET_OS} == "centos" ]]; then
-		service sshd start
+		/usr/sbin/sshd -D &
 		psi_dir=$(find /usr/lib64 -name psi | sort -r | head -1)
 	elif [[ ${TARGET_OS} == "ubuntu" ]]; then
         # Adjust GPHOME if the binary expects it to be /usr/local/gpdb

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -50,7 +50,10 @@ function install_gpdb_binary() {
 	fi
 
 	if [[ ${TARGET_OS} == "centos" ]]; then
-		/usr/sbin/sshd -D &
+		# We can't use service sshd restart as service is not installed on CentOS 7.
+		# Also, we got "Operation not permitted" errors even running service in a
+		# privileged container.
+		/usr/sbin/sshd &
 		psi_dir=$(find /usr/lib64 -name psi | sort -r | head -1)
 	elif [[ ${TARGET_OS} == "ubuntu" ]]; then
         # Adjust GPHOME if the binary expects it to be /usr/local/gpdb

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -86,15 +86,6 @@ function setup_hadoop() {
 	fi
 }
 
-function allow_ping_to_run_as_non_root() {
-	if [ -f /etc/redhat-release ] && [[ "$(cat /etc/redhat-release)" =~ 'CentOS Linux release 7' ]]; then
-		# On CentOS 7, the setuid bit is not set on /bin/ping (as it is in CentOS
-		# 6), so we need to add these capabilities to let non-root users use it. The
-		# capabilities/setuid are needed because ping uses raw sockets.
-		setcap cap_net_admin,cap_net_raw+p /bin/ping
-	fi
-}
-
 function _main() {
 	# kill the sshd background process when this script exits. Otherwise, the
 	# concourse build will run forever.
@@ -116,7 +107,7 @@ EOF
 	fi
 
   # Ping is called by gpinitsystem, which must be run by gpadmin
-	allow_ping_to_run_as_non_root
+	chmod u+s /bin/ping
 
 	# Install GPDB
 	install_gpdb_binary

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -87,6 +87,10 @@ function setup_hadoop() {
 }
 
 function _main() {
+	# kill the sshd background process when this script exits. Otherwise, the
+	# concourse build will run forever.
+	trap "pkill sshd" EXIT
+
 	if [[ ${PROTOCOL} == "s3" ]]; then
 		echo Using S3 protocol
 	elif [[ ${PROTOCOL} == "minio" ]]; then


### PR DESCRIPTION
w/ @sambitesh @soumyadeep2007 

This PR involves changes to support sanity tests on CentOS 7:

1. `service` is not installed by default in CentOS 7. So we replaced commands to start/restart sshd using the service command with direct invocations of sshd and kill. 
Note: We tried installing the `initscripts` package (which contains service). However, we ran into the following error:
```
Redirecting to /bin/systemctl start sshd.service
    Failed to get D-Bus connection: Operation not permitted
```
This happens even when running the container with --privileged.

2. We had to allow ping to run as a non-root user for CentOS 7 by setting capabilities. This is to satisfy gpinitsystem.
