### PR TITLE
Fix paramiko pipeline failure

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -121,17 +121,17 @@ sync_jdbc_config:
 sync_cloud_configs:
 ifneq "$(PROTOCOL)" ""
 	@mkdir -p $(PROTOCOL_HOME)
-	@if [[ ! -f "$(PROTOCOL_HOME)/$(PROTOCOL)-site.xml" ]]; then \
+	@if [ ! -f "$(PROTOCOL_HOME)/$(PROTOCOL)-site.xml" ]; then \
 		cp $(PXF_HOME)/templates/user/templates/$(PROTOCOL)-site.xml $(PROTOCOL_HOME)/; \
 		cp $(PXF_HOME)/templates/user/templates/mapred-site.xml $(PROTOCOL_HOME)/; \
-		if [[ $(PROTOCOL) == s3 ]]; then \
-			if [[ "$(MINIO)" == "true" ]]; then \
+		if [ $(PROTOCOL) = s3 ]; then \
+			if [ "$(MINIO)" = "true" ]; then \
 				cp $(PXF_HOME)/templates/user/templates/minio-site.xml $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
 				sed $(SED_OPTS) "s|YOUR_MINIO_URL|http://localhost:9000|" $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
 			fi; \
 			mkdir -p $(PROTOCOL_HOME)-invalid; \
 			cp $(PXF_HOME)/templates/user/templates/$(PROTOCOL)-site.xml $(PROTOCOL_HOME)-invalid/; \
-			if [[ -z "$(ACCESS_KEY_ID)" ]] || [[ -z "$(SECRET_ACCESS_KEY)" ]]; then \
+			if [ -z "$(ACCESS_KEY_ID)" ] || [ -z "$(SECRET_ACCESS_KEY)" ]; then \
 				echo "AWS Keys (ACCESS_KEY_ID, SECRET_ACCESS_KEY) not set"; \
 				rm -rf $(PROTOCOL_HOME); \
 				exit 1; \
@@ -139,8 +139,8 @@ ifneq "$(PROTOCOL)" ""
 			sed $(SED_OPTS) "s|YOUR_AWS_ACCESS_KEY_ID|$(ACCESS_KEY_ID)|" $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
 			sed $(SED_OPTS) "s|YOUR_AWS_SECRET_ACCESS_KEY|$(SECRET_ACCESS_KEY)|" $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
 		fi; \
-		if [[ $(PROTOCOL) == adl ]]; then \
-			if [[ -z "$(ADL_ACCOUNT)" ]] || [[ -z "$(ADL_REFRESH_URL)" ]] || [[ -z "$(ADL_CLIENT_ID)" ]] || [[ -z "$(ADL_CREDENTIAL)" ]]; then \
+		if [ $(PROTOCOL) = adl ]; then \
+			if [ -z "$(ADL_ACCOUNT)" ] || [ -z "$(ADL_REFRESH_URL)" ] || [ -z "$(ADL_CLIENT_ID)" ] || [ -z "$(ADL_CREDENTIAL)" ]; then \
 				echo "ADL Keys (ADL_ACCOUNT, ADL_CLIENT_ID, ADL_CREDENTIAL, ADL_REFRESH_URL) not set"; \
 				rm -rf $(PROTOCOL_HOME); \
 				exit 1; \
@@ -149,8 +149,8 @@ ifneq "$(PROTOCOL)" ""
 			sed $(SED_OPTS) "s|YOUR_ADL_CLIENT_ID|$(ADL_CLIENT_ID)|" $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
 			sed $(SED_OPTS) "s|YOUR_ADL_CREDENTIAL|$(ADL_CREDENTIAL)|" $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
 		fi; \
-		if [[ $(PROTOCOL) == gs ]]; then \
-			if [[ ! -f /tmp/gsc-ci-service-account.key.json ]]; then \
+		if [ $(PROTOCOL) = gs ]; then \
+			if [ ! -f /tmp/gsc-ci-service-account.key.json ]; then \
 				echo "Google Service Account Key JSON file does exist in /tmp/gsc-ci-service-account.key.json"; \
 				rm -rf $(PROTOCOL_HOME); \
 				exit 1; \
@@ -158,8 +158,8 @@ ifneq "$(PROTOCOL)" ""
 			sed $(SED_OPTS) "s|YOUR_GOOGLE_STORAGE_KEYFILE|/tmp/gsc-ci-service-account.key.json|" $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
 		fi; \
 		echo "Created $(PROTOCOL) server configuration"; \
