### PR TITLE
Make automation JsonTest work on GPDB6

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/json/JsonTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/json/JsonTest.java
@@ -198,7 +198,7 @@ public class JsonTest extends BaseFeature {
      * @throws Exception if test fails to run
      */
     @Test(groups = {"features", "gpdb", "hcfs"})
-    public void malFormattedRecord() throws Exception {
+    public void malformedRecord() throws Exception {
 
         exTable.setName("jsontest_malformed_record");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":json");
@@ -219,7 +219,7 @@ public class JsonTest extends BaseFeature {
      * @throws Exception if test fails to run
      */
     @Test(groups = {"features", "gpdb", "hcfs"})
-    public void malFormattedRecordWithRejectLimit() throws Exception {
+    public void malformedRecordWithRejectLimit() throws Exception {
 
         exTable.setName("jsontest_malformed_record_with_reject_limit");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":json");

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record/expected/query01.ans
@@ -1,7 +1,11 @@
--- start_ignore
--- end_ignore
+-- start_matchsubs
+-- m/^CONTEXT: */
+-- s/^CONTEXT: *//
+-- end_matchsubs
 -- @description query01 for PXF HDFS Readable Json with malformed record test cases
-SELECT * from jsontest_malformed_record ORDER BY id;
+SELECT *
+FROM jsontest_malformed_record
+ORDER BY id;
 ERROR:  error while parsing json record 'Unexpected character (':' (code 58)): was expecting comma to separate Object entries
 DETAIL:
 
@@ -41,7 +45,10 @@ DETAIL:
         }
       }
 External table jsontest_malformed_record
-SELECT * from jsontest_malformed_record WHERE id IS NULL ORDER BY id;
+SELECT *
+FROM jsontest_malformed_record
+WHERE id IS NULL
+ORDER BY id;
 ERROR:  error while parsing json record 'Unexpected character (':' (code 58)): was expecting comma to separate Object entries
 DETAIL:
 

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record/sql/query01.sql
@@ -1,4 +1,12 @@
+-- start_matchsubs
+-- m/^CONTEXT: */
+-- s/^CONTEXT: *//
+-- end_matchsubs
 -- @description query01 for PXF HDFS Readable Json with malformed record test cases
-
-SELECT * from jsontest_malformed_record ORDER BY id;
-SELECT * from jsontest_malformed_record WHERE id IS NULL ORDER BY id;
+SELECT *
+FROM jsontest_malformed_record
+ORDER BY id;
+SELECT *
+FROM jsontest_malformed_record
+WHERE id IS NULL
+ORDER BY id;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_with_reject_limit/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_with_reject_limit/expected/query01.ans
@@ -1,8 +1,12 @@
--- start_ignore
--- end_ignore
+-- start_matchsubs
+-- m/ +:/
+-- s/( +):/\1|/
+-- m/\+$/
+-- s/\+$//
+-- end_matchsubs
 -- @description query01 for PXF HDFS Readable Json with malformed record test cases
 SELECT *
-from jsontest_malformed_record_with_reject_limit
+FROM jsontest_malformed_record_with_reject_limit
 ORDER BY id;
 NOTICE:  Found 1 data formatting errors (1 or more input rows). Rejected related input data.
            created_at           |         id         | text  | user.screen_name | entities.hashtags[0] | coordinates.coordinates[0] | coordinates.coordinates[1]
@@ -12,7 +16,7 @@ NOTICE:  Found 1 data formatting errors (1 or more input rows). Rejected related
 (2 rows)
 
 SELECT relname, errmsg
-from gp_read_error_log('jsontest_malformed_record_with_reject_limit');
+FROM gp_read_error_log('jsontest_malformed_record_with_reject_limit');
                    relname                   |                                                                errmsg
 ---------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------
  jsontest_malformed_record_with_reject_limit | error while parsing json record 'Unexpected character (':' (code 58)): was expecting comma to separate Object entries

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_with_reject_limit/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_with_reject_limit/sql/query01.sql
@@ -1,7 +1,12 @@
+-- start_matchsubs
+-- m/ +:/
+-- s/( +):/\1|/
+-- m/\+$/
+-- s/\+$//
+-- end_matchsubs
 -- @description query01 for PXF HDFS Readable Json with malformed record test cases
-
 SELECT *
-from jsontest_malformed_record_with_reject_limit
+FROM jsontest_malformed_record_with_reject_limit
 ORDER BY id;
 SELECT relname, errmsg
-from gp_read_error_log('jsontest_malformed_record_with_reject_limit');
+FROM gp_read_error_log('jsontest_malformed_record_with_reject_limit');

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/mismatched_types/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/mismatched_types/expected/query01.ans
@@ -1,8 +1,10 @@
--- start_ignore
--- end_ignore
+-- start_matchsubs
+-- m/CONTEXT:/
+-- s/CONTEXT:/DETAIL:/
+-- end_matchsubs
 -- @description query01 for PXF HDFS Readable Json supported primitive types test cases
 SELECT *
-from jsontest_mismatched_types
+FROM jsontest_mismatched_types
 ORDER BY type_int;
 ERROR:  invalid INTEGER input value '"["'
 DETAIL:  External table jsontest_mismatched_types

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/mismatched_types/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/mismatched_types/sql/query01.sql
@@ -1,5 +1,8 @@
+-- start_matchsubs
+-- m/CONTEXT:/
+-- s/CONTEXT:/DETAIL:/
+-- end_matchsubs
 -- @description query01 for PXF HDFS Readable Json supported primitive types test cases
-
 SELECT *
-from jsontest_mismatched_types
+FROM jsontest_mismatched_types
 ORDER BY type_int;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/mismatched_types_with_reject_limit/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/mismatched_types_with_reject_limit/expected/query01.ans
@@ -1,8 +1,6 @@
--- start_ignore
--- end_ignore
 -- @description query01 for PXF HDFS Readable Json supported primitive types test cases
 SELECT *
-from jsontest_mismatched_types_with_reject_limit
+FROM jsontest_mismatched_types_with_reject_limit
 ORDER BY type_int;
 NOTICE:  Found 6 data formatting errors (6 or more input rows). Rejected related input data.
   type_int  | type_bigint | type_smallint | type_float | type_double |                 type_string1                  |                 type_string2                  |                 type_string3                  | type_char | type_boolean
@@ -12,7 +10,7 @@ NOTICE:  Found 6 data formatting errors (6 or more input rows). Rejected related
 (2 rows)
 
 SELECT relname, errmsg
-from gp_read_error_log('jsontest_mismatched_types_with_reject_limit');
+FROM gp_read_error_log('jsontest_mismatched_types_with_reject_limit');
                    relname                   |                errmsg
 ---------------------------------------------+--------------------------------------
  jsontest_mismatched_types_with_reject_limit | invalid INTEGER input value '"["'

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/mismatched_types_with_reject_limit/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/mismatched_types_with_reject_limit/sql/query01.sql
@@ -1,7 +1,6 @@
 -- @description query01 for PXF HDFS Readable Json supported primitive types test cases
-
 SELECT *
-from jsontest_mismatched_types_with_reject_limit
+FROM jsontest_mismatched_types_with_reject_limit
 ORDER BY type_int;
 SELECT relname, errmsg
-from gp_read_error_log('jsontest_mismatched_types_with_reject_limit');
+FROM gp_read_error_log('jsontest_mismatched_types_with_reject_limit');

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonResolverTest.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonResolverTest.java
@@ -43,7 +43,8 @@ public class JsonResolverTest {
     public void testGetFieldsWithUnquotedValues() throws Exception {
 
         //language=JSON
-        String jsonStr = "{\"type_int\":100000001," +
+        String jsonStr = "{" +
+                "\"type_int\":100000001," +
                 "\"type_bigint\":10101010101," +
                 "\"type_smallint\":13," +
                 "\"type_float\":1.1," +
@@ -252,7 +253,7 @@ public class JsonResolverTest {
     }
 
     @Test
-    public void testGetFieldsShouldFailOnMalformattedJson() throws Exception {
+    public void testGetFieldsShouldFailOnMalformedJson() throws Exception {
         thrown.expect(BadRecordException.class);
         thrown.expectMessage("error while parsing json record 'Unexpected character ('}' (code 125))");
 


### PR DESCRIPTION
GPDB gives slightly different outputs in major versions 5 and 6. In order to make our automation tests pass on both versions, we use match substitutions, a feature of Tinc tests that allow us to have more flexible testing.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>