### PR TITLE
PXF cli: fix regression with version command

### DIFF
--- a/server/pxf-service/src/scripts/pxf-service
+++ b/server/pxf-service/src/scripts/pxf-service
@@ -418,7 +418,7 @@ function doCluster()
 {
     pxf_cluster_command=$2
     get_environment
-    GPHOME=${GPHOME:-"${PXF_HOME}/.."} "$parent_script_dir/bin/pxf-cli" "$@"
+    GPHOME=${GPHOME:-"${PXF_HOME}/.."} "${parent_script_dir}/bin/pxf-cli" "$@"
 }
 
 pxf_script_command=$1
@@ -456,7 +456,7 @@ case "${pxf_script_command}" in
         doHelp
         ;;
     'version' | '--version' | '-v' )
-        doCluster --version
+        "${parent_script_dir}/bin/pxf-cli" --version
         ;;
     'cluster' )
         doCluster "$@"


### PR DESCRIPTION
We use the cluster utility to get the version, and since
4c79f94bb, we have been using the get_environment function to validate
that the user has run `pxf init` of some form. We don't need this
validation for the version command.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>