### PR TITLE
Support for FDW

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/FragmenterResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/FragmenterResource.java
@@ -96,6 +96,7 @@ public class FragmenterResource extends BaseResource {
                                  @Context final HttpHeaders headers)
             throws Throwable {
 
+        LOG.debug("Received FRAGMENTER call");
         long startTime = System.currentTimeMillis();
         final RequestContext context = parseRequest(headers);
         final String path = context.getDataSource();

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/FragmenterResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/FragmenterResource.java
@@ -86,7 +86,6 @@ public class FragmenterResource extends BaseResource {
      * @param servletContext Servlet context contains attributes required by
      *            SecuredHDFS
      * @param headers Holds HTTP headers from request
-     * @param path Holds URI path option used in this request
      * @return response object with JSON serialized fragments metadata
      * @throws Exception if getting fragments info failed
      */
@@ -94,15 +93,15 @@ public class FragmenterResource extends BaseResource {
     @Path("getFragments")
     @Produces("application/json")
     public Response getFragments(@Context final ServletContext servletContext,
-                                 @Context final HttpHeaders headers,
-                                 @QueryParam("path") final String path)
+                                 @Context final HttpHeaders headers)
             throws Throwable {
 
         long startTime = System.currentTimeMillis();
-        LOG.debug("FRAGMENTER started for path \"{}\"", path);
-
         final RequestContext context = parseRequest(headers);
+        final String path = context.getDataSource();
         final String fragmenterCacheKey = getFragmenterCacheKey(context);
+
+        LOG.debug("FRAGMENTER started for path \"{}\"", path);
 
         List<Fragment> fragments;
 

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/FragmenterResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/FragmenterResource.java
@@ -51,7 +51,7 @@ import java.util.concurrent.ExecutionException;
  * Class enhances the API of the WEBHDFS REST server. Returns the data fragments
  * that a data resource is made of, enabling parallel processing of the data
  * resource. Example for querying API FRAGMENTER from a web client
- * {@code curl -i "http://localhost:51200/pxf/{version}/Fragmenter/getFragments?path=/dir1/dir2/*txt"}
+ * {@code curl -i "http://localhost:51200/pxf/{version}/Fragmenter/getFragments"}
  * <code>/pxf/</code> is made part of the path when there is a webapp by that
  * name in tomcat.
  */
@@ -81,7 +81,7 @@ public class FragmenterResource extends BaseResource {
 
     /**
      * The function is called when
-     * {@code http://nn:port/pxf/{version}/Fragmenter/getFragments?path=...} is used.
+     * {@code http://host:port/pxf/{version}/Fragmenter/getFragments} is used.
      *
      * @param servletContext Servlet context contains attributes required by
      *            SecuredHDFS

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -220,7 +220,18 @@ under the License.
     <profile>
         <name>hdfs:text</name>
         <description>This profile is suitable for using when reading delimited single line records
-            from plain text files on HDFS.
+            from plain text, tab-delimited, files on HDFS.
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+    </profile>
+    <profile>
+        <name>hdfs:csv</name>
+        <description>This profile is suitable for using when reading delimited single line records
+            from plain text CSV files on HDFS.
         </description>
         <plugins>
             <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
@@ -244,7 +255,23 @@ under the License.
     <profile>
         <name>s3:text</name>
         <description>This profile is suitable for using when reading delimited single line records
-            from plain text files on S3
+            from plain text, tab-delimited, files on S3
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+        <protocol>s3a</protocol>
+        <optionMappings>
+            <mapping option="accesskey" property="fs.s3a.access.key"/>
+            <mapping option="secretkey" property="fs.s3a.secret.key"/>
+        </optionMappings>
+    </profile>
+    <profile>
+        <name>s3:csv</name>
+        <description>This profile is suitable for using when reading delimited single line records
+            from plain text CSV files on S3
         </description>
         <plugins>
             <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
@@ -278,7 +305,19 @@ under the License.
     <profile>
         <name>adl:text</name>
         <description>This profile is suitable for using when reading delimited single line records
-            from plain text files on Azure Data Lake
+            from plain text, tab-delimited, files on Azure Data Lake
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+        <protocol>adl</protocol>
+    </profile>
+    <profile>
+        <name>adl:csv</name>
+        <description>This profile is suitable for using when reading delimited single line records
+            from plain text CSV files on Azure Data Lake
         </description>
         <plugins>
             <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
@@ -303,7 +342,19 @@ under the License.
     <profile>
         <name>gs:text</name>
         <description>This profile is suitable for using when reading delimited single line records
-            from plain text files on Azure Data Lake
+            from plain text, tab-delimited, files on Azure Data Lake
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+        <protocol>gs</protocol>
+    </profile>
+    <profile>
+        <name>gs:csv</name>
+        <description>This profile is suitable for using when reading delimited single line records
+            from plain text CSV files on Azure Data Lake
         </description>
         <plugins>
             <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
@@ -598,7 +649,19 @@ under the License.
     <profile>
         <name>wasbs:text</name>
         <description>This profile is suitable for using when reading delimited single line records
-            from plain text files on Azure Blob Storage
+            from plain text, tab-delimited, files on Azure Blob Storage
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+        <protocol>wasbs</protocol>
+    </profile>
+    <profile>
+        <name>wasbs:csv</name>
+        <description>This profile is suitable for using when reading delimited single line records
+            from plain text CSV files on Azure Blob Storage
         </description>
         <plugins>
             <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/rest/FragmenterResourceTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/rest/FragmenterResourceTest.java
@@ -74,7 +74,7 @@ public class FragmenterResourceTest {
         when(fragmenterFactory.getPlugin(context)).thenReturn(fragmenter1);
 
         new FragmenterResource(parser, fragmenterFactory, fragmenterCacheFactory)
-                .getFragments(servletContext, headersFromRequest1, "/foo/bar");
+                .getFragments(servletContext, headersFromRequest1);
         verify(fragmenter1, times(1)).getFragments();
     }
 
@@ -155,9 +155,9 @@ public class FragmenterResourceTest {
         when(fragmenter1.getFragments()).thenReturn(fragmentList);
 
         Response response1 = new FragmenterResource(parser, fragmenterFactory, fragmenterCacheFactory)
-                .getFragments(servletContext, headersFromRequest1, "/foo/bar");
+                .getFragments(servletContext, headersFromRequest1);
         Response response2 = new FragmenterResource(parser, fragmenterFactory, fragmenterCacheFactory)
-                .getFragments(servletContext, headersFromRequest2, "/foo/bar");
+                .getFragments(servletContext, headersFromRequest2);
 
         verify(fragmenter1, times(1)).getFragments();
         verify(fragmenterFactory, never()).getPlugin(context2);
@@ -196,10 +196,10 @@ public class FragmenterResourceTest {
         when(fragmenter2.getFragments()).thenReturn(fragmentList2);
 
         Response response1 = new FragmenterResource(parser, fragmenterFactory, fragmenterCacheFactory)
-                .getFragments(servletContext, headersFromRequest1, "/foo/bar");
+                .getFragments(servletContext, headersFromRequest1);
         fakeTicker.advanceTime(11 * 1000);
         Response response2 = new FragmenterResource(parser, fragmenterFactory, fragmenterCacheFactory)
-                .getFragments(servletContext, headersFromRequest2, "/foo/bar");
+                .getFragments(servletContext, headersFromRequest2);
 
         verify(fragmenter1, times(1)).getFragments();
         verify(fragmenter2, times(1)).getFragments();
@@ -243,7 +243,7 @@ public class FragmenterResourceTest {
 
                 try {
                     new FragmenterResource(requestParser, factory, cacheFactory)
-                            .getFragments(servletContext, httpHeaders, "/foo/bar/" + index);
+                            .getFragments(servletContext, httpHeaders);
 
                     finishedCount.incrementAndGet();
                 } catch (Throwable e) {
@@ -293,9 +293,9 @@ public class FragmenterResourceTest {
         when(fragmenter2.getFragments()).thenReturn(fragmentList2);
 
         Response response1 = new FragmenterResource(parser, fragmenterFactory, fragmenterCacheFactory)
-                .getFragments(servletContext, headersFromRequest1, "/foo/bar");
+                .getFragments(servletContext, headersFromRequest1);
         Response response2 = new FragmenterResource(parser, fragmenterFactory, fragmenterCacheFactory)
-                .getFragments(servletContext, headersFromRequest2, "/bar/foo");
+                .getFragments(servletContext, headersFromRequest2);
 
         verify(fragmenter1, times(1)).getFragments();
         verify(fragmenter2, times(1)).getFragments();


### PR DESCRIPTION
This PR adds support for FDW:
- The first commit is code clean up in the fragmenter call. This is a backwards compatible change
- The second commit adds new profiles for csv format (which point to the same Fragmenter/Accessor/Resolver as their text counterpart).