-		if [[ $(PROTOCOL) == wasbs ]]; then \
-			if [[ -z "$(WASB_ACCOUNT_NAME)" ]] || [[ -z "$(WASB_ACCOUNT_KEY)" ]]; then \
+		if [ $(PROTOCOL) = wasbs ]; then \
+			if [ -z "$(WASB_ACCOUNT_NAME)" ] || [ -z "$(WASB_ACCOUNT_KEY)" ]; then \
 				echo "Azure Blob Storage Keys (WASB_ACCOUNT_NAME, WASB_ACCOUNT_KEY) not set"; \
 				rm -rf $(PROTOCOL_HOME); \
 				exit 1; \

--- a/cli/go/src/pxf-cli/Makefile
+++ b/cli/go/src/pxf-cli/Makefile
@@ -25,7 +25,7 @@ help:
 all: test tar install
 
 depend:
-	@if [[ -d $(HOME)/.go-dep-cached-sources && ! -d ${GO_DEP_CACHE}/sources ]]; then \
+	@if [ -d $(HOME)/.go-dep-cached-sources ] && [ ! -d ${GO_DEP_CACHE}/sources ]; then \
 		mkdir -p ${GO_DEP_CACHE}; \
 		ln -s $(HOME)/.go-dep-cached-sources ${GO_DEP_CACHE}/sources; \
 	fi
@@ -41,7 +41,7 @@ tar: build
 	cp ${GOPATH}/bin/pxf-cli ${PXF_STAGING_DIR}
 
 install: build
-	@if [[ "$(PXF_HOME)" == "" ]]; then \
+	@if [ -z "$(PXF_HOME)" ]; then \
 		echo "ERROR: PXF_HOME is not set correctly"; exit 2; \
 	fi
 	mkdir -p ${PXF_HOME}/bin

--- a/concourse/docker/pxf-dev-base/Dockerfile
+++ b/concourse/docker/pxf-dev-base/Dockerfile
@@ -24,14 +24,18 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio && \
 
 ADD pxf_src /tmp/pxf_src
 
