### PR TITLE
Implement cluster reset command

### DIFF
--- a/cli/go/.gitignore
+++ b/cli/go/.gitignore
@@ -4,6 +4,8 @@
 !*/
 # then allow everything in pxf-cli
 !src/pxf-cli/**
+
 # reignore some stuff
 .idea
 vendor/
+[._]*.sw[a-p]

--- a/cli/go/src/pxf-cli/cmd/cluster_test.go
+++ b/cli/go/src/pxf-cli/cmd/cluster_test.go
@@ -64,6 +64,11 @@ var _ = Describe("GenerateStatusReport()", func() {
 		_ = cmd.GenerateStatusReport(&pxf.StatusCommand, clusterData)
 		Expect(testStdout).Should(gbytes.Say("Checking status of PXF servers on 2 hosts..."))
 	})
+
+	It("reports the number of hosts that are getting reset", func() {
+		_ = cmd.GenerateStatusReport(&pxf.ResetCommand, clusterData)
+		Expect(testStdout).Should(gbytes.Say("Resetting PXF on master and 2 other hosts..."))
+	})
 })
 
 var _ = Describe("GenerateOutput()", func() {
@@ -99,6 +104,11 @@ var _ = Describe("GenerateOutput()", func() {
 		It("reports all hosts running", func() {
 			_ = cmd.GenerateOutput(&pxf.StatusCommand, clusterData)
 			Expect(testStdout).To(gbytes.Say("PXF is running on 3 out of 3 hosts"))
+		})
+
+		It("reports all hosts reset successfully", func() {
+			_ = cmd.GenerateOutput(&pxf.ResetCommand, clusterData)
+			Expect(testStdout).To(gbytes.Say("PXF has been reset on 3 out of 3 hosts"))
 		})
 	})
 
@@ -138,6 +148,12 @@ var _ = Describe("GenerateOutput()", func() {
 		It("reports the number of hosts that aren't running", func() {
 			_ = cmd.GenerateOutput(&pxf.StatusCommand, clusterData)
 			Expect(testStdout).Should(gbytes.Say("PXF is not running on 1 out of 3 hosts"))
+			Expect(testStderr).Should(gbytes.Say("sdw2 ==> an error happened on sdw2"))
+		})
+
+		It("reports the number of hosts that failed to reset", func() {
+			_ = cmd.GenerateOutput(&pxf.ResetCommand, clusterData)
+			Expect(testStdout).Should(gbytes.Say("Failed to reset PXF on 1 out of 3 hosts"))
 			Expect(testStderr).Should(gbytes.Say("sdw2 ==> an error happened on sdw2"))
 		})
 	})

--- a/cli/go/src/pxf-cli/pxf/pxf.go
+++ b/cli/go/src/pxf-cli/pxf/pxf.go
@@ -1,9 +1,12 @@
 package pxf
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 )
@@ -21,6 +24,7 @@ const (
 	Success MessageType = iota
 	Status
 	Error
+	Warning
 )
 
 type Command struct {
@@ -28,6 +32,7 @@ type Command struct {
 	messages    map[MessageType]string
 	whereToRun  int
 	envVars     []EnvVar
+	warn        bool // whether the command requires a warning/prompt
 }
 
 func (c *Command) Name() string {
@@ -44,6 +49,13 @@ func (c *Command) WhereToRun() int {
 
 func (c *Command) Messages(messageType MessageType) string {
 	return c.messages[messageType]
+}
+
+func (c *Command) Warn(input io.Reader) error {
+	if c.warn == false || promptUser(input, c.Messages(Warning)) {
+		return nil
+	}
+	return fmt.Errorf("pxf %s cancelled", c.commandName)
 }
 
 func (c *Command) GetFunctionToExecute() (func(string) string, error) {
@@ -69,8 +81,19 @@ func (c *Command) GetFunctionToExecute() (func(string) string, error) {
 			pxfCommand += "PXF_CONF=" + inputs[PxfConf] + " "
 		}
 		pxfCommand += inputs[Gphome] + "/pxf/bin/pxf" + " " + c.commandName
+		if c.commandName == "reset" {
+			pxfCommand += " --force" // there is a prompt for local reset as well
+		}
 		return func(_ string) string { return pxfCommand }, nil
 	}
+}
+
+func promptUser(input io.Reader, prompt string) bool {
+	reader := bufio.NewReader(input)
+	fmt.Printf(prompt)
+	text, _ := reader.ReadString('\n')
+	text = strings.TrimRight(text, "\r\n")
+	return strings.ToLower(text) == "y"
 }
 
 type CommandName string
@@ -81,6 +104,7 @@ const (
 	Stop     = "stop"
 	Sync     = "sync"
 	Statuses = "status"
+	Reset    = "reset"
 )
 
 var (
@@ -91,6 +115,7 @@ var (
 			Status:  "Initializing PXF on master and %d other hosts...\n",
 			Error:   "PXF failed to initialize on %d out of %d hosts\n",
 		},
+		warn:       false,
 		envVars:    []EnvVar{Gphome, PxfConf},
 		whereToRun: cluster.ON_HOSTS_AND_MASTER,
 	}
@@ -101,6 +126,7 @@ var (
 			Status:  "Starting PXF on %d segment hosts...\n",
 			Error:   "PXF failed to start on %d out of %d hosts\n",
 		},
+		warn:       false,
 		envVars:    []EnvVar{Gphome},
 		whereToRun: cluster.ON_HOSTS,
 	}
@@ -111,6 +137,7 @@ var (
 			Status:  "Stopping PXF on %d segment hosts...\n",
 			Error:   "PXF failed to stop on %d out of %d hosts\n",
 		},
+		warn:       false,
 		envVars:    []EnvVar{Gphome},
 		whereToRun: cluster.ON_HOSTS,
 	}
@@ -121,6 +148,7 @@ var (
 			Status:  "Syncing PXF configuration files to %d hosts...\n",
 			Error:   "PXF configs failed to sync on %d out of %d hosts\n",
 		},
+		warn:       false,
 		envVars:    []EnvVar{PxfConf},
 		whereToRun: cluster.ON_MASTER_TO_HOSTS,
 	}
@@ -131,8 +159,22 @@ var (
 			Status:  "Checking status of PXF servers on %d hosts...\n",
 			Error:   "PXF is not running on %d out of %d hosts\n",
 		},
+		warn:       false,
 		envVars:    []EnvVar{Gphome},
 		whereToRun: cluster.ON_HOSTS,
+	}
+	ResetCommand = Command{
+		commandName: Reset,
+		messages: map[MessageType]string{
+			Success: "PXF has been reset on %d out of %d hosts\n",
+			Status:  "Resetting PXF on master and %d other hosts...\n",
+			Error:   "Failed to reset PXF on %d out of %d hosts\n",
+			Warning: "Ensure your PXF cluster is stopped before continuing. " +
+				"This is a destructive action. Press y to continue:\n",
+		},
+		warn:       true,
+		envVars:    []EnvVar{Gphome},
+		whereToRun: cluster.ON_HOSTS_AND_MASTER,
 	}
 )
 

--- a/server/pxf-service/src/scripts/pxf-service
+++ b/server/pxf-service/src/scripts/pxf-service
@@ -304,17 +304,54 @@ doHelp() {
 	  start               start the local PXF server instance
 	  stop                stop the local PXF server instance
 	  restart             restart the local PXF server instance (not supported for cluster)
-	  status              show the status of the local PXF server instance (not supported for cluster)
+	  status              show the status of the local PXF server instance
 	  version             show the version of PXF server
-	  cluster <command>   perform <command> on all the hosts in the cluster; try ${bold}pxf cluster help$normal
+	  reset               undo the local PXF initialization
+	  cluster <command>   perform <command> on all the segment hosts in the cluster; try ${bold}pxf cluster help$normal
 
-	  sync <hostname>     sync \$PXF_CONF/{conf,lib,servers} directories onto <hostname>
+	  sync <hostname>     synchronize \$PXF_CONF/{conf,lib,servers} directories onto <hostname>
 
 	${bold}Options${normal}:
 	  -h, --help    show command help
 	  -y            answer yes, use default PXF_CONF=\$HOME/pxf user configuration directory
 	EOF
     exit 0
+}
+
+function promptUser() {
+    echo "$1"
+    read -r answer
+    [[ $answer == y || $answer == Y ]]
+}
+
+# doReset handles the reset command
+function doReset()
+{
+    local force=$2
+    local prompt='Ensure your local PXF instance is stopped before continuing. '
+    prompt+='This is a destructive action. Press y to continue:'
+    if [[ $force != -f && $force != --force ]] && ! promptUser "$prompt"; then
+        echo 'pxf reset cancelled'
+        return 1
+    fi
+
+    if doStatus >/dev/null; then
+        echo "PXF is running. Please stop PXF before running 'pxf reset'"
+        return 1
+    fi
+
+    echo "Cleaning ${PXF_HOME}/conf/pxf-private.classpath..."
+    rm -f "${PXF_HOME}/conf/pxf-private.classpath"
+    echo "Ignoring ${PXF_CONF}..."
+    echo "Cleaning ${instance}..."
+    rm -rf "$instance"
+    echo "Cleaning ${PXF_RUNDIR}..."
+    rm -rf "$PXF_RUNDIR"
+
+    echo "Reverting changes to ${default_env_script}..."
+    sed "${SED_OPTS[@]}" "s|{PXF_CONF:=\"${PXF_CONF}\"}|{PXF_CONF:=NOT_INITIALIZED}|g" "$default_env_script"
+
+    echo "Finished cleaning PXF instance directories"
 }
 
 # doInit handles the init command
@@ -436,6 +473,9 @@ case $pxf_script_command in
         ;;
     'cluster')
         doCluster "$@"
+        ;;
+    'reset')
+        doReset "$@"
         ;;
     *)
         printUsage


### PR DESCRIPTION
`pxf cluster` will call local `pxf-service` script with 'destroy' as a
command on each segment host.

Right now we are deleting `$PXF_CONF`, and we are not sure that's really necessary or a good idea.

Co-authored-by: Oliver Albertini <oalbertini@pivotal.io>
Co-authored-by: Raymond Yin <ryin@pivotal.io>