### PR TITLE
Parquet column projection

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -20,10 +20,10 @@ ifeq "$(PXF_HOME)" ""
 endif
 MAVEN_TEST_OPTS+= -DPXF_TMP_LIB=$(PXF_HOME)/tmp
 
-ifneq "$(OFFLINE)" "false"
-	MAVEN_TEST_OPTS+= -o
-else
+ifneq "$(OFFLINE)" "true"
 	MAVEN_TEST_OPTS+= -U
+else
+	MAVEN_TEST_OPTS+= -o
 endif
 
 ifeq "$(PROTOCOL)" "minio"

--- a/automation/Makefile
+++ b/automation/Makefile
@@ -20,10 +20,10 @@ ifeq "$(PXF_HOME)" ""
 endif
 MAVEN_TEST_OPTS+= -DPXF_TMP_LIB=$(PXF_HOME)/tmp
 
-ifneq "$(OFFLINE)" "true"
-	MAVEN_TEST_OPTS+= -U
-else
+ifneq "$(OFFLINE)" "false"
 	MAVEN_TEST_OPTS+= -o
+else
+	MAVEN_TEST_OPTS+= -U
 endif
 
 ifeq "$(PROTOCOL)" "minio"

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
@@ -64,8 +64,7 @@ public class ParquetTest extends BaseFeature {
         gpdb.createTableAndVerify(exTable);
 
         gpdb.runQuery("CREATE OR REPLACE VIEW parquet_view AS SELECT s1, s2, n1, d1, dc1, " +
-                "CAST (((CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'PDT') AT TIME ZONE " +
-                "current_setting('TIMEZONE')) AS TIMESTAMP WITHOUT TIME ZONE) as tm, " +
+                "CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'PDT' as tm, " +
                 "f, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
 
         runTincTest("pxf.features.parquet.primitive_types.runTest");
@@ -96,8 +95,8 @@ public class ParquetTest extends BaseFeature {
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
 
         gpdb.createTableAndVerify(exTable);
-        gpdb.runQuery("INSERT INTO " + exTable.getName() + " SELECT s1, s2, n1, d1, dc1, " +
-                "tm, f, bg, b, tn, vc1, sml, c1, bin FROM " + pxfParquetTable);
+        gpdb.runQuery("INSERT INTO " + exTable.getName() + " SELECT s1, s2, n1, d1, dc1, tm, " +
+                "f, bg, b, tn, vc1, sml, c1, bin FROM " + pxfParquetTable);
 
         exTable = new ReadableExternalTable("pxf_parquet_read_primitives",
                 parquet_table_columns, hdfsPath + parquetWritePrimitives, "custom");
@@ -107,8 +106,7 @@ public class ParquetTest extends BaseFeature {
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
         gpdb.createTableAndVerify(exTable);
         gpdb.runQuery("CREATE OR REPLACE VIEW parquet_view AS SELECT s1, s2, n1, d1, dc1, " +
-                "CAST (((CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'PDT') AT TIME ZONE " +
-                "current_setting('TIMEZONE')) AS TIMESTAMP WITHOUT TIME ZONE) as tm, " +
+                "CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'PDT' as tm, " +
                 "f, bg, b, tn, sml, vc1, c1, bin FROM pxf_parquet_read_primitives");
 
         runTincTest("pxf.features.parquet.primitive_types.runTest");

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
@@ -76,7 +76,7 @@ public class ParquetTest extends BaseFeature {
 
         gpdb.createTableAndVerify(exTable);
         gpdb.runQuery("INSERT INTO " + exTable.getName() + " SELECT s1, s2, n1, d1, dc1, " +
-                " CAST ((CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'UTC') AT TIME ZONE 'PDT' AS TIMESTAMP WITHOUT TIME ZONE) as tm, f, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
+                " CAST ((CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'UTC') AT TIME ZONE 'PDT' AS TIMESTAMP WITHOUT TIME ZONE) as tm, f, bg, b, tn, vc1, sml, c1, bin FROM " + pxfParquetTable);
 
         exTable = new ReadableExternalTable("pxf_parquet_read_primitives",
                 parquet_table_columns, hdfsPath + parquetWritePrimitives, "custom");

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
@@ -25,8 +25,8 @@ public class ParquetTest extends BaseFeature {
             "bg    BIGINT",
             "b     BOOLEAN",
             "tn    SMALLINT",
-            "sml   SMALLINT",
             "vc1   VARCHAR(5)",
+            "sml   SMALLINT",
             "c1    CHAR(3)",
             "bin   BYTEA"
     };

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
@@ -15,13 +15,13 @@ public class ParquetTest extends BaseFeature {
     private final String parquetWritePrimitives = "parquet_write_primitives";
     private final String parquetPrimitiveTypes = "parquet_primitive_types";
     private final String[] parquet_table_columns = new String[] {
-            "t1    TEXT",
-            "t2    TEXT",
-            "num1  INTEGER",
-            "dub1  DOUBLE PRECISION",
-            "dec1  NUMERIC",
+            "s1    TEXT",
+            "s2    TEXT",
+            "n1    INTEGER",
+            "d1    DOUBLE PRECISION",
+            "dc1   NUMERIC",
             "tm    TIMESTAMP",
-            "r     REAL",
+            "f     REAL",
             "bg    BIGINT",
             "b     BOOLEAN",
             "tn    SMALLINT",
@@ -52,10 +52,14 @@ public class ParquetTest extends BaseFeature {
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
 
         gpdb.createTableAndVerify(exTable);
-        gpdb.runQuery("CREATE OR REPLACE VIEW parquet_view AS SELECT t1, t2, num1, dub1, dec1, " +
+
+        gpdb.runQuery("CREATE OR REPLACE VIEW parquet_view AS SELECT s1, s2, n1, d1, dc1, " +
                 "CAST (((CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'PDT') AT TIME ZONE " +
                 "current_setting('TIMEZONE')) AS TIMESTAMP WITHOUT TIME ZONE) as tm, " +
-                "r, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
+                "f, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
+
+//        gpdb.runQuery("CREATE OR REPLACE VIEW parquet_view AS SELECT s1, s2, n1, d1, dc1, " +
+//                "tm, f, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
 
         runTincTest("pxf.features.parquet.primitive_types.runTest");
     }
@@ -71,8 +75,8 @@ public class ParquetTest extends BaseFeature {
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
 
         gpdb.createTableAndVerify(exTable);
-        gpdb.runQuery("INSERT INTO " + exTable.getName() + " SELECT t1, t2, num1, dub1, dec1, " +
-                "tm, r, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
+        gpdb.runQuery("INSERT INTO " + exTable.getName() + " SELECT s1, s2, n1, d1, dc1, " +
+                " CAST ((CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'UTC') AT TIME ZONE 'PDT' AS TIMESTAMP WITHOUT TIME ZONE) as tm, f, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
 
         exTable = new ReadableExternalTable("pxf_parquet_read_primitives",
                 parquet_table_columns, hdfsPath + parquetWritePrimitives, "custom");
@@ -81,10 +85,10 @@ public class ParquetTest extends BaseFeature {
         exTable.setFormatter("pxfwritable_import");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
         gpdb.createTableAndVerify(exTable);
-        gpdb.runQuery("CREATE OR REPLACE VIEW parquet_view AS SELECT t1, t2, num1, dub1, dec1, " +
+        gpdb.runQuery("CREATE OR REPLACE VIEW parquet_view AS SELECT s1, s2, n1, d1, dc1, " +
                 "CAST (((CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'PDT') AT TIME ZONE " +
                 "current_setting('TIMEZONE')) AS TIMESTAMP WITHOUT TIME ZONE) as tm, " +
-                "r, bg, b, tn, sml, vc1, c1, bin FROM pxf_parquet_read_primitives");
+                "f, bg, b, tn, sml, vc1, c1, bin FROM pxf_parquet_read_primitives");
 
         runTincTest("pxf.features.parquet.primitive_types.runTest");
     }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
@@ -14,7 +14,7 @@ public class ParquetTest extends BaseFeature {
     private final String pxfParquetTable = "pxf_parquet_primitive_types";
     private final String parquetWritePrimitives = "parquet_write_primitives";
     private final String parquetPrimitiveTypes = "parquet_primitive_types";
-    private final String[] parquet_table_columns = new String[] {
+    private final String[] parquet_table_columns = new String[]{
             "s1    TEXT",
             "s2    TEXT",
             "n1    INTEGER",
@@ -28,6 +28,17 @@ public class ParquetTest extends BaseFeature {
             "vc1   VARCHAR(5)",
             "sml   SMALLINT",
             "c1    CHAR(3)",
+            "bin   BYTEA"
+    };
+
+    private final String pxfParquetSubsetTable = "pxf_parquet_subset";
+    private final String[] parquet_table_columns_subset = new String[]{
+            "s1    TEXT",
+            "n1    INTEGER",
+            "d1    DOUBLE PRECISION",
+            "f     REAL",
+            "b     BOOLEAN",
+            "vc1   VARCHAR(5)",
             "bin   BYTEA"
     };
 
@@ -58,6 +69,20 @@ public class ParquetTest extends BaseFeature {
                 "f, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
 
         runTincTest("pxf.features.parquet.primitive_types.runTest");
+    }
+
+    @Test(groups = {"features", "gpdb", "hcfs"})
+    public void parquetReadSubset() throws Exception {
+        exTable = new ReadableExternalTable(pxfParquetSubsetTable,
+                parquet_table_columns_subset, hdfsPath + parquetPrimitiveTypes, "custom");
+        exTable.setHost(pxfHost);
+        exTable.setPort(pxfPort);
+        exTable.setFormatter("pxfwritable_import");
+        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
+
+        gpdb.createTableAndVerify(exTable);
+
+        runTincTest("pxf.features.parquet.read_subset.runTest");
     }
 
     @Test(groups = {"features", "gpdb", "hcfs"})

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetTest.java
@@ -40,7 +40,6 @@ public class ParquetTest extends BaseFeature {
         hdfs.copyFromLocal(resourcePath + parquetPrimitiveTypes, hdfsPath + parquetPrimitiveTypes);
     }
 
-
     @Test(groups = {"features", "gpdb", "hcfs"})
     public void parquetReadPrimitives() throws Exception {
 
@@ -58,9 +57,6 @@ public class ParquetTest extends BaseFeature {
                 "current_setting('TIMEZONE')) AS TIMESTAMP WITHOUT TIME ZONE) as tm, " +
                 "f, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
 
-//        gpdb.runQuery("CREATE OR REPLACE VIEW parquet_view AS SELECT s1, s2, n1, d1, dc1, " +
-//                "tm, f, bg, b, tn, sml, vc1, c1, bin FROM " + pxfParquetTable);
-
         runTincTest("pxf.features.parquet.primitive_types.runTest");
     }
 
@@ -76,7 +72,7 @@ public class ParquetTest extends BaseFeature {
 
         gpdb.createTableAndVerify(exTable);
         gpdb.runQuery("INSERT INTO " + exTable.getName() + " SELECT s1, s2, n1, d1, dc1, " +
-                " CAST ((CAST(tm AS TIMESTAMP WITH TIME ZONE) AT TIME ZONE 'UTC') AT TIME ZONE 'PDT' AS TIMESTAMP WITHOUT TIME ZONE) as tm, f, bg, b, tn, vc1, sml, c1, bin FROM " + pxfParquetTable);
+                "tm, f, bg, b, tn, vc1, sml, c1, bin FROM " + pxfParquetTable);
 
         exTable = new ReadableExternalTable("pxf_parquet_read_primitives",
                 parquet_table_columns, hdfsPath + parquetWritePrimitives, "custom");

--- a/automation/tincrepo/main/pxf/features/parquet/primitive_types/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/parquet/primitive_types/expected/query01.ans
@@ -3,8 +3,8 @@
 -- @description query01 for primitive Parquet data types
 -- Parquet data has been generated using PDT timezone, so we need to shift tm field on difference between PDT and current timezone
 -- TODO: generate Parquet data on fly
-SELECT t1, t2, num1, dub1, dec1, tm, r, bg, b, tn, sml, vc1, c1, bin FROM parquet_view ORDER BY t1;
-          t1          |  t2  | num1 | dub1 |             dec1             |         tm          |  r   |    bg    | b | tn | sml  |  vc1  | c1  | bin
+SELECT s1, s2, n1, d1, dc1, tm, f, bg, b, tn, sml, vc1, c1, bin FROM parquet_view ORDER BY s1;
+          s1          |  s2  |  n1  |  d1  |              dc1             |         tm          |  f   |    bg    | b | tn | sml  |  vc1  | c1  | bin
 ----------------------+------+------+------+------------------------------+---------------------+------+----------+---+----+------+-------+-----+-----
  row1                 | s_6  |    1 |    6 |         1.234560000000000000 | 2013-07-13 21:00:05 |  7.7 | 23456789 | f |  1 |   10 | abcd  | abc | 1
  row10                | s_15 |   10 |   15 |     45678.000023400890000000 | 2013-07-22 21:00:05 |  7.7 | 23456789 | t | 10 | 1000 | abcde | abc | 0
@@ -32,3 +32,4 @@ SELECT t1, t2, num1, dub1, dec1, tm, r, bg, b, tn, sml, vc1, c1, bin FROM parque
  row8                 | s_13 |    8 |   13 |     45678.000023400890000000 | 2013-07-20 21:00:05 |  7.7 | 23456789 | t |  8 |  800 | abcde | abc | 8
  row9                 | s_14 |    9 |   14 |     23457.100000000000000000 | 2013-07-21 21:00:05 |  7.7 | 23456789 | f |  9 |  900 | abcde | abc | 9
 (25 rows)
+

--- a/automation/tincrepo/main/pxf/features/parquet/primitive_types/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/parquet/primitive_types/sql/query01.sql
@@ -1,4 +1,4 @@
 -- @description query01 for primitive Parquet data types
 -- Parquet data has been generated using PDT timezone, so we need to shift tm field on difference between PDT and current timezone
 -- TODO: generate Parquet data on fly
-SELECT t1, t2, num1, dub1, dec1, tm, r, bg, b, tn, sml, vc1, c1, bin FROM parquet_view ORDER BY t1;
+SELECT s1, s2, n1, d1, dc1, tm, f, bg, b, tn, sml, vc1, c1, bin FROM parquet_view ORDER BY s1;

--- a/automation/tincrepo/main/pxf/features/parquet/read_subset/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/parquet/read_subset/expected/query01.ans
@@ -1,0 +1,64 @@
+-- start_ignore
+-- end_ignore
+-- @description query01 for Parquet with Greenplum table as a subset of the parquet file
+SELECT * FROM pxf_parquet_subset ORDER BY s1;
+          s1          | n1 | d1 |  f   | b |  vc1  | bin
+----------------------+----+----+------+---+-------+-----
+ row1                 |  1 |  6 |  7.7 | f | abcd  | 1
+ row10                | 10 | 15 |  7.7 | t | abcde | 0
+ row11                | 11 | 37 |  7.7 | f | abcde | 1
+ row12_text_null      | 11 | 37 |  7.7 | f | abcde | 1
+ row13_int_null       |    | 37 |  7.7 | f | abcde | 1
+ row14_double_null    | 11 |    |  7.7 | f | abcde | 1
+ row15_decimal_null   | 12 | 38 |  7.7 | f | abcde | 1
+ row16_timestamp_null | 11 | 37 |  7.7 | f | abcde | 1
+ row17_real_null      | 11 | 37 |      | f | abcde | 1
+ row18_bigint_null    | 11 | 37 |  7.7 | f | abcde | 1
+ row19_bool_null      | 11 | 37 |  7.7 |   | abcde | 1
+ row2                 |  2 |  7 |  8.7 | t | abcde | 2
+ row20_tinyint_null   | 11 | 37 |  7.7 | f | abcde | 1
+ row21_smallint_null  | 11 | 37 |  7.7 | f | abcde | 1
+ row22_date_null      | 11 | 37 |  7.7 | f | abcde | 1
+ row23_varchar_null   | 11 | 37 |  7.7 | f |       | 1
+ row24_char_null      | 11 | 37 |  7.7 | f | abcde | 1
+ row25_binary_null    | 11 | 37 |  7.7 | f | abcde |
+ row3                 |  3 |  8 |  9.7 | f | abcde | 3
+ row4                 |  4 |  9 | 10.7 | t | abcde | 4
+ row5                 |  5 | 10 | 11.7 | f | abcde | 5
+ row6                 |  6 | 11 | 12.7 | t | abcde | 6
+ row7                 |  7 | 12 |  7.7 | f | abcde | 7
+ row8                 |  8 | 13 |  7.7 | t | abcde | 8
+ row9                 |  9 | 14 |  7.7 | f | abcde | 9
+(25 rows)
+
+-- s1, d1, vc1 are projected columns
+SELECT d1, vc1 FROM pxf_parquet_subset ORDER BY s1;
+ d1 |  vc1
+----+-------
+  6 | abcd
+ 15 | abcde
+ 37 | abcde
+ 37 | abcde
+ 37 | abcde
+    | abcde
+ 38 | abcde
+ 37 | abcde
+ 37 | abcde
+ 37 | abcde
+ 37 | abcde
+  7 | abcde
+ 37 | abcde
+ 37 | abcde
+ 37 | abcde
+ 37 |
+ 37 | abcde
+ 37 | abcde
+  8 | abcde
+  9 | abcde
+ 10 | abcde
+ 11 | abcde
+ 12 | abcde
+ 13 | abcde
+ 14 | abcde
+(25 rows)
+

--- a/automation/tincrepo/main/pxf/features/parquet/read_subset/runTest.py
+++ b/automation/tincrepo/main/pxf/features/parquet/read_subset/runTest.py
@@ -1,0 +1,11 @@
+from mpp.models import SQLConcurrencyTestCase
+
+class ParquetReadSubsetTypes(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/parquet/read_subset/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/parquet/read_subset/sql/query01.sql
@@ -1,0 +1,5 @@
+-- @description query01 for Parquet with Greenplum table as a subset of the parquet file
+SELECT * FROM pxf_parquet_subset ORDER BY s1;
+
+-- s1, d1, vc1 are projected columns
+SELECT d1, vc1 FROM pxf_parquet_subset ORDER BY s1;

--- a/concourse/scripts/pxf-perf-multi-node.bash
+++ b/concourse/scripts/pxf-perf-multi-node.bash
@@ -80,7 +80,7 @@ function write_sub_header() {
 function read_and_validate_table_count() {
     local table_name="$1"
     local expected_count="$2"
-    local num_rows=$(time psql -t -c "SELECT COUNT(*) FROM $table_name" | tr -d ' ')
+    local num_rows=$(time psql -t -c "SELECT COUNT(l_linenumber) FROM $table_name" | tr -d ' ')
 
     if [[ ${num_rows} != ${expected_count} ]]; then
         echo "Expected number of rows in table ${table_name} to be ${expected_count} but was ${num_rows}"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -24,6 +24,7 @@ plugins {
 downloadLicenses {
     dependencyConfiguration = 'bundleJars'
 }
+
 wrapper {
     gradleVersion = '4.10.3'
 }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/OneField.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/OneField.java
@@ -20,8 +20,6 @@ package org.greenplum.pxf.api;
  */
 
 
-import org.greenplum.pxf.api.io.DataType;
-
 /**
  * Defines a one field in a deserialized record.
  */

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessor.java
@@ -124,7 +124,7 @@ public class ParquetFileAccessor extends BasePlugin implements Accessor {
             fileReader.close();
             throw new IOException(e);
         }
-        context.setMetadata(schema);
+        context.setMetadata(readSchema);
         return true;
     }
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetResolver.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetResolver.java
@@ -68,8 +68,7 @@ public class ParquetResolver extends BasePlugin implements Resolver {
             if (!columnDescriptor.isProjected()) {
                 oneField = new OneField(columnDescriptor.columnTypeCode(), null);
             } else if (schema.getType(columnIndex).isPrimitive()) {
-                Type type = schema.getType(columnIndex);
-                oneField = resolvePrimitive(group, columnIndex, type, 0);
+                oneField = resolvePrimitive(group, columnIndex, schema.getType(columnIndex), 0);
                 columnIndex++;
             } else {
                 throw new UnsupportedOperationException("Parquet complex type support is not yet available.");

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetTypeConverter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetTypeConverter.java
@@ -209,7 +209,7 @@ public enum ParquetTypeConverter {
     private static final long MICROS_IN_DAY = 24 * 3600 * 1000 * 1000L;
     private static final long NANOS_IN_MICROS = 1000;
     private static final String DATE_FORMATTER_BASE_PATTERN = "yyyy-MM-dd HH:mm:ss";
-    private static final DateTimeFormatter DATE_FORMATTER =
+    static final DateTimeFormatter DATE_FORMATTER =
             new DateTimeFormatterBuilder().appendPattern(DATE_FORMATTER_BASE_PATTERN)
                     // Parsing nanos in strict mode, the number of parsed digits must be between 0 and 6 (millisecond support)
                     .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true).toFormatter();

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
@@ -212,7 +212,7 @@ public class ParquetResolverTest {
         assertField(fields, 2, 1, DataType.INTEGER);
         assertField(fields, 3, 6.0d, DataType.FLOAT8);
         assertField(fields, 4, BigDecimal.valueOf(1234560000000000000L, 18), DataType.NUMERIC);
-        assertField(fields, 5, java.sql.Timestamp.from(ZonedDateTime.parse("2013-07-13T21:00:05-07:00").toInstant()), DataType.TIMESTAMP);
+        assertField(fields, 5, "2013-07-13 21:00:05", DataType.TIMESTAMP);
         assertField(fields, 6, 7.7f, DataType.REAL);
         assertField(fields, 7, 23456789L, DataType.BIGINT);
         assertField(fields, 8, false, DataType.BOOLEAN);
@@ -384,8 +384,8 @@ public class ParquetResolverTest {
         }
         group.add(4, Binary.fromReusedByteArray(bytes));
 
-        group.add(5, ParquetTypeConverter.getBinary(1549317584246L));
-        group.add(5, ParquetTypeConverter.getBinary(-123456789L));
+        group.add(5, ParquetTypeConverter.getBinaryFromTimestamp("2019-03-14 14:10:28"));
+        group.add(5, ParquetTypeConverter.getBinaryFromTimestamp("1969-12-30 05:42:23.211211"));
 
         group.add(6, 7.7f);
         group.add(6, -12345.35354646f);
@@ -422,7 +422,7 @@ public class ParquetResolverTest {
         assertField(fields, 2, "[1,2,3]", DataType.TEXT);
         assertField(fields, 3, "[6.0,-16.34]", DataType.TEXT);
         assertField(fields, 4, "[123456.789012345987654321]", DataType.TEXT); // scale fixed to 18 in schema
-        assertField(fields, 5, "[1549317584246,-123456789]", DataType.TEXT);
+        assertField(fields, 5, "[\"2019-03-14 14:10:28\",\"1969-12-30 05:42:23.211\"]", DataType.TEXT);
         assertField(fields, 6, "[7.7,-12345.354]", DataType.TEXT); // rounded to the precision of 8
         assertField(fields, 7, "[23456789,-123456789012345]", DataType.TEXT);
         assertField(fields, 8, "[true,false]", DataType.TEXT);

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
@@ -1,427 +1,427 @@
-package org.greenplum.pxf.plugins.hdfs;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.example.data.Group;
-import org.apache.parquet.example.data.simple.NanoTime;
-import org.apache.parquet.example.data.simple.SimpleGroup;
-import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
-import org.apache.parquet.hadoop.ParquetFileReader;
-import org.apache.parquet.io.ColumnIOFactory;
-import org.apache.parquet.io.MessageColumnIO;
-import org.apache.parquet.io.RecordReader;
-import org.apache.parquet.io.api.Binary;
-import org.apache.parquet.pig.convert.DecimalUtils;
-import org.apache.parquet.schema.*;
-import org.greenplum.pxf.api.OneField;
-import org.greenplum.pxf.api.OneRow;
-import org.greenplum.pxf.api.io.DataType;
-import org.greenplum.pxf.api.model.RequestContext;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
-
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import static org.junit.Assert.*;
-
-@RunWith(MockitoJUnitRunner.class)
-public class ParquetResolverTest {
-
-    private ParquetResolver resolver;
-    private RequestContext context;
-    private MessageType schema;
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
-    public void setup() {
-        resolver = new ParquetResolver();
-        context = new RequestContext();
-        schema = new MessageType("test");
-        context.setMetadata(schema);
-    }
-
-    @Test
-    public void testInitialize() {
-        resolver.initialize(context);
-    }
-
-    @Test
-    public void testGetFields_FailsOnMissingSchema() {
-        thrown.expect(RuntimeException.class);
-        thrown.expectMessage("No schema detected in request context");
-
-        context.setMetadata(null);
-        resolver.initialize(context);
-        resolver.getFields(new OneRow());
-    }
-
-    @Test
-    public void testSetFields_FailsOnMissingSchema() throws IOException {
-        thrown.expect(RuntimeException.class);
-        thrown.expectMessage("No schema detected in request context");
-
-        context.setMetadata(null);
-        resolver.initialize(context);
-        resolver.setFields(new ArrayList<>());
-    }
-
-    @Test
-    public void testSetFields_Primitive() throws IOException {
-        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL, false);
-        // schema has changed, set metadata again
-        context.setMetadata(schema);
-        resolver.initialize(context);
-        List<OneField> fields = new ArrayList<>();
-        fields.add(new OneField(DataType.TEXT.getOID(), "row1"));
-        fields.add(new OneField(DataType.TEXT.getOID(), "s_6"));
-        fields.add(new OneField(DataType.INTEGER.getOID(), 1));
-        fields.add(new OneField(DataType.FLOAT8.getOID(), 6.0d));
-        fields.add(new OneField(DataType.NUMERIC.getOID(), "1.234560000000000000"));
-        fields.add(new OneField(DataType.TIMESTAMP.getOID(), "2013-07-13 21:00:05"));
-        fields.add(new OneField(DataType.REAL.getOID(), 7.7f));
-        fields.add(new OneField(DataType.BIGINT.getOID(), 23456789l));
-        fields.add(new OneField(DataType.BOOLEAN.getOID(), false));
-        fields.add(new OneField(DataType.SMALLINT.getOID(), (short) 1));
-        fields.add(new OneField(DataType.SMALLINT.getOID(), (short) 10));
-        fields.add(new OneField(DataType.TEXT.getOID(), "abcd"));
-        fields.add(new OneField(DataType.TEXT.getOID(), "abc"));
-        fields.add(new OneField(DataType.BYTEA.getOID(), new byte[]{(byte) 49}));
-        OneRow row = resolver.setFields(fields);
-        assertNotNull(row);
-        Object data = row.getData();
-        assertNotNull(data);
-        assertTrue(data instanceof Group);
-        Group group = (Group) data;
-
-        // assert column values
-        assertEquals("row1", group.getString(0,0));
-        assertEquals("s_6", group.getString(1,0));
-        assertEquals(1, group.getInteger(2,0));
-        assertEquals(6.0d, group.getDouble(3,0), 0d);
-        assertEquals(BigDecimal.valueOf(1234560000000000000L, 18),
-                DecimalUtils.binaryToDecimal(group.getBinary(4,0), 19, 18));
-
-        NanoTime nanoTime = NanoTime.fromBinary(group.getInt96(5,0));
-        assertEquals(2456487, nanoTime.getJulianDay()); // 13 Jul 2013 in Julian days
-        assertEquals((21*60*60+5L) * 1000 * 1000 * 1000, nanoTime.getTimeOfDayNanos()); // 21:00:05 time
-        assertEquals(7.7f, group.getFloat(6,0), 0f);
-        assertEquals(23456789L, group.getLong(7,0));
-        assertEquals(false, group.getBoolean(8,0));
-        assertEquals(1, group.getInteger(9,0));
-        assertEquals(10, group.getInteger(10,0));
-        assertEquals("abcd", group.getString(11,0));
-        assertEquals("abc", group.getString(12,0));
-        assertArrayEquals(new byte[]{(byte) 49}, group.getBinary(13,0).getBytes());
-
-        // assert value repetition count
-        for (int i=0; i<14; i++) {
-            assertEquals(1, group.getFieldRepetitionCount(i));
-        }
-    }
-
-    @Test
-    public void testSetFields_Primitive_Nulls() throws IOException {
-        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL,false);
-        // schema has changed, set metadata again
-        context.setMetadata(schema);
-        resolver.initialize(context);
-        List<OneField> fields = new ArrayList<>();
-        fields.add(new OneField(DataType.TEXT.getOID(), null));
-        fields.add(new OneField(DataType.TEXT.getOID(), null));
-        fields.add(new OneField(DataType.INTEGER.getOID(), null));
-        fields.add(new OneField(DataType.FLOAT8.getOID(), null));
-        fields.add(new OneField(DataType.NUMERIC.getOID(), null));
-        fields.add(new OneField(DataType.TIMESTAMP.getOID(), null));
-        fields.add(new OneField(DataType.REAL.getOID(), null));
-        fields.add(new OneField(DataType.BIGINT.getOID(), null));
-        fields.add(new OneField(DataType.BOOLEAN.getOID(), null));
-        fields.add(new OneField(DataType.SMALLINT.getOID(), null));
-        fields.add(new OneField(DataType.SMALLINT.getOID(), null));
-        fields.add(new OneField(DataType.TEXT.getOID(), null));
-        fields.add(new OneField(DataType.TEXT.getOID(), null));
-        fields.add(new OneField(DataType.BYTEA.getOID(), null));
-        OneRow row = resolver.setFields(fields);
-        assertNotNull(row);
-        Object data = row.getData();
-        assertNotNull(data);
-        assertTrue(data instanceof Group);
-        Group group = (Group) data;
-        // assert value repetition count
-        for (int i=0; i<14; i++) {
-            assertEquals(0, group.getFieldRepetitionCount(i));
-        }
-    }
-
-    @Test
-    public void testGetFields_Primitive_EmptySchema() throws IOException {
-        resolver.initialize(context);
-
-        List<Group> groups = readParquetFile("primitive_types.parquet", 25);
-        OneRow row1 = new OneRow(groups.get(0)); // get row 1
-        List<OneField> fields = resolver.getFields(row1);
-        assertTrue(fields.isEmpty());
-    }
-
-    @Test
-    public void testGetFields_Primitive() throws IOException {
-        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL,true);
-        // schema has changed, set metadata again
-        context.setMetadata(schema);
-        resolver.initialize(context);
-
-        List<Group> groups = readParquetFile("primitive_types.parquet", 25);
-        assertEquals(25, groups.size());
-
-        List<OneField> fields = assertRow(groups, 0, 14);
-        //s1 : "row1" : TEXT
-        assertField(fields, 0, "row1", DataType.TEXT);
-        assertField(fields, 1, "s_6", DataType.TEXT);
-        assertField(fields, 2, 1, DataType.INTEGER);
-        assertField(fields, 3, 6.0d, DataType.FLOAT8);
-        assertField(fields, 4, BigDecimal.valueOf(1234560000000000000L, 18), DataType.NUMERIC);
-        assertField(fields, 5, java.sql.Timestamp.from(ZonedDateTime.parse("2013-07-13T21:00:05-07:00").toInstant()), DataType.TIMESTAMP);
-        assertField(fields, 6, 7.7f, DataType.REAL);
-        assertField(fields, 7, 23456789l, DataType.BIGINT);
-        assertField(fields, 8, false, DataType.BOOLEAN);
-        assertField(fields, 9, (short) 1, DataType.SMALLINT);
-        assertField(fields, 10, (short) 10, DataType.SMALLINT);
-        assertField(fields, 11, "abcd", DataType.TEXT);
-        assertField(fields, 12, "abc", DataType.TEXT);
-        assertField(fields, 13, new byte[]{(byte) 49}, DataType.BYTEA); // 49 is the ascii code for '1'
-
-        // test nulls
-        fields = assertRow(groups, 11, 14);
-        assertField(fields, 1, null, DataType.TEXT);
-        fields = assertRow(groups, 12, 14);
-        assertField(fields, 2, null, DataType.INTEGER);
-        fields = assertRow(groups, 13, 14);
-        assertField(fields, 3, null, DataType.FLOAT8);
-        fields = assertRow(groups, 14, 14);
-        assertField(fields, 4, null, DataType.NUMERIC);
-        fields = assertRow(groups, 15, 14);
-        assertField(fields, 5, null, DataType.TIMESTAMP);
-        fields = assertRow(groups, 16, 14);
-        assertField(fields, 6, null, DataType.REAL);
-        fields = assertRow(groups, 17, 14);
-        assertField(fields, 7, null, DataType.BIGINT);
-        fields = assertRow(groups, 18, 14);
-        assertField(fields, 8, null, DataType.BOOLEAN);
-        fields = assertRow(groups, 19, 14);
-        assertField(fields, 9, null, DataType.SMALLINT);
-        fields = assertRow(groups, 20, 14);
-        assertField(fields, 10, null, DataType.SMALLINT);
-        fields = assertRow(groups, 22, 14);
-        assertField(fields, 11, null, DataType.TEXT);
-        fields = assertRow(groups, 23, 14);
-        assertField(fields, 12, null, DataType.TEXT);
-        fields = assertRow(groups, 24, 14);
-        assertField(fields, 13, null, DataType.BYTEA);
-    }
-
-    @Test
-    public void testGetFields_Primitive_RepeatedString() throws IOException {
-        List<Type> columns = new ArrayList<>();
-        columns.add(new PrimitiveType(Type.Repetition.REPEATED, PrimitiveTypeName.BINARY, "myString", OriginalType.UTF8));
-        schema = new MessageType("TestProtobuf.StringArray", columns);
-        context.setMetadata(schema);
-        resolver.initialize(context);
-
-        List<Group> groups = readParquetFile("proto-repeated-string.parquet", 3);
-        List<OneField> fields;
-
-        // row 0
-        fields = assertRow(groups, 0, 1);
-        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
-        assertEquals("[\"hello\",\"world\"]", fields.get(0).val);
-
-        // row 1
-        fields = assertRow(groups, 1, 1);
-        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
-        assertEquals("[\"good\",\"bye\"]", fields.get(0).val);
-
-        // row 2
-        fields = assertRow(groups, 2, 1);
-        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
-        assertEquals("[\"one\",\"two\",\"three\"]", fields.get(0).val);
-
-    }
-
-    @Test
-    public void testGetFields_Primitive_Repeated_Synthetic() throws IOException {
-        // this test does not read the actual Parquet file, but rather construct Group object synthetically
-        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.REPEATED,true);
-        // schema has changed, set metadata again
-        context.setMetadata(schema);
-        resolver.initialize(context);
-
-        /*
-        Corresponding DB column types  are:
-        TEXT,TEXT,INTEGER, DOUBLE PRECISION,NUMERIC,TIMESTAMP,REAL,BIGINT,BOOLEAN,SMALLINT,SMALLINT,VARCHAR(5),CHAR(3),BYTEA
-         */
-
-        Group group = new SimpleGroup(schema);
-
-        group.add(0, "row1-1");
-        group.add(0, "row1-2");
-
-        // leave column 1 (t2) unset as part fo the test
-
-        group.add(2, 1);
-        group.add(2, 2);
-        group.add(2, 3);
-
-        group.add(3, 6.0d);
-        group.add(3, -16.34d);
-
-        BigDecimal value = new BigDecimal("12345678.9012345987654321"); // place of dot doesn't matter
-        byte fillByte = (byte) (value.signum() < 0 ? 0xFF : 0x00);
-        byte[] unscaled = value.unscaledValue().toByteArray();
-        byte[] bytes = new byte[16];
-        int offset = bytes.length - unscaled.length;
-        for (int i = 0; i < bytes.length; i += 1) {
-                bytes[i] = (i < offset) ? fillByte : unscaled[i - offset];
-        }
-        group.add(4, Binary.fromReusedByteArray(bytes));
-
-        group.add(5, ParquetTypeConverter.getBinary(1549317584246L));
-        group.add(5, ParquetTypeConverter.getBinary(-123456789L));
-
-        group.add(6, 7.7f);
-        group.add(6, -12345.35354646f);
-
-        group.add(7, 23456789l);
-        group.add(7, -123456789012345l);
-
-        group.add(8, true);
-        group.add(8, false);
-
-        group.add(9, (short) 1);
-        group.add(9, (short) -3);
-
-        group.add(10, (short) 269);
-        group.add(10, (short) -313);
-
-        group.add(11, Binary.fromString("Hello"));
-        group.add(11, Binary.fromString("World"));
-
-        group.add(12, Binary.fromString("foo"));
-        group.add(12, Binary.fromString("bar"));
-
-        byte[] byteArray1 = new byte[]{(byte) 49, (byte) 50, (byte) 51};
-        group.add(13, Binary.fromReusedByteArray(byteArray1, 0, 3));
-        byte[] byteArray2 = new byte[]{(byte) 52, (byte) 53, (byte) 54};
-        group.add(13, Binary.fromReusedByteArray(byteArray2, 0, 3));
-
-        List<Group> groups = new ArrayList<>();
-        groups.add(group);
-        List<OneField> fields = assertRow(groups, 0, 14);
-
-        assertField(fields, 0, "[\"row1-1\",\"row1-2\"]", DataType.TEXT);
-        assertField(fields, 1, "[]", DataType.TEXT);
-        assertField(fields, 2, "[1,2,3]", DataType.TEXT);
-        assertField(fields, 3, "[6.0,-16.34]", DataType.TEXT);
-        assertField(fields, 4, "[123456.789012345987654321]", DataType.TEXT); // scale fixed to 18 in schema
-        assertField(fields, 5, "[1549317584246,-123456789]", DataType.TEXT);
-        assertField(fields, 6, "[7.7,-12345.354]", DataType.TEXT); // rounded to the precision of 8
-        assertField(fields, 7, "[23456789,-123456789012345]", DataType.TEXT);
-        assertField(fields, 8, "[true,false]", DataType.TEXT);
-        assertField(fields, 9, "[1,-3]", DataType.TEXT);
-        assertField(fields, 10, "[269,-313]", DataType.TEXT);
-        assertField(fields, 11, "[\"Hello\",\"World\"]", DataType.TEXT);
-        assertField(fields, 12, "[\"foo\",\"bar\"]", DataType.TEXT); // 3 chars only
-        Base64.Encoder encoder = Base64.getEncoder(); // byte arrays are Base64 encoded into strings
-        String expectedByteArrays = "[\"" + encoder.encodeToString(byteArray1) + "\",\"" + encoder.encodeToString(byteArray2) + "\"]";
-        assertField(fields, 13, expectedByteArrays, DataType.TEXT);
-    }
-
-    @Test
-    public void testGetFields_Primitive_RepeatedInt() throws IOException {
-        List<Type> columns = new ArrayList<>();
-        columns.add(new PrimitiveType(Type.Repetition.REPEATED, PrimitiveTypeName.INT32, "repeatedInt"));
-        schema = new MessageType("TestProtobuf.RepeatedIntMessage", columns);
-        context.setMetadata(schema);
-        resolver.initialize(context);
-
-        List<Group> groups = readParquetFile("old-repeated-int.parquet", 1);
-        List<OneField> fields = assertRow(groups, 0, 1);
-        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
-        assertEquals("[1,2,3]", fields.get(0).val);
-
-    }
-
-    private List<OneField> assertRow(List<Group> groups, int desiredRow, int numFields) {
-        OneRow row = new OneRow(groups.get(desiredRow)); // get row
-        List<OneField> fields = resolver.getFields(row);
-        assertEquals(numFields, fields.size());
-        return fields;
-    }
-
-    private void assertField(List<OneField> fields, int index, Object value, DataType type) {
-        assertEquals(type.getOID(), fields.get(index).type);
-        if (type == DataType.BYTEA) {
-            assertArrayEquals((byte[]) value, (byte[]) fields.get(index).val);
-        } else {
-            assertEquals(value, fields.get(index).val);
-        }
-
-    }
-
-    private MessageType getParquetSchemaForPrimitiveTypes(Type.Repetition repetition, boolean readCase) {
-        List<Type> fields = new ArrayList<>();
-
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "s1", OriginalType.UTF8));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "s2", OriginalType.UTF8));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "n1", null));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.DOUBLE, "d1", null));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, 16, "dc1", OriginalType.DECIMAL, new DecimalMetadata(38, 18), null));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT96, "tm", null));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.FLOAT, "f", null));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT64, "bg", null));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BOOLEAN, "b", null));
-
-        // GPDB only has int16 and not int8 type, so for write tiny numbers int8 are still treated as shorts in16
-        OriginalType tinyType = readCase ? OriginalType.INT_8 : OriginalType.INT_16;
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "tn", tinyType));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "sml", OriginalType.INT_16));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "vc1", OriginalType.UTF8));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "c1", OriginalType.UTF8));
-        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "bin", null));
-
-        return new MessageType("hive_schema", fields);
-    }
-
-    private List<Group> readParquetFile(String file, long expectedSize) throws IOException {
-        List<Group> result = new ArrayList<>();
-        String parquetFile = getClass().getClassLoader().getResource("parquet/" + file).getPath();
-        Path path = new Path(parquetFile);
-
-        ParquetFileReader fileReader = new ParquetFileReader(new Configuration(), path, ParquetMetadataConverter.NO_FILTER);
-        PageReadStore rowGroup;
-        while ((rowGroup = fileReader.readNextRowGroup()) != null) {
-            MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
-            RecordReader<Group> recordReader = columnIO.getRecordReader(rowGroup, new GroupRecordConverter(schema));
-            long rowCount = rowGroup.getRowCount();
-            for (long i = 0; i < rowCount; i++) {
-                result.add(recordReader.read());
-            }
-        }
-        fileReader.close();
-        assertEquals(expectedSize, result.size());
-        return result;
-    }
-
-}
+//package org.greenplum.pxf.plugins.hdfs;
+//
+//import org.apache.hadoop.conf.Configuration;
+//import org.apache.hadoop.fs.Path;
+//import org.apache.parquet.column.page.PageReadStore;
+//import org.apache.parquet.example.data.Group;
+//import org.apache.parquet.example.data.simple.NanoTime;
+//import org.apache.parquet.example.data.simple.SimpleGroup;
+//import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
+//import org.apache.parquet.format.converter.ParquetMetadataConverter;
+//import org.apache.parquet.hadoop.ParquetFileReader;
+//import org.apache.parquet.io.ColumnIOFactory;
+//import org.apache.parquet.io.MessageColumnIO;
+//import org.apache.parquet.io.RecordReader;
+//import org.apache.parquet.io.api.Binary;
+//import org.apache.parquet.pig.convert.DecimalUtils;
+//import org.apache.parquet.schema.*;
+//import org.greenplum.pxf.api.OneField;
+//import org.greenplum.pxf.api.OneRow;
+//import org.greenplum.pxf.api.io.DataType;
+//import org.greenplum.pxf.api.model.RequestContext;
+//import org.junit.Before;
+//import org.junit.Rule;
+//import org.junit.Test;
+//import org.junit.rules.ExpectedException;
+//import org.junit.runner.RunWith;
+//import org.mockito.runners.MockitoJUnitRunner;
+//
+//import java.io.IOException;
+//import java.math.BigDecimal;
+//import java.time.ZonedDateTime;
+//import java.util.ArrayList;
+//import java.util.Base64;
+//import java.util.List;
+//
+//import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+//import static org.junit.Assert.*;
+//
+//@RunWith(MockitoJUnitRunner.class)
+//public class ParquetResolverTest {
+//
+//    private ParquetResolver resolver;
+//    private RequestContext context;
+//    private MessageType schema;
+//
+//    @Rule
+//    public ExpectedException thrown = ExpectedException.none();
+//
+//    @Before
+//    public void setup() {
+//        resolver = new ParquetResolver();
+//        context = new RequestContext();
+//        schema = new MessageType("test");
+//        context.setMetadata(schema);
+//    }
+//
+//    @Test
+//    public void testInitialize() {
+//        resolver.initialize(context);
+//    }
+//
+//    @Test
+//    public void testGetFields_FailsOnMissingSchema() {
+//        thrown.expect(RuntimeException.class);
+//        thrown.expectMessage("No schema detected in request context");
+//
+//        context.setMetadata(null);
+//        resolver.initialize(context);
+//        resolver.getFields(new OneRow());
+//    }
+//
+//    @Test
+//    public void testSetFields_FailsOnMissingSchema() throws IOException {
+//        thrown.expect(RuntimeException.class);
+//        thrown.expectMessage("No schema detected in request context");
+//
+//        context.setMetadata(null);
+//        resolver.initialize(context);
+//        resolver.setFields(new ArrayList<>());
+//    }
+//
+//    @Test
+//    public void testSetFields_Primitive() throws IOException {
+//        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL, false);
+//        // schema has changed, set metadata again
+//        context.setMetadata(schema);
+//        resolver.initialize(context);
+//        List<OneField> fields = new ArrayList<>();
+//        fields.add(new OneField(DataType.TEXT.getOID(), "row1"));
+//        fields.add(new OneField(DataType.TEXT.getOID(), "s_6"));
+//        fields.add(new OneField(DataType.INTEGER.getOID(), 1));
+//        fields.add(new OneField(DataType.FLOAT8.getOID(), 6.0d));
+//        fields.add(new OneField(DataType.NUMERIC.getOID(), "1.234560000000000000"));
+//        fields.add(new OneField(DataType.TIMESTAMP.getOID(), "2013-07-13 21:00:05"));
+//        fields.add(new OneField(DataType.REAL.getOID(), 7.7f));
+//        fields.add(new OneField(DataType.BIGINT.getOID(), 23456789l));
+//        fields.add(new OneField(DataType.BOOLEAN.getOID(), false));
+//        fields.add(new OneField(DataType.SMALLINT.getOID(), (short) 1));
+//        fields.add(new OneField(DataType.SMALLINT.getOID(), (short) 10));
+//        fields.add(new OneField(DataType.TEXT.getOID(), "abcd"));
+//        fields.add(new OneField(DataType.TEXT.getOID(), "abc"));
+//        fields.add(new OneField(DataType.BYTEA.getOID(), new byte[]{(byte) 49}));
+//        OneRow row = resolver.setFields(fields);
+//        assertNotNull(row);
+//        Object data = row.getData();
+//        assertNotNull(data);
+//        assertTrue(data instanceof Group);
+//        Group group = (Group) data;
+//
+//        // assert column values
+//        assertEquals("row1", group.getString(0,0));
+//        assertEquals("s_6", group.getString(1,0));
+//        assertEquals(1, group.getInteger(2,0));
+//        assertEquals(6.0d, group.getDouble(3,0), 0d);
+//        assertEquals(BigDecimal.valueOf(1234560000000000000L, 18),
+//                DecimalUtils.binaryToDecimal(group.getBinary(4,0), 19, 18));
+//
+//        NanoTime nanoTime = NanoTime.fromBinary(group.getInt96(5,0));
+//        assertEquals(2456487, nanoTime.getJulianDay()); // 13 Jul 2013 in Julian days
+//        assertEquals((21*60*60+5L) * 1000 * 1000 * 1000, nanoTime.getTimeOfDayNanos()); // 21:00:05 time
+//        assertEquals(7.7f, group.getFloat(6,0), 0f);
+//        assertEquals(23456789L, group.getLong(7,0));
+//        assertEquals(false, group.getBoolean(8,0));
+//        assertEquals(1, group.getInteger(9,0));
+//        assertEquals(10, group.getInteger(10,0));
+//        assertEquals("abcd", group.getString(11,0));
+//        assertEquals("abc", group.getString(12,0));
+//        assertArrayEquals(new byte[]{(byte) 49}, group.getBinary(13,0).getBytes());
+//
+//        // assert value repetition count
+//        for (int i=0; i<14; i++) {
+//            assertEquals(1, group.getFieldRepetitionCount(i));
+//        }
+//    }
+//
+//    @Test
+//    public void testSetFields_Primitive_Nulls() throws IOException {
+//        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL,false);
+//        // schema has changed, set metadata again
+//        context.setMetadata(schema);
+//        resolver.initialize(context);
+//        List<OneField> fields = new ArrayList<>();
+//        fields.add(new OneField(DataType.TEXT.getOID(), null));
+//        fields.add(new OneField(DataType.TEXT.getOID(), null));
+//        fields.add(new OneField(DataType.INTEGER.getOID(), null));
+//        fields.add(new OneField(DataType.FLOAT8.getOID(), null));
+//        fields.add(new OneField(DataType.NUMERIC.getOID(), null));
+//        fields.add(new OneField(DataType.TIMESTAMP.getOID(), null));
+//        fields.add(new OneField(DataType.REAL.getOID(), null));
+//        fields.add(new OneField(DataType.BIGINT.getOID(), null));
+//        fields.add(new OneField(DataType.BOOLEAN.getOID(), null));
+//        fields.add(new OneField(DataType.SMALLINT.getOID(), null));
+//        fields.add(new OneField(DataType.SMALLINT.getOID(), null));
+//        fields.add(new OneField(DataType.TEXT.getOID(), null));
+//        fields.add(new OneField(DataType.TEXT.getOID(), null));
+//        fields.add(new OneField(DataType.BYTEA.getOID(), null));
+//        OneRow row = resolver.setFields(fields);
+//        assertNotNull(row);
+//        Object data = row.getData();
+//        assertNotNull(data);
+//        assertTrue(data instanceof Group);
+//        Group group = (Group) data;
+//        // assert value repetition count
+//        for (int i=0; i<14; i++) {
+//            assertEquals(0, group.getFieldRepetitionCount(i));
+//        }
+//    }
+//
+//    @Test
+//    public void testGetFields_Primitive_EmptySchema() throws IOException {
+//        resolver.initialize(context);
+//
+//        List<Group> groups = readParquetFile("primitive_types.parquet", 25);
+//        OneRow row1 = new OneRow(groups.get(0)); // get row 1
+//        List<OneField> fields = resolver.getFields(row1);
+//        assertTrue(fields.isEmpty());
+//    }
+//
+//    @Test
+//    public void testGetFields_Primitive() throws IOException {
+//        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL,true);
+//        // schema has changed, set metadata again
+//        context.setMetadata(schema);
+//        resolver.initialize(context);
+//
+//        List<Group> groups = readParquetFile("primitive_types.parquet", 25);
+//        assertEquals(25, groups.size());
+//
+//        List<OneField> fields = assertRow(groups, 0, 14);
+//        //s1 : "row1" : TEXT
+//        assertField(fields, 0, "row1", DataType.TEXT);
+//        assertField(fields, 1, "s_6", DataType.TEXT);
+//        assertField(fields, 2, 1, DataType.INTEGER);
+//        assertField(fields, 3, 6.0d, DataType.FLOAT8);
+//        assertField(fields, 4, BigDecimal.valueOf(1234560000000000000L, 18), DataType.NUMERIC);
+//        assertField(fields, 5, java.sql.Timestamp.from(ZonedDateTime.parse("2013-07-13T21:00:05-07:00").toInstant()), DataType.TIMESTAMP);
+//        assertField(fields, 6, 7.7f, DataType.REAL);
+//        assertField(fields, 7, 23456789l, DataType.BIGINT);
+//        assertField(fields, 8, false, DataType.BOOLEAN);
+//        assertField(fields, 9, (short) 1, DataType.SMALLINT);
+//        assertField(fields, 10, (short) 10, DataType.SMALLINT);
+//        assertField(fields, 11, "abcd", DataType.TEXT);
+//        assertField(fields, 12, "abc", DataType.TEXT);
+//        assertField(fields, 13, new byte[]{(byte) 49}, DataType.BYTEA); // 49 is the ascii code for '1'
+//
+//        // test nulls
+//        fields = assertRow(groups, 11, 14);
+//        assertField(fields, 1, null, DataType.TEXT);
+//        fields = assertRow(groups, 12, 14);
+//        assertField(fields, 2, null, DataType.INTEGER);
+//        fields = assertRow(groups, 13, 14);
+//        assertField(fields, 3, null, DataType.FLOAT8);
+//        fields = assertRow(groups, 14, 14);
+//        assertField(fields, 4, null, DataType.NUMERIC);
+//        fields = assertRow(groups, 15, 14);
+//        assertField(fields, 5, null, DataType.TIMESTAMP);
+//        fields = assertRow(groups, 16, 14);
+//        assertField(fields, 6, null, DataType.REAL);
+//        fields = assertRow(groups, 17, 14);
+//        assertField(fields, 7, null, DataType.BIGINT);
+//        fields = assertRow(groups, 18, 14);
+//        assertField(fields, 8, null, DataType.BOOLEAN);
+//        fields = assertRow(groups, 19, 14);
+//        assertField(fields, 9, null, DataType.SMALLINT);
+//        fields = assertRow(groups, 20, 14);
+//        assertField(fields, 10, null, DataType.SMALLINT);
+//        fields = assertRow(groups, 22, 14);
+//        assertField(fields, 11, null, DataType.TEXT);
+//        fields = assertRow(groups, 23, 14);
+//        assertField(fields, 12, null, DataType.TEXT);
+//        fields = assertRow(groups, 24, 14);
+//        assertField(fields, 13, null, DataType.BYTEA);
+//    }
+//
+//    @Test
+//    public void testGetFields_Primitive_RepeatedString() throws IOException {
+//        List<Type> columns = new ArrayList<>();
+//        columns.add(new PrimitiveType(Type.Repetition.REPEATED, PrimitiveTypeName.BINARY, "myString", OriginalType.UTF8));
+//        schema = new MessageType("TestProtobuf.StringArray", columns);
+//        context.setMetadata(schema);
+//        resolver.initialize(context);
+//
+//        List<Group> groups = readParquetFile("proto-repeated-string.parquet", 3);
+//        List<OneField> fields;
+//
+//        // row 0
+//        fields = assertRow(groups, 0, 1);
+//        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
+//        assertEquals("[\"hello\",\"world\"]", fields.get(0).val);
+//
+//        // row 1
+//        fields = assertRow(groups, 1, 1);
+//        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
+//        assertEquals("[\"good\",\"bye\"]", fields.get(0).val);
+//
+//        // row 2
+//        fields = assertRow(groups, 2, 1);
+//        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
+//        assertEquals("[\"one\",\"two\",\"three\"]", fields.get(0).val);
+//
+//    }
+//
+//    @Test
+//    public void testGetFields_Primitive_Repeated_Synthetic() throws IOException {
+//        // this test does not read the actual Parquet file, but rather construct Group object synthetically
+//        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.REPEATED,true);
+//        // schema has changed, set metadata again
+//        context.setMetadata(schema);
+//        resolver.initialize(context);
+//
+//        /*
+//        Corresponding DB column types  are:
+//        TEXT,TEXT,INTEGER, DOUBLE PRECISION,NUMERIC,TIMESTAMP,REAL,BIGINT,BOOLEAN,SMALLINT,SMALLINT,VARCHAR(5),CHAR(3),BYTEA
+//         */
+//
+//        Group group = new SimpleGroup(schema);
+//
+//        group.add(0, "row1-1");
+//        group.add(0, "row1-2");
+//
+//        // leave column 1 (t2) unset as part fo the test
+//
+//        group.add(2, 1);
+//        group.add(2, 2);
+//        group.add(2, 3);
+//
+//        group.add(3, 6.0d);
+//        group.add(3, -16.34d);
+//
+//        BigDecimal value = new BigDecimal("12345678.9012345987654321"); // place of dot doesn't matter
+//        byte fillByte = (byte) (value.signum() < 0 ? 0xFF : 0x00);
+//        byte[] unscaled = value.unscaledValue().toByteArray();
+//        byte[] bytes = new byte[16];
+//        int offset = bytes.length - unscaled.length;
+//        for (int i = 0; i < bytes.length; i += 1) {
+//                bytes[i] = (i < offset) ? fillByte : unscaled[i - offset];
+//        }
+//        group.add(4, Binary.fromReusedByteArray(bytes));
+//
+//        group.add(5, ParquetTypeConverter.getBinary(1549317584246L));
+//        group.add(5, ParquetTypeConverter.getBinary(-123456789L));
+//
+//        group.add(6, 7.7f);
+//        group.add(6, -12345.35354646f);
+//
+//        group.add(7, 23456789l);
+//        group.add(7, -123456789012345l);
+//
+//        group.add(8, true);
+//        group.add(8, false);
+//
+//        group.add(9, (short) 1);
+//        group.add(9, (short) -3);
+//
+//        group.add(10, (short) 269);
+//        group.add(10, (short) -313);
+//
+//        group.add(11, Binary.fromString("Hello"));
+//        group.add(11, Binary.fromString("World"));
+//
+//        group.add(12, Binary.fromString("foo"));
+//        group.add(12, Binary.fromString("bar"));
+//
+//        byte[] byteArray1 = new byte[]{(byte) 49, (byte) 50, (byte) 51};
+//        group.add(13, Binary.fromReusedByteArray(byteArray1, 0, 3));
+//        byte[] byteArray2 = new byte[]{(byte) 52, (byte) 53, (byte) 54};
+//        group.add(13, Binary.fromReusedByteArray(byteArray2, 0, 3));
+//
+//        List<Group> groups = new ArrayList<>();
+//        groups.add(group);
+//        List<OneField> fields = assertRow(groups, 0, 14);
+//
+//        assertField(fields, 0, "[\"row1-1\",\"row1-2\"]", DataType.TEXT);
+//        assertField(fields, 1, "[]", DataType.TEXT);
+//        assertField(fields, 2, "[1,2,3]", DataType.TEXT);
+//        assertField(fields, 3, "[6.0,-16.34]", DataType.TEXT);
+//        assertField(fields, 4, "[123456.789012345987654321]", DataType.TEXT); // scale fixed to 18 in schema
+//        assertField(fields, 5, "[1549317584246,-123456789]", DataType.TEXT);
+//        assertField(fields, 6, "[7.7,-12345.354]", DataType.TEXT); // rounded to the precision of 8
+//        assertField(fields, 7, "[23456789,-123456789012345]", DataType.TEXT);
+//        assertField(fields, 8, "[true,false]", DataType.TEXT);
+//        assertField(fields, 9, "[1,-3]", DataType.TEXT);
+//        assertField(fields, 10, "[269,-313]", DataType.TEXT);
+//        assertField(fields, 11, "[\"Hello\",\"World\"]", DataType.TEXT);
+//        assertField(fields, 12, "[\"foo\",\"bar\"]", DataType.TEXT); // 3 chars only
+//        Base64.Encoder encoder = Base64.getEncoder(); // byte arrays are Base64 encoded into strings
+//        String expectedByteArrays = "[\"" + encoder.encodeToString(byteArray1) + "\",\"" + encoder.encodeToString(byteArray2) + "\"]";
+//        assertField(fields, 13, expectedByteArrays, DataType.TEXT);
+//    }
+//
+//    @Test
+//    public void testGetFields_Primitive_RepeatedInt() throws IOException {
+//        List<Type> columns = new ArrayList<>();
+//        columns.add(new PrimitiveType(Type.Repetition.REPEATED, PrimitiveTypeName.INT32, "repeatedInt"));
+//        schema = new MessageType("TestProtobuf.RepeatedIntMessage", columns);
+//        context.setMetadata(schema);
+//        resolver.initialize(context);
+//
+//        List<Group> groups = readParquetFile("old-repeated-int.parquet", 1);
+//        List<OneField> fields = assertRow(groups, 0, 1);
+//        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
+//        assertEquals("[1,2,3]", fields.get(0).val);
+//
+//    }
+//
+//    private List<OneField> assertRow(List<Group> groups, int desiredRow, int numFields) {
+//        OneRow row = new OneRow(groups.get(desiredRow)); // get row
+//        List<OneField> fields = resolver.getFields(row);
+//        assertEquals(numFields, fields.size());
+//        return fields;
+//    }
+//
+//    private void assertField(List<OneField> fields, int index, Object value, DataType type) {
+//        assertEquals(type.getOID(), fields.get(index).type);
+//        if (type == DataType.BYTEA) {
+//            assertArrayEquals((byte[]) value, (byte[]) fields.get(index).val);
+//        } else {
+//            assertEquals(value, fields.get(index).val);
+//        }
+//
+//    }
+//
+//    private MessageType getParquetSchemaForPrimitiveTypes(Type.Repetition repetition, boolean readCase) {
+//        List<Type> fields = new ArrayList<>();
+//
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "s1", OriginalType.UTF8));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "s2", OriginalType.UTF8));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "n1", null));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.DOUBLE, "d1", null));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, 16, "dc1", OriginalType.DECIMAL, new DecimalMetadata(38, 18), null));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT96, "tm", null));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.FLOAT, "f", null));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT64, "bg", null));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BOOLEAN, "b", null));
+//
+//        // GPDB only has int16 and not int8 type, so for write tiny numbers int8 are still treated as shorts in16
+//        OriginalType tinyType = readCase ? OriginalType.INT_8 : OriginalType.INT_16;
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "tn", tinyType));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "sml", OriginalType.INT_16));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "vc1", OriginalType.UTF8));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "c1", OriginalType.UTF8));
+//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "bin", null));
+//
+//        return new MessageType("hive_schema", fields);
+//    }
+//
+//    private List<Group> readParquetFile(String file, long expectedSize) throws IOException {
+//        List<Group> result = new ArrayList<>();
+//        String parquetFile = getClass().getClassLoader().getResource("parquet/" + file).getPath();
+//        Path path = new Path(parquetFile);
+//
+//        ParquetFileReader fileReader = new ParquetFileReader(new Configuration(), path, ParquetMetadataConverter.NO_FILTER);
+//        PageReadStore rowGroup;
+//        while ((rowGroup = fileReader.readNextRowGroup()) != null) {
+//            MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
+//            RecordReader<Group> recordReader = columnIO.getRecordReader(rowGroup, new GroupRecordConverter(schema));
+//            long rowCount = rowGroup.getRowCount();
+//            for (long i = 0; i < rowCount; i++) {
+//                result.add(recordReader.read());
+//            }
+//        }
+//        fileReader.close();
+//        assertEquals(expectedSize, result.size());
+//        return result;
+//    }
+//
+//}

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
@@ -205,6 +205,10 @@ public class ParquetResolverTest {
         List<Group> groups = readParquetFile("primitive_types.parquet", 25, schema);
         assertEquals(25, groups.size());
 
+        Instant timestamp = Instant.parse("2013-07-14T04:00:05Z"); // UTC
+        ZonedDateTime localTime = timestamp.atZone(ZoneId.systemDefault());
+        String localTimestampString = localTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")); // should be "2013-07-13 21:00:05" in PST
+
         List<OneField> fields = assertRow(groups, 0, 14);
         //s1 : "row1" : TEXT
         assertField(fields, 0, "row1", DataType.TEXT);
@@ -212,7 +216,7 @@ public class ParquetResolverTest {
         assertField(fields, 2, 1, DataType.INTEGER);
         assertField(fields, 3, 6.0d, DataType.FLOAT8);
         assertField(fields, 4, BigDecimal.valueOf(1234560000000000000L, 18), DataType.NUMERIC);
-        assertField(fields, 5, "2013-07-13 21:00:05", DataType.TIMESTAMP);
+        assertField(fields, 5, localTimestampString, DataType.TIMESTAMP);
         assertField(fields, 6, 7.7f, DataType.REAL);
         assertField(fields, 7, 23456789L, DataType.BIGINT);
         assertField(fields, 8, false, DataType.BOOLEAN);
@@ -465,7 +469,6 @@ public class ParquetResolverTest {
         } else {
             assertEquals(value, fields.get(index).val);
         }
-
     }
 
     private MessageType getParquetSchemaForPrimitiveTypes(Type.Repetition repetition, boolean readCase) {

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
@@ -422,7 +422,7 @@ public class ParquetResolverTest {
         assertField(fields, 2, "[1,2,3]", DataType.TEXT);
         assertField(fields, 3, "[6.0,-16.34]", DataType.TEXT);
         assertField(fields, 4, "[123456.789012345987654321]", DataType.TEXT); // scale fixed to 18 in schema
-        assertField(fields, 5, "[\"2019-03-14 14:10:28\",\"1969-12-30 05:42:23.211\"]", DataType.TEXT);
+        assertField(fields, 5, "[\"2019-03-14 14:10:28\",\"1969-12-30 05:42:23.211211\"]", DataType.TEXT);
         assertField(fields, 6, "[7.7,-12345.354]", DataType.TEXT); // rounded to the precision of 8
         assertField(fields, 7, "[23456789,-123456789012345]", DataType.TEXT);
         assertField(fields, 8, "[true,false]", DataType.TEXT);

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
@@ -484,12 +484,12 @@ public class ParquetResolverTest {
         return new MessageType("hive_schema", fields);
     }
 
+    @SuppressWarnings("deprecation")
     private List<Group> readParquetFile(String file, long expectedSize, MessageType schema) throws IOException {
         List<Group> result = new ArrayList<>();
         String parquetFile = Objects.requireNonNull(getClass().getClassLoader().getResource("parquet/" + file)).getPath();
         Path path = new Path(parquetFile);
 
-        //noinspection deprecation
         ParquetFileReader fileReader = new ParquetFileReader(new Configuration(), path, ParquetMetadataConverter.NO_FILTER);
         PageReadStore rowGroup;
         while ((rowGroup = fileReader.readNextRowGroup()) != null) {

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
@@ -1,427 +1,523 @@
-//package org.greenplum.pxf.plugins.hdfs;
-//
-//import org.apache.hadoop.conf.Configuration;
-//import org.apache.hadoop.fs.Path;
-//import org.apache.parquet.column.page.PageReadStore;
-//import org.apache.parquet.example.data.Group;
-//import org.apache.parquet.example.data.simple.NanoTime;
-//import org.apache.parquet.example.data.simple.SimpleGroup;
-//import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
-//import org.apache.parquet.format.converter.ParquetMetadataConverter;
-//import org.apache.parquet.hadoop.ParquetFileReader;
-//import org.apache.parquet.io.ColumnIOFactory;
-//import org.apache.parquet.io.MessageColumnIO;
-//import org.apache.parquet.io.RecordReader;
-//import org.apache.parquet.io.api.Binary;
-//import org.apache.parquet.pig.convert.DecimalUtils;
-//import org.apache.parquet.schema.*;
-//import org.greenplum.pxf.api.OneField;
-//import org.greenplum.pxf.api.OneRow;
-//import org.greenplum.pxf.api.io.DataType;
-//import org.greenplum.pxf.api.model.RequestContext;
-//import org.junit.Before;
-//import org.junit.Rule;
-//import org.junit.Test;
-//import org.junit.rules.ExpectedException;
-//import org.junit.runner.RunWith;
-//import org.mockito.runners.MockitoJUnitRunner;
-//
-//import java.io.IOException;
-//import java.math.BigDecimal;
-//import java.time.ZonedDateTime;
-//import java.util.ArrayList;
-//import java.util.Base64;
-//import java.util.List;
-//
-//import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-//import static org.junit.Assert.*;
-//
-//@RunWith(MockitoJUnitRunner.class)
-//public class ParquetResolverTest {
-//
-//    private ParquetResolver resolver;
-//    private RequestContext context;
-//    private MessageType schema;
-//
-//    @Rule
-//    public ExpectedException thrown = ExpectedException.none();
-//
-//    @Before
-//    public void setup() {
-//        resolver = new ParquetResolver();
-//        context = new RequestContext();
-//        schema = new MessageType("test");
-//        context.setMetadata(schema);
-//    }
-//
-//    @Test
-//    public void testInitialize() {
-//        resolver.initialize(context);
-//    }
-//
-//    @Test
-//    public void testGetFields_FailsOnMissingSchema() {
-//        thrown.expect(RuntimeException.class);
-//        thrown.expectMessage("No schema detected in request context");
-//
-//        context.setMetadata(null);
-//        resolver.initialize(context);
-//        resolver.getFields(new OneRow());
-//    }
-//
-//    @Test
-//    public void testSetFields_FailsOnMissingSchema() throws IOException {
-//        thrown.expect(RuntimeException.class);
-//        thrown.expectMessage("No schema detected in request context");
-//
-//        context.setMetadata(null);
-//        resolver.initialize(context);
-//        resolver.setFields(new ArrayList<>());
-//    }
-//
-//    @Test
-//    public void testSetFields_Primitive() throws IOException {
-//        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL, false);
-//        // schema has changed, set metadata again
-//        context.setMetadata(schema);
-//        resolver.initialize(context);
-//        List<OneField> fields = new ArrayList<>();
-//        fields.add(new OneField(DataType.TEXT.getOID(), "row1"));
-//        fields.add(new OneField(DataType.TEXT.getOID(), "s_6"));
-//        fields.add(new OneField(DataType.INTEGER.getOID(), 1));
-//        fields.add(new OneField(DataType.FLOAT8.getOID(), 6.0d));
-//        fields.add(new OneField(DataType.NUMERIC.getOID(), "1.234560000000000000"));
-//        fields.add(new OneField(DataType.TIMESTAMP.getOID(), "2013-07-13 21:00:05"));
-//        fields.add(new OneField(DataType.REAL.getOID(), 7.7f));
-//        fields.add(new OneField(DataType.BIGINT.getOID(), 23456789l));
-//        fields.add(new OneField(DataType.BOOLEAN.getOID(), false));
-//        fields.add(new OneField(DataType.SMALLINT.getOID(), (short) 1));
-//        fields.add(new OneField(DataType.SMALLINT.getOID(), (short) 10));
-//        fields.add(new OneField(DataType.TEXT.getOID(), "abcd"));
-//        fields.add(new OneField(DataType.TEXT.getOID(), "abc"));
-//        fields.add(new OneField(DataType.BYTEA.getOID(), new byte[]{(byte) 49}));
-//        OneRow row = resolver.setFields(fields);
-//        assertNotNull(row);
-//        Object data = row.getData();
-//        assertNotNull(data);
-//        assertTrue(data instanceof Group);
-//        Group group = (Group) data;
-//
-//        // assert column values
-//        assertEquals("row1", group.getString(0,0));
-//        assertEquals("s_6", group.getString(1,0));
-//        assertEquals(1, group.getInteger(2,0));
-//        assertEquals(6.0d, group.getDouble(3,0), 0d);
-//        assertEquals(BigDecimal.valueOf(1234560000000000000L, 18),
-//                DecimalUtils.binaryToDecimal(group.getBinary(4,0), 19, 18));
-//
-//        NanoTime nanoTime = NanoTime.fromBinary(group.getInt96(5,0));
-//        assertEquals(2456487, nanoTime.getJulianDay()); // 13 Jul 2013 in Julian days
-//        assertEquals((21*60*60+5L) * 1000 * 1000 * 1000, nanoTime.getTimeOfDayNanos()); // 21:00:05 time
-//        assertEquals(7.7f, group.getFloat(6,0), 0f);
-//        assertEquals(23456789L, group.getLong(7,0));
-//        assertEquals(false, group.getBoolean(8,0));
-//        assertEquals(1, group.getInteger(9,0));
-//        assertEquals(10, group.getInteger(10,0));
-//        assertEquals("abcd", group.getString(11,0));
-//        assertEquals("abc", group.getString(12,0));
-//        assertArrayEquals(new byte[]{(byte) 49}, group.getBinary(13,0).getBytes());
-//
-//        // assert value repetition count
-//        for (int i=0; i<14; i++) {
-//            assertEquals(1, group.getFieldRepetitionCount(i));
-//        }
-//    }
-//
-//    @Test
-//    public void testSetFields_Primitive_Nulls() throws IOException {
-//        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL,false);
-//        // schema has changed, set metadata again
-//        context.setMetadata(schema);
-//        resolver.initialize(context);
-//        List<OneField> fields = new ArrayList<>();
-//        fields.add(new OneField(DataType.TEXT.getOID(), null));
-//        fields.add(new OneField(DataType.TEXT.getOID(), null));
-//        fields.add(new OneField(DataType.INTEGER.getOID(), null));
-//        fields.add(new OneField(DataType.FLOAT8.getOID(), null));
-//        fields.add(new OneField(DataType.NUMERIC.getOID(), null));
-//        fields.add(new OneField(DataType.TIMESTAMP.getOID(), null));
-//        fields.add(new OneField(DataType.REAL.getOID(), null));
-//        fields.add(new OneField(DataType.BIGINT.getOID(), null));
-//        fields.add(new OneField(DataType.BOOLEAN.getOID(), null));
-//        fields.add(new OneField(DataType.SMALLINT.getOID(), null));
-//        fields.add(new OneField(DataType.SMALLINT.getOID(), null));
-//        fields.add(new OneField(DataType.TEXT.getOID(), null));
-//        fields.add(new OneField(DataType.TEXT.getOID(), null));
-//        fields.add(new OneField(DataType.BYTEA.getOID(), null));
-//        OneRow row = resolver.setFields(fields);
-//        assertNotNull(row);
-//        Object data = row.getData();
-//        assertNotNull(data);
-//        assertTrue(data instanceof Group);
-//        Group group = (Group) data;
-//        // assert value repetition count
-//        for (int i=0; i<14; i++) {
-//            assertEquals(0, group.getFieldRepetitionCount(i));
-//        }
-//    }
-//
-//    @Test
-//    public void testGetFields_Primitive_EmptySchema() throws IOException {
-//        resolver.initialize(context);
-//
-//        List<Group> groups = readParquetFile("primitive_types.parquet", 25);
-//        OneRow row1 = new OneRow(groups.get(0)); // get row 1
-//        List<OneField> fields = resolver.getFields(row1);
-//        assertTrue(fields.isEmpty());
-//    }
-//
-//    @Test
-//    public void testGetFields_Primitive() throws IOException {
-//        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL,true);
-//        // schema has changed, set metadata again
-//        context.setMetadata(schema);
-//        resolver.initialize(context);
-//
-//        List<Group> groups = readParquetFile("primitive_types.parquet", 25);
-//        assertEquals(25, groups.size());
-//
-//        List<OneField> fields = assertRow(groups, 0, 14);
-//        //s1 : "row1" : TEXT
-//        assertField(fields, 0, "row1", DataType.TEXT);
-//        assertField(fields, 1, "s_6", DataType.TEXT);
-//        assertField(fields, 2, 1, DataType.INTEGER);
-//        assertField(fields, 3, 6.0d, DataType.FLOAT8);
-//        assertField(fields, 4, BigDecimal.valueOf(1234560000000000000L, 18), DataType.NUMERIC);
-//        assertField(fields, 5, java.sql.Timestamp.from(ZonedDateTime.parse("2013-07-13T21:00:05-07:00").toInstant()), DataType.TIMESTAMP);
-//        assertField(fields, 6, 7.7f, DataType.REAL);
-//        assertField(fields, 7, 23456789l, DataType.BIGINT);
-//        assertField(fields, 8, false, DataType.BOOLEAN);
-//        assertField(fields, 9, (short) 1, DataType.SMALLINT);
-//        assertField(fields, 10, (short) 10, DataType.SMALLINT);
-//        assertField(fields, 11, "abcd", DataType.TEXT);
-//        assertField(fields, 12, "abc", DataType.TEXT);
-//        assertField(fields, 13, new byte[]{(byte) 49}, DataType.BYTEA); // 49 is the ascii code for '1'
-//
-//        // test nulls
-//        fields = assertRow(groups, 11, 14);
-//        assertField(fields, 1, null, DataType.TEXT);
-//        fields = assertRow(groups, 12, 14);
-//        assertField(fields, 2, null, DataType.INTEGER);
-//        fields = assertRow(groups, 13, 14);
-//        assertField(fields, 3, null, DataType.FLOAT8);
-//        fields = assertRow(groups, 14, 14);
-//        assertField(fields, 4, null, DataType.NUMERIC);
-//        fields = assertRow(groups, 15, 14);
-//        assertField(fields, 5, null, DataType.TIMESTAMP);
-//        fields = assertRow(groups, 16, 14);
-//        assertField(fields, 6, null, DataType.REAL);
-//        fields = assertRow(groups, 17, 14);
-//        assertField(fields, 7, null, DataType.BIGINT);
-//        fields = assertRow(groups, 18, 14);
-//        assertField(fields, 8, null, DataType.BOOLEAN);
-//        fields = assertRow(groups, 19, 14);
-//        assertField(fields, 9, null, DataType.SMALLINT);
-//        fields = assertRow(groups, 20, 14);
-//        assertField(fields, 10, null, DataType.SMALLINT);
-//        fields = assertRow(groups, 22, 14);
-//        assertField(fields, 11, null, DataType.TEXT);
-//        fields = assertRow(groups, 23, 14);
-//        assertField(fields, 12, null, DataType.TEXT);
-//        fields = assertRow(groups, 24, 14);
-//        assertField(fields, 13, null, DataType.BYTEA);
-//    }
-//
-//    @Test
-//    public void testGetFields_Primitive_RepeatedString() throws IOException {
-//        List<Type> columns = new ArrayList<>();
-//        columns.add(new PrimitiveType(Type.Repetition.REPEATED, PrimitiveTypeName.BINARY, "myString", OriginalType.UTF8));
-//        schema = new MessageType("TestProtobuf.StringArray", columns);
-//        context.setMetadata(schema);
-//        resolver.initialize(context);
-//
-//        List<Group> groups = readParquetFile("proto-repeated-string.parquet", 3);
-//        List<OneField> fields;
-//
-//        // row 0
-//        fields = assertRow(groups, 0, 1);
-//        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
-//        assertEquals("[\"hello\",\"world\"]", fields.get(0).val);
-//
-//        // row 1
-//        fields = assertRow(groups, 1, 1);
-//        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
-//        assertEquals("[\"good\",\"bye\"]", fields.get(0).val);
-//
-//        // row 2
-//        fields = assertRow(groups, 2, 1);
-//        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
-//        assertEquals("[\"one\",\"two\",\"three\"]", fields.get(0).val);
-//
-//    }
-//
-//    @Test
-//    public void testGetFields_Primitive_Repeated_Synthetic() throws IOException {
-//        // this test does not read the actual Parquet file, but rather construct Group object synthetically
-//        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.REPEATED,true);
-//        // schema has changed, set metadata again
-//        context.setMetadata(schema);
-//        resolver.initialize(context);
-//
-//        /*
-//        Corresponding DB column types  are:
-//        TEXT,TEXT,INTEGER, DOUBLE PRECISION,NUMERIC,TIMESTAMP,REAL,BIGINT,BOOLEAN,SMALLINT,SMALLINT,VARCHAR(5),CHAR(3),BYTEA
-//         */
-//
-//        Group group = new SimpleGroup(schema);
-//
-//        group.add(0, "row1-1");
-//        group.add(0, "row1-2");
-//
-//        // leave column 1 (t2) unset as part fo the test
-//
-//        group.add(2, 1);
-//        group.add(2, 2);
-//        group.add(2, 3);
-//
-//        group.add(3, 6.0d);
-//        group.add(3, -16.34d);
-//
-//        BigDecimal value = new BigDecimal("12345678.9012345987654321"); // place of dot doesn't matter
-//        byte fillByte = (byte) (value.signum() < 0 ? 0xFF : 0x00);
-//        byte[] unscaled = value.unscaledValue().toByteArray();
-//        byte[] bytes = new byte[16];
-//        int offset = bytes.length - unscaled.length;
-//        for (int i = 0; i < bytes.length; i += 1) {
-//                bytes[i] = (i < offset) ? fillByte : unscaled[i - offset];
-//        }
-//        group.add(4, Binary.fromReusedByteArray(bytes));
-//
-//        group.add(5, ParquetTypeConverter.getBinary(1549317584246L));
-//        group.add(5, ParquetTypeConverter.getBinary(-123456789L));
-//
-//        group.add(6, 7.7f);
-//        group.add(6, -12345.35354646f);
-//
-//        group.add(7, 23456789l);
-//        group.add(7, -123456789012345l);
-//
-//        group.add(8, true);
-//        group.add(8, false);
-//
-//        group.add(9, (short) 1);
-//        group.add(9, (short) -3);
-//
-//        group.add(10, (short) 269);
-//        group.add(10, (short) -313);
-//
-//        group.add(11, Binary.fromString("Hello"));
-//        group.add(11, Binary.fromString("World"));
-//
-//        group.add(12, Binary.fromString("foo"));
-//        group.add(12, Binary.fromString("bar"));
-//
-//        byte[] byteArray1 = new byte[]{(byte) 49, (byte) 50, (byte) 51};
-//        group.add(13, Binary.fromReusedByteArray(byteArray1, 0, 3));
-//        byte[] byteArray2 = new byte[]{(byte) 52, (byte) 53, (byte) 54};
-//        group.add(13, Binary.fromReusedByteArray(byteArray2, 0, 3));
-//
-//        List<Group> groups = new ArrayList<>();
-//        groups.add(group);
-//        List<OneField> fields = assertRow(groups, 0, 14);
-//
-//        assertField(fields, 0, "[\"row1-1\",\"row1-2\"]", DataType.TEXT);
-//        assertField(fields, 1, "[]", DataType.TEXT);
-//        assertField(fields, 2, "[1,2,3]", DataType.TEXT);
-//        assertField(fields, 3, "[6.0,-16.34]", DataType.TEXT);
-//        assertField(fields, 4, "[123456.789012345987654321]", DataType.TEXT); // scale fixed to 18 in schema
-//        assertField(fields, 5, "[1549317584246,-123456789]", DataType.TEXT);
-//        assertField(fields, 6, "[7.7,-12345.354]", DataType.TEXT); // rounded to the precision of 8
-//        assertField(fields, 7, "[23456789,-123456789012345]", DataType.TEXT);
-//        assertField(fields, 8, "[true,false]", DataType.TEXT);
-//        assertField(fields, 9, "[1,-3]", DataType.TEXT);
-//        assertField(fields, 10, "[269,-313]", DataType.TEXT);
-//        assertField(fields, 11, "[\"Hello\",\"World\"]", DataType.TEXT);
-//        assertField(fields, 12, "[\"foo\",\"bar\"]", DataType.TEXT); // 3 chars only
-//        Base64.Encoder encoder = Base64.getEncoder(); // byte arrays are Base64 encoded into strings
-//        String expectedByteArrays = "[\"" + encoder.encodeToString(byteArray1) + "\",\"" + encoder.encodeToString(byteArray2) + "\"]";
-//        assertField(fields, 13, expectedByteArrays, DataType.TEXT);
-//    }
-//
-//    @Test
-//    public void testGetFields_Primitive_RepeatedInt() throws IOException {
-//        List<Type> columns = new ArrayList<>();
-//        columns.add(new PrimitiveType(Type.Repetition.REPEATED, PrimitiveTypeName.INT32, "repeatedInt"));
-//        schema = new MessageType("TestProtobuf.RepeatedIntMessage", columns);
-//        context.setMetadata(schema);
-//        resolver.initialize(context);
-//
-//        List<Group> groups = readParquetFile("old-repeated-int.parquet", 1);
-//        List<OneField> fields = assertRow(groups, 0, 1);
-//        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
-//        assertEquals("[1,2,3]", fields.get(0).val);
-//
-//    }
-//
-//    private List<OneField> assertRow(List<Group> groups, int desiredRow, int numFields) {
-//        OneRow row = new OneRow(groups.get(desiredRow)); // get row
-//        List<OneField> fields = resolver.getFields(row);
-//        assertEquals(numFields, fields.size());
-//        return fields;
-//    }
-//
-//    private void assertField(List<OneField> fields, int index, Object value, DataType type) {
-//        assertEquals(type.getOID(), fields.get(index).type);
-//        if (type == DataType.BYTEA) {
-//            assertArrayEquals((byte[]) value, (byte[]) fields.get(index).val);
-//        } else {
-//            assertEquals(value, fields.get(index).val);
-//        }
-//
-//    }
-//
-//    private MessageType getParquetSchemaForPrimitiveTypes(Type.Repetition repetition, boolean readCase) {
-//        List<Type> fields = new ArrayList<>();
-//
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "s1", OriginalType.UTF8));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "s2", OriginalType.UTF8));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "n1", null));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.DOUBLE, "d1", null));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, 16, "dc1", OriginalType.DECIMAL, new DecimalMetadata(38, 18), null));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT96, "tm", null));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.FLOAT, "f", null));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT64, "bg", null));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BOOLEAN, "b", null));
-//
-//        // GPDB only has int16 and not int8 type, so for write tiny numbers int8 are still treated as shorts in16
-//        OriginalType tinyType = readCase ? OriginalType.INT_8 : OriginalType.INT_16;
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "tn", tinyType));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "sml", OriginalType.INT_16));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "vc1", OriginalType.UTF8));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "c1", OriginalType.UTF8));
-//        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "bin", null));
-//
-//        return new MessageType("hive_schema", fields);
-//    }
-//
-//    private List<Group> readParquetFile(String file, long expectedSize) throws IOException {
-//        List<Group> result = new ArrayList<>();
-//        String parquetFile = getClass().getClassLoader().getResource("parquet/" + file).getPath();
-//        Path path = new Path(parquetFile);
-//
-//        ParquetFileReader fileReader = new ParquetFileReader(new Configuration(), path, ParquetMetadataConverter.NO_FILTER);
-//        PageReadStore rowGroup;
-//        while ((rowGroup = fileReader.readNextRowGroup()) != null) {
-//            MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
-//            RecordReader<Group> recordReader = columnIO.getRecordReader(rowGroup, new GroupRecordConverter(schema));
-//            long rowCount = rowGroup.getRowCount();
-//            for (long i = 0; i < rowCount; i++) {
-//                result.add(recordReader.read());
-//            }
-//        }
-//        fileReader.close();
-//        assertEquals(expectedSize, result.size());
-//        return result;
-//    }
-//
-//}
+package org.greenplum.pxf.plugins.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.NanoTime;
+import org.apache.parquet.example.data.simple.SimpleGroup;
+import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.io.ColumnIOFactory;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.io.RecordReader;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.pig.convert.DecimalUtils;
+import org.apache.parquet.schema.DecimalMetadata;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.greenplum.pxf.api.OneField;
+import org.greenplum.pxf.api.OneRow;
+import org.greenplum.pxf.api.io.DataType;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ParquetResolverTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    private ParquetResolver resolver;
+    private RequestContext context;
+    private MessageType schema;
+
+    @Before
+    public void setup() {
+        resolver = new ParquetResolver();
+        context = new RequestContext();
+        schema = new MessageType("test");
+        context.setMetadata(schema);
+    }
+
+    @Test
+    public void testInitialize() {
+        resolver.initialize(context);
+    }
+
+    @Test
+    public void testGetFields_FailsOnMissingSchema() {
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("No schema detected in request context");
+
+        context.setMetadata(null);
+        resolver.initialize(context);
+        resolver.getFields(new OneRow());
+    }
+
+    @Test
+    public void testSetFields_FailsOnMissingSchema() throws IOException {
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("No schema detected in request context");
+
+        context.setMetadata(null);
+        resolver.initialize(context);
+        resolver.setFields(new ArrayList<>());
+    }
+
+    @Test
+    public void testSetFields_Primitive() throws IOException {
+        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL, false);
+        // schema has changed, set metadata again
+        context.setMetadata(schema);
+        resolver.initialize(context);
+        List<OneField> fields = new ArrayList<>();
+        fields.add(new OneField(DataType.TEXT.getOID(), "row1"));
+        fields.add(new OneField(DataType.TEXT.getOID(), "s_6"));
+        fields.add(new OneField(DataType.INTEGER.getOID(), 1));
+        fields.add(new OneField(DataType.FLOAT8.getOID(), 6.0d));
+        fields.add(new OneField(DataType.NUMERIC.getOID(), "1.234560000000000000"));
+        fields.add(new OneField(DataType.TIMESTAMP.getOID(), "2013-07-13 21:00:05"));
+        fields.add(new OneField(DataType.REAL.getOID(), 7.7f));
+        fields.add(new OneField(DataType.BIGINT.getOID(), 23456789L));
+        fields.add(new OneField(DataType.BOOLEAN.getOID(), false));
+        fields.add(new OneField(DataType.SMALLINT.getOID(), (short) 1));
+        fields.add(new OneField(DataType.SMALLINT.getOID(), (short) 10));
+        fields.add(new OneField(DataType.TEXT.getOID(), "abcd"));
+        fields.add(new OneField(DataType.TEXT.getOID(), "abc"));
+        fields.add(new OneField(DataType.BYTEA.getOID(), new byte[]{(byte) 49}));
+        OneRow row = resolver.setFields(fields);
+        assertNotNull(row);
+        Object data = row.getData();
+        assertNotNull(data);
+        assertTrue(data instanceof Group);
+        Group group = (Group) data;
+
+        // assert column values
+        assertEquals("row1", group.getString(0, 0));
+        assertEquals("s_6", group.getString(1, 0));
+        assertEquals(1, group.getInteger(2, 0));
+        assertEquals(6.0d, group.getDouble(3, 0), 0d);
+        assertEquals(BigDecimal.valueOf(1234560000000000000L, 18),
+                DecimalUtils.binaryToDecimal(group.getBinary(4, 0), 19, 18));
+
+        NanoTime nanoTime = NanoTime.fromBinary(group.getInt96(5, 0));
+        assertEquals(2456487, nanoTime.getJulianDay()); // 13 Jul 2013 in Julian days
+        assertEquals((21 * 60 * 60 + 5L) * 1000 * 1000 * 1000, nanoTime.getTimeOfDayNanos()); // 21:00:05 time
+        assertEquals(7.7f, group.getFloat(6, 0), 0f);
+        assertEquals(23456789L, group.getLong(7, 0));
+        assertFalse(group.getBoolean(8, 0));
+        assertEquals(1, group.getInteger(9, 0));
+        assertEquals(10, group.getInteger(10, 0));
+        assertEquals("abcd", group.getString(11, 0));
+        assertEquals("abc", group.getString(12, 0));
+        assertArrayEquals(new byte[]{(byte) 49}, group.getBinary(13, 0).getBytes());
+
+        // assert value repetition count
+        for (int i = 0; i < 14; i++) {
+            assertEquals(1, group.getFieldRepetitionCount(i));
+        }
+    }
+
+    @Test
+    public void testSetFields_Primitive_Nulls() throws IOException {
+        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL, false);
+        // schema has changed, set metadata again
+        context.setMetadata(schema);
+        resolver.initialize(context);
+        List<OneField> fields = new ArrayList<>();
+        fields.add(new OneField(DataType.TEXT.getOID(), null));
+        fields.add(new OneField(DataType.TEXT.getOID(), null));
+        fields.add(new OneField(DataType.INTEGER.getOID(), null));
+        fields.add(new OneField(DataType.FLOAT8.getOID(), null));
+        fields.add(new OneField(DataType.NUMERIC.getOID(), null));
+        fields.add(new OneField(DataType.TIMESTAMP.getOID(), null));
+        fields.add(new OneField(DataType.REAL.getOID(), null));
+        fields.add(new OneField(DataType.BIGINT.getOID(), null));
+        fields.add(new OneField(DataType.BOOLEAN.getOID(), null));
+        fields.add(new OneField(DataType.SMALLINT.getOID(), null));
+        fields.add(new OneField(DataType.SMALLINT.getOID(), null));
+        fields.add(new OneField(DataType.TEXT.getOID(), null));
+        fields.add(new OneField(DataType.TEXT.getOID(), null));
+        fields.add(new OneField(DataType.BYTEA.getOID(), null));
+        OneRow row = resolver.setFields(fields);
+        assertNotNull(row);
+        Object data = row.getData();
+        assertNotNull(data);
+        assertTrue(data instanceof Group);
+        Group group = (Group) data;
+        // assert value repetition count
+        for (int i = 0; i < 14; i++) {
+            assertEquals(0, group.getFieldRepetitionCount(i));
+        }
+    }
+
+    @Test
+    public void testGetFields_Primitive_EmptySchema() throws IOException {
+        resolver.initialize(context);
+
+        List<Group> groups = readParquetFile("primitive_types.parquet", 25, schema);
+        OneRow row1 = new OneRow(groups.get(0)); // get row 1
+        List<OneField> fields = resolver.getFields(row1);
+        assertTrue(fields.isEmpty());
+    }
+
+    @Test
+    public void testGetFields_Primitive() throws IOException {
+        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL, true);
+        // schema has changed, set metadata again
+        context.setMetadata(schema);
+        context.setTupleDescription(getColumnDescriptorsFromSchema(schema));
+        resolver.initialize(context);
+
+        List<Group> groups = readParquetFile("primitive_types.parquet", 25, schema);
+        assertEquals(25, groups.size());
+
+        List<OneField> fields = assertRow(groups, 0, 14);
+        //s1 : "row1" : TEXT
+        assertField(fields, 0, "row1", DataType.TEXT);
+        assertField(fields, 1, "s_6", DataType.TEXT);
+        assertField(fields, 2, 1, DataType.INTEGER);
+        assertField(fields, 3, 6.0d, DataType.FLOAT8);
+        assertField(fields, 4, BigDecimal.valueOf(1234560000000000000L, 18), DataType.NUMERIC);
+        assertField(fields, 5, java.sql.Timestamp.from(ZonedDateTime.parse("2013-07-13T21:00:05-07:00").toInstant()), DataType.TIMESTAMP);
+        assertField(fields, 6, 7.7f, DataType.REAL);
+        assertField(fields, 7, 23456789L, DataType.BIGINT);
+        assertField(fields, 8, false, DataType.BOOLEAN);
+        assertField(fields, 9, (short) 1, DataType.SMALLINT);
+        assertField(fields, 10, (short) 10, DataType.SMALLINT);
+        assertField(fields, 11, "abcd", DataType.TEXT);
+        assertField(fields, 12, "abc", DataType.TEXT);
+        assertField(fields, 13, new byte[]{(byte) 49}, DataType.BYTEA); // 49 is the ascii code for '1'
+
+        // test nulls
+        fields = assertRow(groups, 11, 14);
+        assertField(fields, 1, null, DataType.TEXT);
+        fields = assertRow(groups, 12, 14);
+        assertField(fields, 2, null, DataType.INTEGER);
+        fields = assertRow(groups, 13, 14);
+        assertField(fields, 3, null, DataType.FLOAT8);
+        fields = assertRow(groups, 14, 14);
+        assertField(fields, 4, null, DataType.NUMERIC);
+        fields = assertRow(groups, 15, 14);
+        assertField(fields, 5, null, DataType.TIMESTAMP);
+        fields = assertRow(groups, 16, 14);
+        assertField(fields, 6, null, DataType.REAL);
+        fields = assertRow(groups, 17, 14);
+        assertField(fields, 7, null, DataType.BIGINT);
+        fields = assertRow(groups, 18, 14);
+        assertField(fields, 8, null, DataType.BOOLEAN);
+        fields = assertRow(groups, 19, 14);
+        assertField(fields, 9, null, DataType.SMALLINT);
+        fields = assertRow(groups, 20, 14);
+        assertField(fields, 10, null, DataType.SMALLINT);
+        fields = assertRow(groups, 22, 14);
+        assertField(fields, 11, null, DataType.TEXT);
+        fields = assertRow(groups, 23, 14);
+        assertField(fields, 12, null, DataType.TEXT);
+        fields = assertRow(groups, 24, 14);
+        assertField(fields, 13, null, DataType.BYTEA);
+    }
+
+    @Test
+    public void testGetFields_Primitive_With_Projection() throws IOException {
+        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL, true);
+        // schema has changed, set metadata again
+        context.setMetadata(schema);
+        context.setTupleDescription(getColumnDescriptorsFromSchema(schema));
+
+        // set odd columns to be not projected, their values will become null
+        for (int i = 0; i < context.getTupleDescription().size(); i++) {
+            context.getTupleDescription().get(i).setProjected(i % 2 == 0);
+        }
+
+        resolver.initialize(context);
+
+        // use readSchema to read only specific columns from parquet file into Group
+        List<Group> groups = readParquetFile("primitive_types.parquet", 25, buildReadSchema(schema));
+        assertEquals(25, groups.size());
+
+        List<OneField> fields = assertRow(groups, 0, 14);
+        //s1 : "row1" : TEXT
+        assertField(fields, 0, "row1", DataType.TEXT);
+        assertField(fields, 1, null, DataType.TEXT);
+        assertField(fields, 2, 1, DataType.INTEGER);
+        assertField(fields, 3, null, DataType.FLOAT8);
+        assertField(fields, 4, BigDecimal.valueOf(1234560000000000000L, 18), DataType.NUMERIC);
+        assertField(fields, 5, null, DataType.TIMESTAMP);
+        assertField(fields, 6, 7.7f, DataType.REAL);
+        assertField(fields, 7, null, DataType.BIGINT);
+        assertField(fields, 8, false, DataType.BOOLEAN);
+        assertField(fields, 9, null, DataType.SMALLINT);
+        assertField(fields, 10, (short) 10, DataType.SMALLINT);
+        assertField(fields, 11, null, DataType.TEXT);
+        assertField(fields, 12, "abc", DataType.TEXT);
+        assertField(fields, 13, null, DataType.BYTEA); // 49 is the ascii code for '1'
+
+        // test nulls
+        fields = assertRow(groups, 11, 14);
+        assertField(fields, 1, null, DataType.TEXT);
+        fields = assertRow(groups, 12, 14);
+        assertField(fields, 2, null, DataType.INTEGER);
+        fields = assertRow(groups, 13, 14);
+        assertField(fields, 3, null, DataType.FLOAT8);
+        fields = assertRow(groups, 14, 14);
+        assertField(fields, 4, null, DataType.NUMERIC);
+        fields = assertRow(groups, 15, 14);
+        assertField(fields, 5, null, DataType.TIMESTAMP);
+        fields = assertRow(groups, 16, 14);
+        assertField(fields, 6, null, DataType.REAL);
+        fields = assertRow(groups, 17, 14);
+        assertField(fields, 7, null, DataType.BIGINT);
+        fields = assertRow(groups, 18, 14);
+        assertField(fields, 8, null, DataType.BOOLEAN);
+        fields = assertRow(groups, 19, 14);
+        assertField(fields, 9, null, DataType.SMALLINT);
+        fields = assertRow(groups, 20, 14);
+        assertField(fields, 10, null, DataType.SMALLINT);
+        fields = assertRow(groups, 22, 14);
+        assertField(fields, 11, null, DataType.TEXT);
+        fields = assertRow(groups, 23, 14);
+        assertField(fields, 12, null, DataType.TEXT);
+        fields = assertRow(groups, 24, 14);
+        assertField(fields, 13, null, DataType.BYTEA);
+    }
+
+    @Test
+    public void testGetFields_Primitive_RepeatedString() throws IOException {
+        List<Type> columns = new ArrayList<>();
+        columns.add(new PrimitiveType(Type.Repetition.REPEATED, PrimitiveTypeName.BINARY, "myString", OriginalType.UTF8));
+        schema = new MessageType("TestProtobuf.StringArray", columns);
+        context.setMetadata(schema);
+        context.setTupleDescription(getColumnDescriptorsFromSchema(schema));
+        resolver.initialize(context);
+
+        List<Group> groups = readParquetFile("proto-repeated-string.parquet", 3, schema);
+        List<OneField> fields;
+
+        // row 0
+        fields = assertRow(groups, 0, 1);
+        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
+        assertEquals("[\"hello\",\"world\"]", fields.get(0).val);
+
+        // row 1
+        fields = assertRow(groups, 1, 1);
+        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
+        assertEquals("[\"good\",\"bye\"]", fields.get(0).val);
+
+        // row 2
+        fields = assertRow(groups, 2, 1);
+        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
+        assertEquals("[\"one\",\"two\",\"three\"]", fields.get(0).val);
+
+    }
+
+    @Test
+    public void testGetFields_Primitive_Repeated_Synthetic() {
+        // this test does not read the actual Parquet file, but rather construct Group object synthetically
+        schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.REPEATED, true);
+        // schema has changed, set metadata again
+        context.setMetadata(schema);
+        context.setTupleDescription(getColumnDescriptorsFromSchema(schema));
+        resolver.initialize(context);
+
+        /*
+        Corresponding DB column types  are:
+        TEXT,TEXT,INTEGER, DOUBLE PRECISION,NUMERIC,TIMESTAMP,REAL,BIGINT,BOOLEAN,SMALLINT,SMALLINT,VARCHAR(5),CHAR(3),BYTEA
+         */
+
+        Group group = new SimpleGroup(schema);
+
+        group.add(0, "row1-1");
+        group.add(0, "row1-2");
+
+        // leave column 1 (t2) unset as part fo the test
+
+        group.add(2, 1);
+        group.add(2, 2);
+        group.add(2, 3);
+
+        group.add(3, 6.0d);
+        group.add(3, -16.34d);
+
+        BigDecimal value = new BigDecimal("12345678.9012345987654321"); // place of dot doesn't matter
+        byte fillByte = (byte) (value.signum() < 0 ? 0xFF : 0x00);
+        byte[] unscaled = value.unscaledValue().toByteArray();
+        byte[] bytes = new byte[16];
+        int offset = bytes.length - unscaled.length;
+        for (int i = 0; i < bytes.length; i += 1) {
+            bytes[i] = (i < offset) ? fillByte : unscaled[i - offset];
+        }
+        group.add(4, Binary.fromReusedByteArray(bytes));
+
+        group.add(5, ParquetTypeConverter.getBinary(1549317584246L));
+        group.add(5, ParquetTypeConverter.getBinary(-123456789L));
+
+        group.add(6, 7.7f);
+        group.add(6, -12345.35354646f);
+
+        group.add(7, 23456789L);
+        group.add(7, -123456789012345L);
+
+        group.add(8, true);
+        group.add(8, false);
+
+        group.add(9, (short) 1);
+        group.add(9, (short) -3);
+
+        group.add(10, (short) 269);
+        group.add(10, (short) -313);
+
+        group.add(11, Binary.fromString("Hello"));
+        group.add(11, Binary.fromString("World"));
+
+        group.add(12, Binary.fromString("foo"));
+        group.add(12, Binary.fromString("bar"));
+
+        byte[] byteArray1 = new byte[]{(byte) 49, (byte) 50, (byte) 51};
+        group.add(13, Binary.fromReusedByteArray(byteArray1, 0, 3));
+        byte[] byteArray2 = new byte[]{(byte) 52, (byte) 53, (byte) 54};
+        group.add(13, Binary.fromReusedByteArray(byteArray2, 0, 3));
+
+        List<Group> groups = new ArrayList<>();
+        groups.add(group);
+        List<OneField> fields = assertRow(groups, 0, 14);
+
+        assertField(fields, 0, "[\"row1-1\",\"row1-2\"]", DataType.TEXT);
+        assertField(fields, 1, "[]", DataType.TEXT);
+        assertField(fields, 2, "[1,2,3]", DataType.TEXT);
+        assertField(fields, 3, "[6.0,-16.34]", DataType.TEXT);
+        assertField(fields, 4, "[123456.789012345987654321]", DataType.TEXT); // scale fixed to 18 in schema
+        assertField(fields, 5, "[1549317584246,-123456789]", DataType.TEXT);
+        assertField(fields, 6, "[7.7,-12345.354]", DataType.TEXT); // rounded to the precision of 8
+        assertField(fields, 7, "[23456789,-123456789012345]", DataType.TEXT);
+        assertField(fields, 8, "[true,false]", DataType.TEXT);
+        assertField(fields, 9, "[1,-3]", DataType.TEXT);
+        assertField(fields, 10, "[269,-313]", DataType.TEXT);
+        assertField(fields, 11, "[\"Hello\",\"World\"]", DataType.TEXT);
+        assertField(fields, 12, "[\"foo\",\"bar\"]", DataType.TEXT); // 3 chars only
+        Base64.Encoder encoder = Base64.getEncoder(); // byte arrays are Base64 encoded into strings
+        String expectedByteArrays = "[\"" + encoder.encodeToString(byteArray1) + "\",\"" + encoder.encodeToString(byteArray2) + "\"]";
+        assertField(fields, 13, expectedByteArrays, DataType.TEXT);
+    }
+
+    @Test
+    public void testGetFields_Primitive_RepeatedInt() throws IOException {
+        List<Type> columns = new ArrayList<>();
+        columns.add(new PrimitiveType(Type.Repetition.REPEATED, PrimitiveTypeName.INT32, "repeatedInt"));
+        schema = new MessageType("TestProtobuf.RepeatedIntMessage", columns);
+        context.setMetadata(schema);
+        context.setTupleDescription(getColumnDescriptorsFromSchema(schema));
+        resolver.initialize(context);
+
+        List<Group> groups = readParquetFile("old-repeated-int.parquet", 1, schema);
+        List<OneField> fields = assertRow(groups, 0, 1);
+        assertEquals(DataType.TEXT.getOID(), fields.get(0).type);
+        assertEquals("[1,2,3]", fields.get(0).val);
+
+    }
+
+    private List<OneField> assertRow(List<Group> groups, int desiredRow, int numFields) {
+        OneRow row = new OneRow(groups.get(desiredRow)); // get row
+        List<OneField> fields = resolver.getFields(row);
+        assertEquals(numFields, fields.size());
+        return fields;
+    }
+
+    private void assertField(List<OneField> fields, int index, Object value, DataType type) {
+        assertEquals(type.getOID(), fields.get(index).type);
+        if (type == DataType.BYTEA) {
+            assertArrayEquals((byte[]) value, (byte[]) fields.get(index).val);
+        } else {
+            assertEquals(value, fields.get(index).val);
+        }
+
+    }
+
+    private MessageType getParquetSchemaForPrimitiveTypes(Type.Repetition repetition, boolean readCase) {
+        List<Type> fields = new ArrayList<>();
+
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "s1", OriginalType.UTF8));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "s2", OriginalType.UTF8));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "n1", null));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.DOUBLE, "d1", null));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, 16, "dc1", OriginalType.DECIMAL, new DecimalMetadata(38, 18), null));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT96, "tm", null));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.FLOAT, "f", null));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT64, "bg", null));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BOOLEAN, "b", null));
+
+        // GPDB only has int16 and not int8 type, so for write tiny numbers int8 are still treated as shorts in16
+        OriginalType tinyType = readCase ? OriginalType.INT_8 : OriginalType.INT_16;
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "tn", tinyType));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.INT32, "sml", OriginalType.INT_16));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "vc1", OriginalType.UTF8));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "c1", OriginalType.UTF8));
+        fields.add(new PrimitiveType(repetition, PrimitiveTypeName.BINARY, "bin", null));
+
+        return new MessageType("hive_schema", fields);
+    }
+
+    private List<Group> readParquetFile(String file, long expectedSize, MessageType schema) throws IOException {
+        List<Group> result = new ArrayList<>();
+        String parquetFile = Objects.requireNonNull(getClass().getClassLoader().getResource("parquet/" + file)).getPath();
+        Path path = new Path(parquetFile);
+
+        //noinspection deprecation
+        ParquetFileReader fileReader = new ParquetFileReader(new Configuration(), path, ParquetMetadataConverter.NO_FILTER);
+        PageReadStore rowGroup;
+        while ((rowGroup = fileReader.readNextRowGroup()) != null) {
+            MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
+            RecordReader<Group> recordReader = columnIO.getRecordReader(rowGroup, new GroupRecordConverter(schema));
+            long rowCount = rowGroup.getRowCount();
+            for (long i = 0; i < rowCount; i++) {
+                result.add(recordReader.read());
+            }
+        }
+        fileReader.close();
+        assertEquals(expectedSize, result.size());
+        return result;
+    }
+
+    private List<ColumnDescriptor> getColumnDescriptorsFromSchema(MessageType schema) {
+        return schema.getFields()
+                .stream()
+                .map(f -> new ColumnDescriptor(f.getName(), -1, 1, "", new Integer[]{}))
+                .collect(Collectors.toList());
+    }
+
+    private MessageType buildReadSchema(MessageType originalSchema) {
+        List<Type> originalFields = originalSchema.getFields();
+        List<Type> projectedFields = new ArrayList<>();
+        for (int i = 0; i < context.getTupleDescription().size(); i++) {
+            if (context.getTupleDescription().get(i).isProjected()) {
+                projectedFields.add(originalFields.get(i));
+            }
+        }
+        return new MessageType(originalSchema.getName(), projectedFields);
+    }
+}

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetTypeConverterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetTypeConverterTest.java
@@ -42,4 +42,13 @@ public class ParquetTypeConverterTest {
         ParquetTypeConverter.getBinaryFromTimestamp(timestamp);
     }
 
