### PR TITLE
JDBC Transaction Isolation Level

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -67,9 +67,9 @@ allprojects {
 
     dependencies {
         testCompile "junit:junit:${junitVersion}"
-        testCompile "org.powermock:powermock-core:1.5.1"
-        testCompile "org.powermock:powermock-module-junit4:1.5.1"
-        testCompile "org.powermock:powermock-api-mockito:1.5.1"
+        testCompile "org.powermock:powermock-core:1.5.6"
+        testCompile "org.powermock:powermock-module-junit4:1.5.6"
+        testCompile "org.powermock:powermock-api-mockito:1.5.6"
         testCompile "org.mockito:mockito-core:1.9.5"
     }
 

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/FakeJdbcDriver.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/FakeJdbcDriver.java
@@ -1,0 +1,40 @@
+package org.greenplum.pxf.plugins.jdbc;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class FakeJdbcDriver implements Driver {
+
+    public Connection connect(String url, Properties info) throws SQLException {
+        return null;
+    }
+
+    public boolean acceptsURL(String url) throws SQLException {
+        return false;
+    }
+
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        return new DriverPropertyInfo[0];
+    }
+
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return null;
+    }
+}

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
@@ -19,35 +19,53 @@ package org.greenplum.pxf.plugins.jdbc;
  * under the License.
  */
 
