### PR TITLE
test_pxf: Run sshd directly w/out `service`

### DIFF
--- a/concourse/scripts/install_hadoop.bash
+++ b/concourse/scripts/install_hadoop.bash
@@ -9,7 +9,6 @@ SSH_OPTS="-i cluster_env_files/private_key.pem"
 GPHD_ROOT="/singlecluster"
 
 function install_hadoop_single_cluster() {
-
     local hadoop_ip=${1}
     ssh ${SSH_OPTS} centos@edw0 "sudo mkdir -p /root/.ssh &&
         sudo cp /home/centos/.ssh/authorized_keys /root/.ssh &&

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -67,7 +67,8 @@ function install_gpdb_binary() {
 	fi
 
 	if [[ ${TARGET_OS} == "centos" ]]; then
-		service sshd start
+		# We can't use service sshd restart as service is not installed on CentOS 7.
+		/usr/sbin/sshd &
 		psi_dir=$(find /usr/lib64 -name psi | sort -r | head -1)
 	elif [[ ${TARGET_OS} == "ubuntu" ]]; then
         # Adjust GPHOME if the binary expects it to be /usr/local/gpdb

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -87,6 +87,10 @@ function setup_hadoop() {
 }
 
 function _main() {
+	# kill the sshd background process when this script exits. Otherwise, the
+	# concourse build will run forever.
+	trap "pkill sshd" EXIT
+
 	if [[ ${PROTOCOL} == "s3" ]]; then
 		echo Using S3 protocol
 	elif [[ ${PROTOCOL} == "minio" ]]; then
@@ -101,6 +105,9 @@ EOF
 		# start mapr services before installing GPDB
 		/root/init-script
 	fi
+
+	# Ping is called by gpinitsystem, which must be run by gpadmin
+	chmod u+s /bin/ping
 
 	# Install GPDB
 	install_gpdb_binary

--- a/concourse/tasks/test_pxf.yml
+++ b/concourse/tasks/test_pxf.yml
@@ -12,7 +12,7 @@ params:
   HADOOP_CLIENT: HDP
   GROUP: smoke
   TARGET_OS: centos
-  TARGET_OS_VERSION: 6
+  TARGET_OS_VERSION:
   TEST_ENV:
 run:
   path: pxf_src/concourse/scripts/test_pxf.bash


### PR DESCRIPTION
CentOS 7 moved to systemd and so to have a solution that works for both
CentOS 6 and 7, it's best to just start sshd directly.

Also:
* Kill sshd when the test script exits to keep concourse from
hanging
* Allow gpadmin to run ping on CentOS 6/7 by giving ping the `setuid`
flag
* Stop providing TARGET_OS_VERSION default in the task file, since this
should come from outside the task (pipeline, etc.)

Co-authored-by: Ben Christel <bchristel@pivotal.io>
Co-authored-by: Sambitesh Dash <sdash@pivotal.io>
Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
Co-authored-by: Oliver Albertini <oalbertini@pivotal.io>