### PR TITLE
Hive partition filtering with support for all Logical Operators

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveBaseTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveBaseTest.java
@@ -87,6 +87,11 @@ public class HiveBaseTest extends BaseFeature {
             "num1  INT",
             "d1    DOUBLE"
     };
+    // Hive Table columns for Predicate pushdown test on partitioned hive table
+    static final String[] HIVE_SMALLDATA_PPD_COLS = {
+            "s1    STRING",
+            "d1    DOUBLE",
+    };
     static final String[] PXF_HIVE_SMALLDATA_COLS = {
             "t1    TEXT",
             "t2    TEXT",
@@ -107,6 +112,13 @@ public class HiveBaseTest extends BaseFeature {
             "dub1  DOUBLE PRECISION",
             "fmt   TEXT",
             "prt   TEXT"
+    };
+    // PXF Table columns for Predicate pushdown test on partitioned hive table
+    static final String[] PXF_HIVE_SMALLDATA_PPD_COLS = {
+            "s1    TEXT",
+            "d1    DOUBLE PRECISION",
+            "s2    TEXT",
+            "n1  INTEGER"
     };
     static final String[] PXF_HIVE_COLLECTION_COLS = {
             "t1    TEXT",
@@ -134,6 +146,11 @@ public class HiveBaseTest extends BaseFeature {
             "fmt   STRING",
             "prt   STRING"
     };
+    // Hive table partition columns for Predicate pushdown test
+    static final String[] HIVE_PARTITION_PPD_COLS = {
+            "s2     STRING",
+            "n1   INT"
+    };
 
     static final String HIVE_TYPES_DATA_FILE_NAME = "hive_types.txt";
     static final String HIVE_COLLECTIONS_FILE_NAME = "hive_collections.txt";
@@ -153,11 +170,13 @@ public class HiveBaseTest extends BaseFeature {
     static final String HIVE_PARQUET_TABLE = "hive_parquet_table";
     static final String HIVE_SEQUENCE_TABLE = "hive_sequence_table";
     static final String HIVE_PARTITIONED_TABLE = "hive_partitioned_table";
+    static final String HIVE_PARTITIONED_PPD_TABLE = "hive_partitioned_ppd_table";
     static final String HIVE_REG_HETEROGEN_TABLE = "reg_heterogen";
     static final String PXF_HIVE_SMALL_DATA_TABLE = "pxf_hive_small_data";
     static final String PXF_HIVE_COLLECTIONS_TABLE = "pxf_hive_collections";
     static final String PXF_HIVE_BINARY_TABLE = "pxf_hive_binary";
     static final String PXF_HIVE_PARTITIONED_TABLE = "pxf_hive_partitioned_table";
+    static final String PXF_HIVE_PARTITIONED_PPD_TABLE = "pxf_hive_partitioned_ppd_table";
     static final String PXF_HIVE_TEXT_TABLE = "pxf_hive_text";
     static final String PXF_HIVE_ORC_TABLE = "pxf_hive_orc_types";
     static final String PXF_HIVE_ORC_ZLIB_TABLE = "pxf_hive_orc_zlib";

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table/expected/query01.ans
@@ -1,0 +1,123 @@
+-- start_ignore
+-- end_ignore
+-- @description query01 for PXF Hive partitioned table with predicate pushdown tests cases for logical operators
+--
+-- Terminology
+-- P stands for predicates conforming with hive partition filtering
+-- NP stands for predicates not conforming with hive partition filtering
+--
+-- (P1 AND P2) OR (P3 AND P4)
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=4 AND s2='s_9') OR (n1=1 AND s2='s_6') ORDER BY n1, s2;
+  s1  | d1 | s2  | n1
+------+----+-----+----
+ row1 |  6 | s_6 |  1
+ row4 |  9 | s_9 |  4
+(2 rows)
+
+-- (P1 AND P2) OR .... total of 10 times spanning all partitions
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=1 AND s2='s_6') OR (n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') ORDER BY n1, s2;
+  s1   | d1 |  s2  | n1
+-------+----+------+----
+ row1  |  6 | s_6  |  1
+ row2  |  7 | s_7  |  2
+ row3  |  8 | s_8  |  3
+ row4  |  9 | s_9  |  4
+ row5  | 10 | s_10 |  5
+ row6  | 11 | s_11 |  6
+ row7  | 12 | s_12 |  7
+ row8  | 13 | s_13 |  8
+ row9  | 14 | s_14 |  9
+ row10 | 15 | s_15 | 10
+(10 rows)
+
+-- (P1 AND P2) UNION ALL (P3 AND P4)...
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=1 AND s2='s_6') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=2 AND s2='s_7') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=3 AND s2='s_8') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=4 AND s2='s_9') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=5 AND s2='s_10') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=7 AND s2='s_12') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=6 AND s2='s_11') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=8 AND s2='s_13') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=9 AND s2='s_14') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=10 AND s2='s_15') ORDER BY n1, s2;
+  s1   | d1 |  s2  | n1
+-------+----+------+----
+ row1  |  6 | s_6  |  1
+ row2  |  7 | s_7  |  2
+ row3  |  8 | s_8  |  3
+ row4  |  9 | s_9  |  4
+ row5  | 10 | s_10 |  5
+ row6  | 11 | s_11 |  6
+ row7  | 12 | s_12 |  7
+ row8  | 13 | s_13 |  8
+ row9  | 14 | s_14 |  9
+ row10 | 15 | s_15 | 10
+(10 rows)
+
+-- (P1 AND P2) AND NP
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=4 AND s2='s_9') AND (s1='row1') ORDER BY n1, s2;
+ s1 | d1 | s2 | n1
+----+----+----+----
+(0 rows)
+
+-- (P1 AND P2) OR NP
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=4 AND s2='s_9') OR (s1='row1') ORDER BY n1, s2;
+  s1  | d1 | s2  | n1
+------+----+-----+----
+ row1 |  6 | s_6 |  1
+ row4 |  9 | s_9 |  4
+(2 rows)
+
+-- Test for NOT operator
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (d1 >=9) AND NOT(n1=4 AND s2='s_9') ORDER BY n1,s2;
+  s1   | d1 |  s2  | n1
+-------+----+------+----
+ row5  | 10 | s_10 |  5
+ row6  | 11 | s_11 |  6
+ row7  | 12 | s_12 |  7
+ row8  | 13 | s_13 |  8
+ row9  | 14 | s_14 |  9
+ row10 | 15 | s_15 | 10
+(6 rows)
+
+-- Test for !=
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1!=4 AND s2!='s_9') ORDER BY n1, s2;
+  s1   | d1 |  s2  | n1
+-------+----+------+----
+ row1  |  6 | s_6  |  1
+ row2  |  7 | s_7  |  2
+ row3  |  8 | s_8  |  3
+ row5  | 10 | s_10 |  5
+ row6  | 11 | s_11 |  6
+ row7  | 12 | s_12 |  7
+ row8  | 13 | s_13 |  8
+ row9  | 14 | s_14 |  9
+ row10 | 15 | s_15 | 10
+(9 rows)
+
+-- Test for max filters hitting all but one partition
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') ORDER BY n1, s2;
+  s1   | d1 |  s2  | n1
+-------+----+------+----
+ row2  |  7 | s_7  |  2
+ row3  |  8 | s_8  |  3
+ row4  |  9 | s_9  |  4
+ row5  | 10 | s_10 |  5
+ row6  | 11 | s_11 |  6
+ row7  | 12 | s_12 |  7
+ row8  | 13 | s_13 |  8
+ row9  | 14 | s_14 |  9
+ row10 | 15 | s_15 | 10
+(9 rows)
+

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLTestCase
+from mpp.models import SQLConcurrencyTestCase
+
+class PxfHivePartitionedTable(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table/sql/query01.sql
@@ -1,0 +1,43 @@
+-- @description query01 for PXF Hive partitioned table with predicate pushdown tests cases for logical operators
+--
+-- Terminology
+-- P stands for predicates conforming with hive partition filtering
+-- NP stands for predicates not conforming with hive partition filtering
+--
+-- (P1 AND P2) OR (P3 AND P4)
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=4 AND s2='s_9') OR (n1=1 AND s2='s_6') ORDER BY n1, s2;
+-- (P1 AND P2) OR .... total of 10 times spanning all partitions
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=1 AND s2='s_6') OR (n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') ORDER BY n1, s2;
+-- (P1 AND P2) UNION ALL (P3 AND P4)...
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=1 AND s2='s_6') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=2 AND s2='s_7') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=3 AND s2='s_8') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=4 AND s2='s_9') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=5 AND s2='s_10') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=7 AND s2='s_12') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=6 AND s2='s_11') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=8 AND s2='s_13') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=9 AND s2='s_14') UNION ALL
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=10 AND s2='s_15') ORDER BY n1, s2;
+
+-- (P1 AND P2) AND NP
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=4 AND s2='s_9') AND (s1='row1') ORDER BY n1, s2;
+-- (P1 AND P2) OR NP
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=4 AND s2='s_9') OR (s1='row1') ORDER BY n1, s2;
+-- Test for NOT operator
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (d1 >=9) AND NOT(n1=4 AND s2='s_9') ORDER BY n1,s2;
+-- Test for !=
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1!=4 AND s2!='s_9') ORDER BY n1, s2;
+
+-- Test for max filters hitting all but one partition
+SELECT * FROM pxf_hive_partitioned_ppd_table WHERE (n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') OR
+(n1=2 AND s2='s_7') OR (n1=3 AND s2='s_8') OR (n1=4 AND s2='s_9') OR (n1=5 AND s2='s_10') OR (n1=6 AND s2='s_11') OR (n1=7 AND s2='s_12') OR (n1=8 AND s2='s_13') OR (n1=9 AND s2='s_14') OR (n1=10 AND s2='s_15') ORDER BY n1, s2;

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/expected/query01.ans
@@ -1,0 +1,8 @@
+-- start_ignore
+-- end_ignore
+-- @description query01 for PXF Hive partitioned table with custom filters
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilters ORDER BY n1, s2;
+  s1  | d1 |  s2  | n1
+------+----+------+----
+ row9 | 14 | s_14 |  9
+(1 row)

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLTestCase
+from mpp.models import SQLConcurrencyTestCase
+
+class PxfHivePartitionedTable(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/sql/query01.sql
@@ -1,0 +1,3 @@
+-- @description query01 for PXF Hive partitioned table with custom filters
+
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilters ORDER BY n1, s2;

--- a/dev/configure_singlecluster.bash
+++ b/dev/configure_singlecluster.bash
@@ -181,5 +181,9 @@ EOF
 		<name>datanucleus.autoCreateTables</name>
 		<value>True</value>
 	</property>
+	<property>
+		<name>hive.metastore.integral.jdo.pushdown</name>
+		<value>True</value>
+	</property>
 </configuration>
 EOF

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
@@ -225,13 +225,8 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
             return true;
         }
 
-        if (filterInFragmenter) {
-            LOG.debug("filtering was done in fragmenter");
-            return true;
-        }
-
         String filterStr = context.getFilterString();
-        HiveFilterBuilder eval = new HiveFilterBuilder(context);
+        HiveFilterBuilder eval = new HiveFilterBuilder();
         Object filter = eval.getFilterObject(filterStr);
 
         boolean returnData = isFiltered(partitions, filter);

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenter.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenter.java
@@ -19,6 +19,7 @@ package org.greenplum.pxf.plugins.hive;
  * under the License.
  */
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -28,23 +29,18 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
-import org.greenplum.pxf.api.BasicFilter;
-import org.greenplum.pxf.api.FilterParser;
-import org.greenplum.pxf.api.LogicalFilter;
 import org.greenplum.pxf.api.model.BaseConfigurationFactory;
 import org.greenplum.pxf.api.model.ConfigurationFactory;
 import org.greenplum.pxf.api.model.Fragment;
 import org.greenplum.pxf.api.model.FragmentStats;
 import org.greenplum.pxf.api.model.Metadata;
 import org.greenplum.pxf.api.model.RequestContext;
-import org.greenplum.pxf.api.utilities.ColumnDescriptor;
 import org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter;
 import org.greenplum.pxf.plugins.hdfs.utilities.HdfsUtilities;
 import org.greenplum.pxf.plugins.hive.utilities.HiveUtilities;
@@ -52,8 +48,6 @@ import org.greenplum.pxf.plugins.hive.utilities.ProfileFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,15 +76,8 @@ public class HiveDataFragmenter extends HdfsDataFragmenter {
     public static final String HIVE_PARTITIONS_DELIM = "!HPAD!";
     public static final String HIVE_NO_PART_TBL = "!HNPT!";
 
-    private static final String HIVE_API_EQ = " = ";
-    private static final String HIVE_API_LT = " < ";
-    private static final String HIVE_API_GT = " > ";
-    private static final String HIVE_API_LTE = " <= ";
-    private static final String HIVE_API_GTE = " >= ";
-    private static final String HIVE_API_NE = " != ";
-    private static final String HIVE_API_DQUOTE = "\"";
-
     private HiveMetaStoreClient client;
+    private HiveFilterBuilder filterBuilder;
 
     protected boolean filterInFragmenter = false;
 
@@ -99,14 +86,14 @@ public class HiveDataFragmenter extends HdfsDataFragmenter {
     private Set<String> setPartitions = new TreeSet<String>(
             String.CASE_INSENSITIVE_ORDER);
     private Map<String, String> partitionkeyTypes = new HashMap<>();
-    private boolean canPushDownIntegral;
 
     public HiveDataFragmenter() {
-        this(BaseConfigurationFactory.getInstance());
+        this(BaseConfigurationFactory.getInstance(), new HiveFilterBuilder());
     }
 
-    HiveDataFragmenter(ConfigurationFactory configurationFactory) {
+    HiveDataFragmenter(ConfigurationFactory configurationFactory, HiveFilterBuilder filterBuilder) {
         this.configurationFactory = configurationFactory;
+        this.filterBuilder = filterBuilder;
     }
 
     @Override
@@ -115,8 +102,9 @@ public class HiveDataFragmenter extends HdfsDataFragmenter {
 
         client = HiveUtilities.initHiveClient(configuration);
         // canPushDownIntegral represents hive.metastore.integral.jdo.pushdown property in hive-site.xml
-        canPushDownIntegral = configuration.getBoolean(HiveConf.ConfVars.METASTORE_INTEGER_JDO_PUSHDOWN.varname,
-                false);
+        filterBuilder.setColumnDescriptors(requestContext.getTupleDescription());
+        filterBuilder.setCanPushdownIntegral(configuration.getBoolean(HiveConf.ConfVars.METASTORE_INTEGER_JDO_PUSHDOWN.varname,
+                false));
     }
 
     @Override
@@ -178,14 +166,14 @@ public class HiveDataFragmenter extends HdfsDataFragmenter {
                 partitionkeyTypes.put(fs.getName(), fs.getType());
             }
 
-            LOG.debug("setPartitions :" + setPartitions);
+            LOG.debug("setPartitions: {}", setPartitions);
 
-            // Generate filter string for retrieve match pxf filter/hive
-            // partition name
-            filterStringForHive = buildFilterStringForHive();
+            // Generate filter string for retrieve match pxf filter/hive partition name
+            filterBuilder.setPartitionKeys(partitionkeyTypes);
+            filterStringForHive = filterBuilder.buildFilterStringForHive(context.getFilterString());
         }
 
-        if (!filterStringForHive.isEmpty()) {
+        if (StringUtils.isNotBlank(filterStringForHive)) {
 
             LOG.debug("Filter String for Hive partition retrieval : "
                     + filterStringForHive);
@@ -319,155 +307,6 @@ public class HiveDataFragmenter extends HdfsDataFragmenter {
         }
     }
 
-    /*
-     * Build filter string for HiveMetaStoreClient.listPartitionsByFilter API
-     * method.
-     *
-     * The filter string parameter for
-     * HiveMetaStoreClient.listPartitionsByFilter will be created from the
-     * incoming getFragments filter string parameter. It will be in a format of:
-     * [PARTITON1 NAME] = \"[PARTITON1 VALUE]\" AND [PARTITON2 NAME] =
-     * \"[PARTITON2 VALUE]\" ... Filtering can be done only on string partition
-     * keys and AND operators.
-     *
-     * For Example for query: SELECT * FROM TABLE1 WHERE part1 = 'AAAA' AND
-     * part2 = '1111' For HIVE HiveMetaStoreClient.listPartitionsByFilter, the
-     * incoming GPDB filter string will be mapped into :
-     * "part1 = \"AAAA\" and part2 = \"1111\""
-     */
-    private String buildFilterStringForHive() throws Exception {
-
-        StringBuilder filtersString = new StringBuilder();
-        String filterInput = context.getFilterString();
-
-        if (LOG.isDebugEnabled()) {
-
-            for (ColumnDescriptor cd : context.getTupleDescription()) {
-                LOG.debug("ColumnDescriptor : " + cd);
-            }
-
-            LOG.debug("Filter string input : " + context.getFilterString());
-        }
-
-        HiveFilterBuilder eval = new HiveFilterBuilder(context);
-        Object filter = eval.getFilterObject(filterInput);
-
-        if (filter instanceof LogicalFilter) {
-            buildCompoundFilter((LogicalFilter) filter, filtersString);
-        } else {
-            buildSingleFilter(filter, filtersString, "");
-        }
-
-        return filtersString.toString();
-    }
-
-    private void buildCompoundFilter(LogicalFilter filter, StringBuilder filterString) throws Exception {
-        String prefix;
-        switch (filter.getOperator()) {
-            case HDOP_AND:
-                prefix = " and ";
-                break;
-            case HDOP_OR:
-                prefix = " or ";
-                break;
-            case HDOP_NOT:
-                prefix = " not ";
-                break;
-            default:
-                prefix = "";
-        }
-
-        for (Object f : filter.getFilterList()) {
-            if (f instanceof LogicalFilter) {
-                buildCompoundFilter((LogicalFilter) f, filterString);
-            } else {
-                buildSingleFilter(f, filterString, prefix);
-            }
-        }
-    }
-
-    /*
-     * Build filter string for a single filter and append to the filters string.
-     * Filter string shell be added if filter name match hive partition name
-     * Single filter will be in a format of: [PARTITON NAME] = \"[PARTITON
-     * VALUE]\"
-     */
-    private boolean buildSingleFilter(Object filter,
-                                      StringBuilder filtersString, String prefix)
-            throws Exception {
-
-        // Let's look first at the filter
-        BasicFilter bFilter = (BasicFilter) filter;
-
-        // Extract column name and value
-        int filterColumnIndex = bFilter.getColumn().index();
-        // Avoids NullPointerException in case of operations like HDOP_IS_NULL,
-        // HDOP_IS_NOT_NULL where no constant value is passed as part of query
-        String filterValue = bFilter.getConstant() != null ? bFilter.getConstant().constant().toString() : "";
-        ColumnDescriptor filterColumn = context.getColumn(filterColumnIndex);
-        String filterColumnName = filterColumn.columnName();
-        FilterParser.Operation operation = ((BasicFilter) filter).getOperation();
-        String colType = partitionkeyTypes.get(filterColumnName);
-        boolean isIntegralSupported =
-                canPushDownIntegral &&
-                        (operation == FilterParser.Operation.HDOP_EQ || operation == FilterParser.Operation.HDOP_NE);
-        // In case this filter is not a partition, we ignore this filter (no add
-        // to filter list)
-        if (!setPartitions.contains(filterColumnName)) {
-            LOG.debug("Filter name is not a partition , ignore this filter for hive: "
-                    + filter);
-            return false;
-        }
-
-        /*
-         * HAWQ-1527 - Filtering only supported for partition columns of type string or
-         * intgeral datatype. Integral datatypes include - TINYINT, SMALLINT, INT, BIGINT.
-         * Note that with integral data types only equals("=") and not equals("!=") operators
-         * are supported. There are no operator restrictions with String.
-         */
-        if (!colType.equalsIgnoreCase(serdeConstants.STRING_TYPE_NAME)
-                && (!isIntegralSupported || !serdeConstants.IntegralTypes.contains(colType))) {
-            LOG.debug("Column type is neither string nor an integral data type, ignore this filter for hive: "
-                    + filter);
-            return false;
-        }
-
-        if (filtersString.length() != 0)
-            filtersString.append(prefix);
-        filtersString.append(filterColumnName);
-
-        switch (operation) {
-            case HDOP_EQ:
-                filtersString.append(HIVE_API_EQ);
-                break;
-            case HDOP_LT:
-                filtersString.append(HIVE_API_LT);
-                break;
-            case HDOP_GT:
-                filtersString.append(HIVE_API_GT);
-                break;
-            case HDOP_LE:
-                filtersString.append(HIVE_API_LTE);
-                break;
-            case HDOP_GE:
-                filtersString.append(HIVE_API_GTE);
-                break;
-            case HDOP_NE:
-                filtersString.append(HIVE_API_NE);
-                break;
-            default:
-                // Set filter string to blank in case of unimplemented operations
-                filtersString.setLength(0);
-                return false;
-        }
-
-        filtersString.append(HIVE_API_DQUOTE);
-        filtersString.append(filterValue);
-        filtersString.append(HIVE_API_DQUOTE);
-
-        return true;
-    }
-
     /**
      * Returns statistics for Hive table. Currently it's not implemented.
      */
@@ -483,4 +322,5 @@ public class HiveDataFragmenter extends HdfsDataFragmenter {
         long firstFragmentSize = totalSize / split_count;
         return new FragmentStats(split_count, firstFragmentSize, totalSize);
     }
+
 }

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
@@ -143,11 +143,10 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
         String filterString;
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Filter string input : " + filterInput);
+            LOG.debug("Filter string input: {}", filterInput);
         }
 
-        HiveFilterBuilder eval = new HiveFilterBuilder();
-        Object filter = eval.getFilterObject(filterInput);
+        Object filter = new HiveFilterBuilder().getFilterObject(filterInput);
 
         if (filter instanceof LogicalFilter) {
             filterString = buildCompoundFilter((LogicalFilter) filter);
@@ -187,14 +186,14 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
                     filterString.append(logicalOperator);
                 }
                 filterString.append(serializedFilter);
-            } else if(filter.getOperator() == FilterParser.LogicalOperation.HDOP_OR) {
+            } else if (filter.getOperator() == FilterParser.LogicalOperation.HDOP_OR) {
                 // Case when one of the predicates is non-compliant and with OR operator
                 // P OR NP -> null
                 return null;
             }
         }
 
