### PR TITLE
pxf cluster: stop checking that hostname is master

### DIFF
--- a/cli/go/src/pxf-cli/cmd/cluster.go
+++ b/cli/go/src/pxf-cli/cmd/cluster.go
@@ -7,8 +7,6 @@ import (
 	"pxf-cli/pxf"
 	"strings"
 
-	"github.com/greenplum-db/gp-common-go-libs/operating"
-
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -92,18 +90,10 @@ func exitWithReturnCode(err error) {
 	os.Exit(0)
 }
 
-func (r *ClusterData) CountHostsAndValidateMaster() error {
+func (r *ClusterData) CountHostsExcludingMaster() error {
 	hostSegMap := make(map[string]int, 0)
-	master, err := operating.System.Hostname()
-	if err != nil {
-		return err
-	}
 	for contentID, seg := range r.Cluster.Segments {
 		if contentID == -1 {
-			if seg.Hostname != master {
-				r.NumHosts = -1
-				return errors.New("ERROR: pxf cluster commands should only be run from Greenplum master")
-			}
 			continue
 		}
 		hostSegMap[seg.Hostname]++
@@ -160,7 +150,7 @@ func doSetup() (*ClusterData, error) {
 	}
 	segConfigs := cluster.MustGetSegmentConfiguration(connectionPool)
 	clusterData := &ClusterData{Cluster: cluster.NewCluster(segConfigs), connectionPool: connectionPool}
-	err = clusterData.CountHostsAndValidateMaster()
+	err = clusterData.CountHostsExcludingMaster()
 	if err != nil {
 		gplog.Error(err.Error())
 		return nil, err

--- a/cli/go/src/pxf-cli/cmd/cluster_test.go
+++ b/cli/go/src/pxf-cli/cmd/cluster_test.go
@@ -25,22 +25,14 @@ var (
 	}
 )
 
-var _ = Describe("CountHostsAndValidateMaster()", func() {
+var _ = Describe("CountHostsExcludingMaster()", func() {
 	It("calculates the correct number of hosts when run from master", func() {
 		operating.System.Hostname = func() (string, error) {
 			return "mdw", nil
 		}
-		err := clusterData.CountHostsAndValidateMaster()
+		err := clusterData.CountHostsExcludingMaster()
 		Expect(err).To(BeNil())
 		Expect(clusterData.NumHosts).To(Equal(2))
-	})
-	It("returns an error if not run from master host; number of hosts set to -1", func() {
-		operating.System.Hostname = func() (string, error) {
-			return "wrong-hostname", nil
-		}
-		err := clusterData.CountHostsAndValidateMaster()
-		Expect(err.Error()).To(Equal("ERROR: pxf cluster commands should only be run from Greenplum master"))
-		Expect(clusterData.NumHosts).To(Equal(-1))
 	})
 })
 


### PR DESCRIPTION
Checking that the user is running `pxf cluster` from master is helpful
for ensuring that the source of truth for PXF configs lives on master.
We don't want users doing cluster configuration from segment-only hosts.

However, this causes issues when the hostname reported by the OS doesn't
match what Greenplum knows about, so we are foregoing this check for
now.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>