### PR TITLE
 Upgrade postgres driver to version 42.2.5

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -172,9 +172,9 @@
         </dependency>
 
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>8.4-702.jdbc4</version>
+            <version>42.2.5</version>
         </dependency>
 
         <dependency>

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -225,7 +225,7 @@ project('pxf-jdbc') {
     dependencies {
         compile(project(':pxf-api'))
 
-        bundleJars "postgresql:postgresql:9.1-901-1.jdbc4"
+        bundleJars "org.postgresql:postgresql:42.2.5"
         bundleJars "org.apache.hive:hive-jdbc:1.1.0"     // 1.2.2 breaks on CDH-5.x
         bundleJars "org.apache.hive:hive-service:1.1.0"  // 1.2.2 breaks on CDH-5.x
     }


### PR DESCRIPTION
Our existing postgres driver is 8 years old. The new version of the
driver was moved to the org.postgres namespace and the latest released
version is 42.2.5 released in August 2018.