+    @Test
+    public void testBinaryWithNanos() {
+        String expected = "2019-03-14 20:52:48.123456";
+        byte[] source = new byte[]{0, 106, 9, 53, -76, 12, 0, 0, -66, -125, 37, 0}; // represents 2019-03-14 20:52:48.1234567
+        String timestamp = ParquetTypeConverter.bytesToTimestamp(source); // nanos get dropped
+
+        assertEquals(expected, timestamp);
+    }
+
 }

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetTypeConverterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetTypeConverterTest.java
@@ -1,0 +1,45 @@
+package org.greenplum.pxf.plugins.hdfs;
+
+import org.apache.parquet.io.api.Binary;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.format.DateTimeParseException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ParquetTypeConverterTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testStringConversionRoundTrip() {
+        String timestamp = "2019-03-14 20:52:48.123456";
+        Binary binary = ParquetTypeConverter.getBinaryFromTimestamp(timestamp);
+        String convertedTimestamp = ParquetTypeConverter.bytesToTimestamp(binary.getBytes());
+
+        assertEquals(timestamp, convertedTimestamp);
+    }
+
+    @Test
+    public void testBinaryConversionRoundTrip() {
+        // 2019-03-14 21:22:05.987654
+        byte[] source = new byte[]{112, 105, -24, 125, 77, 14, 0, 0, -66, -125, 37, 0};
+        String timestamp = ParquetTypeConverter.bytesToTimestamp(source);
+        Binary binary = ParquetTypeConverter.getBinaryFromTimestamp(timestamp);
+
+        assertArrayEquals(source, binary.getBytes());
+    }
+
+    @Test
+    public void testUnsupportedNanoSeconds() {
+        thrown.expect(DateTimeParseException.class);
+        thrown.expectMessage("Text '2019-03-14 20:52:48.1234567' could not be parsed, unparsed text found at index 26");
+        String timestamp = "2019-03-14 20:52:48.1234567";
+        ParquetTypeConverter.getBinaryFromTimestamp(timestamp);
+    }
+
+}

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetTypeConverterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetTypeConverterTest.java
@@ -5,6 +5,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -44,10 +47,12 @@ public class ParquetTypeConverterTest {
 
     @Test
     public void testBinaryWithNanos() {
-        String expected = "2019-03-14 20:52:48.123456";
+        Instant instant = Instant.parse("2019-03-15T03:52:48.123456Z"); // UTC
+        ZonedDateTime localTime = instant.atZone(ZoneId.systemDefault());
+        String expected = localTime.format(ParquetTypeConverter.DATE_FORMATTER); // should be "2019-03-14 20:52:48.123456" in PST
+
         byte[] source = new byte[]{0, 106, 9, 53, -76, 12, 0, 0, -66, -125, 37, 0}; // represents 2019-03-14 20:52:48.1234567
         String timestamp = ParquetTypeConverter.bytesToTimestamp(source); // nanos get dropped
-
         assertEquals(expected, timestamp);
     }
 

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
@@ -464,7 +464,7 @@ public abstract class PxfUnit {
 
         List<String> output = new ArrayList<String>();
 
-        OneRow row = null;
+        OneRow row;
         while ((row = accessor.readNextObject()) != null) {
 
             StringBuilder bldr = new StringBuilder();


### PR DESCRIPTION
- Enable column projection for the parquet profile.
- Allows for greenplum schema and parquet schema to be in different order (but names need to match).
- Supports parquet schemas with mixed case i.e. two columns with the same name in different case "column" and "CoLuMn"
- Supports a subset of columns in the target schema