### PR TITLE
Add debug statements for the JDBC connection

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
@@ -105,7 +105,7 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
      */
     @Override
     public void closeForRead() throws SQLException {
-        JdbcBasePlugin.closeStatementAndConnection(statementRead);
+        closeStatementAndConnection(statementRead);
     }
 
     /**
@@ -265,9 +265,8 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
             if (e != null) {
                 throw e;
             }
-        }
-        finally {
-            JdbcBasePlugin.closeStatementAndConnection(statementWrite);
+        } finally {
+            closeStatementAndConnection(statementWrite);
         }
     }
 

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/writercallable/SimpleWriterCallable.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/writercallable/SimpleWriterCallable.java
@@ -67,11 +67,9 @@ class SimpleWriterCallable implements WriterCallable {
             if (statement.executeUpdate() != 1) {
                 throw new SQLException("The number of rows affected by INSERT query is not equal to the number of rows provided");
             }
-        }
-        catch (SQLException e) {
+        } catch (SQLException e) {
             return e;
-        }
-        finally {
+        } finally {
             row = null;
             if (statementMustBeDeleted) {
                 JdbcBasePlugin.closeStatementAndConnection(statement);


### PR DESCRIPTION
Log JDBC connection lifecycle to make sure connections are being properly closed.

Co-authored-by: Alexander Denissov (adenissov@pivotal.io)