### PR TITLE
Pipeline: add Ubuntu18 jobs for master/6X

### DIFF
--- a/concourse/deploy
+++ b/concourse/deploy
@@ -85,6 +85,7 @@ def how_to_use_generated_pipeline_message():
         cmd += '    -v icw_green_bucket=' + ARGS.ICW_GREEN_BUCKET + ' \\\n'
         if ARGS.gpdb_branch != '5X_STABLE':
             cmd += '    -v gcs-bucket-intermediates=pivotal-gpdb-concourse-resources-intermediates-prod \\\n'
+            cmd += '    -v gcs-bucket-resources-prod=pivotal-gpdb-concourse-resources-prod\\\n'
     if ARGS.compile_gpdb:
         cmd += '    -v configure_flags=--enable-cassert -v gpaddon-git-branch=master \\\n'
     cmd += '    -v gpdb-branch=' + ARGS.actual_gpdb_branch

--- a/concourse/docker/pxf-dev-base/Dockerfile
+++ b/concourse/docker/pxf-dev-base/Dockerfile
@@ -38,4 +38,13 @@ RUN ["/bin/bash", "-c", "export BUILD_PARAMS=-Dorg.gradle.daemon=false && \
       yum install -y python-paramiko && yum clean all; \
     else \
       pip install psi paramiko --no-cache-dir; \
+    fi && \
+    if grep 'VERSION=.*18.04.*LTS.*Bionic Beaver.*$' /etc/os-release; then \
+      PERL_VERSION=perl-5.22.1 && \
+      wget http://www.cpan.org/src/5.0/${PERL_VERSION}.tar.gz && \
+      tar -xzf ${PERL_VERSION}.tar.gz && \
+      pushd $PERL_VERSION && \
+        ./Configure -des -Dprefix=/usr && \
+        make && make install && \
+      popd && rm -rf ${PERL_VERSION}*; \
     fi"]

--- a/concourse/pipelines/docker-images.yml
+++ b/concourse/pipelines/docker-images.yml
@@ -9,11 +9,13 @@ groups:
 #  - docker-gpdb-dev-centos7-hdp-secure
   - docker-gpdb-dev-centos7
   - docker-gpdb-dev-ubuntu16
+  - docker-gpdb-dev-ubuntu18
   - singlecluster_noarch_cdh
   - singlecluster_noarch_hdp
   - docker-gpdb-pxf-dev-centos6
   - docker-gpdb-pxf-dev-centos7
   - docker-gpdb-pxf-dev-ubuntu16
+  - docker-gpdb-pxf-dev-ubuntu18
   - docker-gpdb-pxf-dev-centos6-mapr-server
   - docker-gpdb-pxf-dev-centos6-cdh-server
   - docker-gpdb-pxf-dev-centos6-hdp-server
@@ -21,7 +23,9 @@ groups:
   - docker-gpdb-pxf-dev-centos7-cdh-server
   - docker-gpdb-pxf-dev-centos7-hdp-server
   - docker-gpdb-pxf-dev-ubuntu16-cdh-server
+  - docker-gpdb-pxf-dev-ubuntu18-cdh-server
   - docker-gpdb-pxf-dev-ubuntu16-hdp-server
+  - docker-gpdb-pxf-dev-ubuntu18-hdp-server
 
 - name: centos6
   jobs:
@@ -47,6 +51,13 @@ groups:
   - docker-gpdb-pxf-dev-ubuntu16
   - docker-gpdb-pxf-dev-ubuntu16-cdh-server
   - docker-gpdb-pxf-dev-ubuntu16-hdp-server
+
+- name: ubuntu18
+  jobs:
+  - docker-gpdb-dev-ubuntu18
+  - docker-gpdb-pxf-dev-ubuntu18
+  - docker-gpdb-pxf-dev-ubuntu18-cdh-server
+  - docker-gpdb-pxf-dev-ubuntu18-hdp-server
 
 ## ======================================================================
 ## RESOURCES
@@ -202,7 +213,7 @@ resources:
 #      uri: https://github.com/greenplum-db/pxf.git
 #      paths: [concourse/docker/centos6-hdp-secure/Dockerfile]
 
-  - name: dockerfile-gpdb-dev-ubuntu16
+  - name: dockerfile-gpdb-dev-ubuntu
     type: git
     source:
       branch: master
