### PR TITLE
Remove support for Logical operator NOT with Hive Partition Filtering

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
@@ -379,8 +379,8 @@ public class HiveTest extends HiveBaseTest {
 
         exTable = TableFactory.getPxfHiveReadableTable(extTableName,
                 PXF_HIVE_SMALLDATA_PPD_COLS, hivePartitionedPPDTable, false);
-        exTable.setName(extTableName + "_1");
         filterString = "a0c25s4drow1o7a3c23s3d999o1l0a2c25s4ds_14o5l0";
+        exTable.setName(extTableName + "_1");
         exTable.setUserParameters(hiveTestFilter(filterString));
         exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
         createTable(exTable);
@@ -395,6 +395,13 @@ public class HiveTest extends HiveBaseTest {
         // Filter with P1 OR (NOT P2 OR NOT P3)
         filterString = "a2c25s3ds_7o5a3c23s1d4o5l2a2c25s3ds_9o5l2l1l1";
         exTable.setName(extTableName + "_3");
+        exTable.setUserParameters(hiveTestFilter(filterString));
+        exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
+        createTable(exTable);
+
+        // Test for != operators
+        filterString = "a2c25s4ds_14o6";
+        exTable.setName(extTableName + "_4");
         exTable.setUserParameters(hiveTestFilter(filterString));
         exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
         createTable(exTable);

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
@@ -374,7 +374,7 @@ public class HiveTest extends HiveBaseTest {
         hive.runQuery("SET hive.exec.dynamic.partition.mode = nonstrict");
         hive.insertDataToPartition(hiveSmallDataTable, hivePartitionedPPDTable,
                 new String[]{"s2, n1"}, new String[]{"s1", "d1", "s2", "n1"});
-        
+
         String extTableName = PXF_HIVE_PARTITIONED_PPD_TABLE + "_customfilter";
         String filterString;
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
@@ -385,8 +385,16 @@ public class HiveTest extends HiveBaseTest {
         exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
         createTable(exTable);
 
-        filterString = "a1c701s1d9o4a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0";
+        // Filter with P1 AND (NOT P2 OR NOT P3)
+        filterString = "a2c25s3ds_7o5a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0";
         exTable.setName(extTableName + "_2");
+        exTable.setUserParameters(hiveTestFilter(filterString));
+        exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
+        createTable(exTable);
+
+        // Filter with P1 OR (NOT P2 OR NOT P3)
+        filterString = "a2c25s3ds_7o5a3c23s1d4o5l2a2c25s3ds_9o5l2l1l1";
+        exTable.setName(extTableName + "_3");
         exTable.setUserParameters(hiveTestFilter(filterString));
         exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
         createTable(exTable);

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
@@ -374,13 +374,23 @@ public class HiveTest extends HiveBaseTest {
                 new String[]{"s2, n1"}, new String[]{"s1", "d1", "s2", "n1"});
 
         // Create GPDB table without using profiles
-        exTable = TableFactory.getPxfHiveReadableTable(PXF_HIVE_PARTITIONED_PPD_TABLE + "_customfilters",
-                PXF_HIVE_SMALLDATA_PPD_COLS, hivePartitionedPPDTable, false);
+        String extTableName = PXF_HIVE_PARTITIONED_PPD_TABLE + "_customfilter";
+        String filterString;
 
-        String filterString = "a0c25s4drow1o7a3c23s3d999o1l0a2c25s4ds_14o5l0";
+        exTable = TableFactory.getPxfHiveReadableTable(extTableName,
+                PXF_HIVE_SMALLDATA_PPD_COLS, hivePartitionedPPDTable, false);
+        exTable.setName(extTableName + "_1");
+        filterString = "a0c25s4drow1o7a3c23s3d999o1l0a2c25s4ds_14o5l0";
         exTable.setUserParameters(hiveTestFilter(filterString));
         exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
         createTable(exTable);
+
+        filterString = "a1c701s1d9o4a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0";
+        exTable.setName(extTableName + "_2");
+        exTable.setUserParameters(hiveTestFilter(filterString));
+        exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
+        createTable(exTable);
+
         runTincTest("pxf.features.hive.hive_partitioned_ppd_table_customfilters.runTest");
     }
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
@@ -364,6 +364,8 @@ public class HiveTest extends HiveBaseTest {
     @Test(groups = { "hive", "features", "gpdb" })
     public void hivePartitionedPPDTableCustomFilters() throws Exception {
 
+        // Hive talbe with partition columns s2, n1.
+        // 10 partition with one row in each partition
         HiveExternalTable hivePartitionedPPDTable = TableFactory.getHiveByRowCommaExternalTable(HIVE_PARTITIONED_PPD_TABLE, HIVE_SMALLDATA_PPD_COLS);
         hivePartitionedPPDTable.setPartitionedBy(HIVE_PARTITION_PPD_COLS);
         hive.createTableAndVerify(hivePartitionedPPDTable);
@@ -372,11 +374,12 @@ public class HiveTest extends HiveBaseTest {
         hive.runQuery("SET hive.exec.dynamic.partition.mode = nonstrict");
         hive.insertDataToPartition(hiveSmallDataTable, hivePartitionedPPDTable,
                 new String[]{"s2, n1"}, new String[]{"s1", "d1", "s2", "n1"});
-
-        // Create GPDB table without using profiles
+        
         String extTableName = PXF_HIVE_PARTITIONED_PPD_TABLE + "_customfilter";
         String filterString;
 
+        // Filter with NP1 AND NP2 AND P3 -> P3
+        // Test for (s1 LIKE 'row1') AND (n1 < 999) AND (s2 = 's_14) return one partitions
         exTable = TableFactory.getPxfHiveReadableTable(extTableName,
                 PXF_HIVE_SMALLDATA_PPD_COLS, hivePartitionedPPDTable, false);
         filterString = "a0c25s4drow1o7a3c23s3d999o1l0a2c25s4ds_14o5l0";
@@ -385,14 +388,16 @@ public class HiveTest extends HiveBaseTest {
         exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
         createTable(exTable);
 
-        // Filter with P1 AND (NOT P2 OR NOT P3)
+        // Filter with P1 AND (NOT P2 OR NOT P3) -> P1
+        // (s2 = 's_9') AND (NOT(s2 = 's_7') OR NOT(n1 = 4)) should return one partition
         filterString = "a2c25s3ds_7o5a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0";
         exTable.setName(extTableName + "_2");
         exTable.setUserParameters(hiveTestFilter(filterString));
         exTable.setFragmenter(TEST_PACKAGE + "HiveDataFragmenterWithFilter");
         createTable(exTable);
 
-        // Filter with P1 OR (NOT P2 OR NOT P3)
+        // Filter with P1 OR (NOT P2 OR NOT P3) -> null
+        // (s2 = 's_9') OR (NOT(s2 = 's_7') OR NOT(n1 = 4)) should return all partitions
         filterString = "a2c25s3ds_7o5a3c23s1d4o5l2a2c25s3ds_9o5l2l1l1";
         exTable.setName(extTableName + "_3");
         exTable.setUserParameters(hiveTestFilter(filterString));
@@ -400,6 +405,7 @@ public class HiveTest extends HiveBaseTest {
         createTable(exTable);
 
         // Test for != operators
+        // (s2 != 's_14') should return 9 rows
         filterString = "a2c25s4ds_14o6";
         exTable.setName(extTableName + "_4");
         exTable.setUserParameters(hiveTestFilter(filterString));

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/expected/query01.ans
@@ -1,8 +1,30 @@
 -- start_ignore
 -- end_ignore
 -- @description query01 for PXF Hive partitioned table with custom filters
-SELECT * FROM pxf_hive_partitioned_ppd_table_customfilters ORDER BY n1, s2;
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_1 ORDER BY n1, s2;
   s1  | d1 |  s2  | n1
 ------+----+------+----
  row9 | 14 | s_14 |  9
 (1 row)
+
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_2 ORDER BY n1, s2;
+  s1  | d1 | s2  | n1
+------+----+-----+----
+ row2 |  7 | s_7 |  2
+(1 row)
+
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_3 ORDER BY n1, s2;
+  s1   | d1 |  s2  | n1
+-------+----+------+----
+ row1  |  6 | s_6  |  1
+ row2  |  7 | s_7  |  2
+ row3  |  8 | s_8  |  3
+ row4  |  9 | s_9  |  4
+ row5  | 10 | s_10 |  5
+ row6  | 11 | s_11 |  6
+ row7  | 12 | s_12 |  7
+ row8  | 13 | s_13 |  8
+ row9  | 14 | s_14 |  9
+ row10 | 15 | s_15 | 10
+(10 rows)
+

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/expected/query01.ans
@@ -28,3 +28,17 @@ SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_3 ORDER BY n1, s2;
  row10 | 15 | s_15 | 10
 (10 rows)
 
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_4 ORDER BY n1, s2;
+  s1   | d1 |  s2  | n1
+-------+----+------+----
+ row1  |  6 | s_6  |  1
+ row2  |  7 | s_7  |  2
+ row3  |  8 | s_8  |  3
+ row4  |  9 | s_9  |  4
+ row5  | 10 | s_10 |  5
+ row6  | 11 | s_11 |  6
+ row7  | 12 | s_12 |  7
+ row8  | 13 | s_13 |  8
+ row10 | 15 | s_15 | 10
+(9 rows)
+

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/sql/query01.sql
@@ -5,3 +5,5 @@ SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_1 ORDER BY n1, s2;
 SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_2 ORDER BY n1, s2;
 
 SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_3 ORDER BY n1, s2;
+
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_4 ORDER BY n1, s2;

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/sql/query01.sql
@@ -1,3 +1,5 @@
 -- @description query01 for PXF Hive partitioned table with custom filters
 
-SELECT * FROM pxf_hive_partitioned_ppd_table_customfilters ORDER BY n1, s2;
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_1 ORDER BY n1, s2;
+
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_2 ORDER BY n1, s2;

--- a/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/hive_partitioned_ppd_table_customfilters/sql/query01.sql
@@ -3,3 +3,5 @@
 SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_1 ORDER BY n1, s2;
 
 SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_2 ORDER BY n1, s2;
+
+SELECT * FROM pxf_hive_partitioned_ppd_table_customfilter_3 ORDER BY n1, s2;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
@@ -167,7 +167,7 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
                 logicalOperator = " or ";
                 break;
             case HDOP_NOT:
-                logicalOperator = " not ";
+                logicalOperator = "not ";
                 break;
             default:
                 logicalOperator = "";
@@ -184,9 +184,8 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
             if (serializedFilter != null) {
                 if (filter.getOperator() == FilterParser.LogicalOperation.HDOP_NOT) {
                     filterString
-                            .append("NOT(")
-                            .append(serializedFilter)
-                            .append(")");
+                            .append(logicalOperator)
+                            .append(serializedFilter);
                 } else {
                     // We only append the operator if there is something on the
                     // filterString
@@ -204,6 +203,9 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
         }
 
         if (filterString.length() > 0) {
+            if (filter.getOperator() == FilterParser.LogicalOperation.HDOP_NOT) {
+                return filterString.toString();
+            }
             return String.format("(%s)", filterString.toString());
         } else {
             return null;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
@@ -166,9 +166,6 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
             case HDOP_OR:
                 logicalOperator = " or ";
                 break;
-            case HDOP_NOT:
-                logicalOperator = "not ";
-                break;
             default:
                 logicalOperator = "";
         }
@@ -183,9 +180,7 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
             }
             if (serializedFilter != null) {
                 if (filter.getOperator() == FilterParser.LogicalOperation.HDOP_NOT) {
-                    filterString
-                            .append(logicalOperator)
-                            .append(serializedFilter);
+                    return null;
                 } else {
                     // We only append the operator if there is something on the
                     // filterString
@@ -203,9 +198,6 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
         }
 
         if (filterString.length() > 0) {
-            if (filter.getOperator() == FilterParser.LogicalOperation.HDOP_NOT) {
-                return filterString.toString();
-            }
             return String.format("(%s)", filterString.toString());
         } else {
             return null;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
@@ -54,7 +54,7 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
     private static final String HIVE_API_GT = " > ";
     private static final String HIVE_API_LTE = " <= ";
     private static final String HIVE_API_GTE = " >= ";
-    private static final String HIVE_API_NE = " != ";
+    private static final String HIVE_API_NE = " <> ";
     private static final String HIVE_API_DQUOTE = "\"";
 
     /**
@@ -161,10 +161,10 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
         String logicalOperator;
         switch (filter.getOperator()) {
             case HDOP_AND:
-                logicalOperator = " and ";
+                logicalOperator = " AND ";
                 break;
             case HDOP_OR:
-                logicalOperator = " or ";
+                logicalOperator = " OR ";
                 break;
             default:
                 logicalOperator = "";

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
@@ -167,7 +167,8 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
                 logicalOperator = " OR ";
                 break;
             default:
-                logicalOperator = "";
+                // NOT not supported
+                return null;
         }
 
         StringBuilder filterString = new StringBuilder();
@@ -179,17 +180,11 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
                 serializedFilter = buildSingleFilter(f, filter.getOperator());
             }
             if (serializedFilter != null) {
-                if (filter.getOperator() == FilterParser.LogicalOperation.HDOP_NOT) {
-                    return null;
-                } else {
-                    // We only append the operator if there is something on the
-                    // filterString
-                    if (filterString.length() > 0) {
-                        filterString.append(logicalOperator);
-                    }
-                    filterString.append(serializedFilter);
+                // We only append the operator if there is something on the filterString
+                if (filterString.length() > 0) {
+                    filterString.append(logicalOperator);
                 }
-
+                filterString.append(serializedFilter);
             } else if (filter.getOperator() == FilterParser.LogicalOperation.HDOP_OR) {
                 // Case when one of the predicates is non-compliant and with OR operator
                 // P OR NP -> null
@@ -197,11 +192,8 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
             }
         }
 
-        if (filterString.length() > 0) {
-            return String.format("(%s)", filterString.toString());
-        } else {
-            return null;
-        }
+        return (filterString.length() > 0) ?
+                String.format("(%s)", filterString.toString()) : null;
     }
 
     private boolean isFilterCompatible(String filterColumnName, FilterParser.Operation operation, FilterParser.LogicalOperation logicalOperation) {

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilderTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilderTest.java
@@ -65,8 +65,8 @@ public class HiveFilterBuilderTest {
         builder.setCanPushdownIntegral(true);
         builder.setPartitionKeys(getPartitionKeyTypes());
 
-        //assertEquals("(stringColumn >= \"9.0\" and ((NOT(bigIntColumn = \"4\")) or (NOT(intColumn = \"s_9\"))))", builder.buildFilterStringForHive("a1c701s1d9o4a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0"));
-        assertEquals("(stringColumn >= \"9.0\" and (not bigIntColumn = \"4\" or not intColumn = \"s_9\"))", builder.buildFilterStringForHive("a1c701s1d9o4a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0"));
+        assertNull(builder.buildFilterStringForHive("a3c23s1d4o5l2a2c25s3ds_9o5l2l1"));
+        assertEquals("(stringColumn >= \"9.0\")", builder.buildFilterStringForHive("a1c701s1d9o4a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0"));
     }
 
     @Test

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilderTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilderTest.java
@@ -65,7 +65,8 @@ public class HiveFilterBuilderTest {
         builder.setCanPushdownIntegral(true);
         builder.setPartitionKeys(getPartitionKeyTypes());
 
-        assertEquals("(stringColumn >= \"9.0\" and ((NOT(bigIntColumn = \"4\")) or (NOT(intColumn = \"s_9\"))))", builder.buildFilterStringForHive("a1c701s1d9o4a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0"));
+        //assertEquals("(stringColumn >= \"9.0\" and ((NOT(bigIntColumn = \"4\")) or (NOT(intColumn = \"s_9\"))))", builder.buildFilterStringForHive("a1c701s1d9o4a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0"));
+        assertEquals("(stringColumn >= \"9.0\" and (not bigIntColumn = \"4\" or not intColumn = \"s_9\"))", builder.buildFilterStringForHive("a1c701s1d9o4a3c23s1d4o5l2a2c25s3ds_9o5l2l1l0"));
     }
 
     @Test

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilderTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilderTest.java
@@ -137,7 +137,7 @@ public class HiveFilterBuilderTest {
         builder.setCanPushdownIntegral(false);
         builder.setPartitionKeys(partitionKeyTypes);
 
-        assertEquals("textColumn != \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o6"));
+        assertEquals("textColumn <> \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o6"));
         assertEquals("textColumn = \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o5"));
         assertEquals("textColumn >= \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o4"));
         assertEquals("textColumn <= \"2016-01-03\"", builder.buildFilterStringForHive("a3c25s10d2016-01-03o3"));
@@ -160,22 +160,22 @@ public class HiveFilterBuilderTest {
 
         assertEquals("stringColumn >= \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o4"));
         assertEquals("stringColumn = \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o5"));
-        assertEquals("stringColumn != \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o6"));
+        assertEquals("stringColumn <> \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o6"));
 
         // Don't support > for integral types
         assertNull(builder.buildFilterStringForHive("a2c23s3d126o4"));
         // Support = for integral types
         assertEquals("intColumn = \"126\"", builder.buildFilterStringForHive("a2c23s3d126o5"));
-        // Support != for integral types
-        assertEquals("intColumn != \"126\"", builder.buildFilterStringForHive("a2c23s3d126o6"));
+        // Support <> for integral types
+        assertEquals("intColumn <> \"126\"", builder.buildFilterStringForHive("a2c23s3d126o6"));
 
         assertNull(builder.buildFilterStringForHive("a3c20s3d126o4"));
         assertEquals("bigIntColumn = \"126\"", builder.buildFilterStringForHive("a3c20s3d126o5"));
-        assertEquals("bigIntColumn != \"126\"", builder.buildFilterStringForHive("a3c20s3d126o6"));
+        assertEquals("bigIntColumn <> \"126\"", builder.buildFilterStringForHive("a3c20s3d126o6"));
 
         assertNull(builder.buildFilterStringForHive("a4c21s3d126o4"));
         assertEquals("smallIntColumn = \"126\"", builder.buildFilterStringForHive("a4c21s3d126o5"));
-        assertEquals("smallIntColumn != \"126\"", builder.buildFilterStringForHive("a4c21s3d126o6"));
+        assertEquals("smallIntColumn <> \"126\"", builder.buildFilterStringForHive("a4c21s3d126o6"));
     }
 
     @Test
@@ -192,7 +192,7 @@ public class HiveFilterBuilderTest {
 
         assertEquals("stringColumn >= \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o4"));
         assertEquals("stringColumn = \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o5"));
-        assertEquals("stringColumn != \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o6"));
+        assertEquals("stringColumn <> \"2016-01-03\"", builder.buildFilterStringForHive("a1c25s10d2016-01-03o6"));
 
         // Integral types not supported
         assertNull(builder.buildFilterStringForHive("a2c23s3d126o4"));
@@ -225,9 +225,9 @@ public class HiveFilterBuilderTest {
         // NP is a predicate based on either a non-partition column or an unsupported operator.
 
         // P1 AND P2 -> P1 AND P2
-        assertEquals("(stringColumn = \"foobar\" and intColumn != \"999\")", builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l0"));
+        assertEquals("(stringColumn = \"foobar\" AND intColumn <> \"999\")", builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l0"));
         // P1 OR P2 -> P1 OR P2
-        assertEquals("(stringColumn = \"foobar\" or intColumn != \"999\")", builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l1"));
+        assertEquals("(stringColumn = \"foobar\" OR intColumn <> \"999\")", builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l1"));
         // P1 AND NP1 -> P1
         assertEquals("(stringColumn = \"foobar\")", builder.buildFilterStringForHive("a1c25s6dfoobaro5a3c20s3d999o6l0"));
         // P1 OR NP1 -> null
@@ -237,7 +237,7 @@ public class HiveFilterBuilderTest {
         // (P1 AND P2) OR NP1 -> null
         assertNull(builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l0a2c20s3d999o4l1"));
         // (P1 AND P2) AND (P3 OR NP1) -> P1 AND P2
-        assertEquals("((stringColumn = \"foobar\" and intColumn != \"999\"))", builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l0a1c25s6dfoobaro5a3c20s3d999o6l1l0"));
+        assertEquals("((stringColumn = \"foobar\" AND intColumn <> \"999\"))", builder.buildFilterStringForHive("a1c25s6dfoobaro5a2c23s3d999o6l0a1c25s6dfoobaro5a3c20s3d999o6l1l0"));
     }
 
     private List<ColumnDescriptor> getColumnDescriptors() {


### PR DESCRIPTION
Removed log. op. NOT from hive partition filter
Logical operators are now upper case with hive partition filtering string
!= is now <>

Predicates with NOT logical operator eg: NOT(a='foo') are not supported with hive partition filtering. 
https://cwiki.apache.org/confluence/display/Hive/Partition+Filter+Syntax
Will need a follow up PR to handle this case. One possibility we could reverse the underlying predicate in order to avoid NOT. eg: NOT(a='foo') -> (a!='foo)