### PR TITLE
Run a named query that ends with semicolon

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
@@ -330,7 +330,8 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
             throw new RuntimeException(String.format("Query text file is empty for query %s", queryName));
         }
 
-        // Remove semicolon at the end of the query
+        // Remove one or more semicolons followed by optional blank space
+        // happening at the end of the query
         queryText = queryText.replaceFirst("(;+\\s*)+$", "");
 
         return queryText;

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
@@ -330,13 +330,8 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
             throw new RuntimeException(String.format("Query text file is empty for query %s", queryName));
         }
 
-        int semicolonIndex = queryText.lastIndexOf(";");
         // Remove semicolon at the end of the query
-        if (semicolonIndex > -1) {
-            if (StringUtils.isBlank(queryText.substring(semicolonIndex + 1))) {
-                queryText = queryText.substring(0, semicolonIndex);
-            }
-        }
+        queryText = queryText.replaceFirst("(;+\\s*)+$", "");
 
         return queryText;
     }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
@@ -329,6 +329,15 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
         if (StringUtils.isBlank(queryText)) {
             throw new RuntimeException(String.format("Query text file is empty for query %s", queryName));
         }
+
+        int semicolonIndex = queryText.lastIndexOf(";");
+        // Remove semicolon at the end of the query
+        if (semicolonIndex > -1) {
+            if (StringUtils.isBlank(queryText.substring(semicolonIndex + 1))) {
+                queryText = queryText.substring(0, semicolonIndex);
+            }
+        }
+
         return queryText;
     }
 

--- a/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithsemicolon.sql
+++ b/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithsemicolon.sql
@@ -1,0 +1,8 @@
+SELECT dept.name, count(), max(emp.salary)
+FROM dept JOIN emp
+ON dept.id = emp.dept_id
+GROUP BY dept.name;
+
+
+
+

--- a/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithsemicolon.sql
+++ b/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithsemicolon.sql
@@ -1,8 +1,7 @@
 SELECT dept.name, count(), max(emp.salary)
 FROM dept JOIN emp
 ON dept.id = emp.dept_id
-GROUP BY dept.name;
-
+GROUP BY dept.name;;                  
 
 
 

--- a/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithvalidsemicolon.sql
+++ b/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithvalidsemicolon.sql
@@ -2,4 +2,7 @@ SELECT dept.name, count(), max(emp.salary)
 FROM dept JOIN emp
 ON dept.id = emp.dept_id
 WHERE dept.name LIKE '%;%'
-GROUP BY dept.name
+GROUP BY dept.name;     ;  
+
+
+

--- a/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithvalidsemicolon.sql
+++ b/server/pxf-jdbc/src/test/resources/servers/test-server/testquerywithvalidsemicolon.sql
@@ -1,0 +1,5 @@
+SELECT dept.name, count(), max(emp.salary)
+FROM dept JOIN emp
+ON dept.id = emp.dept_id
+WHERE dept.name LIKE '%;%'
+GROUP BY dept.name


### PR DESCRIPTION
Named queries should work correctly even when semicolon is present at the end of the query