-        if(filterString.length() > 0) {
+        if (filterString.length() > 0) {
             return String.format("(%s)", filterString.toString());
         } else {
             return null;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
@@ -20,14 +20,18 @@ package org.greenplum.pxf.plugins.hive;
  */
 
 
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.greenplum.pxf.api.BasicFilter;
 import org.greenplum.pxf.api.FilterParser;
 import org.greenplum.pxf.api.LogicalFilter;
-import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Uses the filter parser code to build a filter object, either simple - a
@@ -38,16 +42,20 @@ import java.util.List;
  * partition filtering.
  */
 public class HiveFilterBuilder implements FilterParser.FilterBuilder {
-    private RequestContext requestContext;
 
-    /**
-     * Constructs a HiveFilterBuilder object.
-     *
-     * @param input input data containing filter string
-     */
-    public HiveFilterBuilder(RequestContext input) {
-        requestContext = input;
-    }
+    private static final Logger LOG = LoggerFactory.getLogger(HiveFilterBuilder.class);
+
+    private List<ColumnDescriptor> columnDescriptors;
+    private boolean canPushdownIntegral;
+    private Map<String, String> partitionKeys;
+
+    private static final String HIVE_API_EQ = " = ";
+    private static final String HIVE_API_LT = " < ";
+    private static final String HIVE_API_GT = " > ";
+    private static final String HIVE_API_LTE = " <= ";
+    private static final String HIVE_API_GTE = " >= ";
+    private static final String HIVE_API_NE = " != ";
+    private static final String HIVE_API_DQUOTE = "\"";
 
     /**
      * Translates a filterString into a {@link BasicFilter} or a
@@ -107,6 +115,177 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
     }
 
     /*
+     * Build filter string for HiveMetaStoreClient.listPartitionsByFilter API
+     * method.
+     *
+     * The filter string parameter for
+     * HiveMetaStoreClient.listPartitionsByFilter will be created from the
+     * incoming getFragments filter string parameter. It will be in a format of:
+     * [PARTITON1 NAME] = \"[PARTITON1 VALUE]\" AND [PARTITON2 NAME] =
+     * \"[PARTITON2 VALUE]\" ... Filtering can be done only on string partition
+     * keys. Integral partition keys are supported only if its enabled in Hive and PXF.
+     *
+     * For Example for query: SELECT * FROM TABLE1 WHERE part1 = 'AAAA' AND
+     * part2 = '1111' For HIVE HiveMetaStoreClient.listPartitionsByFilter, the
+     * incoming GPDB filter string will be mapped into :
+     * "part1 = \"AAAA\" and part2 = \"1111\""
+     *
+     * Say P is a conforming predicate based on partition column and supported comparison operator
+     * NP is a non conforming predicate based on either a non-partition column or an unsupported operator.
+     * The following rule will be used during filter processing
+     * P <op> P -> P <op> P (op can be any logical operator)
+     * P AND NP -> P
+     * P OR NP -> null
+     * NP <op> NP -> null
+     */
+    public String buildFilterStringForHive(String filterInput) throws Exception {
+
+        String filterString;
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Filter string input : " + filterInput);
+        }
+
+        HiveFilterBuilder eval = new HiveFilterBuilder();
+        Object filter = eval.getFilterObject(filterInput);
+
+        if (filter instanceof LogicalFilter) {
+            filterString = buildCompoundFilter((LogicalFilter) filter);
+        } else {
+            filterString = buildSingleFilter(filter, null);
+        }
+
+        return filterString;
+    }
+
+    private String buildCompoundFilter(LogicalFilter filter) throws Exception {
+        String logicalOperator;
+        switch (filter.getOperator()) {
+            case HDOP_AND:
+                logicalOperator = " and ";
+                break;
+            case HDOP_OR:
+                logicalOperator = " or ";
+                break;
+            case HDOP_NOT:
+                logicalOperator = " not ";
+                break;
+            default:
+                logicalOperator = "";
+        }
+
+        StringBuilder filterString = new StringBuilder();
+        String serializedFilter;
+        for (Object f : filter.getFilterList()) {
+            if (f instanceof LogicalFilter) {
+                serializedFilter = buildCompoundFilter((LogicalFilter) f);
+            } else {
+                serializedFilter = buildSingleFilter(f, filter.getOperator());
+            }
+            if (serializedFilter != null) {
+                if (filterString.length() > 0) {
+                    filterString.append(logicalOperator);
+                }
+                filterString.append(serializedFilter);
+            } else if(filter.getOperator() == FilterParser.LogicalOperation.HDOP_OR) {
+                // Case when one of the predicates is non-compliant and with OR operator
+                // P OR NP -> null
+                return null;
+            }
+        }
+
+        if(filterString.length() > 0) {
+            return String.format("(%s)", filterString.toString());
+        } else {
+            return null;
+        }
+    }
+
+    private boolean isFilterCompatible(String filterColumnName, FilterParser.Operation operation, FilterParser.LogicalOperation logicalOperation) {
+
+        String colType = partitionKeys.get(filterColumnName);
+        boolean isPartitionColumn = colType != null;
+
+        boolean isIntegralSupported =
+                canPushdownIntegral &&
+                        (operation == FilterParser.Operation.HDOP_EQ || operation == FilterParser.Operation.HDOP_NE);
+
+        boolean canPushDown = isPartitionColumn && (
+                colType.equalsIgnoreCase(serdeConstants.STRING_TYPE_NAME) ||
+                        isIntegralSupported && serdeConstants.IntegralTypes.contains(colType)
+        );
+
+        if (!canPushDown) {
+            if (logicalOperation != null && logicalOperation == FilterParser.LogicalOperation.HDOP_OR) {
+                return false;
+            } else { // AND and NOT logical operators
+                LOG.trace("Filter is on a non-partition column or on a partition column that is not supported for pushdown, ignore this filter for column: {}", filterColumnName);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /*
+     * Build filter string for a single filter and append to the filters string.
+     * Filter string shell be added if filter name match hive partition name
+     * Single filter will be in a format of: [PARTITON NAME] = \"[PARTITON
+     * VALUE]\"
+     */
+    private String buildSingleFilter(Object filter, FilterParser.LogicalOperation logicalOperation) {
+
+        // Let's look first at the filter
+        BasicFilter bFilter = (BasicFilter) filter;
+
+        // Extract column name and value
+        int filterColumnIndex = bFilter.getColumn().index();
+        // Avoids NullPointerException in case of operations like HDOP_IS_NULL,
+        // HDOP_IS_NOT_NULL where no constant value is passed as part of query
+        String filterValue = bFilter.getConstant() != null ? bFilter.getConstant().constant().toString() : "";
+        ColumnDescriptor filterColumn = columnDescriptors.get(filterColumnIndex);
+        String filterColumnName = filterColumn.columnName();
+        FilterParser.Operation operation = ((BasicFilter) filter).getOperation();
+
+        // if filter is determined to be not being able to be pushed down, but not violating logical correctness,
+        // we just skip it and return null
+        if (!isFilterCompatible(filterColumnName, operation, logicalOperation)) {
+            return null;
+        }
+
+        StringBuilder result = new StringBuilder(filterColumnName);
+        switch (operation) {
+            case HDOP_EQ:
+                result.append(HIVE_API_EQ);
+                break;
+            case HDOP_LT:
+                result.append(HIVE_API_LT);
+                break;
+            case HDOP_GT:
+                result.append(HIVE_API_GT);
+                break;
+            case HDOP_LE:
+                result.append(HIVE_API_LTE);
+                break;
+            case HDOP_GE:
+                result.append(HIVE_API_GTE);
+                break;
+            case HDOP_NE:
+                result.append(HIVE_API_NE);
+                break;
+            default:
+                // Set filter string to blank in case of unimplemented operations
+                result.setLength(0);
+                return null;
+        }
+
+        result.append(HIVE_API_DQUOTE);
+        result.append(filterValue);
+        result.append(HIVE_API_DQUOTE);
+
+        return result.toString();
+    }
+
+    /*
      * Handles simple column-operator-constant expressions Creates a special
      * filter in the case the column is the row key column
      */
@@ -160,5 +339,17 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
 
     private Object handleLogicalOperation(FilterParser.LogicalOperation operator, Object filter) {
         return new LogicalFilter(operator, Arrays.asList(filter));
+    }
+
+    public void setColumnDescriptors(List<ColumnDescriptor> columnDescriptors) {
+        this.columnDescriptors = columnDescriptors;
+    }
+
+    public void setCanPushdownIntegral(boolean canPushdownIntegral) {
+        this.canPushdownIntegral = canPushdownIntegral;
+    }
+
+    public void setPartitionKeys(Map <String, String> partitionKeys) {
+        this.partitionKeys = partitionKeys;
     }
 }

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveORCAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveORCAccessor.java
@@ -122,7 +122,7 @@ public class HiveORCAccessor extends HiveAccessor implements StatsAccessor {
 
         /* Predicate pushdown configuration */
         String filterStr = context.getFilterString();
-        HiveFilterBuilder eval = new HiveFilterBuilder(context);
+        HiveFilterBuilder eval = new HiveFilterBuilder();
         Object filter = eval.getFilterObject(filterStr);
         SearchArgument.Builder filterBuilder = SearchArgumentFactory.newBuilder();
 

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
@@ -93,7 +93,6 @@ public class HiveResolver extends HivePlugin implements Resolver {
         super.initialize(requestContext);
 
         hiveDefaultPartName = HiveConf.getVar(configuration, HiveConf.ConfVars.DEFAULTPARTITIONNAME);
-        LOG.debug("Hive's default partition name is " + hiveDefaultPartName);
 
         try {
             parseUserData(context);
@@ -191,7 +190,6 @@ public class HiveResolver extends HivePlugin implements Resolver {
             Object convertedValue = null;
             boolean isDefaultPartition = false;
 
-            LOG.debug("Partition type: " + type + ", value: " + val);
             // check if value is default partition
             isDefaultPartition = isDefaultPartition(type, val);
             // ignore the type's parameters

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenterTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenterTest.java
@@ -20,13 +20,8 @@ package org.greenplum.pxf.plugins.hive;
  */
 
 
-import org.greenplum.pxf.api.FilterParser;
 import org.greenplum.pxf.api.model.ConfigurationFactory;
 import org.greenplum.pxf.api.model.RequestContext;
-import org.greenplum.pxf.api.BasicFilter;
-import org.greenplum.pxf.api.utilities.ColumnDescriptor;
-
-import static org.greenplum.pxf.api.FilterParser.Operation.*;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -44,10 +39,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.*;
 
 @RunWith(PowerMockRunner.class)
@@ -62,6 +54,7 @@ public class HiveDataFragmenterTest {
     HiveConf hiveConfiguration;
     HiveMetaStoreClient hiveClient;
     HiveDataFragmenter fragmenter;
+    HiveFilterBuilder filterBuilder;
     private ConfigurationFactory configurationFactory;
 
 
@@ -69,6 +62,7 @@ public class HiveDataFragmenterTest {
         configurationFactory = mock(ConfigurationFactory.class);
         requestContext = mock(RequestContext.class);
         hadoopConfiguration = mock(Configuration.class);
+        filterBuilder = mock(HiveFilterBuilder.class);
 
         jobConf = mock(JobConf.class);
         PowerMockito.whenNew(JobConf.class).withArguments(hadoopConfiguration, HiveDataFragmenter.class).thenReturn(jobConf);
@@ -92,7 +86,7 @@ public class HiveDataFragmenterTest {
     @Test
     public void construction() throws Exception {
         prepareConstruction();
-        fragmenter = new HiveDataFragmenter(configurationFactory);
+        fragmenter = new HiveDataFragmenter(configurationFactory, filterBuilder);
         fragmenter.initialize(requestContext);
 
         PowerMockito.verifyNew(JobConf.class).withArguments(hadoopConfiguration, HiveDataFragmenter.class);
@@ -105,7 +99,7 @@ public class HiveDataFragmenterTest {
         PowerMockito.whenNew(HiveMetaStoreClient.class).withArguments(hiveConfiguration).thenThrow(new MetaException("which way to albuquerque"));
 
         try {
-            fragmenter = new HiveDataFragmenter(configurationFactory);
+            fragmenter = new HiveDataFragmenter(configurationFactory, filterBuilder);
             fragmenter.initialize(requestContext);
             fail("Expected a RuntimeException");
         } catch (RuntimeException ex) {
@@ -116,7 +110,7 @@ public class HiveDataFragmenterTest {
     @Test
     public void invalidTableName() throws Exception {
         prepareConstruction();
-        fragmenter = new HiveDataFragmenter(configurationFactory);
+        fragmenter = new HiveDataFragmenter(configurationFactory, filterBuilder);
         fragmenter.initialize(requestContext);
 
         when(requestContext.getDataSource()).thenReturn("t.r.o.u.b.l.e.m.a.k.e.r");
@@ -126,218 +120,6 @@ public class HiveDataFragmenterTest {
             fail("Expected an IllegalArgumentException");
         } catch (IllegalArgumentException ex) {
             assertEquals(ex.getMessage(), "\"t.r.o.u.b.l.e.m.a.k.e.r\" is not a valid Hive table name. Should be either <table_name> or <db_name.table_name>");
-        }
-    }
-
-    @Test
-    public void testBuildSingleFilter() throws Exception {
-        prepareConstruction();
-        fragmenter = new HiveDataFragmenter(configurationFactory);
-        fragmenter.initialize(requestContext);
-        ColumnDescriptor columnDescriptor =
-                new ColumnDescriptor("textColumn", 25, 3, "text", null, true);
-        String filterColumnName = columnDescriptor.columnName();
-        int filterColumnIndex = columnDescriptor.columnIndex();
-        HiveFilterBuilder builder = new HiveFilterBuilder(null);
-        when(requestContext.getColumn(filterColumnIndex)).thenReturn(columnDescriptor);
-
-        // Mock private field partitionkeyTypes
-        Field partitionkeyTypes = PowerMockito.field(HiveDataFragmenter.class, "partitionkeyTypes");
-        Map<String, String> localpartitionkeyTypes = new HashMap<>();
-        localpartitionkeyTypes.put(filterColumnName, "string");
-        partitionkeyTypes.set(fragmenter, localpartitionkeyTypes);
-
-        //Mock private field setPartitions
-        Field setPartitions = PowerMockito.field(HiveDataFragmenter.class, "setPartitions");
-        Set<String> localSetPartitions = new TreeSet<String>(
-                String.CASE_INSENSITIVE_ORDER);
-        localSetPartitions.add(filterColumnName);
-        setPartitions.set(fragmenter, localSetPartitions);
-
-        Map<FilterParser.Operation, String> filterStrings = new HashMap<>();
-        /*
-         * Filter string representation in the respective order of their declaration
-            testColumn != 2016-01-03
-            testColumn = 2016-01-03
-            testColumn >= 2016-01-03
-            testColumn <= 2016-01-03
-            testColumn >= 2016-01-03
-            testColumn < 2016-01-03
-            testColumn like '2016-01-0%'
-         */
-        filterStrings.put(HDOP_NE, "a3c25s10d2016-01-03o6");
-        filterStrings.put(HDOP_EQ, "a3c25s10d2016-01-03o5");
-        filterStrings.put(HDOP_GE, "a3c25s10d2016-01-03o4");
-        filterStrings.put(HDOP_LE, "a3c25s10d2016-01-03o3");
-        filterStrings.put(HDOP_GT, "a3c25s10d2016-01-03o2");
-        filterStrings.put(HDOP_LT, "a3c25s10d2016-01-03o1");
-        filterStrings.put(HDOP_LIKE, "a3c25s10d2016-01-0%o7");
-
-        for (FilterParser.Operation operation : filterStrings.keySet()) {
-            BasicFilter bFilter = (BasicFilter) builder.getFilterObject(filterStrings.get(operation));
-            checkFilters(fragmenter, bFilter, operation);
-        }
-    }
-
-    @Test
-    public void testIntegralPushdown() throws Exception {
-        prepareConstruction();
-        fragmenter = new HiveDataFragmenter(configurationFactory);
-        fragmenter.initialize(requestContext);
-        // Mock private field partitionkeyTypes
-        Field partitionkeyTypes = PowerMockito.field(HiveDataFragmenter.class, "partitionkeyTypes");
-        // Mock private method buildSingleFilter
-        Method method = PowerMockito.method(HiveDataFragmenter.class, "buildSingleFilter",
-                new Class[]{Object.class, StringBuilder.class, String.class});
-        //Mock private field setPartitions
-        Field setPartitions = PowerMockito.field(HiveDataFragmenter.class, "setPartitions");
-        //Mock private field canPushDownIntegral
-        Field canPushDownIntegral = PowerMockito.field(HiveDataFragmenter.class, "canPushDownIntegral");
-        canPushDownIntegral.set(fragmenter, true);
-
-        ColumnDescriptor dateColumnDescriptor =
-                new ColumnDescriptor("dateColumn", 1082, 1, "date", null, true);
-        ColumnDescriptor stringColumnDescriptor =
-                new ColumnDescriptor("stringColumn", 25, 1, "string", null, true);
-        ColumnDescriptor intColumnDescriptor =
-                new ColumnDescriptor("intColumn", 23, 1, "int", null, true);
-        ColumnDescriptor bigIntColumnDescriptor =
-                new ColumnDescriptor("bigIntColumn", 20, 1, "bigint", null, true);
-        ColumnDescriptor smallIntColumnDescriptor =
-                new ColumnDescriptor("smallIntColumn", 21, 1, "smallint", null, true);
-        List<ColumnDescriptor> columnDescriptors = new ArrayList<>();
-
-        columnDescriptors.add(dateColumnDescriptor);
-        columnDescriptors.add(stringColumnDescriptor);
-        columnDescriptors.add(intColumnDescriptor);
-        columnDescriptors.add(bigIntColumnDescriptor);
-        columnDescriptors.add(smallIntColumnDescriptor);
-
-        for (ColumnDescriptor cd : columnDescriptors) {
-
-            checkPushDownFilter(fragmenter, cd, method, partitionkeyTypes, setPartitions);
-        }
-    }
-
-    private void checkPushDownFilter(HiveDataFragmenter fragmenter, ColumnDescriptor columnDescriptor, Method method,
-                                     Field partitionkeyTypes, Field setPartitions) throws Exception {
-        String filterColumnName = columnDescriptor.columnName();
-        int filterColumnIndex = columnDescriptor.columnIndex();
-        String typeName = columnDescriptor.columnTypeName();
-        int typeCode = columnDescriptor.columnTypeCode();
-        String data = "2016-08-11";
-        String dataIntegralDataTypes = "126";
-        String filterString = "a" + filterColumnIndex + "c" + typeCode + "s" + data.length() + "d" + data + "o";
-        String filterIntegralDataTypes =
-                "a" + filterColumnIndex + "c" + typeCode + "s" + dataIntegralDataTypes.length() + "d" + dataIntegralDataTypes + "o";
-        int notEquals = 6;
-        int equals = 5;
-        int greaterEquals = 4;
-
-        when(requestContext.getColumn(filterColumnIndex)).thenReturn(columnDescriptor);
-        //Set partition Key type
-        Map<String, String> localpartitionkeyTypes = new HashMap<>();
-        localpartitionkeyTypes.put(filterColumnName, typeName);
-        partitionkeyTypes.set(fragmenter, localpartitionkeyTypes);
-        // Set column as partition
-        Set<String> localSetPartitions = new TreeSet<String>(
-                String.CASE_INSENSITIVE_ORDER);
-        localSetPartitions.add(filterColumnName);
-        setPartitions.set(fragmenter, localSetPartitions);
-
-        switch (typeName) {
-
-            case "date":
-                assertFalse(isColumnStringOrIntegral(method, filterString + notEquals));
-                assertFalse(isColumnStringOrIntegral(method, filterString + equals));
-                assertFalse(isColumnStringOrIntegral(method, filterString + greaterEquals));
-                break;
-            case "string":
-                assertTrue(isColumnStringOrIntegral(method, filterString + notEquals));
-                assertTrue(isColumnStringOrIntegral(method, filterString + equals));
-                assertTrue(isColumnStringOrIntegral(method, filterString + greaterEquals));
-                break;
-            case "int":
-                assertTrue(isColumnStringOrIntegral(method, filterIntegralDataTypes + notEquals));
-                assertTrue(isColumnStringOrIntegral(method, filterIntegralDataTypes + equals));
-                assertFalse(isColumnStringOrIntegral(method, filterIntegralDataTypes + greaterEquals));
-                break;
-            case "bigint":
-                assertTrue(isColumnStringOrIntegral(method, filterIntegralDataTypes + notEquals));
-                assertTrue(isColumnStringOrIntegral(method, filterIntegralDataTypes + equals));
-                assertFalse(isColumnStringOrIntegral(method, filterIntegralDataTypes + greaterEquals));
-                break;
-            case "smallint":
-                assertTrue(isColumnStringOrIntegral(method, filterIntegralDataTypes + notEquals));
-                assertTrue(isColumnStringOrIntegral(method, filterIntegralDataTypes + equals));
-                assertFalse(isColumnStringOrIntegral(method, filterIntegralDataTypes + greaterEquals));
-                break;
-        }
-    }
-
-    private boolean isColumnStringOrIntegral(Method method, String filterString) throws Exception {
-        BasicFilter bFilter;
-        String prefix = "";
-        StringBuilder localFilterString = new StringBuilder();
-        boolean result;
-        HiveFilterBuilder builder = new HiveFilterBuilder(null);
-
-        bFilter = (BasicFilter) builder.getFilterObject(filterString);
-        result = (Boolean) method.invoke(fragmenter, new Object[]{bFilter, localFilterString, prefix});
-        return result;
-    }
-
-    private void checkFilters(HiveDataFragmenter fragmenter, BasicFilter bFilter, FilterParser.Operation operation)
-            throws Exception {
-
-        String prefix = "";
-        StringBuilder localFilterString = new StringBuilder();
-        String expectedResult;
-
-        // Mock private method buildSingleFilter
-        Method method = PowerMockito.method(HiveDataFragmenter.class, "buildSingleFilter",
-                new Class[]{Object.class, StringBuilder.class, String.class});
-        boolean result = (Boolean) method.invoke(fragmenter, new Object[]{bFilter, localFilterString, prefix});
-
-        switch (operation) {
-            case HDOP_NE:
-                expectedResult = "textColumn != \"2016-01-03\"";
-                assertTrue(result);
-                assertEquals(expectedResult, localFilterString.toString());
-                break;
-            case HDOP_EQ:
-                expectedResult = "textColumn = \"2016-01-03\"";
-                assertTrue(result);
-                assertEquals(expectedResult, localFilterString.toString());
-                break;
-            case HDOP_GE:
-                expectedResult = "textColumn >= \"2016-01-03\"";
-                assertTrue(result);
-                assertEquals(expectedResult, localFilterString.toString());
-                break;
-            case HDOP_LE:
-                expectedResult = "textColumn <= \"2016-01-03\"";
-                assertTrue(result);
-                assertEquals(expectedResult, localFilterString.toString());
-                break;
-            case HDOP_GT:
-                expectedResult = "textColumn > \"2016-01-03\"";
-                assertTrue(result);
-                assertEquals(expectedResult, localFilterString.toString());
-                break;
-            case HDOP_LT:
-                expectedResult = "textColumn < \"2016-01-03\"";
-                assertTrue(result);
-                assertEquals(expectedResult, localFilterString.toString());
-                break;
-            case HDOP_LIKE:
-                expectedResult = "";
-                assertFalse(result);
-                assertEquals(expectedResult, localFilterString.toString());
-                break;
-            default:
-                assertFalse(result);
-                break;
         }
     }
 }

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilderTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilderTest.java
@@ -20,11 +20,18 @@ package org.greenplum.pxf.plugins.hive;
  */
 
 
+import com.google.common.collect.Lists;
 import org.greenplum.pxf.api.FilterParser.LogicalOperation;
 import org.greenplum.pxf.api.LogicalFilter;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
 import org.junit.Test;
 
 import org.greenplum.pxf.api.BasicFilter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.greenplum.pxf.api.FilterParser.Operation;
 import static org.greenplum.pxf.api.FilterParser.Operation.*;
@@ -34,7 +41,7 @@ import static org.junit.Assert.assertNull;
 public class HiveFilterBuilderTest {
     @Test
     public void parseFilterWithThreeOperations() throws Exception {
-        HiveFilterBuilder builder = new HiveFilterBuilder(null);
+        HiveFilterBuilder builder = new HiveFilterBuilder();
         String[] consts = new String[] {"first", "2"};
         Operation[] ops = new Operation[] {HDOP_EQ, HDOP_GT};
         int[] idx = new int[] {1, 2};
@@ -49,14 +56,14 @@ public class HiveFilterBuilderTest {
 
     @Test
     public void parseNullFilter() throws Exception {
-        HiveFilterBuilder builder = new HiveFilterBuilder(null);
+        HiveFilterBuilder builder = new HiveFilterBuilder();
         LogicalFilter filterList = (LogicalFilter) builder.getFilterObject(null);
         assertNull(builder.getFilterObject(null));
     }
 
     @Test
     public void parseFilterWithLogicalOperation() throws Exception {
-        HiveFilterBuilder builder = new HiveFilterBuilder(null);
+        HiveFilterBuilder builder = new HiveFilterBuilder();
         LogicalFilter filter = (LogicalFilter) builder.getFilterObject("a1c25s5dfirsto5a2c20s1d2o2l0");
         assertEquals(LogicalOperation.HDOP_AND, filter.getOperator());
         assertEquals(2, filter.getFilterList().size());
@@ -64,7 +71,7 @@ public class HiveFilterBuilderTest {
 
     @Test
     public void parseNestedExpressionWithLogicalOperation() throws Exception {
-        HiveFilterBuilder builder = new HiveFilterBuilder(null);
+        HiveFilterBuilder builder = new HiveFilterBuilder();
         LogicalFilter filter = (LogicalFilter) builder.getFilterObject("a1c25s5dfirsto5a2c20s1d2o2l0a1c20s1d1o1l1");
         assertEquals(LogicalOperation.HDOP_OR, filter.getOperator());
         assertEquals(LogicalOperation.HDOP_AND, ((LogicalFilter) filter.getFilterList().get(0)).getOperator());
@@ -73,7 +80,7 @@ public class HiveFilterBuilderTest {
 
     @Test
     public void parseISNULLExpression() throws Exception {
-        HiveFilterBuilder builder = new HiveFilterBuilder(null);
+        HiveFilterBuilder builder = new HiveFilterBuilder();
         BasicFilter filter = (BasicFilter) builder.getFilterObject("a1o8");
         assertEquals(Operation.HDOP_IS_NULL, filter.getOperation());
         assertEquals(1, filter.getColumn().index());
@@ -82,11 +89,172 @@ public class HiveFilterBuilderTest {
 
     @Test
     public void parseISNOTNULLExpression() throws Exception {
-        HiveFilterBuilder builder = new HiveFilterBuilder(null);
+        HiveFilterBuilder builder = new HiveFilterBuilder();
         BasicFilter filter = (BasicFilter) builder.getFilterObject("a1o9");
         assertEquals(Operation.HDOP_IS_NOT_NULL, filter.getOperation());
         assertEquals(1, filter.getColumn().index());
         assertNull(filter.getConstant());
     }
 
+    @Test
+    public void testBuildFilterWithCompatibleAndIncompatiblePredicates() throws Exception {
+
+        Map<String, String> partitionKeyTypes = new HashMap<>();
+        partitionKeyTypes.put("stringColumn", "string");
+
+        HiveFilterBuilder builder = new HiveFilterBuilder();
+        builder.setColumnDescriptors(getColumnDescriptors());
+        builder.setCanPushdownIntegral(true);
+        builder.setPartitionKeys(getPartitionKeyTypes());
+
+        assertEquals("(stringColumn = \"seq\")", builder.buildFilterStringForHive("a1c25s4drow1o7a2c23s3d999o1l0a1c25s3dseqo5l0"));
+    }
+
+    @Test
+    public void testBuildSingleFilter() throws Exception {
+        ColumnDescriptor columnDescriptor =
+                new ColumnDescriptor("textColumn", 25, 3, "text", null, true);
+        Map<String, String> partitionKeyTypes = new HashMap<>();
+        partitionKeyTypes.put("textColumn", "string");
+
+        HiveFilterBuilder builder = new HiveFilterBuilder();
+        builder.setColumnDescriptors(Lists.newArrayList(null, null, null, columnDescriptor));
+        builder.setCanPushdownIntegral(false);
+        builder.setPartitionKeys(partitionKeyTypes);
+
+        assertEquals("textColumn != \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o6"));
+        assertEquals("textColumn = \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o5"));
+        assertEquals("textColumn >= \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o4"));
+        assertEquals("textColumn <= \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o3"));
+        assertEquals("textColumn > \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o2"));
+        assertEquals("textColumn < \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o1"));
+        assertNull(builder.buildFilterStringForHive("a3c25s10d2016-01-0%o7"));
+    }
+
+    @Test
+    public void testIntegralPushdownTrue() throws Exception {
+
+        HiveFilterBuilder builder = new HiveFilterBuilder();
+        builder.setColumnDescriptors(getColumnDescriptors());
+        builder.setCanPushdownIntegral(true);
+        builder.setPartitionKeys(getPartitionKeyTypes());
+
+        assertNull(builder.buildFilterStringForHive("a0c1082s10d2016-01-03o4"));
+        assertNull(builder.buildFilterStringForHive("a0c1082s10d2016-01-03o5"));
+        assertNull(builder.buildFilterStringForHive("a0c1082s10d2016-01-03o6"));
+
+        assertEquals("stringColumn >= \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o4"));
+        assertEquals("stringColumn = \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o5"));
+        assertEquals("stringColumn != \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o6"));
+
+        // Don't support > for integral types
+        assertNull(builder.buildFilterStringForHive("a2c23s3d126o4"));
+        // Support = for integral types
+        assertEquals("intColumn = \"126\"", builder.buildFilterStringForHive("a2c23s3d126o5"));
+        // Support != for integral types
+        assertEquals("intColumn != \"126\"", builder.buildFilterStringForHive("a2c23s3d126o6"));
+
+        assertNull(builder.buildFilterStringForHive("a3c20s3d126o4"));
+        assertEquals("bigIntColumn = \"126\"", builder.buildFilterStringForHive("a3c20s3d126o5"));
+        assertEquals("bigIntColumn != \"126\"", builder.buildFilterStringForHive("a3c20s3d126o6"));
+
+        assertNull(builder.buildFilterStringForHive("a4c21s3d126o4"));
+        assertEquals("smallIntColumn = \"126\"", builder.buildFilterStringForHive("a4c21s3d126o5"));
+        assertEquals("smallIntColumn != \"126\"", builder.buildFilterStringForHive("a4c21s3d126o6"));
+    }
+
+    @Test
+    public void testIntegralPushdownFalse() throws Exception {
+
+        HiveFilterBuilder builder = new HiveFilterBuilder();
+        builder.setColumnDescriptors(getColumnDescriptors());
+        builder.setCanPushdownIntegral(false);
+        builder.setPartitionKeys(getPartitionKeyTypes());
+
+        assertNull(builder.buildFilterStringForHive("a0c1082s10d2016-01-03o4"));
+        assertNull(builder.buildFilterStringForHive("a0c1082s10d2016-01-03o5"));
+        assertNull(builder.buildFilterStringForHive("a0c1082s10d2016-01-03o6"));
+
+        assertEquals("stringColumn >= \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o4"));
+        assertEquals("stringColumn = \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o5"));
+        assertEquals("stringColumn != \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o6"));
+
+        // Integral types not supported
+        assertNull(builder.buildFilterStringForHive("a2c23s3d126o4"));
+        assertNull(builder.buildFilterStringForHive("a2c23s3d126o5"));
+        assertNull(builder.buildFilterStringForHive("a2c23s3d126o6"));
+
+        assertNull(builder.buildFilterStringForHive("a3c20s3d126o4"));
+        assertNull(builder.buildFilterStringForHive("a3c20s3d126o5"));
+        assertNull(builder.buildFilterStringForHive("a3c20s3d126o6"));
+
+        assertNull(builder.buildFilterStringForHive("a4c21s3d126o4"));
+        assertNull(builder.buildFilterStringForHive("a4c21s3d126o5"));
+        assertNull(builder.buildFilterStringForHive("a4c21s3d126o6"));
+    }
+
+    @Test
+    public void buildFilterStringForHiveWithLogicalOps() throws Exception{
+
+        Map<String, String> partitionKeyTypes = new HashMap<>();
+        partitionKeyTypes.put("stringColumn", "string");
+        partitionKeyTypes.put("intColumn", "int");
+
+        HiveFilterBuilder builder = new HiveFilterBuilder();
+        builder.setColumnDescriptors(getColumnDescriptors());
+        builder.setCanPushdownIntegral(true);
+        builder.setPartitionKeys(partitionKeyTypes);
+
+        // Terminology:
+        // P is a predicate based on partition column
+        // NP is a predicate based on either a non-partition column or an unsupported operator.
+
+        // P1 AND P2 -> P1 AND P2
+        assertEquals("(stringColumn = \"foobar\" and intColumn != \"999\")", builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l0"));
+        // P1 OR P2 -> P1 OR P2
+        assertEquals("(stringColumn = \"foobar\" or intColumn != \"999\")", builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l1"));
+        // P1 AND NP1 -> P1
+        assertEquals("(stringColumn = \"foobar\")", builder.buildFilterStringForHive("a1c25s6dfoobaro5a3c20s3d999o6l0"));
+        // P1 OR NP1 -> null
+        assertNull(builder.buildFilterStringForHive("a1c25s6dfoobaro5a3c20s3d999o6l1"));
+        // NP1 OR NP2 -> null
+        assertNull(builder.buildFilterStringForHive("a3c20s3d999o6a2c20s3d999o4l1"));
+        // (P1 AND P2) OR NP1 -> null
+        assertNull(builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l0a2c20s3d999o4l1"));
+        // (P1 AND P2) AND (P3 OR NP1) -> P1 AND P2
+        assertEquals("((stringColumn = \"foobar\" and intColumn != \"999\"))", builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l0a1c25s6dfoobaro5a3c20s3d999o6l1l0"));
+    }
+
+    private List<ColumnDescriptor> getColumnDescriptors() {
+        ColumnDescriptor dateColumnDescriptor =
+                new ColumnDescriptor("dateColumn", 1082, 0, "date", null, true);
+        ColumnDescriptor stringColumnDescriptor =
+                new ColumnDescriptor("stringColumn", 25, 1, "string", null, true);
+        ColumnDescriptor intColumnDescriptor =
+                new ColumnDescriptor("intColumn", 23, 2, "int", null, true);
+        ColumnDescriptor bigIntColumnDescriptor =
+                new ColumnDescriptor("bigIntColumn", 20, 3, "bigint", null, true);
+        ColumnDescriptor smallIntColumnDescriptor =
+                new ColumnDescriptor("smallIntColumn", 21, 4, "smallint", null, true);
+        List<ColumnDescriptor> columnDescriptors = new ArrayList<>();
+
+        columnDescriptors.add(dateColumnDescriptor);
+        columnDescriptors.add(stringColumnDescriptor);
+        columnDescriptors.add(intColumnDescriptor);
+        columnDescriptors.add(bigIntColumnDescriptor);
+        columnDescriptors.add(smallIntColumnDescriptor);
+
+        return columnDescriptors;
+    }
+
+    private Map<String, String> getPartitionKeyTypes() {
+        Map<String, String> partitionKeyTypes = new HashMap<>();
+        partitionKeyTypes.put("dateColumn", "date");
+        partitionKeyTypes.put("stringColumn", "string");
+        partitionKeyTypes.put("intColumn", "int");
+        partitionKeyTypes.put("bigIntColumn", "bigint");
+        partitionKeyTypes.put("smallIntColumn", "smallint");
+
+        return partitionKeyTypes;
+    }
 }

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveORCSearchArgumentTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveORCSearchArgumentTest.java
@@ -37,7 +37,7 @@ public class HiveORCSearchArgumentTest {
 
         /* Predicate pushdown configuration */
         String filterStr = "a2c23s1d1o2a3c23s1d3o3l0a4c23s1d5o1l1";
-        HiveFilterBuilder eval = new HiveFilterBuilder(null);
+        HiveFilterBuilder eval = new HiveFilterBuilder();
         Object filter = eval.getFilterObject(filterStr);
 
         SearchArgument.Builder filterBuilder = SearchArgumentFactory.newBuilder();
@@ -49,7 +49,7 @@ public class HiveORCSearchArgumentTest {
     @Test
     public void buildIn() throws Exception {
         String filterStr = "a0m1009s4drow1s4drow2o10a1m1009s3ds_6s3ds_7o10l0";
-        HiveFilterBuilder eval = new HiveFilterBuilder(null);
+        HiveFilterBuilder eval = new HiveFilterBuilder();
         Object filter = eval.getFilterObject(filterStr);
 
         SearchArgument.Builder filterBuilder = SearchArgumentFactory.newBuilder();

--- a/server/pxf-service/src/templates/user/templates/hive-site.xml
+++ b/server/pxf-service/src/templates/user/templates/hive-site.xml
@@ -3,5 +3,11 @@
     <property>
         <name>hive.metastore.uris</name>
         <value>thrift://localhost:9083</value>
+        <description>URI for client to contact metastore server</description>
+    </property>
+    <property>
+        <name>hive.metastore.integral.jdo.pushdown</name>
+        <value>true</value>
+        <description> Allow query pushdown for integral partition columns in metastore.  This improves metastore perf for integral columns, especially if there's a large number of partitions</description>
     </property>
 </configuration>


### PR DESCRIPTION
Moved out partition filtering functionality to HiveFitlerBuilder
Updated Hive Partition filtering to support AND, OR and NOT logical operators
Added Unit tests in HiveFilterBuilderTest
Added integration tests in HiveTest#hivePartitionedPPDTable
Updated hive-site template to hive.metastore.integral.jdo.pushdown to true
This PR doesn't address or refactor existing unit tests for HiveDataFragmenter