### PR TITLE
Support optional MASTER_HOSTNAME env var

### DIFF
--- a/cli/go/src/pxf-cli/Makefile
+++ b/cli/go/src/pxf-cli/Makefile
@@ -44,7 +44,7 @@ install: build
 	cp ${GOPATH}/bin/pxf-cli ${PXF_HOME}/bin
 
 test: build
-	ginkgo pxf cmd end_to_end
+	ginkgo pxf cmd end_to_end operating
 
 clean:
 	go clean -i

--- a/cli/go/src/pxf-cli/cmd/cluster.go
+++ b/cli/go/src/pxf-cli/cmd/cluster.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"os"
+	"pxf-cli/operating"
 	"pxf-cli/pxf"
 	"strings"
 
@@ -89,7 +89,7 @@ func GenerateHostList(cluster *cluster.Cluster) (map[string]int, error) {
 	hostSegMap := make(map[string]int, 0)
 	for contentID, seg := range cluster.Segments {
 		if contentID == -1 {
-			master, _ := operating.System.Hostname()
+			master, _ := operating.SystemHostname()
 			if seg.Hostname != master {
 				return nil, errors.New("ERROR: pxf cluster commands should only be run from Greenplum master")
 			}

--- a/cli/go/src/pxf-cli/cmd/cluster_test.go
+++ b/cli/go/src/pxf-cli/cmd/cluster_test.go
@@ -2,9 +2,10 @@ package cmd_test
 
 import (
 	"fmt"
-	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"pxf-cli/cmd"
 	"pxf-cli/pxf"
+
+	"github.com/greenplum-db/gp-common-go-libs/operating"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	. "github.com/onsi/ginkgo"

--- a/cli/go/src/pxf-cli/operating/operating.go
+++ b/cli/go/src/pxf-cli/operating/operating.go
@@ -1,0 +1,15 @@
+package operating
+
+import (
+	"os"
+
+	"github.com/greenplum-db/gp-common-go-libs/operating"
+)
+
+func SystemHostname() (string, error) {
+	masterHostname := os.Getenv("PXF_MASTER_HOSTNAME")
+	if masterHostname != "" {
+		return masterHostname, nil
+	}
+	return operating.System.Hostname()
+}

--- a/cli/go/src/pxf-cli/operating/operating_suite_test.go
+++ b/cli/go/src/pxf-cli/operating/operating_suite_test.go
@@ -1,0 +1,13 @@
+package operating_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOperating(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operating Suite")
+}

--- a/cli/go/src/pxf-cli/operating/operating_test.go
+++ b/cli/go/src/pxf-cli/operating/operating_test.go
@@ -1,0 +1,46 @@
+package operating_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "pxf-cli/operating"
+
+	"github.com/greenplum-db/gp-common-go-libs/operating"
+)
+
+var _ = Describe("Operating", func() {
+	BeforeEach(func() {
+		operating.System.Hostname = func() (string, error) {
+			return "system_hostname", nil
+		}
+	})
+
+	Context("SystemHostname", func() {
+		Context("When PXF_MASTER_HOSTNAME env var is unset", func() {
+			It("Reports the system hostname", func() {
+				Expect(SystemHostname()).To(Equal("system_hostname"))
+			})
+		})
+
+		Context("When PXF_MASTER_HOSTNAME env var is set to empty string", func() {
+			BeforeEach(func() {
+				_ = os.Setenv("PXF_MASTER_HOSTNAME", "")
+			})
+			It("Reports the system hostname", func() {
+				Expect(SystemHostname()).To(Equal("system_hostname"))
+			})
+		})
+
+		Context("When PXF_MASTER_HOSTNAME env var is set to something", func() {
+			BeforeEach(func() {
+				_ = os.Setenv("PXF_MASTER_HOSTNAME", "my-real-hostname")
+			})
+			It("Reports the hostname from PXF_MASTER_HOSTNAME", func() {
+				Expect(SystemHostname()).To(Equal("my-real-hostname"))
+			})
+		})
+	})
+})

--- a/cli/go/src/pxf-cli/pxf/pxf.go
+++ b/cli/go/src/pxf-cli/pxf/pxf.go
@@ -2,8 +2,9 @@ package pxf
 
 import (
 	"errors"
-	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"os"
+
+	"pxf-cli/operating"
 )
 
 type CliInputs struct {
@@ -89,7 +90,7 @@ func RemoteCommandToRunOnSegments(command Command) (string, error) {
 	pxfCommand += inputs.Gphome + "/pxf/bin/pxf" + " " + string(inputs.Cmd)
 
 	if command == Sync {
-		hostname, _ := operating.System.Hostname()
+		hostname, _ := operating.SystemHostname()
 		pxfCommand += " " + hostname
 	}
 


### PR DESCRIPTION
This env var would override the hostname that the operating system
reports, for users who have, for example, an internal network/hostname
for GPDB and external network/hostname for other things. If the hostname
that the system reports is not known to the GPDB, the user can avoid
errors by setting `MASTER_HOSTNAME` to their GPDB-facing hostname.