### PR TITLE
Upgrade jackson 2 version from 2.9.8 -> 2.9.9

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -170,9 +170,9 @@ project('pxf-hdfs') {
     dependencies {
         compile(project(':pxf-api'))
         compile "org.apache.avro:avro-mapred:1.7.7"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.9.8"
-        compile "com.fasterxml.jackson.core:jackson-core:2.9.8"
-        compile "com.fasterxml.jackson.core:jackson-annotations:2.9.8"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.9"
+        compile "com.fasterxml.jackson.core:jackson-core:2.9.9"
+        compile "com.fasterxml.jackson.core:jackson-annotations:2.9.9"
         compile "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}"
         compile "org.apache.hadoop:hadoop-yarn-api:${hadoopVersion}" // Kerberos dependency
         compile "org.apache.hadoop:hadoop-yarn-client:${hadoopVersion}" // Kerberos dependency


### PR DESCRIPTION
From the github security report:
A Polymorphic Typing issue was discovered in FasterXML
jackson-databind 2.x before 2.9.9. When Default Typing
is enabled (either globally or for a specific property)
for an externally exposed JSON endpoint, the service
has the mysql-connector-java jar (8.0.14 or earlier)
in the classpath, and an attacker can host a crafted
MySQL server reachable by the victim, an attacker can
send a crafted JSON message that allows them to read
arbitrary local files on the server. This occurs
because of missing com.mysql.cj.jdbc.admin.MiniAdmin
validation.