### PR TITLE
LICENSE: Remove reference to hadoop binaries dependencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -208,20 +208,3 @@ Apache License, Version 2.0 (ALv2).
     Apache Tomcat 7.0.62
 
 =======================================================================
-
-PXF runtime dependent subcomponents:
-
-  PXF is an extensible framework that allows HAWQ to query external data
-  files, whose metadata is not managed by HAWQ. PXF includes built-in
-  connectors for accessing data that exists inside HDFS files, Hive
-  tables, HBase tables and more. Users can also create their own
-  connectors to other data storages or processing engines. To create
-  these connectors using JAVA plugins, see the PXF API and Reference
-  Guide online.
-
-  The convenience binaries require the following hadoop components are
-  higher:
-
-    hadoop: 2.7.1
-    hadoop-hdfs: 2.7.1
-    hadoop-mapreduce: 2.7.1


### PR DESCRIPTION
Since we are bundling the libraries, we no longer require the jars
described in the LICENSE file