-RUN cd /tmp/pxf_src && \
-    export BUILD_PARAMS='-Dorg.gradle.daemon=false' && \
-    GOPATH=/opt/go PATH=/opt/go/bin:/usr/local/go/bin:$PATH make tar && \
+RUN ["/bin/bash", "-c", "export BUILD_PARAMS=-Dorg.gradle.daemon=false && \
+    GOPATH=/opt/go PATH=/opt/go/bin:/usr/local/go/bin:$PATH make -C /tmp/pxf_src tar && \
     PXF_HOME=/tmp/pxf_src/server/build/stage make -C /tmp/pxf_src/automation dev && \
-    mkdir -p /home/gpadmin/.tomcat && \
-    mv /tmp/pxf_src/server/tomcat/build/apache-tomcat-*.tar.gz /home/gpadmin/.tomcat && \
-    mv /tmp/pxf_src/cli/go/pkg/dep/sources /home/gpadmin/.go-dep-cached-sources && \
-    mv /root/.gradle /root/.m2 /home/gpadmin && \
-    ln -s /home/gpadmin/.tomcat /home/gpadmin/.go-dep-cached-sources /home/gpadmin/.m2 /home/gpadmin/.gradle /root && \
-    chown -R gpadmin:gpadmin /home/gpadmin && \
-    rm -rf /tmp/pxf_src
+    mkdir -p ~gpadmin/.tomcat && \
+    mv /tmp/pxf_src/server/tomcat/build/apache-tomcat-*.tar.gz ~gpadmin/.tomcat && \
+    mv /tmp/pxf_src/cli/go/pkg/dep/sources ~gpadmin/.go-dep-cached-sources && \
+    mv /root/.{gradle,m2} ~gpadmin && \
+    ln -s ~gpadmin/.{tomcat,go-dep-cached-sources,m2,gradle} ~root && \
+    chown -R gpadmin:gpadmin ~gpadmin && \
+    rm -rf /tmp/pxf_src && \
+    if grep 'CentOS release 6' /etc/centos-release; then \
+      yum install -y python-paramiko && yum clean all; \
+    else \
+      pip install psi paramiko --no-cache-dir; \
+    fi"]

--- a/concourse/pipelines/docker-images.yml
+++ b/concourse/pipelines/docker-images.yml
@@ -325,12 +325,18 @@ jobs:
             trigger: true
           - get: dockerfile-gpdb-pxf-dev-base
             trigger: true
+          - get: gpdb-dev-centos6-image
+            passed: [docker-gpdb-dev-centos6]
+            trigger: true
+            params:
+              save: true
       - put: gpdb-pxf-dev-centos6-image
         params:
           build: .
           dockerfile: pxf_src/concourse/docker/pxf-dev-base/Dockerfile
           build_args:
             BASE_IMAGE: "gpdb-dev:centos6"
+          load_base: gpdb-dev-centos6-image
 
   - name: docker-gpdb-dev-centos7
     plan:
@@ -350,12 +356,18 @@ jobs:
             trigger: true
           - get: dockerfile-gpdb-pxf-dev-base
             trigger: true
+          - get: gpdb-dev-centos7-image
+            passed: [docker-gpdb-dev-centos7]
+            trigger: true
+            params:
+              save: true
       - put: gpdb-pxf-dev-centos7-image
         params:
           build: .
           dockerfile: pxf_src/concourse/docker/pxf-dev-base/Dockerfile
           build_args:
             BASE_IMAGE: "gpdb-dev:centos7"
+          load_base: gpdb-dev-centos7-image
 
   - name: docker-gpdb-dev-ubuntu16
     plan:
@@ -375,44 +387,68 @@ jobs:
             trigger: true
           - get: dockerfile-gpdb-pxf-dev-base
             trigger: true
+          - get: gpdb-dev-ubuntu16-image
+            passed: [docker-gpdb-dev-ubuntu16]
+            trigger: true
+            params:
+              save: true
       - put: gpdb-pxf-dev-ubuntu16-image
         params:
           build: .
           dockerfile: pxf_src/concourse/docker/pxf-dev-base/Dockerfile
           build_args:
             BASE_IMAGE: "gpdb-dev:ubuntu16"
+          load_base: gpdb-dev-ubuntu16-image
 
   - name: docker-gpdb-pxf-dev-centos6-mapr-server
     plan:
     - aggregate:
       - get: pxf_src
+      - get: dockerfile-gpdb-dev-centos6
+        passed: [docker-gpdb-pxf-dev-centos6]
+        trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
       - get: dockerfile-gpdb-pxf-mapr
         trigger: true
+      - get: gpdb-pxf-dev-centos6-image
+        passed: [docker-gpdb-pxf-dev-centos6]
+        trigger: true
+        params:
+          save: true
     - put: gpdb-pxf-dev-centos6-mapr-image
       params:
         build: .
         dockerfile: pxf_src/concourse/docker/mapr/Dockerfile
         build_args:
           BASE_IMAGE: "gpdb-pxf-dev:centos6"
+        load_base: gpdb-pxf-dev-centos6-image
 
   - name: docker-gpdb-pxf-dev-centos7-mapr-server
     plan:
     - aggregate:
       - get: pxf_src
+      - get: dockerfile-gpdb-dev-centos7
+        passed: [docker-gpdb-pxf-dev-centos7]
+        trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
       - get: dockerfile-gpdb-pxf-mapr
         trigger: true
+      - get: gpdb-pxf-dev-centos7-image
+        passed: [docker-gpdb-pxf-dev-centos7]
+        trigger: true
+        params:
+          save: true
     - put: gpdb-pxf-dev-centos7-mapr-image
       params:
         build: .
         dockerfile: pxf_src/concourse/docker/mapr/Dockerfile
         build_args:
           BASE_IMAGE: "gpdb-pxf-dev:centos7"
+        load_base: gpdb-pxf-dev-centos7-image
 
   - name: docker-gpdb-dev-centos6-hdp-secure
     plan:
@@ -424,11 +460,17 @@ jobs:
       - get: dockerfile
         resource: dockerfile-gpdb-dev-centos6-hdp-secure
         trigger: true
+      - get: gpdb-dev-centos6-image
+        passed: [docker-gpdb-dev-centos6]
+        trigger: true
+        params:
+          save: true
     - put: gpdb-dev-centos6-hdp-secure-image
       params:
         build: pxf_src/concourse/docker/centos6-hdp-secure
         build_args:
           BASE_IMAGE: "gpdb-dev:centos6"
+        load_base: gpdb-dev-centos6-image
 
 #  - name: docker-gpdb-dev-centos7-hdp-secure
 #    plan:
@@ -488,6 +530,9 @@ jobs:
     plan:
     - aggregate:
       - get: pxf_src
+      - get: dockerfile-gpdb-dev-centos6
+        passed: [docker-gpdb-pxf-dev-centos6]
+        trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
@@ -497,17 +542,26 @@ jobs:
         resource: singlecluster-CDH
         passed: [singlecluster_noarch_cdh]
         trigger: true
+      - get: gpdb-pxf-dev-centos6-image
+        passed: [docker-gpdb-pxf-dev-centos6]
+        trigger: true
+        params:
+          save: true
     - put: gpdb-pxf-dev-centos6-cdh-server-image
       params:
         build: .
         dockerfile: pxf_src/concourse/docker/pxf-dev-server/Dockerfile
         build_args:
           BASE_IMAGE: "gpdb-pxf-dev:centos6"
+        load_base: gpdb-pxf-dev-centos6-image
 
   - name: docker-gpdb-pxf-dev-centos7-cdh-server
     plan:
     - aggregate:
       - get: pxf_src
+      - get: dockerfile-gpdb-dev-centos7
+        passed: [docker-gpdb-pxf-dev-centos7]
+        trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
@@ -517,17 +571,26 @@ jobs:
         resource: singlecluster-CDH
         passed: [singlecluster_noarch_cdh]
         trigger: true
+      - get: gpdb-pxf-dev-centos7-image
+        passed: [docker-gpdb-pxf-dev-centos7]
+        trigger: true
+        params:
+          save: true
     - put: gpdb-pxf-dev-centos7-cdh-server-image
       params:
         build: .
         dockerfile: pxf_src/concourse/docker/pxf-dev-server/Dockerfile
         build_args:
           BASE_IMAGE: "gpdb-pxf-dev:centos7"
+        load_base: gpdb-pxf-dev-centos7-image
 
   - name: docker-gpdb-pxf-dev-centos6-hdp-server
     plan:
     - aggregate:
       - get: pxf_src
+      - get: dockerfile-gpdb-dev-centos6
+        passed: [docker-gpdb-pxf-dev-centos6]
+        trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
@@ -537,17 +600,26 @@ jobs:
         resource: singlecluster-HDP
         passed: [singlecluster_noarch_hdp]
         trigger: true
+      - get: gpdb-pxf-dev-centos6-image
+        passed: [docker-gpdb-pxf-dev-centos6]
+        trigger: true
+        params:
+          save: true
     - put: gpdb-pxf-dev-centos6-hdp-server-image
       params:
         build: .
         dockerfile: pxf_src/concourse/docker/pxf-dev-server/Dockerfile
         build_args:
           BASE_IMAGE: "gpdb-pxf-dev:centos6"
+        load_base: gpdb-pxf-dev-centos6-image
 
   - name: docker-gpdb-pxf-dev-centos7-hdp-server
     plan:
     - aggregate:
       - get: pxf_src
+      - get: dockerfile-gpdb-dev-centos7
+        passed: [docker-gpdb-pxf-dev-centos7]
+        trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
@@ -557,17 +629,26 @@ jobs:
         resource: singlecluster-HDP
         passed: [singlecluster_noarch_hdp]
         trigger: true
+      - get: gpdb-pxf-dev-centos7-image
+        passed: [docker-gpdb-pxf-dev-centos7]
+        trigger: true
+        params:
+          save: true
     - put: gpdb-pxf-dev-centos7-hdp-server-image
       params:
         build: .
         dockerfile: pxf_src/concourse/docker/pxf-dev-server/Dockerfile
         build_args:
           BASE_IMAGE: "gpdb-pxf-dev:centos7"
+        load_base: gpdb-pxf-dev-centos7-image
 
   - name: docker-gpdb-pxf-dev-ubuntu16-cdh-server
     plan:
     - aggregate:
       - get: pxf_src
+      - get: dockerfile-gpdb-dev-ubuntu16
+        passed: [docker-gpdb-pxf-dev-ubuntu16]
+        trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
@@ -577,17 +658,26 @@ jobs:
         resource: singlecluster-CDH
         passed: [singlecluster_noarch_cdh]
         trigger: true
+      - get: gpdb-pxf-dev-ubuntu16-image
+        passed: [docker-gpdb-pxf-dev-ubuntu16]
+        trigger: true
+        params:
+          save: true
     - put: gpdb-pxf-dev-ubuntu16-cdh-server-image
       params:
         build: .
         dockerfile: pxf_src/concourse/docker/pxf-dev-server/Dockerfile
         build_args:
           BASE_IMAGE: "gpdb-pxf-dev:ubuntu16"
+        load_base:  gpdb-pxf-dev-ubuntu16-image
 
   - name: docker-gpdb-pxf-dev-ubuntu16-hdp-server
     plan:
     - aggregate:
       - get: pxf_src
+      - get: dockerfile-gpdb-dev-ubuntu16
+        passed: [docker-gpdb-pxf-dev-ubuntu16]
+        trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
@@ -597,10 +687,16 @@ jobs:
         resource: singlecluster-HDP
         passed: [singlecluster_noarch_hdp]
         trigger: true
+      - get: gpdb-pxf-dev-ubuntu16-image
+        passed: [docker-gpdb-pxf-dev-ubuntu16]
+        trigger: true
+        params:
+          save: true
     - put: gpdb-pxf-dev-ubuntu16-hdp-server-image
       params:
         build: .
         dockerfile: pxf_src/concourse/docker/pxf-dev-server/Dockerfile
         build_args:
           BASE_IMAGE: "gpdb-pxf-dev:ubuntu16"
+        load_base:  gpdb-pxf-dev-ubuntu16-image
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -59,9 +59,9 @@ doc:
 
 .PHONY: tomcat
 tomcat:
-	@if [[ -f "${TOMCAT_DIR}/${TOMCAT_TAR}" ]]; then \
+	@if [ -f "${TOMCAT_DIR}/${TOMCAT_TAR}" ]; then \
 		echo "${TOMCAT_TAR} already exists, nothing to do"; \
-	elif [[ -f "${HOME}/.tomcat/${TOMCAT_TAR}" ]]; then \
+	elif [ -f "${HOME}/.tomcat/${TOMCAT_TAR}" ]; then \
 		echo "Found Tomcat tarball at: ${HOME}/.tomcat/${TOMCAT_TAR}, creating symlink"; \
 		mkdir -p "${TOMCAT_DIR}"; \
 		ln -s "${HOME}/.tomcat/${TOMCAT_TAR}" "$(shell pwd)/${TOMCAT_DIR}"; \
@@ -70,7 +70,7 @@ tomcat:
 		mkdir -p ${TOMCAT_DIR}; \
 		wget -q ${TOMCAT_URL} -P ${TOMCAT_DIR}; \
 	fi
-	@if [[ ! -d "${TOMCAT_DIR}/apache-tomcat" ]]; then \
+	@if [ ! -d "${TOMCAT_DIR}/apache-tomcat" ]; then \
 		mkdir -p ${TOMCAT_DIR}/apache-tomcat; \
 		echo "Extracting Tomcat into ${TOMCAT_DIR}..."; \
 		pushd ${TOMCAT_DIR} > /dev/null; \
@@ -80,7 +80,7 @@ tomcat:
 
 .PHONY: install
 install: tomcat
-	@if [[ "$(PXF_HOME)" == "" ]]; then \
+	@if [ -z "$(PXF_HOME)" ]; then \
 		echo "ERROR: PXF_HOME is not set correctly"; exit 2; \
 	fi
 	./gradlew install ${BUILD_PARAMS}


### PR DESCRIPTION
Paramiko is available on the CentOS concourse boxes, but not inside the
`PYTHONPATH` that is normally defined inside
`$GPHOME/greenplum_path.sh`. Because we source this [very late in the
Tinc run process](https://github.com/greenplum-db/pxf/blob/4be25a53e3e422d873b6d03999af9b706a1d74df/automation/src/main/java/org/greenplum/pxf/automation/components/tinc/Tinc.java#L32), we should try to make a change in `greenplum_path.sh`.

The alternative is to copy some files into `$GPHOME/lib/python` from the
system python libraries.

On CentOS 6, these are the dirs we would need:

```
/usr/lib/python2.6/site-packages/paramiko
/usr/lib64/python2.6/site-packages/Crypto
```

On CentOS 7, these are the files/dirs we would need:

```
/usr/lib/python2.7/site-packages/{pip{,/_vendor/pkg_resources},paramiko,pyasn1,idna,six.py,setuptools,enum,ipaddress.py,pycparser}
/usr/lib64/python2.7/site-packages/{cryptography,cffi}
```

Authored-by: Oliver Albertini <oalbertini@pivotal.io>