### PR TITLE
pxf cli: Add cluster status command

### DIFF
--- a/cli/go/src/pxf-cli/cmd/cluster.go
+++ b/cli/go/src/pxf-cli/cmd/cluster.go
@@ -80,12 +80,27 @@ var (
 			exitWithReturnCode(err)
 		},
 	}
+
+	statusCmd = &cobra.Command{
+		Use:   "status",
+		Short: "Get status of PXF servers on the segment hosts",
+		Run: func(cmd *cobra.Command, args []string) {
+			command := &pxf.StatusCommand
+			clusterData, err := doSetup(command)
+			if err == nil {
+				err = clusterRun(command, clusterData)
+			}
+
+			exitWithReturnCode(err)
+		},
+	}
 )
 
 func init() {
 	rootCmd.AddCommand(clusterCmd)
 	clusterCmd.AddCommand(initCmd)
 	clusterCmd.AddCommand(startCmd)
+	clusterCmd.AddCommand(statusCmd)
 	clusterCmd.AddCommand(stopCmd)
 	clusterCmd.AddCommand(syncCmd)
 }

--- a/cli/go/src/pxf-cli/cmd/cluster_test.go
+++ b/cli/go/src/pxf-cli/cmd/cluster_test.go
@@ -59,6 +59,11 @@ var _ = Describe("GenerateStatusReport()", func() {
 		_ = cmd.GenerateStatusReport(&pxf.SyncCommand, clusterData)
 		Expect(testStdout).Should(gbytes.Say("Syncing PXF configuration files to 2 hosts..."))
 	})
+
+	It("reports the number of hosts that are getting status checked", func() {
+		_ = cmd.GenerateStatusReport(&pxf.StatusCommand, clusterData)
+		Expect(testStdout).Should(gbytes.Say("Checking status of PXF servers on 2 hosts..."))
+	})
 })
 
 var _ = Describe("GenerateOutput()", func() {
@@ -90,6 +95,11 @@ var _ = Describe("GenerateOutput()", func() {
 			_ = cmd.GenerateOutput(&pxf.SyncCommand, clusterData)
 			Expect(testStdout).To(gbytes.Say("PXF configs synced successfully on 3 out of 3 hosts"))
 		})
+
+		It("reports all hosts running", func() {
+			_ = cmd.GenerateOutput(&pxf.StatusCommand, clusterData)
+			Expect(testStdout).To(gbytes.Say("PXF is running on 3 out of 3 hosts"))
+		})
 	})
 
 	Context("when some hosts fail", func() {
@@ -117,14 +127,18 @@ var _ = Describe("GenerateOutput()", func() {
 			_ = cmd.GenerateOutput(&pxf.StopCommand, clusterData)
 			Expect(testStdout).Should(gbytes.Say("PXF failed to stop on 1 out of 3 hosts"))
 			Expect(testStderr).Should(gbytes.Say("sdw2 ==> an error happened on sdw2"))
-
 		})
 
 		It("reports the number of hosts that failed to sync", func() {
 			_ = cmd.GenerateOutput(&pxf.SyncCommand, clusterData)
 			Expect(testStdout).Should(gbytes.Say("PXF configs failed to sync on 1 out of 3 hosts"))
 			Expect(testStderr).Should(gbytes.Say("sdw2 ==> an error happened on sdw2"))
+		})
 
+		It("reports the number of hosts that aren't running", func() {
+			_ = cmd.GenerateOutput(&pxf.StatusCommand, clusterData)
+			Expect(testStdout).Should(gbytes.Say("PXF is not running on 1 out of 3 hosts"))
+			Expect(testStderr).Should(gbytes.Say("sdw2 ==> an error happened on sdw2"))
 		})
 	})
 

