### PR TITLE
JDBC profile can execute a query to read data from an external DB

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -105,6 +105,7 @@ sync_jdbc_config:
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_USER||" $(PXF_CONF_SERVERS)/database/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_PASSWORD||" $(PXF_CONF_SERVERS)/database/jdbc-site.xml; \
 	fi
+	@cp src/test/resources/report.sql $(PXF_CONF_SERVERS)/database
 
 	@mkdir -p $(PXF_CONF_SERVERS)/db-session-params
 	@if [ ! -f "$(PXF_CONF_SERVERS)/db-session-params/jdbc-site.xml" ]; then \

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
@@ -363,6 +363,22 @@ public class JdbcTest extends BaseFeature {
         pxfJdbcNamedQuery.setHost(pxfHost);
         pxfJdbcNamedQuery.setPort(pxfPort);
         gpdb.createTableAndVerify(pxfJdbcNamedQuery);
+
+        pxfJdbcNamedQuery = TableFactory.getPxfJdbcReadablePartitionedTable(
+                "pxf_jdbc_read_named_query_partitioned",
+                NAMED_QUERY_FIELDS,
+                "query:report",
+                null,
+                null,
+                1,
+                "1:5",
+                "1",
+                null,
+                EnumPartitionType.INT,
+                "database");
+        pxfJdbcNamedQuery.setHost(pxfHost);
+        pxfJdbcNamedQuery.setPort(pxfPort);
+        gpdb.createTableAndVerify(pxfJdbcNamedQuery);
     }
 
     @Test(groups = {"features", "gpdb"})

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
@@ -50,6 +50,11 @@ public class JdbcTest extends BaseFeature {
             "\"does_not_exist_on_source\" text",
             "\"num 1\" int",
             "\"n@m2\" int"};
+    private static final String[] NAMED_QUERY_FIELDS = new String[]{
+            "name  text",
+            "count int",
+            "max  int"};
+
     private ExternalTable pxfJdbcSingleFragment;
     private ExternalTable pxfJdbcMultipleFragmentsByInt;
     private ExternalTable pxfJdbcMultipleFragmentsByDate;