@@ -214,6 +225,14 @@ resources:
     source:
       repository: pivotaldata/gpdb-dev
       tag: ubuntu16
+      username: {{docker-username}}
+      password: {{docker-password}}
+
+  - name: gpdb-dev-ubuntu18-image
+    type: docker-image
+    source:
+      repository: pivotaldata/gpdb-dev
+      tag: ubuntu18
       username: {{docker-username}}
       password: {{docker-password}}
 
@@ -245,6 +264,14 @@ resources:
     source:
       repository: pivotaldata/gpdb-pxf-dev
       tag: ubuntu16
+      username: {{docker-username}}
+      password: {{docker-password}}
+
+  - name: gpdb-pxf-dev-ubuntu18-image
+    type: docker-image
+    source:
+      repository: pivotaldata/gpdb-pxf-dev
+      tag: ubuntu18
       username: {{docker-username}}
       password: {{docker-password}}
 
@@ -295,11 +322,27 @@ resources:
       username: {{docker-username}}
       password: {{docker-password}}
 
+  - name: gpdb-pxf-dev-ubuntu18-cdh-server-image
+    type: docker-image
+    source:
+      repository: pivotaldata/gpdb-pxf-dev
+      tag: ubuntu18-cdh-server
+      username: {{docker-username}}
+      password: {{docker-password}}
+
   - name: gpdb-pxf-dev-ubuntu16-hdp-server-image
     type: docker-image
     source:
       repository: pivotaldata/gpdb-pxf-dev
       tag: ubuntu16-hdp-server
+      username: {{docker-username}}
+      password: {{docker-password}}
+
+  - name: gpdb-pxf-dev-ubuntu18-hdp-server-image
+    type: docker-image
+    source:
+      repository: pivotaldata/gpdb-pxf-dev
+      tag: ubuntu18-hdp-server
       username: {{docker-username}}
       password: {{docker-password}}
 
@@ -372,17 +415,19 @@ jobs:
   - name: docker-gpdb-dev-ubuntu16
     plan:
       - get: dockerfile
-        resource: dockerfile-gpdb-dev-ubuntu16
+        resource: dockerfile-gpdb-dev-ubuntu
         trigger: true
       - put: gpdb-dev-ubuntu16-image
         params:
-          build: dockerfile/src/tools/docker/ubuntu16
+          build: dockerfile/src/tools/docker/ubuntu
+          build_args:
+            BASE_IMAGE: "ubuntu:16.04"
 
   - name: docker-gpdb-pxf-dev-ubuntu16
     plan:
       - aggregate:
           - get: pxf_src
-          - get: dockerfile-gpdb-dev-ubuntu16
+          - get: dockerfile-gpdb-dev-ubuntu
             passed: [docker-gpdb-dev-ubuntu16]
             trigger: true
           - get: dockerfile-gpdb-pxf-dev-base
@@ -399,6 +444,39 @@ jobs:
           build_args:
             BASE_IMAGE: "gpdb-dev:ubuntu16"
           load_base: gpdb-dev-ubuntu16-image
+
+  - name: docker-gpdb-dev-ubuntu18
+    plan:
+      - get: dockerfile
+        resource: dockerfile-gpdb-dev-ubuntu
+        trigger: true
+      - put: gpdb-dev-ubuntu18-image
+        params:
+          build: dockerfile/src/tools/docker/ubuntu
+          build_args:
+            BASE_IMAGE: "ubuntu:18.04"
+
+  - name: docker-gpdb-pxf-dev-ubuntu18
+    plan:
+      - aggregate:
+          - get: pxf_src
+          - get: dockerfile-gpdb-dev-ubuntu
+            passed: [docker-gpdb-dev-ubuntu18]
+            trigger: true
+          - get: dockerfile-gpdb-pxf-dev-base
+            trigger: true
+          - get: gpdb-dev-ubuntu18-image
+            passed: [docker-gpdb-dev-ubuntu18]
+            trigger: true
+            params:
+              save: true
+      - put: gpdb-pxf-dev-ubuntu18-image
+        params:
+          build: .
+          dockerfile: pxf_src/concourse/docker/pxf-dev-base/Dockerfile
+          build_args:
+            BASE_IMAGE: "gpdb-dev:ubuntu18"
+          load_base: gpdb-dev-ubuntu18-image
 
   - name: docker-gpdb-pxf-dev-centos6-mapr-server
     plan:
@@ -646,7 +724,7 @@ jobs:
     plan:
     - aggregate:
       - get: pxf_src
-      - get: dockerfile-gpdb-dev-ubuntu16
+      - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
@@ -675,7 +753,7 @@ jobs:
     plan:
     - aggregate:
       - get: pxf_src
-      - get: dockerfile-gpdb-dev-ubuntu16
+      - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
@@ -700,3 +778,60 @@ jobs:
           BASE_IMAGE: "gpdb-pxf-dev:ubuntu16"
         load_base:  gpdb-pxf-dev-ubuntu16-image
 
+  - name: docker-gpdb-pxf-dev-ubuntu18-cdh-server
+    plan:
+    - aggregate:
+      - get: pxf_src
+      - get: dockerfile-gpdb-dev-ubuntu
+        passed: [docker-gpdb-pxf-dev-ubuntu18]
+        trigger: true
+      - get: dockerfile-gpdb-pxf-dev-base
+        passed: [docker-gpdb-pxf-dev-ubuntu18]
+        trigger: true
+      - get: dockerfile-gpdb-pxf-dev-server
+        trigger: true
+      - get: singlecluster
+        resource: singlecluster-CDH
+        passed: [singlecluster_noarch_cdh]
+        trigger: true
+      - get: gpdb-pxf-dev-ubuntu18-image
+        passed: [docker-gpdb-pxf-dev-ubuntu18]
+        trigger: true
+        params:
+          save: true
+    - put: gpdb-pxf-dev-ubuntu18-cdh-server-image
+      params:
+        build: .
+        dockerfile: pxf_src/concourse/docker/pxf-dev-server/Dockerfile
+        build_args:
+          BASE_IMAGE: "gpdb-pxf-dev:ubuntu18"
+        load_base:  gpdb-pxf-dev-ubuntu18-image
+
+  - name: docker-gpdb-pxf-dev-ubuntu18-hdp-server
+    plan:
+    - aggregate:
+      - get: pxf_src
+      - get: dockerfile-gpdb-dev-ubuntu
+        passed: [docker-gpdb-pxf-dev-ubuntu18]
+        trigger: true
+      - get: dockerfile-gpdb-pxf-dev-base
+        passed: [docker-gpdb-pxf-dev-ubuntu18]
+        trigger: true
+      - get: dockerfile-gpdb-pxf-dev-server
+        trigger: true
+      - get: singlecluster
+        resource: singlecluster-HDP
+        passed: [singlecluster_noarch_hdp]
+        trigger: true
+      - get: gpdb-pxf-dev-ubuntu18-image
+        passed: [docker-gpdb-pxf-dev-ubuntu18]
+        trigger: true
+        params:
+          save: true
+    - put: gpdb-pxf-dev-ubuntu18-hdp-server-image
+      params:
+        build: .
+        dockerfile: pxf_src/concourse/docker/pxf-dev-server/Dockerfile
+        build_args:
+          BASE_IMAGE: "gpdb-pxf-dev:ubuntu18"
+        load_base:  gpdb-pxf-dev-ubuntu18-image

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -11,6 +11,8 @@ groups:
       - test_pxf_cdh_centos6
 {% if gpdb_type == "5X_STABLE" %}
       - test_pxf_hdp_ubuntu16
+{% else %}
+      - test_pxf_hdp_ubuntu18
 {% endif %}
       - test_pxf_hdp_multinode_gpdb
       - test_pxf_s3_no_impersonation
@@ -39,6 +41,8 @@ groups:
       - test_pxf_cdh_centos6
 {% if gpdb_type == "5X_STABLE" %}
       - test_pxf_hdp_ubuntu16
+{% else %}
+      - test_pxf_hdp_ubuntu18
 {% endif %}
       - test_pxf_hdp_multinode_gpdb
 {% if pipeline_type == "release" %}
@@ -187,6 +191,12 @@ resources:
   source:
     repository: pivotaldata/gpdb-pxf-dev
     tag: ubuntu16-hdp-server
+{% else %}
+- name: gpdb-pxf-dev-ubuntu18-hdp-server
+  type: docker-image
+  source:
+    repository: pivotaldata/gpdb-pxf-dev
+    tag: ubuntu18-hdp-server
 {% endif %}
 
 - name: gpdb-pxf-dev-centos6-hdp-secure
