### PR TITLE
pxf-cli: Support sync and init on standby master

### DIFF
--- a/cli/go/src/pxf-cli/cmd/cluster_test.go
+++ b/cli/go/src/pxf-cli/cmd/cluster_test.go
@@ -41,22 +41,22 @@ var _ = Describe("GenerateStatusReport()", func() {
 		clusterData.NumHosts = 2
 	})
 	It("reports the number of hosts that will be initialized", func() {
-		_ = cmd.GenerateStatusReport(&pxf.Init, clusterData)
-		Expect(testStdout).Should(gbytes.Say("Initializing PXF on master and 2 segment hosts..."))
+		_ = cmd.GenerateStatusReport(&pxf.InitCommand, clusterData)
+		Expect(testStdout).Should(gbytes.Say("Initializing PXF on master and 2 other hosts..."))
 	})
 
 	It("reports the number of hosts that will be started", func() {
-		_ = cmd.GenerateStatusReport(&pxf.Start, clusterData)
+		_ = cmd.GenerateStatusReport(&pxf.StartCommand, clusterData)
 		Expect(testStdout).Should(gbytes.Say("Starting PXF on 2 segment hosts..."))
 	})
 
 	It("reports the number of hosts that will be stopped", func() {
-		_ = cmd.GenerateStatusReport(&pxf.Stop, clusterData)
+		_ = cmd.GenerateStatusReport(&pxf.StopCommand, clusterData)
 		Expect(testStdout).Should(gbytes.Say("Stopping PXF on 2 segment hosts..."))
 	})
 
 	It("reports the number of hosts that will be synced", func() {
-		_ = cmd.GenerateStatusReport(&pxf.Sync, clusterData)
+		_ = cmd.GenerateStatusReport(&pxf.SyncCommand, clusterData)
 		Expect(testStdout).Should(gbytes.Say("Syncing PXF configuration files to 2 hosts..."))
 	})
 })
@@ -72,22 +72,22 @@ var _ = Describe("GenerateOutput()", func() {
 	})
 	Context("when all hosts are successful", func() {
 		It("reports all hosts initialized successfully", func() {
-			_ = cmd.GenerateOutput(&pxf.Init, clusterData)
+			_ = cmd.GenerateOutput(&pxf.InitCommand, clusterData)
 			Expect(testStdout).To(gbytes.Say("PXF initialized successfully on 3 out of 3 hosts"))
 		})
 
 		It("reports all hosts started successfully", func() {
-			_ = cmd.GenerateOutput(&pxf.Start, clusterData)
+			_ = cmd.GenerateOutput(&pxf.StartCommand, clusterData)
 			Expect(testStdout).To(gbytes.Say("PXF started successfully on 3 out of 3 hosts"))
 		})
 
 		It("reports all hosts stopped successfully", func() {
-			_ = cmd.GenerateOutput(&pxf.Stop, clusterData)
+			_ = cmd.GenerateOutput(&pxf.StopCommand, clusterData)
 			Expect(testStdout).To(gbytes.Say("PXF stopped successfully on 3 out of 3 hosts"))
 		})
 
 		It("reports all hosts synced successfully", func() {
-			_ = cmd.GenerateOutput(&pxf.Sync, clusterData)
+			_ = cmd.GenerateOutput(&pxf.SyncCommand, clusterData)
 			Expect(testStdout).To(gbytes.Say("PXF configs synced successfully on 3 out of 3 hosts"))
 		})
 	})
@@ -102,26 +102,26 @@ var _ = Describe("GenerateOutput()", func() {
 			}
 		})
 		It("reports the number of hosts that failed to initialize", func() {
-			_ = cmd.GenerateOutput(&pxf.Init, clusterData)
+			_ = cmd.GenerateOutput(&pxf.InitCommand, clusterData)
 			Expect(testStdout).Should(gbytes.Say("PXF failed to initialize on 1 out of 3 hosts"))
 			Expect(testStderr).Should(gbytes.Say("sdw2 ==> an error happened on sdw2"))
 		})
 
 		It("reports the number of hosts that failed to start", func() {
-			_ = cmd.GenerateOutput(&pxf.Start, clusterData)
+			_ = cmd.GenerateOutput(&pxf.StartCommand, clusterData)
 			Expect(testStdout).Should(gbytes.Say("PXF failed to start on 1 out of 3 hosts"))
 			Expect(testStderr).Should(gbytes.Say("sdw2 ==> an error happened on sdw2"))
 		})
 
 		It("reports the number of hosts that failed to stop", func() {
-			_ = cmd.GenerateOutput(&pxf.Stop, clusterData)
+			_ = cmd.GenerateOutput(&pxf.StopCommand, clusterData)
 			Expect(testStdout).Should(gbytes.Say("PXF failed to stop on 1 out of 3 hosts"))
 			Expect(testStderr).Should(gbytes.Say("sdw2 ==> an error happened on sdw2"))
 
 		})
 
 		It("reports the number of hosts that failed to sync", func() {
-			_ = cmd.GenerateOutput(&pxf.Sync, clusterData)
+			_ = cmd.GenerateOutput(&pxf.SyncCommand, clusterData)
 			Expect(testStdout).Should(gbytes.Say("PXF configs failed to sync on 1 out of 3 hosts"))
 			Expect(testStderr).Should(gbytes.Say("sdw2 ==> an error happened on sdw2"))
 
@@ -136,7 +136,7 @@ var _ = Describe("GenerateOutput()", func() {
 				Stdouts:   map[int]string{-1: "typical stdout", 0: "typical stdout", 1: "typical stdout"},
 				Errors:    map[int]error{-1: nil, 0: nil, 1: nil},
 			}
-			_ = cmd.GenerateOutput(&pxf.Stop, clusterData)
+			_ = cmd.GenerateOutput(&pxf.StopCommand, clusterData)
 			Expect(testStdout).To(gbytes.Say("PXF stopped successfully on 3 out of 3 hosts"))
 		})
 	})