@@ -62,11 +67,13 @@ public class JdbcTest extends BaseFeature {
     private ExternalTable pxfJdbcColumns;
     private ExternalTable pxfJdbcColumnProjectionSubset;
     private ExternalTable pxfJdbcColumnProjectionSuperset;
+    private ExternalTable pxfJdbcNamedQuery;
 
     private static final String gpdbTypesDataFileName = "gpdb_types.txt";
     private static final String gpdbColumnsDataFileName = "gpdb_columns.txt";
     private Table gpdbNativeTableTypes, gpdbNativeTableColumns, gpdbWritableTargetTable;
     private Table gpdbWritableTargetTableNoBatch, gpdbWritableTargetTablePool;
+    private Table gpdbDeptTable, gpdbEmpTable;
 
     @Override
     protected void beforeClass() throws Exception {
@@ -86,6 +93,7 @@ public class JdbcTest extends BaseFeature {
         prepareColumnProjectionSubsetInDifferentOrder();
         prepareColumnProjectionSuperset();
         prepareFetchSizeZero();
+        prepareNamedQuery();
     }
 
     private void prepareTypesData() throws Exception {
@@ -117,6 +125,37 @@ public class JdbcTest extends BaseFeature {
         gpdb.createTableAndVerify(gpdbNativeTableColumns);
         gpdb.copyFromFile(gpdbNativeTableColumns, new File(localDataResourcesFolder
                 + "/gpdb/" + gpdbColumnsDataFileName), "E'\\t'", "E'\\\\N'", true);
+
+        // create emp and dept tables for named query test
+        String[] deptTableFields = new String[]{"name text", "id int"};
+        gpdbDeptTable = new Table("gpdb_dept", deptTableFields);
+        gpdbDeptTable.setDistributionFields(new String[]{"name"});
+        gpdb.createTableAndVerify(gpdbDeptTable);
+        String[][] deptRows = new String[][] {
+                { "sales", "1"},
+                { "finance", "2"},
+                { "it", "3"}};
+        Table dataTable = new Table("data", deptTableFields);
+        dataTable.addRows(deptRows);
+        gpdb.insertData(dataTable, gpdbDeptTable);
+
+        String[] empTableFields = new String[]{"name text", "dept_id int", "salary int"};
+        gpdbEmpTable = new Table("gpdb_emp", empTableFields);
+        gpdbEmpTable.setDistributionFields(new String[]{"name"});
+        gpdb.createTableAndVerify(gpdbEmpTable);
+        final String[][] empRows = new String[][] {
+                { "alice", "1", "115" },
+                { "bob", "1", "120" },
+                { "charli", "1", "93" },
+                { "daniel", "2", "87" },
+                { "emma", "2", "100" },
+                { "frank", "2", "103" },
+                { "george", "2", "90" },
+                { "henry", "3", "96" },
+                { "ivanka", "3", "70" }};
+        dataTable = new Table("data", empTableFields);
+        dataTable.addRows(empRows);
+        gpdb.insertData(dataTable, gpdbEmpTable);
     }
 
     private void prepareSingleFragment() throws Exception {
@@ -315,6 +354,17 @@ public class JdbcTest extends BaseFeature {
         gpdb.createTableAndVerify(pxfJdbcSingleFragment);
     }
 
+    private void prepareNamedQuery() throws Exception {
+        pxfJdbcNamedQuery = TableFactory.getPxfJdbcReadableTable(
+                "pxf_jdbc_read_named_query",
+                NAMED_QUERY_FIELDS,
+                "query:report",
+                "database");
+        pxfJdbcNamedQuery.setHost(pxfHost);
+        pxfJdbcNamedQuery.setPort(pxfPort);
+        gpdb.createTableAndVerify(pxfJdbcNamedQuery);
+    }
+
     @Test(groups = {"features", "gpdb"})
     public void singleFragmentTable() throws Exception {
         runTincTest("pxf.features.jdbc.single_fragment.runTest");
@@ -363,6 +413,11 @@ public class JdbcTest extends BaseFeature {
     @Test(groups = {"features", "gpdb"})
     public void jdbcReadableTableNoBatch() throws Exception {
         runTincTest("pxf.features.jdbc.readable_nobatch.runTest");
+    }
+
+    @Test(groups = {"features", "gpdb"})
+    public void jdbcNamedQuery() throws Exception {
+        runTincTest("pxf.features.jdbc.named_query.runTest");
     }
 
 }

--- a/automation/src/test/resources/report.sql
+++ b/automation/src/test/resources/report.sql
@@ -1,4 +1,4 @@
-SELECT gpdb_dept.name, count(), max(gpdb_emp.salary)
+SELECT gpdb_dept.name, count(*), max(gpdb_emp.salary)
 FROM gpdb_dept JOIN gpdb_emp
 ON gpdb_dept.id = gpdb_emp.dept_id
 GROUP BY gpdb_dept.name

--- a/automation/src/test/resources/report.sql
+++ b/automation/src/test/resources/report.sql
@@ -1,4 +1,5 @@
 SELECT gpdb_dept.name, count(*), max(gpdb_emp.salary)
 FROM gpdb_dept JOIN gpdb_emp
 ON gpdb_dept.id = gpdb_emp.dept_id
+WHERE gpdb_dept.id < 10
 GROUP BY gpdb_dept.name

--- a/automation/src/test/resources/report.sql
+++ b/automation/src/test/resources/report.sql
@@ -1,0 +1,4 @@
+SELECT gpdb_dept.name, count(), max(gpdb_emp.salary)
+FROM gpdb_dept JOIN gpdb_emp
+ON gpdb_dept.id = gpdb_emp.dept_id
+GROUP BY gpdb_dept.name

--- a/automation/tincrepo/main/pxf/features/jdbc/named_query/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/named_query/expected/query01.ans
@@ -2,7 +2,7 @@
 -- start_ignore
 -- end_ignore
 
-SELECT gpdb_dept.name, count(), max(gpdb_emp.salary)
+SELECT gpdb_dept.name, count(*), max(gpdb_emp.salary)
 FROM gpdb_dept JOIN gpdb_emp
 ON gpdb_dept.id = gpdb_emp.dept_id
 GROUP BY gpdb_dept.name;

--- a/automation/tincrepo/main/pxf/features/jdbc/named_query/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/named_query/expected/query01.ans
@@ -33,3 +33,18 @@ SELECT max(max) FROM pxf_jdbc_read_named_query;
 -----
  120
 (1 row)
+
+SELECT * FROM pxf_jdbc_read_named_query_partitioned ORDER BY name;
+  name   | count | max
+---------+-------+-----
+ finance |     4 | 103
+ it      |     2 |  96
+ sales   |     3 | 120
+(3 rows)
+
+SELECT name, count FROM pxf_jdbc_read_named_query_partitioned WHERE count > 2 ORDER BY name;
+  name   | count
+---------+-------
+ finance |     4
+ sales   |     3
+(2 rows)

--- a/automation/tincrepo/main/pxf/features/jdbc/named_query/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/named_query/expected/query01.ans
@@ -1,0 +1,35 @@
+-- @description query01 for JDBC named queries
+-- start_ignore
+-- end_ignore
+
+SELECT gpdb_dept.name, count(), max(gpdb_emp.salary)
+FROM gpdb_dept JOIN gpdb_emp
+ON gpdb_dept.id = gpdb_emp.dept_id
+GROUP BY gpdb_dept.name;
+name   | count | max
+---------+-------+-----
+finance |     4 | 103
+it      |     2 |  96
+sales   |     3 | 120
+(3 rows)
+
+SELECT * FROM pxf_jdbc_read_named_query ORDER BY name;
+  name   | count | max
+---------+-------+-----
+ finance |     4 | 103
+ it      |     2 |  96
+ sales   |     3 | 120
+(3 rows)
+
+SELECT name, count FROM pxf_jdbc_read_named_query WHERE max > 100 ORDER BY name;
+  name   | count
+---------+-------
+ finance |     4
+ sales   |     3
+(2 rows)
+
+SELECT max(max) FROM pxf_jdbc_read_named_query;
+ max
+-----
+ 120
+(1 row)

--- a/automation/tincrepo/main/pxf/features/jdbc/named_query/runTest.py
+++ b/automation/tincrepo/main/pxf/features/jdbc/named_query/runTest.py
@@ -1,0 +1,13 @@
+from mpp.models import SQLConcurrencyTestCase
+from mpp.models import SQLTestCase
+
+class JdbcNamedQueries(SQLConcurrencyTestCase):
+    """
+    @product_version  gpdb: [2.0-]
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/jdbc/named_query/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/jdbc/named_query/sql/query01.sql
@@ -13,3 +13,6 @@ SELECT name, count FROM pxf_jdbc_read_named_query WHERE max > 100 ORDER BY name;
 
 SELECT max(max) FROM pxf_jdbc_read_named_query;
 
+SELECT * FROM pxf_jdbc_read_named_query_partitioned ORDER BY name;
+
+SELECT name, count FROM pxf_jdbc_read_named_query_partitioned WHERE count > 2 ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/jdbc/named_query/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/jdbc/named_query/sql/query01.sql
@@ -2,7 +2,7 @@
 -- start_ignore
 -- end_ignore
 
-SELECT gpdb_dept.name, count(), max(gpdb_emp.salary)
+SELECT gpdb_dept.name, count(*), max(gpdb_emp.salary)
 FROM gpdb_dept JOIN gpdb_emp
 ON gpdb_dept.id = gpdb_emp.dept_id
 GROUP BY gpdb_dept.name;

--- a/automation/tincrepo/main/pxf/features/jdbc/named_query/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/jdbc/named_query/sql/query01.sql
@@ -1,0 +1,15 @@
+-- @description query01 for JDBC named queries
+-- start_ignore
+-- end_ignore
+
+SELECT gpdb_dept.name, count(), max(gpdb_emp.salary)
+FROM gpdb_dept JOIN gpdb_emp
+ON gpdb_dept.id = gpdb_emp.dept_id
+GROUP BY gpdb_dept.name;
+
+SELECT * FROM pxf_jdbc_read_named_query ORDER BY name;
+
+SELECT name, count FROM pxf_jdbc_read_named_query WHERE max > 100 ORDER BY name;
+
+SELECT max(max) FROM pxf_jdbc_read_named_query;
+

--- a/concourse/scripts/test_pxf_multinode.bash
+++ b/concourse/scripts/test_pxf_multinode.bash
@@ -89,6 +89,8 @@ function setup_pxf_on_segment {
 }
 
 function setup_pxf_on_cluster() {
+    # drop named query file for JDBC test to gpadmin's home on mdw
+    scp ${SSH_OPTS} pxf_src/automation/src/test/resources/report.sql gpadmin@mdw:
     # untar pxf on all nodes in the cluster
     for node in ${gpdb_nodes}; do
         setup_pxf_on_segment ${node} &
@@ -110,6 +112,7 @@ function setup_pxf_on_cluster() {
         sed -i \"s|YOUR_DATABASE_JDBC_URL|jdbc:postgresql://mdw:5432/pxfautomation|\" ${PXF_CONF_DIR}/servers/database/jdbc-site.xml &&
         sed -i \"s|YOUR_DATABASE_JDBC_USER|gpadmin|\" ${PXF_CONF_DIR}/servers/database/jdbc-site.xml &&
         sed -i \"s|YOUR_DATABASE_JDBC_PASSWORD||\" ${PXF_CONF_DIR}/servers/database/jdbc-site.xml &&
+        cp ~gpadmin/report.sql ${PXF_CONF_DIR}/servers/database/ &&
         mkdir -p ${PXF_CONF_DIR}/servers/db-session-params &&
         cp ${PXF_CONF_DIR}/templates/jdbc-site.xml ${PXF_CONF_DIR}/servers/db-session-params/ &&
         sed -i \"s|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.postgresql.Driver|\" ${PXF_CONF_DIR}/servers/db-session-params/jdbc-site.xml &&

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/ConfigurationFactory.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/ConfigurationFactory.java
@@ -12,6 +12,7 @@ public interface ConfigurationFactory {
             System.getProperty(PXF_CONF_PROPERTY) + File.separator + "servers");
     String DEFAULT_SERVER_CONFIG_DIR = SERVERS_CONFIG_DIR + File.separator + "default";
     String PXF_CONFIG_RESOURCE_PATH_PROPERTY = "pxf.config.resource.path";
+    String PXF_CONFIG_SERVER_DIRECTORY_PROPERTY = "pxf.config.server.directory";
 
     /**
      * Initializes a configuration object that applies server-specific configurations and

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseConfigurationFactoryTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseConfigurationFactoryTest.java
@@ -8,12 +8,14 @@ import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.greenplum.pxf.api.model.ConfigurationFactory.PXF_CONFIG_RESOURCE_PATH_PROPERTY;
+import static org.greenplum.pxf.api.model.ConfigurationFactory.PXF_CONFIG_SERVER_DIRECTORY_PROPERTY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -108,13 +110,20 @@ public class BaseConfigurationFactoryTest {
     @Test
     public void testConfigurationSetsResourcePath() throws MalformedURLException {
         Configuration configuration = factory.initConfiguration("default", additionalProperties);
-
         File defaultServerDirectory = new File(serversDirectory, "default");
 
         assertEquals(new File(defaultServerDirectory, "test-blue-site.xml").toPath().toUri().toURL().toString(),
                 configuration.get(String.format("%s.%s", PXF_CONFIG_RESOURCE_PATH_PROPERTY, "test-blue-site.xml")));
         assertEquals(new File(defaultServerDirectory, "test-red-site.xml").toPath().toUri().toURL().toString(),
                 configuration.get(String.format("%s.%s", PXF_CONFIG_RESOURCE_PATH_PROPERTY, "test-red-site.xml")));
+    }
+
+    @Test
+    public void testConfigurationSetsServerDirectoryPath() throws IOException {
+        Configuration configuration = factory.initConfiguration("default", additionalProperties);
+        File defaultServerDirectory = new File(serversDirectory, "default");
+
+        assertEquals(defaultServerDirectory.getCanonicalPath(), configuration.get(PXF_CONFIG_SERVER_DIRECTORY_PROPERTY));
     }
 
 }

--- a/server/pxf-jdbc/README.md
+++ b/server/pxf-jdbc/README.md
@@ -279,7 +279,7 @@ insert into emp values(3, 'charlie', 10500);
 
 Then a complex aggregation query is created and placed in a file, say `report.sql`. The file needs to be placed in the server configuration directory under `$PXF_CONF/servers/`. So, let's assume we have created a `mydb` server configuration directory, then this file will be `$PXF_CONF/servers/mydb/report.sql`. Jdbc driver name and connection parameters should be configured in `$PXF_CONF/servers/mydb/jdbc-site.xml` for this server.
 ```
-SELECT dept.name, count(), max(emp.salary)
+SELECT dept.name AS name, count(*) AS count, max(emp.salary) AS max
 FROM demodb.dept JOIN demodb.emp
 ON dept.id = emp.dept_id 
 GROUP BY dept.name;

--- a/server/pxf-jdbc/README.md
+++ b/server/pxf-jdbc/README.md
@@ -200,12 +200,12 @@ Connection properties (`java.util.Properties`) passed to JDBC driver when openin
 
 
 ## SELECT queries
-PXF JDBC plugin allows to perform SELECT queries to external tables.
+PXF JDBC plugin allows to perform SELECT queries to external tables. An external table can refer to a table in a remote database or to a file that contains a pre-defined complex query to execute against a remote database.
 
 To perform SELECT queries, create an `EXTERNAL READABLE TABLE` or just an `EXTERNAL TABLE` with `FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import')` in PXF.
 
 
-### `EXTERNAL READABLE TABLE` example
+### `EXTERNAL READABLE TABLE` using remote table name - example
 The following example shows how to access a MySQL table via PXF JDBC plugin.
 
 Suppose MySQL instance is available at `192.168.200.6:3306`. A table in MySQL is created:
@@ -235,7 +235,7 @@ CREATE EXTERNAL TABLE myclass(
     degree float8
 )
 LOCATION (
-    'pxf://localhost:51200/demodb.myclass?PROFILE=JDBC&JDBC_DRIVER=com.mysql.jdbc.Driver&DB_URL=jdbc:mysql://192.168.200.6:3306/demodb&USER=root&PASS=root'
+    'pxf://demodb.myclass?PROFILE=JDBC&JDBC_DRIVER=com.mysql.jdbc.Driver&DB_URL=jdbc:mysql://192.168.200.6:3306/demodb&USER=root&PASS=root'
 )
 FORMAT 'CUSTOM' (
     FORMATTER='pxfwritable_import'
@@ -246,6 +246,67 @@ Finally, a query to a GPDB external table is made:
 ```
 SELECT * FROM myclass;
 SELECT id, name FROM myclass WHERE id = 2;
+```
+
+### `EXTERNAL READABLE TABLE` using pre-defined query - example
+The following example shows how to execute an aggregation query in MySQL and return results via PXF JDBC plugin.
+
+Suppose MySQL instance is available at `192.168.200.6:3306`. The following tables are created in MySQL:
+```
+use demodb;
+create table dept(
+    id int(4) not null primary key,
+    name varchar(20) not null
+);
+
+create table emp(
+    dept_id int(4) not null,
+    name varchar(20) not null,
+    salary int(8)
+);
+```
+
+Then some data is inserted into MySQL tables:
+```
+insert into dept values(1, 'sales');
+insert into dept values(2, 'finance');
+insert into dept values(3, 'it');
+
+insert into emp values(1, 'alice', 11000);
+insert into emp values(2, 'bob', 10000);
+insert into emp values(3, 'charlie', 10500);
+```
+
+Then a complex aggregation query is created and placed in a file, say `report.sql`. The file needs to be placed in the server configuration directory under `$PXF_CONF/servers/`. So, let's assume we have created a `mydb` server configuration directory, then this file will be `$PXF_CONF/servers/mydb/report.sql`. Jdbc driver name and connection parameters should be configured in `$PXF_CONF/servers/mydb/jdbc-site.xml` for this server.
+```
+SELECT dept.name, count(), max(emp.salary)
+FROM demodb.dept JOIN demodb.emp
+ON dept.id = emp.dept_id 
+GROUP BY dept.name;
+```
+This query returns a name of the department, count of employees, and the maximal salary in each department.  
+
+The MySQL JDBC driver files (JAR) are copied to `$PXF_CONF/lib` on all hosts with PXF. After this, all PXF segments are restarted.
+
+Then a table in GPDB is created with the schema corresponding to the results returned by the aggregation query. It is important that the table column names and types correspond to those returned by the aggregation query.
+```
+CREATE EXTERNAL TABLE dept_report (
+    name text,
+    count int,
+    max int
+)
+LOCATION (
+    'pxf://query:report?PROFILE=JDBC&SERVER=mydb'
+)
+FORMAT 'CUSTOM' (
+    FORMATTER='pxfwritable_import'
+);
+```
+
+Finally, a query to a GPDB external table is made:
+```
+SELECT * FROM dept_report;
+SELECT name, count FROM dept_report WHERE max > 10000;
 ```
 
 

--- a/server/pxf-jdbc/README.md
+++ b/server/pxf-jdbc/README.md
@@ -37,7 +37,7 @@ CREATE [ READABLE | WRITABLE ] EXTERNAL TABLE <table_name> (
     { <column_name> <data_type> [, ...] | LIKE <other_table> }
 )
 LOCATION (
-    'pxf://<full_external_table_name>?<pxf_parameters>[&SERVER=<server_name>]<jdbc_settings>'
+    'pxf://{<full_external_table_name> | query:<query_file_without_extension>}?<pxf_parameters>[&SERVER=<server_name>]<jdbc_settings>'
 )
 FORMAT 'CUSTOM' (FORMATTER={'pxfwritable_import' | 'pxfwritable_export'})
 ```

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/IntervalType.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/IntervalType.java
@@ -1,0 +1,11 @@
+package org.greenplum.pxf.plugins.jdbc;
+
+public enum IntervalType {
+    DAY,
+    MONTH,
+    YEAR;
+
+    public static IntervalType typeOf(String str) {
+        return valueOf(str.toUpperCase());
+    }
+}

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
@@ -300,7 +300,7 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
 
     /**
      * Gets the text of the query by reading the file from the server configuration directory. The name of the file
-     * es expected to be the same as the name of the query provided by the user and have extension ".sql"
+     * is expected to be the same as the name of the query provided by the user and have extension ".sql"
      *
      * @return text of the query
      */
@@ -323,6 +323,9 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
             queryText = FileUtils.readFileToString(queryFile);
         } catch (IOException e) {
             throw new RuntimeException(String.format("Failed to read text of query %s : %s", queryName, e.getMessage()), e);
+        }
+        if (StringUtils.isBlank(queryText)) {
+            throw new RuntimeException(String.format("Query text file is empty for query %s", queryName));
         }
         return queryText;
     }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
@@ -19,13 +19,17 @@ package org.greenplum.pxf.plugins.jdbc;
  * under the License.
  */
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.api.OneRow;
 import org.greenplum.pxf.api.model.Accessor;
+import org.greenplum.pxf.api.model.ConfigurationFactory;
 import org.greenplum.pxf.plugins.jdbc.writercallable.WriterCallable;
 import org.greenplum.pxf.plugins.jdbc.writercallable.WriterCallableFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -49,6 +53,22 @@ import java.util.concurrent.Future;
  * built-in JDBC batches of arbitrary size
  */
 public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcAccessor.class);
+
+    // Read variables
+    private String queryRead = null;
+    private Statement statementRead = null;
+    private ResultSet resultSetRead = null;
+
+    // Write variables
+    private String queryWrite = null;
+    private PreparedStatement statementWrite = null;
+    private WriterCallableFactory writerCallableFactory = null;
+    private WriterCallable writerCallable = null;
+    private ExecutorService executorServiceWrite = null;
+    private List<Future<SQLException> > poolTasks = null;
+
     /**
      * openForRead() implementation
      * Create query, open JDBC connection, execute query and store the result into resultSet
@@ -66,7 +86,7 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
         }
 
         Connection connection = super.getConnection();
-        SQLQueryBuilder sqlQueryBuilder = new SQLQueryBuilder(context, connection.getMetaData());
+        SQLQueryBuilder sqlQueryBuilder = new SQLQueryBuilder(context, connection.getMetaData(), getQueryText());
 
         // Build SELECT query
         if (quoteColumns == null) {
@@ -122,6 +142,10 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
      */
     @Override
     public boolean openForWrite() throws SQLException, SQLTimeoutException, ParseException, ClassNotFoundException {
+        if (queryName != null) {
+            throw new IllegalArgumentException("specifying query name in data path is not supported for JDBC writable external tables");
+        }
+
         if (statementWrite != null && !statementWrite.isClosed()) {
             throw new SQLException("The connection to an external database is already open.");
         }
@@ -273,19 +297,34 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
         }
     }
 
-    // Read variables
-    private String queryRead = null;
-    private Statement statementRead = null;
-    private ResultSet resultSetRead = null;
 
-    // Write variables
-    private String queryWrite = null;
-    private PreparedStatement statementWrite = null;
-    private WriterCallableFactory writerCallableFactory = null;
-    private WriterCallable writerCallable = null;
-    private ExecutorService executorServiceWrite = null;
-    private List<Future<SQLException> > poolTasks = null;
+    /**
+     * Gets the text of the query by reading the file from the server configuration directory. The name of the file
+     * es expected to be the same as the name of the query provided by the user and have extension ".sql"
+     *
+     * @return text of the query
+     */
+    private String getQueryText() {
+        if (StringUtils.isBlank(queryName)) {
+            return null;
+        }
+        // read the contents of the file holding the text of the query with a given name
+        String serverDirectory = configuration.get(ConfigurationFactory.PXF_CONFIG_SERVER_DIRECTORY_PROPERTY);
+        if (StringUtils.isBlank(serverDirectory)) {
+            throw new IllegalStateException("No server configuration directory found for server " + context.getServerName());
+        }
 
-    // Static variables
-    private static final Logger LOG = LoggerFactory.getLogger(JdbcAccessor.class);
+        String queryText;
+        try {
+            File queryFile = new File(serverDirectory, queryName + ".sql");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Reading text of query={} from {}", queryName, queryFile.getCanonicalPath());
+            }
+            queryText = FileUtils.readFileToString(queryFile);
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Failed to read text of query %s : %s", queryName, e.getMessage()), e);
+        }
+        return queryText;
+    }
+
 }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/PartitionType.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/PartitionType.java
@@ -1,0 +1,11 @@
+package org.greenplum.pxf.plugins.jdbc;
+
+public enum PartitionType {
+    DATE,
+    INT,
+    ENUM;
+
+    public static PartitionType typeOf(String str) {
+        return valueOf(str.toUpperCase());
+    }
+}

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/SQLQueryBuilder.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/SQLQueryBuilder.java
@@ -89,8 +89,7 @@ public class SQLQueryBuilder {
         if (internalQuery == null) {
             source = context.getDataSource();
         } else {
-            // TODO does this work for all DBs ?
-            source = String.format("(%s) AS source", internalQuery);
+            source = String.format("(%s) userquery", internalQuery);
         }
 
         quoteString = "";

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -1,6 +1,5 @@
 package org.greenplum.pxf.plugins.jdbc;
 
-import org.greenplum.pxf.api.model.BaseConfigurationFactory;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.junit.Before;
 import org.junit.Rule;
@@ -8,7 +7,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatcher;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -51,6 +49,7 @@ public class JdbcAccessorTest {
         DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
         Connection mockConnection = mock(Connection.class);
         mockStatement = mock(Statement.class);
+        mockResultSet = mock(ResultSet.class);
 
         when(DriverManager.getConnection(anyString(), anyObject())).thenReturn(mockConnection);
         when(mockConnection.getMetaData()).thenReturn(mockMetaData);
@@ -108,7 +107,14 @@ public class JdbcAccessorTest {
 
         accessor.initialize(context);
         accessor.openForRead();
-        assertEquals("John", queryPassed.getValue());
+
+        StringBuilder b = new StringBuilder()
+        .append("SELECT  FROM (SELECT dept.name, count(), max(emp.salary)\n")
+        .append("FROM dept JOIN emp\n")
+        .append("ON dept.id = emp.dept_id\n")
+        .append("GROUP BY dept.name) AS source");
+
+        assertEquals(b.toString(), queryPassed.getValue());
 
     }
 

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -1,0 +1,115 @@
+package org.greenplum.pxf.plugins.jdbc;
+
+import org.greenplum.pxf.api.model.BaseConfigurationFactory;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DriverManager.class, JdbcAccessor.class})
+public class JdbcAccessorTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private JdbcAccessor accessor;
+    private RequestContext context;
+
+    private Statement mockStatement;
+    private ResultSet mockResultSet;
+
+    @Before
+    public void setup() throws SQLException {
+        accessor = new JdbcAccessor();
+        context = new RequestContext();
+        context.setDataSource("test-table");
+        Map<String, String> additionalProps = new HashMap<>();
+        additionalProps.put("jdbc.driver", "org.greenplum.pxf.plugins.jdbc.FakeJdbcDriver");
+        additionalProps.put("jdbc.url", "test-url");
+        context.setAdditionalConfigProps(additionalProps);
+
+        PowerMockito.mockStatic(DriverManager.class);
+        DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+        Connection mockConnection = mock(Connection.class);
+        mockStatement = mock(Statement.class);
+
+        when(DriverManager.getConnection(anyString(), anyObject())).thenReturn(mockConnection);
+        when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+        when(mockConnection.createStatement()).thenReturn(mockStatement);
+        when(mockMetaData.getDatabaseProductName()).thenReturn("Greenplum");
+        when(mockMetaData.getExtraNameCharacters()).thenReturn("");
+    }
+
+    @Test
+    public void testWriteFailsWhenQueryIsSpecified() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("specifying query name in data path is not supported for JDBC writable external tables");
+        context.setDataSource("query:foo");
+        accessor.initialize(context);
+        accessor.openForWrite();
+    }
+
+    @Test
+    public void testReadFromQueryFailsWhenServerDirectoryIsNotSpecified() throws Exception {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("No server configuration directory found for server unknown");
+        context.setServerName("unknown");
+        context.setDataSource("query:foo");
+        accessor.initialize(context);
+        accessor.openForRead();
+    }
+
+    @Test
+    public void testReadFromQueryFailsWhenServerDirectoryDoesNotExist() throws Exception {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("Failed to read text of query foo : File '/non-existing-directory/foo.sql' does not exist");
+        context.getAdditionalConfigProps().put("pxf.config.server.directory", "/non-existing-directory");
+        context.setDataSource("query:foo");
+        accessor.initialize(context);
+        accessor.openForRead();
+    }
+
+    @Test
+    public void testReadFromQueryFailsWhenQueryFileIsNotFoundInExistingDirectory() throws Exception {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("Failed to read text of query foo : File '/tmp/foo.sql' does not exist");
+        context.getAdditionalConfigProps().put("pxf.config.server.directory", "/tmp/");
+        context.setDataSource("query:foo");
+        accessor.initialize(context);
+        accessor.openForRead();
+    }
+
+    @Test
+    public void testReadFromQuery() throws Exception {
+        String serversDirectory = new File(this.getClass().getClassLoader().getResource("servers").toURI()).getCanonicalPath();
+        context.getAdditionalConfigProps().put("pxf.config.server.directory", serversDirectory + File.separator + "test-server");
+        context.setDataSource("query:testquery");
+        ArgumentCaptor<String> queryPassed = ArgumentCaptor.forClass(String.class);
+        when(mockStatement.executeQuery(queryPassed.capture())).thenReturn(mockResultSet);
+
+        accessor.initialize(context);
+        accessor.openForRead();
+        assertEquals("John", queryPassed.getValue());
+
+    }
+
+}

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -13,7 +13,12 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -98,6 +98,17 @@ public class JdbcAccessorTest {
     }
 
     @Test
+    public void testReadFromQueryFailsWhenQueryFileIsEmpty() throws Exception {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("Query text file is empty for query emptyquery");
+        String serversDirectory = new File(this.getClass().getClassLoader().getResource("servers").toURI()).getCanonicalPath();
+        context.getAdditionalConfigProps().put("pxf.config.server.directory", serversDirectory + File.separator + "test-server");
+        context.setDataSource("query:emptyquery");
+        accessor.initialize(context);
+        accessor.openForRead();
+    }
+
+    @Test
     public void testReadFromQuery() throws Exception {
         String serversDirectory = new File(this.getClass().getClassLoader().getResource("servers").toURI()).getCanonicalPath();
         context.getAdditionalConfigProps().put("pxf.config.server.directory", serversDirectory + File.separator + "test-server");

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -112,7 +112,7 @@ public class JdbcAccessorTest {
         .append("SELECT  FROM (SELECT dept.name, count(), max(emp.salary)\n")
         .append("FROM dept JOIN emp\n")
         .append("ON dept.id = emp.dept_id\n")
-        .append("GROUP BY dept.name) AS source");
+        .append("GROUP BY dept.name) userquery");
 
         assertEquals(b.toString(), queryPassed.getValue());
 

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/SQLQueryBuilderTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/SQLQueryBuilderTest.java
@@ -308,7 +308,7 @@ public class SQLQueryBuilderTest {
     public void testSimpleNamedQuery() throws Exception {
         SQLQueryBuilder builder = new SQLQueryBuilder(context, mockMetaData, NAMED_QUERY);
         String query = builder.buildSelectQuery();
-        assertEquals("SELECT id, cdate, amt, grade FROM (SELECT a, b FROM c WHERE d = 'foo') AS source", query);
+        assertEquals("SELECT id, cdate, amt, grade FROM (SELECT a, b FROM c WHERE d = 'foo') userquery", query);
     }
 
     @Test
@@ -319,7 +319,7 @@ public class SQLQueryBuilderTest {
         SQLQueryBuilder builder = new SQLQueryBuilder(context, mockMetaData, NAMED_QUERY);
         builder.forceSetQuoteString();
         String query = builder.buildSelectQuery();
-        assertEquals("SELECT \"id\", \"cdate\", \"amt\", \"grade\" FROM (SELECT a, b FROM c WHERE d = 'foo') AS source WHERE \"id\" = 1", query);
+        assertEquals("SELECT \"id\", \"cdate\", \"amt\", \"grade\" FROM (SELECT a, b FROM c WHERE d = 'foo') userquery WHERE \"id\" = 1", query);
     }
 
     @Test
@@ -331,7 +331,7 @@ public class SQLQueryBuilderTest {
 
         SQLQueryBuilder builder = new SQLQueryBuilder(context, mockMetaData, NAMED_QUERY);
         String query = builder.buildSelectQuery();
-        assertEquals("SELECT id, amt FROM (SELECT a, b FROM c WHERE d = 'foo') AS source WHERE id = 1", query);
+        assertEquals("SELECT id, amt FROM (SELECT a, b FROM c WHERE d = 'foo') userquery WHERE id = 1", query);
     }
 
     @Test
@@ -350,7 +350,7 @@ public class SQLQueryBuilderTest {
         SQLQueryBuilder builder = new SQLQueryBuilder(context, mockMetaData, NAMED_QUERY);
         builder.autoSetQuoteString();
         String query = builder.buildSelectQuery();
-        assertEquals("SELECT id, cdate, amt, grade FROM (SELECT a, b FROM c WHERE d = 'foo') AS source WHERE id > 5 AND grade = 'excellent'", query);
+        assertEquals("SELECT id, cdate, amt, grade FROM (SELECT a, b FROM c WHERE d = 'foo') userquery WHERE id > 5 AND grade = 'excellent'", query);
     }
 
 

--- a/server/pxf-jdbc/src/test/resources/servers/test-server/testquery.sql
+++ b/server/pxf-jdbc/src/test/resources/servers/test-server/testquery.sql
@@ -1,0 +1,4 @@
+SELECT dept.name, count(), max(emp.salary)
+FROM dept JOIN emp
+ON dept.id = emp.dept_id
+GROUP BY dept.name

--- a/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithwhere.sql
+++ b/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithwhere.sql
@@ -1,0 +1,5 @@
+SELECT dept.name, count(), max(emp.salary)
+FROM dept JOIN emp
+ON dept.id = emp.dept_id
+WHERE dept.id < 10
+GROUP BY dept.name


### PR DESCRIPTION
This PR implements a feature where a user can define a query in a SQL file under sever's configuration directory. This query will be run by the JDBC plugin and the data returned by the query will be sent to GPDB.
 
The following example shows how to execute an aggregation query in MySQL and return results via PXF JDBC plugin.

The following tables are created in MySQL:
```
use demodb;
create table dept(
    id int(4) not null primary key,
    name varchar(20) not null
);

create table emp(
    dept_id int(4) not null,
    name varchar(20) not null,
    salary int(8)
);
```
Then some data is inserted into MySQL tables:
```
insert into dept values(1, 'sales');
insert into dept values(2, 'finance');
insert into dept values(3, 'it');

insert into emp values(1, 'alice', 11000);
insert into emp values(2, 'bob', 10000);
insert into emp values(3, 'charlie', 10500);
```
Then a complex aggregation query is created and placed in a file, say report.sql. The file needs to be placed in the server configuration directory under `$PXF_CONF/servers/`. So, let's assume we have created a `mydb` server configuration directory, then this file will be `$PXF_CONF/servers/mydb/report.sql`. Jdbc driver name and connection parameters should be configured in `$PXF_CONF/servers/mydb/jdbc-site.xml` for this server.
```
SELECT dept.name AS name, count(*) AS count, max(emp.salary) AS max
FROM demodb.dept JOIN demodb.emp
ON dept.id = emp.dept_id 
GROUP BY dept.name;
```
This query returns a name of the department, count of employees, and the maximal salary in each department.

The MySQL JDBC driver files (JAR) are copied to `$PXF_CONF/lib` on all hosts with PXF. After this, all PXF segments are restarted.

Then a table in GPDB is created with the schema corresponding to the results returned by the aggregation query. It is important that the table column names and types correspond to those returned by the aggregation query.
```
CREATE EXTERNAL TABLE dept_report (
    name text,
    count int,
    max int
)
LOCATION (
    'pxf://query:report?PROFILE=JDBC&SERVER=mydb'
)
FORMAT 'CUSTOM' (
    FORMATTER='pxfwritable_import'
);
```
Finally, a query to a GPDB external table is made:
```
SELECT * FROM dept_report;
SELECT name, count FROM dept_report WHERE max > 10000;
```