### PR TITLE
HdfsFileFragmenter

### DIFF
--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsAtomicDataAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsAtomicDataAccessor.java
@@ -48,8 +48,7 @@ import java.net.URI;
  * reading does not support splitting: a protocol-buffer file, regular file, ...
  */
 public abstract class HdfsAtomicDataAccessor extends BasePlugin implements Accessor {
-    protected InputStream inp;
-
+    InputStream inputStream;
     private FileSplit fileSplit;
 
     @Override
@@ -75,9 +74,9 @@ public abstract class HdfsAtomicDataAccessor extends BasePlugin implements Acces
         // input data stream, FileSystem.get actually
         // returns an FSDataInputStream
         FileSystem fs = FileSystem.get(uri, configuration);
-        inp = fs.open(new Path(context.getDataSource()));
+        inputStream = fs.open(new Path(context.getDataSource()));
 
-        return (inp != null);
+        return (inputStream != null);
     }
 
     /**
@@ -103,8 +102,8 @@ public abstract class HdfsAtomicDataAccessor extends BasePlugin implements Acces
             return;
         }
 
-        if (inp != null) {
-            inp.close();
+        if (inputStream != null) {
+            inputStream.close();
         }
     }
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
@@ -45,7 +45,7 @@ import java.util.List;
 public class HdfsDataFragmenter extends BaseFragmenter {
 
     protected JobConf jobConf;
-    private HcfsType hcfsType;
+    protected HcfsType hcfsType;
 
     @Override
     public void initialize(RequestContext context) {

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -39,7 +39,7 @@ public class HdfsFileFragmenter extends BaseFragmenter {
     public List<Fragment> getFragments() throws Exception {
         String fileName = hcfsType.getDataUri(configuration, context);
         Path path = new Path(fileName);
-        // The hostname is not used anymore, so we hardcode it to localhost
+        // The hostname is no longer used, hardcoding it to localhost
         String[] hosts = {"localhost"};
         byte[] dummyMetadata = HdfsUtilities
                 .prepareFragmentMetadata(0, Integer.MAX_VALUE, hosts);

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -7,6 +7,8 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.greenplum.pxf.api.model.BaseFragmenter;
 import org.greenplum.pxf.api.model.Fragment;
 import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.api.utilities.FragmentMetadata;
+import org.greenplum.pxf.plugins.hdfs.utilities.HdfsUtilities;
 
 import java.net.URI;
 import java.util.List;
@@ -54,6 +56,9 @@ public class HdfsFileFragmenter extends BaseFragmenter {
         Path path = new Path(fileName);
         // The hostname is not used anymore, so we hardcode it to localhost
         String[] hosts = {"localhost"};
+        byte[] dummyMetadata = HdfsUtilities
+                .writeBaseFragmentInfo(0, Integer.MAX_VALUE, hosts)
+                .toByteArray();
 
         FileSystem fs = FileSystem.get(URI.create(fileName), configuration);
         RemoteIterator<LocatedFileStatus> fileStatusListIterator =
@@ -62,7 +67,7 @@ public class HdfsFileFragmenter extends BaseFragmenter {
         while (fileStatusListIterator.hasNext()) {
             LocatedFileStatus fileStatus = fileStatusListIterator.next();
             String sourceName = fileStatus.getPath().toUri().toString();
-            Fragment fragment = new Fragment(sourceName, hosts, null);
+            Fragment fragment = new Fragment(sourceName, hosts, dummyMetadata);
             fragments.add(fragment);
         }
         LOG.debug("Total number of fragments = {}", fragments.size());

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -7,12 +7,10 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.greenplum.pxf.api.model.BaseFragmenter;
 import org.greenplum.pxf.api.model.Fragment;
 import org.greenplum.pxf.api.model.RequestContext;
-import org.greenplum.pxf.api.utilities.FragmentMetadata;
 import org.greenplum.pxf.plugins.hdfs.utilities.HdfsUtilities;
 
 import java.net.URI;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Fragmenter class for file resources. This fragmenter
@@ -23,12 +21,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class HdfsFileFragmenter extends BaseFragmenter {
 
     private HcfsType hcfsType;
-
-    /*
-     * Keeps track of the number of getFragments calls made
-     * during the lifetime of the application
-     */
-    static AtomicLong fragmenterAccessCount = new AtomicLong(0L);
 
     @Override
     public void initialize(RequestContext context) {
@@ -45,13 +37,6 @@ public class HdfsFileFragmenter extends BaseFragmenter {
      */
     @Override
     public List<Fragment> getFragments() throws Exception {
-        long fragmenterAccessCountCurrent = fragmenterAccessCount.incrementAndGet();
-
-        if (fragmenterAccessCountCurrent % 100 == 0) {
-            LOG.debug("HdfsFileFragmenter has been invoked {} times during the lifetime of this application",
-                    fragmenterAccessCountCurrent);
-        }
-
         String fileName = hcfsType.getDataUri(configuration, context);
         Path path = new Path(fileName);
         // The hostname is not used anymore, so we hardcode it to localhost

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -4,9 +4,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
-import org.greenplum.pxf.api.model.BaseFragmenter;
 import org.greenplum.pxf.api.model.Fragment;
-import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.plugins.hdfs.utilities.HdfsUtilities;
 
 import java.net.URI;
@@ -18,17 +16,7 @@ import java.util.List;
  * splits. The list of fragments will be the list of files
  * at the storage layer.
  */
-public class HdfsFileFragmenter extends BaseFragmenter {
-
-    private HcfsType hcfsType;
-
-    @Override
-    public void initialize(RequestContext context) {
-        super.initialize(context);
-
-        // Check if the underlying configuration is for HDFS
-        hcfsType = HcfsType.getHcfsType(configuration, context);
-    }
+public class HdfsFileFragmenter extends HdfsDataFragmenter {
 
     /**
      * Gets the fragments for a data source URI that can appear as a file name,
@@ -42,7 +30,7 @@ public class HdfsFileFragmenter extends BaseFragmenter {
         // The hostname is no longer used, hardcoding it to localhost
         String[] hosts = {"localhost"};
         byte[] dummyMetadata = HdfsUtilities
-                .prepareFragmentMetadata(0, Integer.MAX_VALUE, hosts);
+                .prepareFragmentMetadata(0, 0, hosts);
 
         FileSystem fs = FileSystem.get(URI.create(fileName), configuration);
         RemoteIterator<LocatedFileStatus> fileStatusListIterator =

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -57,8 +57,7 @@ public class HdfsFileFragmenter extends BaseFragmenter {
         // The hostname is not used anymore, so we hardcode it to localhost
         String[] hosts = {"localhost"};
         byte[] dummyMetadata = HdfsUtilities
-                .writeBaseFragmentInfo(0, Integer.MAX_VALUE, hosts)
-                .toByteArray();
+                .prepareFragmentMetadata(0, Integer.MAX_VALUE, hosts);
 
         FileSystem fs = FileSystem.get(URI.create(fileName), configuration);
         RemoteIterator<LocatedFileStatus> fileStatusListIterator =

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -1,0 +1,75 @@
+package org.greenplum.pxf.plugins.hdfs;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.greenplum.pxf.api.model.BaseFragmenter;
+import org.greenplum.pxf.api.model.Fragment;
+import org.greenplum.pxf.api.model.RequestContext;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Fragmenter class for file resources. This fragmenter
+ * adds support for profiles that require files without
+ * splits. The list of fragments will be the list of files
+ * at the storage layer.
+ */
+public class HdfsFileFragmenter extends BaseFragmenter {
+
+    private HcfsType hcfsType;
+
+    /*
+     * Keeps track of the number of getFragments calls made
+     * during the lifetime of the application
+     */
+    private static AtomicLong fragmenterAccessCount = new AtomicLong(0L);
+
+    @Override
+    public void initialize(RequestContext context) {
+        super.initialize(context);
+
+        // Check if the underlying configuration is for HDFS
+        hcfsType = HcfsType.getHcfsType(configuration, context);
+    }
+
+    /**
+     * Gets the fragments for a data source URI that can appear as a file name,
+     * a directory name or a wildcard. Returns the data fragments in JSON
+     * format.
+     */
+    @Override
+    public List<Fragment> getFragments() throws Exception {
+        long fragmenterAccessCountCurrent = fragmenterAccessCount.incrementAndGet();
+
+        if (fragmenterAccessCountCurrent % 100 == 0) {
+            LOG.debug("HdfsFileFragmenter has been invoked {} times during the lifetime of this application",
+                    fragmenterAccessCountCurrent);
+        }
+
+        String fileName = hcfsType.getDataUri(configuration, context);
+        Path path = new Path(fileName);
+        /*
+         * For S3, the hosts is always localhost on the API call.
+         * No need to calculate it, we can just hardcode it.
+         */
+        String[] hosts = {"localhost"};
+
+        FileSystem fs = FileSystem.get(URI.create(fileName), configuration);
+        RemoteIterator<LocatedFileStatus> fileStatusListIterator =
+                fs.listFiles(path, false);
+
+        while (fileStatusListIterator.hasNext()) {
+            LocatedFileStatus fileStatus = fileStatusListIterator.next();
+            String sourceName = fileStatus.getPath().toUri().toString();
+            Fragment fragment = new Fragment(sourceName, hosts, null);
+            fragments.add(fragment);
+        }
+        LOG.debug("Total number of fragments = {}", fragments.size());
+
+        return fragments;
+    }
+}

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -26,7 +26,7 @@ public class HdfsFileFragmenter extends BaseFragmenter {
      * Keeps track of the number of getFragments calls made
      * during the lifetime of the application
      */
-    private static AtomicLong fragmenterAccessCount = new AtomicLong(0L);
+    static AtomicLong fragmenterAccessCount = new AtomicLong(0L);
 
     @Override
     public void initialize(RequestContext context) {
@@ -52,10 +52,7 @@ public class HdfsFileFragmenter extends BaseFragmenter {
 
         String fileName = hcfsType.getDataUri(configuration, context);
         Path path = new Path(fileName);
-        /*
-         * For S3, the hosts is always localhost on the API call.
-         * No need to calculate it, we can just hardcode it.
-         */
+        // The hostname is not used anymore, so we hardcode it to localhost
         String[] hosts = {"localhost"};
 
         FileSystem fs = FileSystem.get(URI.create(fileName), configuration);

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
@@ -142,7 +142,7 @@ public class HdfsUtilities {
         return prepareFragmentMetadata(fsp.getStart(), fsp.getLength(), fsp.getLocations());
     }
 
-    private static byte[] prepareFragmentMetadata(long start, long length, String[] locations)
+    public static byte[] prepareFragmentMetadata(long start, long length, String[] locations)
             throws IOException {
 
         ByteArrayOutputStream byteArrayStream = writeBaseFragmentInfo(start, length, locations);
@@ -150,7 +150,7 @@ public class HdfsUtilities {
     }
 
 
-    private static ByteArrayOutputStream writeBaseFragmentInfo(long start, long length, String[] locations) throws IOException {
+    public static ByteArrayOutputStream writeBaseFragmentInfo(long start, long length, String[] locations) throws IOException {
         ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
         ObjectOutputStream objectStream = new ObjectOutputStream(byteArrayStream);
         objectStream.writeLong(start);

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
@@ -150,7 +150,7 @@ public class HdfsUtilities {
     }
 
 
-    public static ByteArrayOutputStream writeBaseFragmentInfo(long start, long length, String[] locations) throws IOException {
+    private static ByteArrayOutputStream writeBaseFragmentInfo(long start, long length, String[] locations) throws IOException {
         ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
         ObjectOutputStream objectStream = new ObjectOutputStream(byteArrayStream);
         objectStream.writeLong(start);

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertNotNull;
 public class HdfsFileFragmenterTest {
 
     @Test
-    public void testFragmeneterReturnsListOfFiles() throws Exception {
+    public void testFragmenterReturnsListOfFiles() throws Exception {
         String path = this.getClass().getClassLoader().getResource("csv/").getPath();
 
         RequestContext context = new RequestContext();
@@ -30,6 +30,7 @@ public class HdfsFileFragmenterTest {
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
         assertEquals(4, fragmentList.size());
+        assertEquals(1, HdfsFileFragmenter.fragmenterAccessCount.intValue());
     }
 
 }

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -1,0 +1,35 @@
+package org.greenplum.pxf.plugins.hdfs;
+
+import org.greenplum.pxf.api.model.Fragment;
+import org.greenplum.pxf.api.model.Fragmenter;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Francisco Guerrero (me@frankgh.com)
+ * @since 1.0 (5/19/19 7:41 AM)
+ */
+public class HdfsFileFragmenterTest {
+
+    @Test
+    public void testFragmeneterReturnsListOfFiles() throws Exception {
+        String path = this.getClass().getClassLoader().getResource("csv/").getPath();
+
+        RequestContext context = new RequestContext();
+        context.setProtocol("localfile");
+        context.setDataSource(path);
+
+        Fragmenter fragmenter = new HdfsFileFragmenter();
+        fragmenter.initialize(context);
+
+        List<Fragment> fragmentList = fragmenter.getFragments();
+        assertNotNull(fragmentList);
+        assertEquals(4, fragmentList.size());
+    }
+
+}

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -11,8 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * @author Francisco Guerrero (me@frankgh.com)
- * @since 1.0 (5/19/19 7:41 AM)
+ * Test the HdfsFileFragmenter
  */
 public class HdfsFileFragmenterTest {
 
@@ -32,5 +31,4 @@ public class HdfsFileFragmenterTest {
         assertEquals(4, fragmentList.size());
         assertEquals(1, HdfsFileFragmenter.fragmenterAccessCount.intValue());
     }
-
 }

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -29,6 +29,5 @@ public class HdfsFileFragmenterTest {
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
         assertEquals(4, fragmentList.size());
-        assertEquals(1, HdfsFileFragmenter.fragmenterAccessCount.intValue());
     }
 }

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -128,7 +128,7 @@ under the License.
             parallel) and slower than HdfsTextSimple.
         </description>
         <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
             <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
         </plugins>
@@ -235,7 +235,7 @@ under the License.
             parallel) and slower than HdfsTextSimple.
         </description>
         <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
             <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
         </plugins>
@@ -264,7 +264,7 @@ under the License.
             parallel) and slower than HdfsTextSimple.
         </description>
         <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
             <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
         </plugins>
@@ -294,7 +294,7 @@ under the License.
             parallel) and slower than HdfsTextSimple.
         </description>
         <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
             <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
         </plugins>
@@ -319,7 +319,7 @@ under the License.
             parallel) and slower than HdfsTextSimple.
         </description>
         <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
             <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
         </plugins>
@@ -614,7 +614,7 @@ under the License.
             splittable (non parallel) and slower than HdfsTextSimple.
         </description>
         <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
             <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
         </plugins>


### PR DESCRIPTION
HdfsFileFragmenter returns a Fragment per file (instead of a split) from HDFS, S3, or any other hadoop compatible filesystem.

This fragmenter is useful for accessors that process full files (instead of splits) such as the HdfsAtomicDataAccessor or the QuotedLineBreakAccessor