@@ -238,6 +248,17 @@ resources:
     bucket: ((gcs-bucket-intermediates))
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: gpdb_master/compiled_bits_ubuntu16/compiled_bits_ubuntu16.tar.gz
+{% endif %}
+{% else %}
+- name: bin_gpdb_ubuntu18
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-resources-prod))
+    json_key: ((concourse-gcs-resources-service-account-key))
+{% if gpdb_branch == '6X_STABLE' %}
+    regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.tar.gz
+{% else %}
+    regexp: server/published/master/server-rc-(.*)-ubuntu18.04_x86_64.tar.gz
 {% endif %}
 {% endif %}
 
@@ -503,7 +524,7 @@ jobs:
 {% endif %}
 {% endif %}
 
-  {% if gpdb_type == "5X_STABLE" %}
+{% if gpdb_type == "5X_STABLE" %}
 - name: test_pxf_hdp_ubuntu16
   plan:
   - aggregate:
@@ -533,6 +554,39 @@ jobs:
       TEST_OS: ubuntu
       TARGET_OS: ubuntu
       TARGET_OS_VERSION: 16
+{% if acceptance %}
+      ACCEPTANCE: true
+{% endif %}
+{% else %}
+- name: test_pxf_hdp_ubuntu18
+  plan:
+  - aggregate:
+    - get: gpdb_src
+      passed:
+      - compile_pxf
+    - get: bin_gpdb
+      resource: bin_gpdb_ubuntu18
+    - get: pxf_src
+      passed:
+      - compile_pxf
+      trigger: true
+    - get: pxf_tarball
+      passed:
+      - compile_pxf
+      trigger: true
+    - get: gpdb-pxf-dev-ubuntu18-hdp-server
+  - task: test_pxf
+    file: pxf_src/concourse/tasks/test_pxf.yml
+    image: gpdb-pxf-dev-ubuntu18-hdp-server
+    params:
+      ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+      GROUP: gpdb,proxy,profile
+      TEST_ENV: {{test-env}}
+      HADOOP_CLIENT: HDP
+      TEST_OS: ubuntu
+      TARGET_OS: ubuntu
+      TARGET_OS_VERSION: 18
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -991,6 +1045,8 @@ jobs:
     - test_pxf_cdh_centos6
 {% if gpdb_type == "5X_STABLE" %}
     - test_pxf_hdp_ubuntu16
+{% else %}
+    - test_pxf_hdp_ubuntu18
 {% endif %}
     - test_pxf_s3_no_impersonation
     - test_pxf_s3_with_impersonation
@@ -1013,6 +1069,8 @@ jobs:
     #- test_pxf_mapr_centos6
 {% if gpdb_type == "5X_STABLE" %}
     - test_pxf_hdp_ubuntu16
+{% else %}
+    - test_pxf_hdp_ubuntu18
 {% endif %}
     - test_pxf_adl
     - test_pxf_gs
@@ -1031,6 +1089,8 @@ jobs:
     - test_pxf_cdh_centos6
 {% if gpdb_type == "5X_STABLE" %}
     - test_pxf_hdp_ubuntu16
+{% else %}
+    - test_pxf_hdp_ubuntu18
 {% endif %}
     #- test_pxf_mapr_centos6
     - test_pxf_adl

--- a/concourse/tasks/test_pxf.yml
+++ b/concourse/tasks/test_pxf.yml
@@ -8,11 +8,14 @@ inputs:
   - name: pxf_tarball
     optional: true
 params:
-  IMPERSONATION: true
-  HADOOP_CLIENT: HDP
+  ACCESS_KEY_ID:
   GROUP: smoke
+  HADOOP_CLIENT: HDP
+  IMPERSONATION: true
+  SECRET_ACCESS_KEY:
   TARGET_OS: centos
   TARGET_OS_VERSION:
   TEST_ENV:
+  TEST_OS:
 run:
   path: pxf_src/concourse/scripts/test_pxf.bash


### PR DESCRIPTION
So far this just builds the Docker images for Ubuntu 16/18. [Ubuntu 18](https://ud.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_pxf_docker-images?groups=ubuntu18) appears under its own group now.