### PR TITLE
Reverse direction of rsync in pxf sync command

### DIFF
--- a/cli/go/src/pxf-cli/cmd/cluster.go
+++ b/cli/go/src/pxf-cli/cmd/cluster.go
@@ -28,7 +28,7 @@ var (
 
 	initCmd = &cobra.Command{
 		Use:   "init",
-		Short: "Initialize the local PXF server instance",
+		Short: "Initialize the PXF server instances on master, standby master, and the segment hosts",
 		Run: func(cmd *cobra.Command, args []string) {
 			command := &pxf.InitCommand
 			clusterData, err := doSetup(command)
@@ -41,7 +41,7 @@ var (
 
 	startCmd = &cobra.Command{
 		Use:   "start",
-		Short: "Start the local PXF server instance",
+		Short: "Start the PXF server instances on the segment hosts",
 		Run: func(cmd *cobra.Command, args []string) {
 			command := &pxf.StartCommand
 			clusterData, err := doSetup(command)
@@ -55,7 +55,7 @@ var (
 
 	stopCmd = &cobra.Command{
 		Use:   "stop",
-		Short: "Stop the local PXF server instance",
+		Short: "Stop the PXF server instances on the segment hosts",
 		Run: func(cmd *cobra.Command, args []string) {
 			command := &pxf.StopCommand
 			clusterData, err := doSetup(command)
@@ -69,7 +69,7 @@ var (
 
 	syncCmd = &cobra.Command{
 		Use:   "sync",
-		Short: "Sync PXF configs from master to all segment hosts",
+		Short: "Sync PXF configs from master to standby master and the segment hosts",
 		Run: func(cmd *cobra.Command, args []string) {
 			command := &pxf.SyncCommand
 			clusterData, err := doSetup(command)

--- a/server/pxf-service/src/scripts/pxf-service
+++ b/server/pxf-service/src/scripts/pxf-service
@@ -322,18 +322,18 @@ doHelp() {
     local bold=$(tput bold)
     local tab=$(printf '\t')
     printUsage
-	cat <<-EOF
+    cat <<-EOF
 
 	${bold}List of commands${normal}:
-	  init      initialize the local PXF server instance
-	  start     start the local PXF server instance
-	  stop      stop the local PXF server instance
-	  restart   restart the local PXF server instance (not supported for cluster)
-	  status    show the status of the local PXF server instance (not supported for cluster)
-	  version   show the version of PXF server
-	  cluster   perform <command> on each segment host in the cluster
+	  init                initialize the local PXF server instance
+	  start               start the local PXF server instance
+	  stop                stop the local PXF server instance
+	  restart             restart the local PXF server instance (not supported for cluster)
+	  status              show the status of the local PXF server instance (not supported for cluster)
+	  version             show the version of PXF server
+	  cluster <command>   perform <command> on all the hosts in the cluster; try ${bold}pxf cluster help$normal
 
-	  sync <hostname>    sync PXF_CONF/{conf,lib,servers} directories
+	  sync <hostname>     sync \$PXF_CONF/{conf,lib,servers} directories onto <hostname>
 
 	${bold}Options${normal}:
 	  -h, --help    show command help
@@ -402,16 +402,16 @@ function doStatus()
 
 function doSync()
 {
-    local source_host=$1
-    if [[ -z ${source_host} ]]; then
-        fail "PXF config source host must be set to use this option"
+    local target_host=$1
+    if [[ -z $target_host ]]; then
+        fail "A destination hostname must be provided"
     fi
     instanceExists
     if (( $? != 0 )); then
         fail "Can't find PXF instance, maybe call init?"
     fi
     get_environment
-    rsync -az -e "ssh -o StrictHostKeyChecking=no" "${source_host}:${PXF_CONF}/"{conf,lib,servers} "${PXF_CONF}"
+    rsync -az -e "ssh -o StrictHostKeyChecking=no" "$PXF_CONF"/{conf,lib,servers} "${target_host}:$PXF_CONF"
 }
 
 function doCluster()


### PR DESCRIPTION
`pxf sync` is documented as being run from master, i.e. `pxf sync
remote` should sync $PXF_CONF/{conf,lib,servers} from master to remote.
Instead, it syncs from remote to local. This is a vestige of the
original implementation of `pxf cluster sync`, which has now been
changed.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>