### PR TITLE
pxf-api: Fix BaseConfigurationFactory logging

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
@@ -46,16 +46,20 @@ public class BaseConfigurationFactory implements ConfigurationFactory {
                         f.canRead() &&
                         StringUtils.equalsIgnoreCase(serverName, f.getName()));
 
-        String serverDirectoryName = serversConfigDirectory + serverName;
-
         if (serverDirectories == null || serverDirectories.length == 0) {
-            LOG.warn("Directory {} does not exist, no configuration resources are added for server {}", serverDirectoryName, serverName);
+            LOG.warn("Directory {} does not exist or cannot be read by PXF, no configuration resources are added for server {}",
+                serversConfigDirectory + File.separator + serverName,
+                serverName
+            );
         } else if (serverDirectories.length > 1) {
             throw new IllegalStateException(String.format(
-                    "Multiple directories found for server %s. Server directories are expected to be case-insensitive.", serverName));
+                    "Multiple directories found for server %s. Server directories are expected to be case-insensitive.", serverName
+            ));
         } else {
             // add all site files as URL resources to the configuration, no resources will be added from the classpath
-            LOG.debug("Using directory {} for server {} configuration", serverDirectoryName, serverName);
+            LOG.debug("Using directory {} for server {} configuration",
+                serverDirectories[0], serverName
+            );
             addSiteFilesAsResources(configuration, serverName, serverDirectories[0]);
         }
 

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
@@ -47,8 +47,8 @@ public class BaseConfigurationFactory implements ConfigurationFactory {
                         StringUtils.equalsIgnoreCase(serverName, f.getName()));
 
         if (serverDirectories == null || serverDirectories.length == 0) {
-            LOG.warn("Directory {} does not exist or cannot be read by PXF, no configuration resources are added for server {}",
-                serversConfigDirectory + File.separator + serverName,
+            LOG.warn("Directory {}{}{} does not exist or cannot be read by PXF, no configuration resources are added for server {}",
+                serversConfigDirectory, File.separator, serverName,
                 serverName
             );
         } else if (serverDirectories.length > 1) {


### PR DESCRIPTION
Fix logging of server configuration file directory in `BaseConfigurationFactory.initConfiguration()`.

Three issues with the mentioned logging are fixed by this PR:
* `serverDirectoryName` does not include a path separator;
* Instead of logging actual server configuration file directory, server name is logged (while the former can differ from server name, as the comparison between them is case-insensitive);
* When server configuration file directory cannot be read by PXF (due to lack of permissions), a logged message states the directory does not exist.

No changes to unit tests are required.