### PR TITLE
Support config option to specify the server configuration directory

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
@@ -38,7 +38,7 @@ public class BaseConfigurationFactory implements ConfigurationFactory {
     }
 
     @Override
-    public Configuration initConfiguration(String serverName, String userName, Map<String, String> additionalProperties) {
+    public Configuration initConfiguration(String configDirectory, String serverName, String userName, Map<String, String> additionalProperties) {
         // start with built-in Hadoop configuration that loads core-site.xml
         LOG.debug("Initializing configuration for server {}", serverName);
         Configuration configuration = new Configuration();
@@ -46,11 +46,11 @@ public class BaseConfigurationFactory implements ConfigurationFactory {
         File[] serverDirectories = serversConfigDirectory
                 .listFiles(f -> f.isDirectory() &&
                         f.canRead() &&
-                        StringUtils.equalsIgnoreCase(serverName, f.getName()));
+                        StringUtils.equalsIgnoreCase(configDirectory, f.getName()));
 
         if (ArrayUtils.isEmpty(serverDirectories)) {
             LOG.warn("Directory {}{}{} does not exist or cannot be read by PXF, no configuration resources are added for server {}",
-                serversConfigDirectory, File.separator, serverName, serverName);
+                serversConfigDirectory, File.separator, configDirectory, serverName);
         } else if (serverDirectories.length > 1) {
             throw new IllegalStateException(String.format(
                     "Multiple directories found for server %s. Server directories are expected to be case-insensitive.", serverName

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
@@ -43,14 +43,25 @@ public class BaseConfigurationFactory implements ConfigurationFactory {
         LOG.debug("Initializing configuration for server {}", serverName);
         Configuration configuration = new Configuration();
 
-        File[] serverDirectories = serversConfigDirectory
-                .listFiles(f -> f.isDirectory() &&
-                        f.canRead() &&
-                        StringUtils.equalsIgnoreCase(configDirectory, f.getName()));
+        File[] serverDirectories = null;
+        Path p = Paths.get(configDirectory);
+
+        if (p.isAbsolute()) {
+            File f = p.toFile();
+            if (f.exists() && f.isDirectory() && f.canRead()) {
+                serverDirectories = new File[]{f};
+            }
+        } else {
+            serverDirectories = serversConfigDirectory
+                    .listFiles(f ->
+                            f.isDirectory() &&
+                                    f.canRead() &&
+                                    StringUtils.equalsIgnoreCase(configDirectory, f.getName()));
+        }
 
         if (ArrayUtils.isEmpty(serverDirectories)) {
             LOG.warn("Directory {}{}{} does not exist or cannot be read by PXF, no configuration resources are added for server {}",
-                serversConfigDirectory, File.separator, configDirectory, serverName);
+                    serversConfigDirectory, File.separator, configDirectory, serverName);
         } else if (serverDirectories.length > 1) {
             throw new IllegalStateException(String.format(
                     "Multiple directories found for server %s. Server directories are expected to be case-insensitive.", serverName
@@ -68,7 +79,7 @@ public class BaseConfigurationFactory implements ConfigurationFactory {
         }
 
         // add user configuration
-        if(!ArrayUtils.isEmpty(serverDirectories)) {
+        if (!ArrayUtils.isEmpty(serverDirectories)) {
             processUserResource(configuration, serverName, userName, serverDirectories[0]);
         }
 
@@ -107,7 +118,7 @@ public class BaseConfigurationFactory implements ConfigurationFactory {
                 configuration.set(String.format("%s.%s", PXF_CONFIG_RESOURCE_PATH_PROPERTY, path.getFileName().toString()), resourceURL.toString());
             }
         } catch (Exception e) {
-            throw new RuntimeException(String.format("Unable to read user configuration for user % using server %s from %s",
+            throw new RuntimeException(String.format("Unable to read user configuration for user %s using server %s from %s",
                     userName, serverName, directory.getAbsolutePath()), e);
         }
     }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BasePlugin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BasePlugin.java
@@ -19,6 +19,7 @@ package org.greenplum.pxf.api.model;
  * under the License.
  */
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,8 +52,13 @@ public class BasePlugin implements Plugin {
     @Override
     public void initialize(RequestContext requestContext) {
         this.context = requestContext;
+
+        String serverName = !StringUtils.isBlank(context.getConfig()) ?
+                context.getConfig() :
+                context.getServerName();
+
         this.configuration = configurationFactory.
-                initConfiguration(context.getServerName(), context.getUser(), context.getAdditionalConfigProps());
+                initConfiguration(serverName, context.getUser(), context.getAdditionalConfigProps());
         this.initialized = true;
     }
 

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BasePlugin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BasePlugin.java
@@ -52,13 +52,8 @@ public class BasePlugin implements Plugin {
     @Override
     public void initialize(RequestContext requestContext) {
         this.context = requestContext;
-
-        String serverName = !StringUtils.isBlank(context.getConfig()) ?
-                context.getConfig() :
-                context.getServerName();
-
         this.configuration = configurationFactory.
-                initConfiguration(serverName, context.getUser(), context.getAdditionalConfigProps());
+                initConfiguration(context.getConfig(), context.getServerName(), context.getUser(), context.getAdditionalConfigProps());
         this.initialized = true;
     }
 

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/ConfigurationFactory.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/ConfigurationFactory.java
@@ -18,10 +18,11 @@ public interface ConfigurationFactory {
      * Initializes a configuration object that applies server-specific configurations and
      * adds additional properties on top of it, if specified.
      *
+     * @param configDirectory name of the configuration directory
      * @param serverName name of the server
      * @param userName name of the user
      * @param additionalProperties additional properties to be added to the configuration
      * @return configuration object
      */
-    Configuration initConfiguration(String serverName, String userName, Map<String, String> additionalProperties);
+    Configuration initConfiguration(String configDirectory, String serverName, String userName, Map<String, String> additionalProperties);
 }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
@@ -609,7 +609,7 @@ public class RequestContext {
     public void setServerName(String serverName) {
         if (StringUtils.isNotBlank(serverName)) {
 
-            if (!Utilities.isValidDirectoryName(serverName)) {
+            if (!Utilities.isValidRestrictedDirectoryName(serverName)) {
                 throw new IllegalArgumentException(String.format("Invalid server name '%s'", serverName));
             }
 
@@ -737,10 +737,6 @@ public class RequestContext {
         // accessor and resolver are user properties, might be missing if profile is not set
         ensureNotNull("ACCESSOR", accessor);
         ensureNotNull("RESOLVER", resolver);
-
-        if (StringUtils.isNotBlank(config) && !Utilities.isValidDirectoryName(config)) {
-            fail("invalid CONFIG directory name '%s'", config);
-        }
     }
 
     private void ensureNotNull(String property, Object value) {

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
@@ -43,6 +43,7 @@ public class RequestContext {
     // ----- NAMED PROPERTIES -----
     private String accessor;
     private EnumAggregationType aggType;
+    private String config;
     private int dataFragment = -1; /* should be deprecated */
     private String dataSource;
     private String fragmenter;
@@ -346,6 +347,27 @@ public class RequestContext {
      */
     public ColumnDescriptor getColumn(int index) {
         return tupleDescription.get(index);
+    }
+
+    /**
+     * Returns the name of the server configuration for this request.
+     *
+     * @return (optional) the name of the server configuration for this request
+     */
+    public String getConfig() {
+        return config;
+    }
+
+    /**
+     * Sets the name of the server configuration for this request.
+     *
+     * @param config the directory name for the configuration
+     */
+    public void setConfig(String config) {
+        if (StringUtils.isNotBlank(config) && !Utilities.isValidDirectoryName(config)) {
+            fail("invalid CONFIG directory name '%s'", config);
+        }
+        this.config = config;
     }
 
     /**
@@ -715,6 +737,10 @@ public class RequestContext {
         // accessor and resolver are user properties, might be missing if profile is not set
         ensureNotNull("ACCESSOR", accessor);
         ensureNotNull("RESOLVER", resolver);
+
+        if (StringUtils.isNotBlank(config) && !Utilities.isValidDirectoryName(config)) {
+            fail("invalid CONFIG directory name '%s'", config);
+        }
     }
 
     private void ensureNotNull(String property, Object value) {

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/Utilities.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/Utilities.java
@@ -132,13 +132,39 @@ public class Utilities {
 
     /**
      * Validation for directory names that can be created
-     * for the server configuration directory.
+     * for the server directory.
      *
-     * @param name
+     * @param name the directory name
      * @return true if valid, false otherwise
      */
     public static boolean isValidDirectoryName(String name) {
-        if (StringUtils.isBlank(name) || StringUtils.containsAny(name, PROHIBITED_CHARS)) {
+        return isValidRestrictedDirectoryName(name, false);
+    }
+
+    /**
+     * Validation for directory names that can be created
+     * for the server configuration directory. Perform validation
+     * for prohibited characters.
+     *
+     * @param name the directory name
+     * @return true if valid, false otherwise
+     */
+    public static boolean isValidRestrictedDirectoryName(String name) {
+        return isValidRestrictedDirectoryName(name, true);
+    }
+
+    /**
+     * Validation for directory names that can be created
+     * for the server configuration directory. Optionally checking for
+     * prohibited characters in the directory name.
+     *
+     * @param name                    the directory name
+     * @param checkForProhibitedChars true to check for prohibited chars, false otherwise
+     * @return true if value, false otherwise
+     */
+    private static boolean isValidRestrictedDirectoryName(String name, boolean checkForProhibitedChars) {
+        if (StringUtils.isBlank(name) ||
+                (checkForProhibitedChars && StringUtils.containsAny(name, PROHIBITED_CHARS))) {
             return false;
         }
         File file = new File(name);

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoAccessorTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoAccessorTest.java
@@ -37,6 +37,7 @@ public class DemoAccessorTest {
     @Before
     public void setup() {
         context = new RequestContext();
+        context.setConfig("default");
         accessor = new DemoAccessor();
         accessor.initialize(context);
     }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoAccessorTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoAccessorTest.java
@@ -22,60 +22,50 @@ package org.greenplum.pxf.api;
 
 import org.greenplum.pxf.api.examples.DemoAccessor;
 import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.when;
-
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({DemoAccessor.class}) // Enables mocking 'new' calls
 
 public class DemoAccessorTest {
 
-    @Mock
-    RequestContext requestContext;
-    DemoAccessor accessor;
+    private RequestContext context;
+    private DemoAccessor accessor;
 
     @Before
     public void setup() {
+        context = new RequestContext();
         accessor = new DemoAccessor();
-        accessor.initialize(requestContext);
+        accessor.initialize(context);
     }
 
     @Test
     public void testRowsWithSingleColumn() throws Exception {
-
-        when(requestContext.getDataFragment()).thenReturn(0);
-        when(requestContext.getFragmentMetadata()).thenReturn("fragment1".getBytes(), "fragment1".getBytes());
-        when(requestContext.getColumns()).thenReturn(1);
+        context.setDataFragment(0);
+        context.setFragmentMetadata("fragment1".getBytes());
 
         int numRows = 2;
         for (int i = 0; i < numRows; i++) {
             OneRow row = accessor.readNextObject();
-            assertEquals(String.format("OneRow:0.%d->fragment1 row%d", i,
-                    i + 1), row.toString());
+            assertEquals(String.format("OneRow:0.%d->fragment1 row%d", i, i + 1), row.toString());
         }
         assertNull(accessor.readNextObject());
     }
 
     @Test
     public void testRowsWithMultipleColumns() throws Exception {
-
-        when(requestContext.getDataFragment()).thenReturn(0);
-        when(requestContext.getFragmentMetadata()).thenReturn("fragment1".getBytes(), "fragment1".getBytes());
-        when(requestContext.getColumns()).thenReturn(3);
+        context.setDataFragment(0);
+        context.setFragmentMetadata("fragment1".getBytes());//, "fragment1".getBytes());
+        context.getTupleDescription().add(new ColumnDescriptor("col1", 1, 1, "TEXT", null));
+        context.getTupleDescription().add(new ColumnDescriptor("col2", 1, 1, "TEXT", null));
+        context.getTupleDescription().add(new ColumnDescriptor("col3", 1, 1, "TEXT", null));
 
         int numRows = 2;
         for (int i = 0; i < numRows; i++) {
             OneRow row = accessor.readNextObject();
-            assertEquals(String.format("OneRow:0.%d->fragment1 row%d,value1," +
-                    "value2", i, i+1), row.toString());
+            assertEquals(String.format("OneRow:0.%d->fragment1 row%d,value1,value2", i, i + 1), row.toString());
         }
         assertNull(accessor.readNextObject());
     }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
@@ -20,45 +20,40 @@ package org.greenplum.pxf.api;
  */
 
 
-import org.greenplum.pxf.api.examples.DemoAccessor;
 import org.greenplum.pxf.api.examples.DemoResolver;
 import org.greenplum.pxf.api.examples.DemoTextResolver;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.greenplum.pxf.api.io.DataType.VARCHAR;
-import static org.junit.Assert.*;
-
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({DemoAccessor.class}) // Enables mocking 'new' calls
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class DemoResolverTest {
 
     private static final String DATA = "value1,value2";
 
-    @Mock
-    RequestContext requestContext;
-    DemoResolver customResolver;
-    DemoTextResolver textResolver;
-    OneRow row;
-    OneField field;
+    private RequestContext context;
+    private DemoResolver customResolver;
+    private DemoTextResolver textResolver;
+    private OneRow row;
+    private OneField field;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
+        context = new RequestContext();
+
         customResolver = new DemoResolver();
         textResolver = new DemoTextResolver();
 
-        customResolver.initialize(requestContext);
-        textResolver.initialize(requestContext);
+        customResolver.initialize(context);
+        textResolver.initialize(context);
 
         row = new OneRow("0.0", DATA);
         field = new OneField(VARCHAR.getOID(), DATA.getBytes());

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
@@ -48,6 +48,7 @@ public class DemoResolverTest {
     @Before
     public void setup() {
         context = new RequestContext();
+        context.setConfig("default");
 
         customResolver = new DemoResolver();
         textResolver = new DemoTextResolver();

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/io/GPDBWritableTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/io/GPDBWritableTest.java
@@ -20,40 +20,21 @@ package org.greenplum.pxf.api.io;
  */
 
 
-import org.apache.commons.logging.Log;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.mockito.stubbing.OngoingStubbing;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import java.io.DataInput;
 import java.io.EOFException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@SuppressStaticInitializationFor("GPDBWritable")
-@PrepareForTest({GPDBWritable.class})
 public class GPDBWritableTest {
 
-    DataInput inputStream;
-    OngoingStubbing<Integer> ongoing;
-    Log LOG;
-
-    @Before
-    public void setupStaticLog() {
-        LOG = mock(Log.class);
-        Whitebox.setInternalState(GPDBWritable.class, LOG);
-    }
+    private DataInput inputStream;
 
     /*
      * Test the readFields method: empty stream
@@ -68,7 +49,6 @@ public class GPDBWritableTest {
 
         gpdbWritable.readFields(inputStream);
 
-        verifyLog("Reached end of stream (EOFException)");
         assertTrue(gpdbWritable.isEmpty());
     }
 
@@ -85,7 +65,6 @@ public class GPDBWritableTest {
 
         gpdbWritable.readFields(inputStream);
 
-        verifyLog("Reached end of stream (returned -1)");
         assertTrue(gpdbWritable.isEmpty());
     }
 
@@ -173,9 +152,7 @@ public class GPDBWritableTest {
 
         typeName = GPDBWritable.getTypeName(DataType.NUMERIC.getOID());
         assertEquals(typeName, DataType.NUMERIC.name());
-
     }
-
 
     /*
      * helpers functions
@@ -188,7 +165,7 @@ public class GPDBWritableTest {
     // add data to stream, end with EOFException on demand.
     private DataInput buildStream(int[] data, boolean throwException) throws Exception {
         inputStream = mock(DataInput.class);
-        ongoing = when(inputStream.readInt());
+        OngoingStubbing<Integer> ongoing = when(inputStream.readInt());
         for (int b : data) {
             ongoing = ongoing.thenReturn(b);
         }
@@ -197,9 +174,5 @@ public class GPDBWritableTest {
             ongoing.thenThrow(new EOFException());
         }
         return inputStream;
-    }
-
-    private void verifyLog(String msg) {
-        Mockito.verify(LOG).debug(msg);
     }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseConfigurationFactoryTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseConfigurationFactoryTest.java
@@ -54,12 +54,27 @@ public class BaseConfigurationFactoryTest {
         factory = new BaseConfigurationFactory(mockServersDirectory);
         when(mockServersDirectory.listFiles(any(FileFilter.class))).thenReturn(new File[]{new File("a"), new File("b")});
 
-        factory.initConfiguration("dummy", "dummy", null);
+        factory.initConfiguration("dummy", "dummy", "dummy", null);
     }
 
     @Test
     public void testConfigurationsLoadedFromMultipleFilesForDefaultServer() {
-        Configuration configuration = factory.initConfiguration("default", "dummy", null);
+        Configuration configuration = factory.initConfiguration("default", "default", "dummy", null);
+
+        assertEquals("blue", configuration.get("test.blue"));
+        assertEquals("red", configuration.get("test.red"));
+
+        // Should return null because the file name does not end in -site.xml
+        assertNull(configuration.get("test.green"));
+
+        assertEquals("bluevaluefromuser", configuration.get("test.blue.key"));
+        assertEquals("redvaluefromuser", configuration.get("test.red.key"));
+        assertEquals("uservalue", configuration.get("test.user.key"));
+    }
+
+    @Test
+    public void testConfigurationsLoadedFromMultipleFilesForDefaultServerWithCustomName() {
+        Configuration configuration = factory.initConfiguration("default", "my-fancy-server-name", "dummy", null);
 
         assertEquals("blue", configuration.get("test.blue"));
         assertEquals("red", configuration.get("test.red"));
@@ -74,7 +89,7 @@ public class BaseConfigurationFactoryTest {
 
     @Test
     public void testConfigurationsLoadedForCaseInsensitiveServerName() {
-        Configuration configuration = factory.initConfiguration("DeFAulT", "dummy", null);
+        Configuration configuration = factory.initConfiguration("DeFAulT", "DeFAulT", "dummy", null);
 
         assertEquals("blue", configuration.get("test.blue"));
         assertEquals("red", configuration.get("test.red"));
@@ -93,7 +108,7 @@ public class BaseConfigurationFactoryTest {
         additionalProperties.put("test.red", "purple");
         additionalProperties.put("test.blue.key", "bluevaluechanged");
         additionalProperties.put("test.user.key", "uservaluechanged");
-        Configuration configuration = factory.initConfiguration("default", "dummy", additionalProperties);
+        Configuration configuration = factory.initConfiguration("default", "default", "dummy", additionalProperties);
 
         assertEquals("blue", configuration.get("test.blue"));
         assertEquals("purple", configuration.get("test.red"));
@@ -112,7 +127,7 @@ public class BaseConfigurationFactoryTest {
     public void testConfigurationsNotLoadedForUnknownServer() {
         additionalProperties.put("test.newOption", "newOption");
         additionalProperties.put("test.red", "purple");
-        Configuration configuration = factory.initConfiguration("unknown", "dummy", additionalProperties);
+        Configuration configuration = factory.initConfiguration("unknown", "unknown", "dummy", additionalProperties);
 
         assertNull(configuration.get("test.blue"));
         assertNull(configuration.get("test.blue.key"));
@@ -127,7 +142,7 @@ public class BaseConfigurationFactoryTest {
 
     @Test
     public void testConfigurationSetsResourcePath() throws MalformedURLException {
-        Configuration configuration = factory.initConfiguration("default", "dummy", additionalProperties);
+        Configuration configuration = factory.initConfiguration("default", "default", "dummy", additionalProperties);
         File defaultServerDirectory = new File(serversDirectory, "default");
 
         assertEquals(new File(defaultServerDirectory, "test-blue-site.xml").toPath().toUri().toURL().toString(),
@@ -140,7 +155,7 @@ public class BaseConfigurationFactoryTest {
 
     @Test
     public void testConfigurationSetsServerDirectoryPath() throws IOException {
-        Configuration configuration = factory.initConfiguration("default", "dummy", additionalProperties);
+        Configuration configuration = factory.initConfiguration("default", "default", "dummy", additionalProperties);
         File defaultServerDirectory = new File(serversDirectory, "default");
 
         assertEquals(defaultServerDirectory.getCanonicalPath(), configuration.get(PXF_CONFIG_SERVER_DIRECTORY_PROPERTY));

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseConfigurationFactoryTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseConfigurationFactoryTest.java
@@ -88,6 +88,22 @@ public class BaseConfigurationFactoryTest {
     }
 
     @Test
+    public void testConfigurationsLoadedFromMultipleFilesForDefaultServerWithAbsolutePath() {
+        String config = this.getClass().getClassLoader().getResource("servers/default").getPath();
+        Configuration configuration = factory.initConfiguration(config, "default", "dummy", null);
+
+        assertEquals("blue", configuration.get("test.blue"));
+        assertEquals("red", configuration.get("test.red"));
+
+        // Should return null because the file name does not end in -site.xml
+        assertNull(configuration.get("test.green"));
+
+        assertEquals("bluevaluefromuser", configuration.get("test.blue.key"));
+        assertEquals("redvaluefromuser", configuration.get("test.red.key"));
+        assertEquals("uservalue", configuration.get("test.user.key"));
+    }
+
+    @Test
     public void testConfigurationsLoadedForCaseInsensitiveServerName() {
         Configuration configuration = factory.initConfiguration("DeFAulT", "DeFAulT", "dummy", null);
 

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BasePluginTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BasePluginTest.java
@@ -25,7 +25,7 @@ public class BasePluginTest {
         RequestContext context = new RequestContext();
 
         when(mockConfigurationFactory.
-                initConfiguration(context.getServerName(), context.getUser(), context.getAdditionalConfigProps()))
+                initConfiguration(context.getConfig(), context.getServerName(), context.getUser(), context.getAdditionalConfigProps()))
                 .thenReturn(configuration);
 
         BasePlugin basePlugin = new BasePlugin(mockConfigurationFactory);

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/RequestContextTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/RequestContextTest.java
@@ -192,18 +192,20 @@ public class RequestContextTest {
     }
 
     @Test
-    public void testFailsWhenConfigOptionIsAnInvalidDirectoryName() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("invalid CONFIG directory name '../../malicious'");
-
-        context.setConfig("../../malicious");
+    public void testSucceedsWhenConfigOptionIsARelativeDirectoryName() {
+        context.setConfig("../../relative");
+        assertEquals("../../relative", context.getConfig());
     }
 
     @Test
-    public void testFailsWhenConfigOptionIsTwoDirectories() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("invalid CONFIG directory name 'foo/bar'");
+    public void testSucceedsWhenConfigOptionIsAnAbsoluteDirectoryName() {
+        context.setConfig("/etc/hadoop/conf");
+        assertEquals("/etc/hadoop/conf", context.getConfig());
+    }
 
+    @Test
+    public void testSucceedsWhenConfigOptionIsTwoDirectories() {
         context.setConfig("foo/bar");
+        assertEquals("foo/bar", context.getConfig());
     }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/RequestContextTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/RequestContextTest.java
@@ -184,4 +184,26 @@ public class RequestContextTest {
         Map<String, String> unmodifiableMap = context.getOptions();
         unmodifiableMap.put("foo", "bar");
     }
+
+    @Test
+    public void testConfigOptionIsSetWhenProvided() {
+        context.setConfig("foobar");
+        assertEquals("foobar", context.getConfig());
+    }
+
+    @Test
+    public void testFailsWhenConfigOptionIsAnInvalidDirectoryName() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("invalid CONFIG directory name '../../malicious'");
+
+        context.setConfig("../../malicious");
+    }
+
+    @Test
+    public void testFailsWhenConfigOptionIsTwoDirectories() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("invalid CONFIG directory name 'foo/bar'");
+
+        context.setConfig("foo/bar");
+    }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/utilities/UtilitiesTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/utilities/UtilitiesTest.java
@@ -28,10 +28,6 @@ import org.greenplum.pxf.api.model.Accessor;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.model.Resolver;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
@@ -47,8 +43,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Class.class})
+
 public class UtilitiesTest {
 
     private String PROPERTY_KEY_USER_IMPERSONATION = "pxf.service.user.impersonation.enabled";
@@ -246,22 +241,34 @@ public class UtilitiesTest {
     }
 
     @Test
-    public void invalidDirectoryName() {
-        assertFalse(Utilities.isValidDirectoryName(null));
-        assertFalse(Utilities.isValidDirectoryName("\0"));
-        assertFalse(Utilities.isValidDirectoryName("a/a"));
-        assertFalse(Utilities.isValidDirectoryName("."));
-        assertFalse(Utilities.isValidDirectoryName(".."));
-        assertFalse(Utilities.isValidDirectoryName("abc ac"));
-        assertFalse(Utilities.isValidDirectoryName("abc;ac"));
-        assertFalse(Utilities.isValidDirectoryName("\\"));
-        assertFalse(Utilities.isValidDirectoryName("a,b"));
+    public void validDirectoryName() {
+        assertTrue(Utilities.isValidDirectoryName("/etc/hadoop/conf"));
+        assertTrue(Utilities.isValidDirectoryName("foo"));
     }
 
     @Test
-    public void validDirectoryName() {
-        assertTrue(Utilities.isValidDirectoryName("pxf"));
-        assertTrue(Utilities.isValidDirectoryName("\uD83D\uDE0A"));
+    public void invalidDirectoryName() {
+        assertFalse(Utilities.isValidDirectoryName(null));
+        assertFalse(Utilities.isValidDirectoryName("\0"));
+    }
+
+    @Test
+    public void invalidRestrictedDirectoryName() {
+        assertFalse(Utilities.isValidRestrictedDirectoryName(null));
+        assertFalse(Utilities.isValidRestrictedDirectoryName("\0"));
+        assertFalse(Utilities.isValidRestrictedDirectoryName("a/a"));
+        assertFalse(Utilities.isValidRestrictedDirectoryName("."));
+        assertFalse(Utilities.isValidRestrictedDirectoryName(".."));
+        assertFalse(Utilities.isValidRestrictedDirectoryName("abc ac"));
+        assertFalse(Utilities.isValidRestrictedDirectoryName("abc;ac"));
+        assertFalse(Utilities.isValidRestrictedDirectoryName("\\"));
+        assertFalse(Utilities.isValidRestrictedDirectoryName("a,b"));
+    }
+
+    @Test
+    public void validRestrictedDirectoryName() {
+        assertTrue(Utilities.isValidRestrictedDirectoryName("pxf"));
+        assertTrue(Utilities.isValidRestrictedDirectoryName("\uD83D\uDE0A"));
     }
 
     @Test
@@ -302,9 +309,6 @@ public class UtilitiesTest {
 
         RequestContext metaData = mock(RequestContext.class);
         String className = "com.pivotal.pxf.Lucy";
-        ClassNotFoundException exception = new ClassNotFoundException(className);
-        PowerMockito.mockStatic(Class.class);
-        when(Class.forName(className)).thenThrow(exception);
 
         try {
             Utilities.createAnyInstance(RequestContext.class,
@@ -320,14 +324,14 @@ public class UtilitiesTest {
     }
 
     @Test
-    public void maskNonPrintable() throws Exception {
+    public void maskNonPrintable() {
         String input = "";
         String result = Utilities.maskNonPrintables(input);
         assertEquals("", result);
 
         input = null;
         result = Utilities.maskNonPrintables(input);
-        assertEquals(null, result);
+        assertNull(result);
 
         input = "Lucy in the sky";
         result = Utilities.maskNonPrintables(input);

--- a/server/pxf-hbase/src/test/java/org/greenplum/pxf/plugins/hbase/HBaseAccessorTest.java
+++ b/server/pxf-hbase/src/test/java/org/greenplum/pxf/plugins/hbase/HBaseAccessorTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.*;
 public class HBaseAccessorTest {
     static final String tableName = "fishy_HBase_table";
 
-    RequestContext requestContext;
+    private RequestContext context;
     HBaseTupleDescription tupleDescription;
     Table table;
     Scan scanDetails;
@@ -79,8 +79,8 @@ public class HBaseAccessorTest {
     public void construction() throws Exception {
         prepareConstruction();
         HBaseAccessor accessor = new HBaseAccessor();
-        accessor.initialize(requestContext);
-        PowerMockito.verifyNew(HBaseTupleDescription.class).withArguments(requestContext);
+        accessor.initialize(context);
+        PowerMockito.verifyNew(HBaseTupleDescription.class).withArguments(context);
     }
 
 	/*
@@ -98,10 +98,8 @@ public class HBaseAccessorTest {
         prepareTableOpen();
         prepareEmptyScanner();
 
-        when(requestContext.getFragmentMetadata()).thenReturn(null);
-
         accessor = new HBaseAccessor();
-        accessor.initialize(requestContext);
+        accessor.initialize(context);
 
         try {
             accessor.openForRead();
@@ -118,9 +116,10 @@ public class HBaseAccessorTest {
      * Creates a mock for HBaseTupleDescription and RequestContext
      */
     private void prepareConstruction() throws Exception {
-        requestContext = mock(RequestContext.class);
+        context = new RequestContext();
+        context.setConfig("default");
         tupleDescription = mock(HBaseTupleDescription.class);
-        PowerMockito.whenNew(HBaseTupleDescription.class).withArguments(requestContext).thenReturn(tupleDescription);
+        PowerMockito.whenNew(HBaseTupleDescription.class).withArguments(context).thenReturn(tupleDescription);
     }
 
     /*
@@ -129,7 +128,7 @@ public class HBaseAccessorTest {
      */
     private void prepareTableOpen() throws Exception {
         // Set table name
-        when(requestContext.getDataSource()).thenReturn(tableName);
+        context.setDataSource(tableName);
 
         // Make sure we mock static functions in HBaseConfiguration
         PowerMockito.mockStatic(HBaseConfiguration.class);
@@ -154,7 +153,6 @@ public class HBaseAccessorTest {
         PowerMockito.whenNew(Scan.class).withNoArguments().thenReturn(scanDetails);
 
         when(tupleDescription.columns()).thenReturn(0);
-        when(requestContext.hasFilter()).thenReturn(false);
     }
 
     /*

--- a/server/pxf-hbase/src/test/java/org/greenplum/pxf/plugins/hbase/HBaseResolverTest.java
+++ b/server/pxf-hbase/src/test/java/org/greenplum/pxf/plugins/hbase/HBaseResolverTest.java
@@ -37,8 +37,8 @@ import static org.mockito.Mockito.mock;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({HBaseResolver.class})
 public class HBaseResolverTest {
-    RequestContext requestContext;
-    HBaseTupleDescription tupleDesc;
+    private RequestContext context;
+    private HBaseTupleDescription tupleDesc;
 
     @Test
     /*
@@ -48,14 +48,15 @@ public class HBaseResolverTest {
 	 * creation is verified
 	 */
     public void construction() throws Exception {
-        requestContext = mock(RequestContext.class);
+        context = new RequestContext();
+        context.setConfig("default");
         tupleDesc = mock(HBaseTupleDescription.class);
-        PowerMockito.whenNew(HBaseTupleDescription.class).withArguments(requestContext).thenReturn(tupleDesc);
+        PowerMockito.whenNew(HBaseTupleDescription.class).withArguments(context).thenReturn(tupleDesc);
 
         HBaseResolver resolver = new HBaseResolver();
-        resolver.initialize(requestContext);
+        resolver.initialize(context);
 
-        PowerMockito.verifyNew(HBaseTupleDescription.class).withArguments(requestContext);
+        PowerMockito.verifyNew(HBaseTupleDescription.class).withArguments(context);
     }
 
     @Test
@@ -65,12 +66,13 @@ public class HBaseResolverTest {
     public void testConvertToJavaObject() throws Exception {
         Object result;
 
-        requestContext = mock(RequestContext.class);
+        context = new RequestContext();
+        context.setConfig("default");
         tupleDesc = mock(HBaseTupleDescription.class);
-        PowerMockito.whenNew(HBaseTupleDescription.class).withArguments(requestContext).thenReturn(tupleDesc);
+        PowerMockito.whenNew(HBaseTupleDescription.class).withArguments(context).thenReturn(tupleDesc);
 
         HBaseResolver resolver = new HBaseResolver();
-        resolver.initialize(requestContext);
+        resolver.initialize(context);
 
         /*
 		 * Supported type, No value.

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -20,6 +20,7 @@ public class HdfsFileFragmenterTest {
         String path = this.getClass().getClassLoader().getResource("csv/").getPath();
 
         RequestContext context = new RequestContext();
+        context.setConfig("default");
         context.setProfileScheme("localfile");
         context.setDataSource(path);
 

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessorTest.java
@@ -18,6 +18,7 @@ public class ParquetFileAccessorTest {
     public void setup() {
         accessor = new ParquetFileAccessor();
         context = new RequestContext();
+        context.setConfig("default");
         schema = new MessageType("hive_schema");
     }
 

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
@@ -66,6 +66,7 @@ public class ParquetResolverTest {
         context = new RequestContext();
         schema = new MessageType("test");
         context.setMetadata(schema);
+        context.setConfig("default");
 
         // for test cases that test conversions against server's time zone
         Instant timestamp = Instant.parse("2013-07-14T04:00:05Z"); // UTC

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorReadLineTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorReadLineTest.java
@@ -37,6 +37,7 @@ public class QuotedLineBreakAccessorReadLineTest {
     public void setup() {
         FileSplit fileSplitMock = mock(FileSplit.class);
         RequestContext context = new RequestContext();
+        context.setConfig("default");
         context.addOption("FILE_AS_ROW", "true");
         context.getTupleDescription().add(new ColumnDescriptor(
                 "file_as_row", 1, 1, "TEXT", null

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorTest.java
@@ -40,6 +40,7 @@ public class QuotedLineBreakAccessorTest {
         context = new RequestContext();
         accessor = new QuotedLineBreakAccessor();
 
+        context.setConfig("default");
         context.setProfileScheme("localfile");
 
         FileSplit fileSplitMock = mock(FileSplit.class);

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/SequenceFileAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/SequenceFileAccessorTest.java
@@ -57,10 +57,11 @@ public class SequenceFileAccessorTest {
         Configuration configuration = new Configuration();
 
         mockConfigurationFactory = mock(ConfigurationFactory.class);
-        when(mockConfigurationFactory.initConfiguration("dummy", "dummy", null))
+        when(mockConfigurationFactory.initConfiguration("dummy", "dummy", "dummy", null))
                 .thenReturn(configuration);
 
         context = new RequestContext();
+        context.setConfig("dummy");
         context.setServerName("dummy");
         context.setUser("dummy");
         context.setDataSource(path);

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/StringPassResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/StringPassResolverTest.java
@@ -19,23 +19,22 @@ package org.greenplum.pxf.plugins.hdfs;
  * under the License.
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.greenplum.pxf.api.OneField;
 import org.greenplum.pxf.api.OneRow;
 import org.greenplum.pxf.api.io.DataType;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 public class StringPassResolverTest {
-    RequestContext mockRequestContext;
+    RequestContext context;
 
     @Test
     /*
@@ -89,9 +88,10 @@ public class StringPassResolverTest {
      * helpers functions
      */
     private StringPassResolver buildResolver() throws Exception {
-        mockRequestContext = mock(RequestContext.class);
+        context = new RequestContext();
+        context.setConfig("default");
         StringPassResolver resolver = new StringPassResolver();
-        resolver.initialize(mockRequestContext);
+        resolver.initialize(context);
         return resolver;
     }
 
@@ -100,6 +100,6 @@ public class StringPassResolverTest {
         byte[] bytes = (byte[]) oneRow.getData();
         byte[] result = Arrays.copyOfRange(bytes, 0, bytes.length);
         assertEquals(result.length, expected.length);
-        assertTrue(Arrays.equals(result, expected));
+        assertArrayEquals(result, expected);
     }
 }

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveORCAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveORCAccessor.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.ql.io.orc.Reader;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.mapred.JobConf;
 import org.greenplum.pxf.api.BasicFilter;
 import org.greenplum.pxf.api.LogicalFilter;
 import org.greenplum.pxf.api.OneRow;
@@ -274,6 +275,15 @@ public class HiveORCAccessor extends HiveAccessor implements StatsAccessor {
             }
         }
         return row;
+    }
+
+    /**
+     * Package private for unit testing
+     *
+     * @return the jobConf
+     */
+    JobConf getJobConf() {
+        return jobConf;
     }
 
 }

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
@@ -49,6 +49,7 @@ public class HiveAccessorTest {
 
         when(inputFormat.getRecordReader(any(InputSplit.class), any(JobConf.class), any(Reporter.class))).thenReturn(reader);
         PowerMockito.when(requestContext.getAccessor()).thenReturn(HiveORCAccessor.class.getName());
+        PowerMockito.when(requestContext.getConfig()).thenReturn("default");
 
         @SuppressWarnings("unchecked")
         OngoingStubbing ongoingStubbing = when(HiveDataFragmenter.makeInputFormat(any(String.class), any(JobConf.class))).thenReturn(inputFormat);

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenterTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenterTest.java
@@ -46,7 +46,8 @@ import java.util.*;
 @PrepareForTest({HiveDataFragmenter.class}) // Enables mocking 'new' calls
 @SuppressStaticInitializationFor({"org.apache.hadoop.mapred.JobConf",
         "org.apache.hadoop.hive.metastore.api.MetaException",
-        "org.greenplum.pxf.plugins.hive.utilities.HiveUtilities"}) // Prevents static inits
+        "org.greenplum.pxf.plugins.hive.utilities.HiveUtilities"})
+// Prevents static inits
 public class HiveDataFragmenterTest {
     RequestContext requestContext;
     Configuration hadoopConfiguration;
@@ -75,10 +76,11 @@ public class HiveDataFragmenterTest {
 
         Map<String, String> map = new HashMap<>();
 
+        when(requestContext.getConfig()).thenReturn("default");
         when(requestContext.getServerName()).thenReturn("default");
         when(requestContext.getUser()).thenReturn("dummy");
         when(requestContext.getOptions()).thenReturn(map);
-        when(configurationFactory.initConfiguration("default", "dummy", map)).
+        when(configurationFactory.initConfiguration("default", "default", "dummy", map)).
                 thenReturn(hadoopConfiguration);
 
         when(hadoopConfiguration.get("fs.defaultFS", "file:///")).thenReturn("hdfs:///");

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetadataFetcherTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetadataFetcherTest.java
@@ -57,7 +57,8 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({HiveMetadataFetcher.class}) // Enables mocking 'new' calls
 @SuppressStaticInitializationFor({"org.apache.hadoop.hive.metastore.api.MetaException",
-        "org.greenplum.pxf.plugins.hive.utilities.HiveUtilities"}) // Prevents static inits
+        "org.greenplum.pxf.plugins.hive.utilities.HiveUtilities"})
+// Prevents static inits
 public class HiveMetadataFetcherTest {
     private RequestContext requestContext;
     private Logger LOG;
@@ -93,11 +94,12 @@ public class HiveMetadataFetcherTest {
         hiveClient = mock(HiveMetaStoreClient.class);
         PowerMockito.whenNew(HiveMetaStoreClient.class).withArguments(hiveConfiguration).thenReturn(hiveClient);
 
+        when(requestContext.getConfig()).thenReturn("default");
         when(requestContext.getServerName()).thenReturn("default");
         when(requestContext.getUser()).thenReturn("dummy");
         when(requestContext.getAdditionalConfigProps()).thenReturn(null);
         mockConfigurationFactory = mock(ConfigurationFactory.class);
-        when(mockConfigurationFactory.initConfiguration("default", "dummy", null)).thenReturn(hadoopConfiguration);
+        when(mockConfigurationFactory.initConfiguration("default", "default", "dummy", null)).thenReturn(hadoopConfiguration);
     }
 
     @Test

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -53,6 +53,7 @@ public class JdbcAccessorTest {
 
         accessor = new JdbcAccessor(mockConnectionManager);
         context = new RequestContext();
+        context.setConfig("default");
         context.setDataSource("test-table");
         Map<String, String> additionalProps = new HashMap<>();
         additionalProps.put("jdbc.driver", "org.greenplum.pxf.plugins.jdbc.FakeJdbcDriver");

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
@@ -67,6 +67,7 @@ public class JdbcBasePluginTest {
 
     @Before public void before() {
         context = new RequestContext();
+        context.setConfig("default");
         context.setDataSource("test-table");
         additionalProps = new HashMap<>();
         context.setAdditionalConfigProps(additionalProps);

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTestInitialize.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTestInitialize.java
@@ -113,7 +113,7 @@ public class JdbcBasePluginTestInitialize {
      */
     private void prepareBaseConfigurationFactory(Configuration configuration) throws Exception {
         BaseConfigurationFactory configurationFactory = mock(BaseConfigurationFactory.class);
-        Mockito.when(configurationFactory.initConfiguration(Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenReturn(configuration);
+        Mockito.when(configurationFactory.initConfiguration(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenReturn(configuration);
         PowerMockito.mockStatic(BaseConfigurationFactory.class);
         PowerMockito.when(BaseConfigurationFactory.getInstance()).thenReturn(configurationFactory);
     }

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcPartitionFragmenterTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcPartitionFragmenterTest.java
@@ -29,8 +29,6 @@ import org.junit.rules.ExpectedException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class JdbcPartitionFragmenterTest {
     @Rule
@@ -39,13 +37,14 @@ public class JdbcPartitionFragmenterTest {
     private RequestContext context;
 
     @Before
-    public void setUp() throws Exception {
-        context = mock(RequestContext.class);
-        when(context.getDataSource()).thenReturn("table");
+    public void setUp() {
+        context = new RequestContext();
+        context.setConfig("default");
+        context.setDataSource("table");
     }
 
     @Test
-    public void testNoPartition() throws Exception {
+    public void testNoPartition() {
 
         JdbcPartitionFragmenter fragment = new JdbcPartitionFragmenter();
         fragment.initialize(context);
@@ -55,20 +54,18 @@ public class JdbcPartitionFragmenterTest {
     }
 
     @Test
-    public void testPartitionByTypeInvalid() throws Exception {
+    public void testPartitionByTypeInvalid() {
         thrown.expect(IllegalArgumentException.class);
 
-        when(context.getOption("PARTITION_BY")).thenReturn("level:float");
-
+        context.addOption("PARTITION_BY", "level:float");
         new JdbcPartitionFragmenter().initialize(context);
     }
 
     @Test
-    public void testPartitionByFormatInvalid() throws Exception {
+    public void testPartitionByFormatInvalid() {
         thrown.expect(IllegalArgumentException.class);
 
-        when(context.getOption("PARTITION_BY")).thenReturn("level-enum");
-
+        context.addOption("PARTITION_BY", "level-enum");
         new JdbcPartitionFragmenter().initialize(context);
     }
 }

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/SQLQueryBuilderTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/SQLQueryBuilderTest.java
@@ -54,6 +54,7 @@ public class SQLQueryBuilderTest {
     @Before
     public void setup() throws Exception {
         context = new RequestContext();
+        context.setConfig("default");
         context.setDataSource("sales");
         List<ColumnDescriptor> columns = new ArrayList<>();
         columns.add(new ColumnDescriptor("id", DataType.INTEGER.getOID(), 0, "int4", null));

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonResolverTest.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonResolverTest.java
@@ -30,6 +30,7 @@ public class JsonResolverTest {
     public void setUp() {
         resolver = new JsonResolver();
         context = new RequestContext();
+        context.setConfig("default");
         context.setTupleDescription(schema);
         resolver.initialize(context);
     }

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/PxfUnit.java
@@ -347,6 +347,7 @@ public abstract class PxfUnit {
 
         // 2.1.0 Properties
         // HDMetaData parameters
+        context.setConfig("default");
         context.setUser("who");
         System.setProperty("greenplum.alignment", "what");
         context.setSegmentId(1);

--- a/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3SelectAccessorTest.java
+++ b/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3SelectAccessorTest.java
@@ -176,6 +176,7 @@ public class S3SelectAccessorTest {
     @Test
     public void testCorrectlyParsesDataSource() {
         RequestContext context = getDefaultRequestContext();
+        context.setConfig("default");
         context.setDataSource("s3a://my-bucket/my/s3/path/");
 
         S3SelectAccessor accessor = new S3SelectAccessor();
@@ -188,6 +189,7 @@ public class S3SelectAccessorTest {
     @Test
     public void testCorrectlyParsesDataSourceWithNoKey() {
         RequestContext context = getDefaultRequestContext();
+        context.setConfig("default");
         context.setDataSource("s3a://my-bucket");
 
         S3SelectAccessor accessor = new S3SelectAccessor();

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
@@ -92,6 +92,10 @@ public class HttpRequestParser implements RequestParser<HttpHeaders> {
         context.setAccessor(params.removeUserProperty("ACCESSOR"));
         context.setAggType(EnumAggregationType.getAggregationType(params.removeOptionalProperty("AGG-TYPE")));
 
+        // An optional CONFIG value specifies the name of the server
+        // configuration
+        context.setConfig(params.removeUserProperty("CONFIG"));
+
         /*
          * Some resources don't require a fragment, hence the list can be empty.
          */

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
@@ -92,10 +92,6 @@ public class HttpRequestParser implements RequestParser<HttpHeaders> {
         context.setAccessor(params.removeUserProperty("ACCESSOR"));
         context.setAggType(EnumAggregationType.getAggregationType(params.removeOptionalProperty("AGG-TYPE")));
 
-        // An optional CONFIG value specifies the name of the server
-        // configuration
-        context.setConfig(params.removeUserProperty("CONFIG"));
-
         /*
          * Some resources don't require a fragment, hence the list can be empty.
          */
@@ -134,6 +130,11 @@ public class HttpRequestParser implements RequestParser<HttpHeaders> {
         context.setResolver(params.removeUserProperty("RESOLVER"));
         context.setSegmentId(params.removeIntProperty("SEGMENT-ID"));
         context.setServerName(params.removeUserProperty("SERVER"));
+
+        // An optional CONFIG value specifies the name of the server
+        // configuration directory, if not provided the config is the server name
+        String config = params.removeUserProperty("CONFIG");
+        context.setConfig(StringUtils.isNotBlank(config) ? config : context.getServerName());
 
         String maxFrags = params.removeUserProperty("STATS-MAX-FRAGMENTS");
         if (!StringUtils.isBlank(maxFrags)) {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/SecureLogin.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/SecureLogin.java
@@ -70,7 +70,7 @@ public class SecureLogin {
             boolean isUserImpersonationEnabled = Utilities.isUserImpersonationEnabled();
             LOG.info("User impersonation is {}", (isUserImpersonationEnabled ? "enabled" : "disabled"));
 
-            Configuration configuration = configurationFactory.initConfiguration("default", null, null);
+            Configuration configuration = configurationFactory.initConfiguration("default", "default", null, null);
             UserGroupInformation.setConfiguration(configuration);
 
             if (!UserGroupInformation.isSecurityEnabled()) {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/SecureLogin.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/SecureLogin.java
@@ -70,7 +70,7 @@ public class SecureLogin {
             boolean isUserImpersonationEnabled = Utilities.isUserImpersonationEnabled();
             LOG.info("User impersonation is {}", (isUserImpersonationEnabled ? "enabled" : "disabled"));
 
-            Configuration configuration = configurationFactory.initConfiguration("default", "dummy", null);
+            Configuration configuration = configurationFactory.initConfiguration("default", null, null);
             UserGroupInformation.setConfiguration(configuration);
 
             if (!UserGroupInformation.isSecurityEnabled()) {


### PR DESCRIPTION
This is motivated by the following:
Access to Hadoop clusters is nuanced, because with a single set of configurations
users are able to access HDFS, Hive, HBase and other services.

Suppose an enterprise user has a Hortonworks hadoop installation that includes
HDFS, Hive, and HBase. We would configure one server per technology we access,
for example:

     CREATE SERVER hdfs_hdp
          FOREIGN DATA WRAPPER hdfs_pxf_fdw
          OPTIONS ( config 'hdp_1' );

     CREATE SERVER hive_hdp
          FOREIGN DATA WRAPPER hive_pxf_fdw
          OPTIONS ( config 'hdp_1' );

     CREATE SERVER hbase_hdp
          FOREIGN DATA WRAPPER hbase_pxf_fdw
          OPTIONS ( config 'hdp_1' );

To reduce the amount of configuration required for each server, we introduce a
new option `config`. This new option provides the name of the server directory where
the configuration files reside. In the example above, configuration files live
in the `$PXF_CONF/servers/hdp_1` directory, and all three servers share the same
configuration directory.

The `config` option is intended for Hadoop based configurations, but we do
not intend to restrict usage by other connectors.