### PR TITLE
Update path to the ubuntu dockerfile

### DIFF
--- a/concourse/pipelines/docker-images.yml
+++ b/concourse/pipelines/docker-images.yml
@@ -207,7 +207,7 @@ resources:
     source:
       branch: master
       uri: https://github.com/greenplum-db/gpdb.git
-      paths: [src/tools/docker/ubuntu16/Dockerfile]
+      paths: [src/tools/docker/ubuntu/Dockerfile]
 
   - name: gpdb-dev-ubuntu16-image
     type: docker-image


### PR DESCRIPTION
The Ubuntu image location will change in the GPDB repo from src/tools/docker/ubuntu16/Dockerfile to src/tools/docker/ubuntu/Dockerfile. This PR reflects that change in the docker images pipeline