### PR TITLE
Fix Oracle timestamp wrapping

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DbProduct.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DbProduct.java
@@ -53,7 +53,7 @@ public enum DbProduct {
 
         @Override
         public String wrapTimestamp(Object val) {
-            return "to_timestamp('" + val + "', 'YYYY-MM-DD HH:MI:SS.FF')";
+            return "to_timestamp('" + val + "', 'YYYY-MM-DD HH24:MI:SS.FF')";
         }
 
         @Override

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/DbProductTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/DbProductTest.java
@@ -96,7 +96,7 @@ public class DbProductTest {
 
     @Test
     public void testOracleTimestamps() {
-        final String[] expected = {"to_timestamp('2001-01-01 00:00:00.0', 'YYYY-MM-DD HH:MI:SS.FF')"};
+        final String[] expected = {"to_timestamp('2001-01-01 00:00:00.0', 'YYYY-MM-DD HH24:MI:SS.FF')"};
 
         DbProduct dbProduct = DbProduct.getDbProduct(DB_NAME_ORACLE);
 


### PR DESCRIPTION
When a timestamp is coming from GPDB like '2017-12-01
14:01:02'::timestamp, Oracle is reporting an error "ORA-01849: hour must
be between 1 and 12".

Oracle requires 24 hour format like this:
to_timestamp('...', 'YYYY-MM-DD HH24:MI:SS.FF'), where HH24 represents
the Hour of day from 0-23.

This PR fixes timestamp wrapping for Oracle.

Co-authored-by: Alexander Denissov <adenissov@pivotal.io>