### PR TITLE
Ensure pxf version can be run before pxf init

### DIFF
--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -264,6 +264,9 @@ function start_hadoop_services() {
 function init_and_configure_pxf_server() {
 	pushd ${PXF_HOME} > /dev/null
 
+	echo 'Ensure pxf status can be run before pxf init'
+	./bin/pxf version | grep -E "^PXF version [0-9]+.[0-9]+.[0-9]+$" || exit 1
+
 	echo 'Initializing PXF service'
 	su gpadmin -c "PXF_CONF=${PXF_CONF_DIR} ./bin/pxf init"
 

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -264,7 +264,7 @@ function start_hadoop_services() {
 function init_and_configure_pxf_server() {
 	pushd ${PXF_HOME} > /dev/null
 
-	echo 'Ensure pxf status can be run before pxf init'
+	echo 'Ensure pxf version can be run before pxf init'
 	./bin/pxf version | grep -E "^PXF version [0-9]+.[0-9]+.[0-9]+$" || exit 1
 
 	echo 'Initializing PXF service'


### PR DESCRIPTION
Fail scripts when pxf version cannot run without init