@@ -152,7 +152,7 @@ stderr line three`
 				Stdouts:   map[int]string{-1: "everything fine", 0: "everything fine", 1: "everything not fine"},
 				Errors:    map[int]error{-1: nil, 0: nil, 1: errors.New("some error")},
 			}
-			_ = cmd.GenerateOutput(&pxf.Stop, clusterData)
+			_ = cmd.GenerateOutput(&pxf.StopCommand, clusterData)
 			Expect(testStdout).Should(gbytes.Say(fmt.Sprintf("PXF failed to stop on 1 out of 3 hosts")))
 			Expect(testStderr).Should(gbytes.Say("sdw2 ==> stderr line one\nstderr line two..."))
 		})
@@ -166,7 +166,7 @@ stderr line three`
 				Stdouts:   map[int]string{-1: "everything fine", 0: "everything fine", 1: "something wrong on sdw2\nstderr line2\nstderr line3"},
 				Errors:    map[int]error{-1: nil, 0: nil, 1: errors.New("some error")},
 			}
-			_ = cmd.GenerateOutput(&pxf.Stop, clusterData)
+			_ = cmd.GenerateOutput(&pxf.StopCommand, clusterData)
 			Expect(testStdout).Should(gbytes.Say("PXF failed to stop on 1 out of 3 hosts"))
 			Expect(testStderr).Should(gbytes.Say("sdw2 ==> something wrong on sdw2\nstderr line2..."))
 		})

--- a/cli/go/src/pxf-cli/pxf/pxf.go
+++ b/cli/go/src/pxf-cli/pxf/pxf.go
@@ -30,6 +30,10 @@ type Command struct {
 	envVars     []EnvVar
 }
 
+func (c *Command) Name() string {
+	return c.commandName
+}
+
 func (c *Command) requiredEnvVars() []EnvVar {
 	return c.envVars
 }
@@ -69,19 +73,28 @@ func (c *Command) GetFunctionToExecute() (func(string) string, error) {
 	}
 }
 