+import org.greenplum.pxf.api.model.RequestContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-
-import org.junit.Test;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
-
-import org.mockito.Mockito;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DriverManager.class, JdbcBasePlugin.class})
 public class JdbcBasePluginTest {
     @Test
     public void testCloseConnectionWithCommit() throws Exception {
         DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
-        Mockito.when(databaseMetaData.supportsTransactions()).thenReturn(true);
+        when(databaseMetaData.supportsTransactions()).thenReturn(true);
 
         Connection connection = mock(Connection.class);
-        Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
-        Mockito.when(connection.isClosed()).thenReturn(false);
-        Mockito.when(connection.getAutoCommit()).thenReturn(false);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.getAutoCommit()).thenReturn(false);
         Mockito.doNothing().when(connection).commit();
         Mockito.doNothing().when(connection).close();
 
         Statement statement = mock(Statement.class);
-        Mockito.when(statement.getConnection()).thenReturn(connection);
+        when(statement.getConnection()).thenReturn(connection);
         Mockito.doNothing().when(statement).close();
 
         // Test method
@@ -63,16 +81,16 @@ public class JdbcBasePluginTest {
     @Test
     public void testCloseConnectionWithoutCommit() throws Exception {
         DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
-        Mockito.when(databaseMetaData.supportsTransactions()).thenReturn(true);
+        when(databaseMetaData.supportsTransactions()).thenReturn(true);
 
         Connection connection = mock(Connection.class);
-        Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
-        Mockito.when(connection.isClosed()).thenReturn(false);
-        Mockito.when(connection.getAutoCommit()).thenReturn(true);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.getAutoCommit()).thenReturn(true);
         Mockito.doNothing().when(connection).close();
 
         Statement statement = mock(Statement.class);
-        Mockito.when(statement.getConnection()).thenReturn(connection);
+        when(statement.getConnection()).thenReturn(connection);
         Mockito.doNothing().when(statement).close();
 
         // Test method
@@ -86,16 +104,16 @@ public class JdbcBasePluginTest {
     @Test
     public void testCloseConnectionWithoutTransactions() throws Exception {
         DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
-        Mockito.when(databaseMetaData.supportsTransactions()).thenReturn(false);
+        when(databaseMetaData.supportsTransactions()).thenReturn(false);
 
         Connection connection = mock(Connection.class);
-        Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
-        Mockito.when(connection.isClosed()).thenReturn(false);
-        Mockito.when(connection.getAutoCommit()).thenReturn(true);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.getAutoCommit()).thenReturn(true);
         Mockito.doNothing().when(connection).close();
 
         Statement statement = mock(Statement.class);
-        Mockito.when(statement.getConnection()).thenReturn(connection);
+        when(statement.getConnection()).thenReturn(connection);
         Mockito.doNothing().when(statement).close();
 
         // Test method
@@ -109,16 +127,16 @@ public class JdbcBasePluginTest {
     @Test
     public void testCloseConnectionClosed() throws Exception {
         DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
-        Mockito.when(databaseMetaData.supportsTransactions()).thenReturn(false);
+        when(databaseMetaData.supportsTransactions()).thenReturn(false);
 
         Connection connection = mock(Connection.class);
-        Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
-        Mockito.when(connection.isClosed()).thenReturn(true);
-        Mockito.when(connection.getAutoCommit()).thenReturn(true);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(connection.isClosed()).thenReturn(true);
+        when(connection.getAutoCommit()).thenReturn(true);
         Mockito.doNothing().when(connection).close();
 
         Statement statement = mock(Statement.class);
-        Mockito.when(statement.getConnection()).thenReturn(connection);
+        when(statement.getConnection()).thenReturn(connection);
         Mockito.doNothing().when(statement).close();
 
         // Test method
@@ -136,22 +154,21 @@ public class JdbcBasePluginTest {
         Mockito.doThrow(exception).when(databaseMetaData).supportsTransactions();
 
         Connection connection = mock(Connection.class);
-        Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
-        Mockito.when(connection.isClosed()).thenReturn(false);
-        Mockito.when(connection.getAutoCommit()).thenReturn(false);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.getAutoCommit()).thenReturn(false);
         Mockito.doNothing().when(connection).commit();
         Mockito.doNothing().when(connection).close();
 
         Statement statement = mock(Statement.class);
-        Mockito.when(statement.getConnection()).thenReturn(connection);
+        when(statement.getConnection()).thenReturn(connection);
         Mockito.doNothing().when(statement).close();
 
         // Test method and check
         try {
             JdbcBasePlugin.closeStatementAndConnection(statement);
             fail("SQLException must have been thrown");
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             assertSame(exception, e);
         }
 
@@ -164,25 +181,24 @@ public class JdbcBasePluginTest {
         SQLException exception = new SQLException("SQLException");
 
         DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
-        Mockito.when(databaseMetaData.supportsTransactions()).thenReturn(true);
+        when(databaseMetaData.supportsTransactions()).thenReturn(true);
 
         Connection connection = mock(Connection.class);
-        Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
-        Mockito.when(connection.isClosed()).thenReturn(false);
-        Mockito.when(connection.getAutoCommit()).thenReturn(false);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.getAutoCommit()).thenReturn(false);
         Mockito.doThrow(exception).when(connection).commit();
         Mockito.doNothing().when(connection).close();
 
         Statement statement = mock(Statement.class);
-        Mockito.when(statement.getConnection()).thenReturn(connection);
+        when(statement.getConnection()).thenReturn(connection);
         Mockito.doNothing().when(statement).close();
 
         // Test method and check
         try {
             JdbcBasePlugin.closeStatementAndConnection(statement);
             fail("SQLException must have been thrown");
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             assertSame(exception, e);
         }
 
@@ -195,27 +211,20 @@ public class JdbcBasePluginTest {
         SQLException exception = new SQLException("SQLException");
 
         DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
-        Mockito.when(databaseMetaData.supportsTransactions()).thenReturn(false);
+        when(databaseMetaData.supportsTransactions()).thenReturn(false);
 
         Connection connection = mock(Connection.class);
-        Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
-        Mockito.when(connection.isClosed()).thenReturn(false);
-        Mockito.when(connection.getAutoCommit()).thenReturn(false);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.getAutoCommit()).thenReturn(false);
         Mockito.doNothing().when(connection).commit();
         Mockito.doThrow(exception).when(connection).close();
 
         Statement statement = mock(Statement.class);
-        Mockito.when(statement.getConnection()).thenReturn(connection);
+        when(statement.getConnection()).thenReturn(connection);
         Mockito.doNothing().when(statement).close();
 
-        // Test method and check
-        try {
-            JdbcBasePlugin.closeStatementAndConnection(statement);
-            fail("SQLException must have been thrown");
-        }
-        catch (Exception e) {
-            assertSame(exception, e);
-        }
+        JdbcBasePlugin.closeStatementAndConnection(statement);
 
         Mockito.verify(statement, times(1)).close();
     }
@@ -225,25 +234,24 @@ public class JdbcBasePluginTest {
         SQLException exception = new SQLException("SQLException");
 
         DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
-        Mockito.when(databaseMetaData.supportsTransactions()).thenReturn(false);
+        when(databaseMetaData.supportsTransactions()).thenReturn(false);
 
         Connection connection = mock(Connection.class);
-        Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
-        Mockito.when(connection.isClosed()).thenReturn(false);
-        Mockito.when(connection.getAutoCommit()).thenReturn(false);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.getAutoCommit()).thenReturn(false);
         Mockito.doNothing().when(connection).commit();
         Mockito.doNothing().when(connection).close();
 
         Statement statement = mock(Statement.class);
-        Mockito.when(statement.getConnection()).thenReturn(connection);
+        when(statement.getConnection()).thenReturn(connection);
         Mockito.doThrow(exception).when(statement).close();
 
         // Test method and check
         try {
             JdbcBasePlugin.closeStatementAndConnection(statement);
             fail("SQLException must have been thrown");
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             assertSame(exception, e);
         }
 
@@ -255,12 +263,12 @@ public class JdbcBasePluginTest {
         SQLException exception = new SQLException("SQLException");
 
         DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
-        Mockito.when(databaseMetaData.supportsTransactions()).thenReturn(false);
+        when(databaseMetaData.supportsTransactions()).thenReturn(false);
 
         Connection connection = mock(Connection.class);
-        Mockito.when(connection.getMetaData()).thenReturn(databaseMetaData);
-        Mockito.when(connection.isClosed()).thenReturn(false);
-        Mockito.when(connection.getAutoCommit()).thenReturn(false);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.getAutoCommit()).thenReturn(false);
         Mockito.doNothing().when(connection).commit();
         Mockito.doNothing().when(connection).close();
 
@@ -272,12 +280,131 @@ public class JdbcBasePluginTest {
         try {
             JdbcBasePlugin.closeStatementAndConnection(statement);
             fail("SQLException must have been thrown");
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             assertSame(exception, e);
         }
 
         Mockito.verify(statement, times(1)).close();
     }
-}
 
+    @Test
+    public void testTransactionIsolationNotSetByUser() throws SQLException {
+        PowerMockito.mockStatic(DriverManager.class);
+
+        RequestContext context = new RequestContext();
+        context.setDataSource("test-table");
+        Map<String, String> additionalProps = new HashMap<>();
+        additionalProps.put("jdbc.driver", "org.greenplum.pxf.plugins.jdbc.FakeJdbcDriver");
+        additionalProps.put("jdbc.url", "test-url");
+        context.setAdditionalConfigProps(additionalProps);
+
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData fakeMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(fakeMetaData);
+        when(DriverManager.getConnection(anyString(), anyObject())).thenReturn(mockConnection);
+
+        JdbcBasePlugin plugin = new JdbcBasePlugin();
+        plugin.initialize(context);
+        Connection conn = plugin.getConnection();
+
+        verify(conn, never()).setTransactionIsolation(anyInt());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTransactionIsolationSetByUserToInvalidValue() throws SQLException {
+        PowerMockito.mockStatic(DriverManager.class);
+
+        RequestContext context = new RequestContext();
+        context.setDataSource("test-table");
+        Map<String, String> additionalProps = new HashMap<>();
+        additionalProps.put("jdbc.driver", "org.greenplum.pxf.plugins.jdbc.FakeJdbcDriver");
+        additionalProps.put("jdbc.url", "test-url");
+        additionalProps.put("jdbc.connection.transactionIsolation", "foobarValue");
+        context.setAdditionalConfigProps(additionalProps);
+
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData fakeMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(fakeMetaData);
+        when(DriverManager.getConnection(anyString(), anyObject())).thenReturn(mockConnection);
+
+        JdbcBasePlugin plugin = new JdbcBasePlugin();
+        plugin.initialize(context);
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testTransactionIsolationSetByUserToUnsupportedValue() throws SQLException {
+        PowerMockito.mockStatic(DriverManager.class);
+
+        RequestContext context = new RequestContext();
+        context.setDataSource("test-table");
+        Map<String, String> additionalProps = new HashMap<>();
+        additionalProps.put("jdbc.driver", "org.greenplum.pxf.plugins.jdbc.FakeJdbcDriver");
+        additionalProps.put("jdbc.url", "test-url");
+        additionalProps.put("jdbc.connection.transactionIsolation", "READ_UNCOMMITTED");
+        context.setAdditionalConfigProps(additionalProps);
+
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData fakeMetaData = mock(DatabaseMetaData.class);
+        // READ_UNCOMMITTED is level 1
+        when(fakeMetaData.supportsTransactionIsolationLevel(1)).thenReturn(false);
+        when(mockConnection.getMetaData()).thenReturn(fakeMetaData);
+        when(DriverManager.getConnection(anyString(), anyObject())).thenReturn(mockConnection);
+
+        JdbcBasePlugin plugin = new JdbcBasePlugin();
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Transaction isolation level READ_UNCOMMITTED is not supported");
+        plugin.initialize(context);
+        plugin.getConnection();
+    }
+
+    @Test
+    public void testTransactionIsolationSetByUserToValidValue() throws SQLException {
+        PowerMockito.mockStatic(DriverManager.class);
+
+        RequestContext context = new RequestContext();
+        context.setDataSource("test-table");
+        Map<String, String> additionalProps = new HashMap<>();
+        additionalProps.put("jdbc.driver", "org.greenplum.pxf.plugins.jdbc.FakeJdbcDriver");
+        additionalProps.put("jdbc.url", "test-url");
+        additionalProps.put("jdbc.connection.transactionIsolation", "READ_COMMITTED");
+        context.setAdditionalConfigProps(additionalProps);
+
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData fakeMetaData = mock(DatabaseMetaData.class);
+        // READ_COMMITTED is level 2
+        when(fakeMetaData.supportsTransactionIsolationLevel(2)).thenReturn(true);
+        when(mockConnection.getMetaData()).thenReturn(fakeMetaData);
+        when(DriverManager.getConnection(anyString(), anyObject())).thenReturn(mockConnection);
+
+        JdbcBasePlugin plugin = new JdbcBasePlugin();
+        plugin.initialize(context);
+        Connection conn = plugin.getConnection();
+
+        // READ_COMMITTED is level 2
+        verify(conn).setTransactionIsolation(2);
+    }
+
+    @Test(expected = SQLException.class)
+    public void testTransactionIsolationSetByUserFailedToGetMetadata() throws SQLException {
+        PowerMockito.mockStatic(DriverManager.class);
+
+        RequestContext context = new RequestContext();
+        context.setDataSource("test-table");
+        Map<String, String> additionalProps = new HashMap<>();
+        additionalProps.put("jdbc.driver", "org.greenplum.pxf.plugins.jdbc.FakeJdbcDriver");
+        additionalProps.put("jdbc.url", "test-url");
+        context.setAdditionalConfigProps(additionalProps);
+
+        Connection mockConnection = mock(Connection.class);
+        doThrow(new SQLException("")).when(mockConnection).getMetaData();
+        when(DriverManager.getConnection(anyString(), anyObject())).thenReturn(mockConnection);
+
+        JdbcBasePlugin plugin = new JdbcBasePlugin();
+        plugin.initialize(context);
+        plugin.getConnection();
+    }
+}

--- a/server/pxf-service/src/templates/user/templates/jdbc-site.xml
+++ b/server/pxf-service/src/templates/user/templates/jdbc-site.xml
@@ -20,6 +20,14 @@
         <value>YOUR_DATABASE_JDBC_PASSWORD</value>
         <description>Password for connecting to the database (e.g. postgres)</description>
     </property>
+    <!-- Uncomment to set transaction isolation level
+        Set to one of: READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, or SERIALIZABLE
+    <property>
+        <name>jdbc.connection.transactionIsolation</name>
+        <value>YOUR_CHOSEN_TRANSACTION_ISOLATION_FROM_ABOVE</value>
+        <description>JDBC connection transaction isolation level. Make sure your database supports the level you define here.</description>
+    </property>
+    -->
     <!-- Uncomment to set session-level variable for queries to external database
     <property>
         <name>jdbc.session.property.some_property_1</name>


### PR DESCRIPTION
Adds ability for user to set the transaction isolation level, which would allow e.g. dirty reads if permitted by the external database.