--- a/cli/go/src/pxf-cli/pxf/pxf.go
+++ b/cli/go/src/pxf-cli/pxf/pxf.go
@@ -76,10 +76,11 @@ func (c *Command) GetFunctionToExecute() (func(string) string, error) {
 type CommandName string
 
 const (
-	Init  = "init"
-	Start = "start"
-	Stop  = "stop"
-	Sync  = "sync"
+	Init     = "init"
+	Start    = "start"
+	Stop     = "stop"
+	Sync     = "sync"
+	Statuses = "status"
 )
 
 var (
@@ -122,6 +123,16 @@ var (
 		},
 		envVars:    []EnvVar{PxfConf},
 		whereToRun: cluster.ON_MASTER_TO_HOSTS,
+	}
+	StatusCommand = Command{
+		commandName: Statuses,
+		messages: map[MessageType]string{
+			Success: "PXF is running on %d out of %d hosts\n",
+			Status:  "Checking status of PXF servers on %d hosts...\n",
+			Error:   "PXF is not running on %d out of %d hosts\n",
+		},
+		envVars:    []EnvVar{Gphome},
+		whereToRun: cluster.ON_HOSTS,
 	}
 )
 

--- a/cli/go/src/pxf-cli/pxf/pxf_test.go
+++ b/cli/go/src/pxf-cli/pxf/pxf_test.go
@@ -30,13 +30,16 @@ var _ = Describe("CommandFunc", func() {
 			_ = os.Unsetenv("PXF_CONF")
 		})
 
-		It("successfully generates start and stop commands", func() {
+		It("successfully generates start, stop, and status commands", func() {
 			commandFunc, err := pxf.StartCommand.GetFunctionToExecute()
 			Expect(err).To(BeNil())
 			Expect(commandFunc("foo")).To(Equal("/test/gphome/pxf/bin/pxf start"))
 			commandFunc, err = pxf.StopCommand.GetFunctionToExecute()
 			Expect(err).To(BeNil())
 			Expect(commandFunc("foo")).To(Equal("/test/gphome/pxf/bin/pxf stop"))
+			commandFunc, err = pxf.StatusCommand.GetFunctionToExecute()
+			Expect(err).To(BeNil())
+			Expect(commandFunc("foo")).To(Equal("/test/gphome/pxf/bin/pxf status"))
 		})
 		It("fails to init or sync", func() {
 			commandFunc, err := pxf.InitCommand.GetFunctionToExecute()
@@ -73,7 +76,7 @@ var _ = Describe("CommandFunc", func() {
 			))
 		})
 
-		It("fails to init, start, or stop", func() {
+		It("fails to init, start, stop, or tell status", func() {
 			commandFunc, err := pxf.InitCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME must be set")))
@@ -81,6 +84,9 @@ var _ = Describe("CommandFunc", func() {
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME must be set")))
 			commandFunc, err = pxf.StopCommand.GetFunctionToExecute()
+			Expect(commandFunc).To(BeNil())
+			Expect(err).To(Equal(errors.New("GPHOME must be set")))
+			commandFunc, err = pxf.StatusCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME must be set")))
 		})
@@ -107,7 +113,7 @@ var _ = Describe("CommandFunc", func() {
 			_ = os.Setenv("GPHOME", "")
 			_ = os.Unsetenv("PXF_CONF")
 		})
-		It("fails to init, start, or stop", func() {
+		It("fails to init, start, stop, or status", func() {
 			_ = os.Setenv("GPHOME", "")
 			commandFunc, err := pxf.InitCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
@@ -116,6 +122,9 @@ var _ = Describe("CommandFunc", func() {
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME cannot be blank")))
 			commandFunc, err = pxf.StopCommand.GetFunctionToExecute()
+			Expect(commandFunc).To(BeNil())
+			Expect(err).To(Equal(errors.New("GPHOME cannot be blank")))
+			commandFunc, err = pxf.StatusCommand.GetFunctionToExecute()
 			Expect(commandFunc).To(BeNil())
 			Expect(err).To(Equal(errors.New("GPHOME cannot be blank")))
 		})


### PR DESCRIPTION
This allows users to check the status of the cluster with a simple
command.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>