+type CommandName string
+
+const (
+	Init  = "init"
+	Start = "start"
+	Stop  = "stop"
+	Sync  = "sync"
+)
+
 var (
-	Init = Command{
-		commandName: "init",
+	InitCommand = Command{
+		commandName: Init,
 		messages: map[MessageType]string{
 			Success: "PXF initialized successfully on %d out of %d hosts\n",
-			Status:  "Initializing PXF on master and %d segment hosts...\n",
+			Status:  "Initializing PXF on master and %d other hosts...\n",
 			Error:   "PXF failed to initialize on %d out of %d hosts\n",
 		},
 		envVars:    []EnvVar{Gphome, PxfConf},
 		whereToRun: cluster.ON_HOSTS_AND_MASTER,
 	}
-	Start = Command{
-		commandName: "start",
+	StartCommand = Command{
+		commandName: Start,
 		messages: map[MessageType]string{
 			Success: "PXF started successfully on %d out of %d hosts\n",
 			Status:  "Starting PXF on %d segment hosts...\n",
@@ -90,8 +103,8 @@ var (
 		envVars:    []EnvVar{Gphome},
 		whereToRun: cluster.ON_HOSTS,
 	}
-	Stop = Command{
-		commandName: "stop",
+	StopCommand = Command{
+		commandName: Stop,
 		messages: map[MessageType]string{
 			Success: "PXF stopped successfully on %d out of %d hosts\n",
 			Status:  "Stopping PXF on %d segment hosts...\n",
@@ -100,8 +113,8 @@ var (
 		envVars:    []EnvVar{Gphome},
 		whereToRun: cluster.ON_HOSTS,
 	}
-	Sync = Command{
-		commandName: "sync",
+	SyncCommand = Command{
+		commandName: Sync,
 		messages: map[MessageType]string{
 			Success: "PXF configs synced successfully on %d out of %d hosts\n",
 			Status:  "Syncing PXF configuration files to %d hosts...\n",

--- a/cli/go/src/pxf-cli/pxf/pxf_test.go
+++ b/cli/go/src/pxf-cli/pxf/pxf_test.go
@@ -17,7 +17,7 @@ var _ = Describe("CommandFunc", func() {
 		})
 
 		It("successfully generates init command", func() {
-			commandFunc, err := pxf.Init.GetFunctionToExecute()
+			commandFunc, err := pxf.InitCommand.GetFunctionToExecute()
 			Expect(err).To(BeNil())
 			expected := "PXF_CONF=/test/gphome/pxf_conf /test/gphome/pxf/bin/pxf init"
 			Expect(commandFunc("foo")).To(Equal(expected))
@@ -31,18 +31,18 @@ var _ = Describe("CommandFunc", func() {
 		})
 
 		It("successfully generates start and stop commands", func() {
-			commandFunc, err := pxf.Start.GetFunctionToExecute()
+			commandFunc, err := pxf.StartCommand.GetFunctionToExecute()
 			Expect(err).To(BeNil())
 			Expect(commandFunc("foo")).To(Equal("/test/gphome/pxf/bin/pxf start"))
-			commandFunc, err = pxf.Stop.GetFunctionToExecute()
+			commandFunc, err = pxf.StopCommand.GetFunctionToExecute()
 			Expect(err).To(BeNil())
 			Expect(commandFunc("foo")).To(Equal("/test/gphome/pxf/bin/pxf stop"))
 		})
 		It("fails to init or sync", func() {
-			commandFunc, err := pxf.Init.GetFunctionToExecute()
+			commandFunc, err := pxf.InitCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("PXF_CONF must be set")))
-			commandFunc, err = pxf.Sync.GetFunctionToExecute()
+			commandFunc, err = pxf.SyncCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("PXF_CONF must be set")))
 		})
@@ -55,7 +55,7 @@ var _ = Describe("CommandFunc", func() {
 		})
 
 		It("sets up rsync commands of $PXF_CONF/{conf,lib,servers} dirs", func() {
-			commandFunc, err := pxf.Sync.GetFunctionToExecute()
+			commandFunc, err := pxf.SyncCommand.GetFunctionToExecute()
 			Expect(err).To(BeNil())
 			Expect(commandFunc("sdw1")).To(Equal(
 				"rsync -az -e 'ssh -o StrictHostKeyChecking=no' " +
@@ -74,13 +74,13 @@ var _ = Describe("CommandFunc", func() {
 		})
 
 		It("fails to init, start, or stop", func() {
-			commandFunc, err := pxf.Init.GetFunctionToExecute()
+			commandFunc, err := pxf.InitCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME must be set")))
-			commandFunc, err = pxf.Start.GetFunctionToExecute()
+			commandFunc, err = pxf.StartCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME must be set")))
-			commandFunc, err = pxf.Stop.GetFunctionToExecute()
+			commandFunc, err = pxf.StopCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME must be set")))
 		})
@@ -93,10 +93,10 @@ var _ = Describe("CommandFunc", func() {
 		})
 		It("fails to init or sync", func() {
 			_ = os.Setenv("PXF_CONF", "")
-			commandFunc, err := pxf.Init.GetFunctionToExecute()
+			commandFunc, err := pxf.InitCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("PXF_CONF cannot be blank")))
-			commandFunc, err = pxf.Sync.GetFunctionToExecute()
+			commandFunc, err = pxf.SyncCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("PXF_CONF cannot be blank")))
 		})
@@ -109,13 +109,13 @@ var _ = Describe("CommandFunc", func() {
 		})
 		It("fails to init, start, or stop", func() {
 			_ = os.Setenv("GPHOME", "")
-			commandFunc, err := pxf.Init.GetFunctionToExecute()
+			commandFunc, err := pxf.InitCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME cannot be blank")))
-			commandFunc, err = pxf.Start.GetFunctionToExecute()
+			commandFunc, err = pxf.StartCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME cannot be blank")))
-			commandFunc, err = pxf.Stop.GetFunctionToExecute()
+			commandFunc, err = pxf.StopCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME cannot be blank")))
 		})


### PR DESCRIPTION
This is a temporary solution until [this issue on `gp-common-go-libs` is
addressed](https://github.com/greenplum-db/gp-common-go-libs/issues/38).

This issue would allow us to add standby/mirrors to the hosts we
want to execute on. Instead, in this commit, we are using a direct query
to the database to find out standby master (`contentID`: -1, not primary).
With the standby, we add it to our list of segments early in execution,
but only if we are doing sync or init.

This change also includes adding the ability to add extra nodes in the
perf pipeline.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>