### PR TITLE
Support NOT and OR operators for S3 Select

### DIFF
--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveFilterBuilder.java
@@ -63,10 +63,10 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
      *
      * @param filterString the string representation of the filter
      * @return a single {@link BasicFilter}
-     *         object or a {@link java.util.List} of
-     *         {@link BasicFilter} objects.
+     * object or a {@link java.util.List} of
+     * {@link BasicFilter} objects.
      * @throws Exception if parsing the filter failed or filter is not a basic
-     *             filter or list of basic filters
+     *                   filter or list of basic filters
      */
     public Object getFilterObject(String filterString) throws Exception {
         if (filterString == null)
@@ -142,9 +142,7 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
 
         String filterString;
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Filter string input: {}", filterInput);
-        }
+        LOG.debug("Filter string input: {}", filterInput);
 
         Object filter = new HiveFilterBuilder().getFilterObject(filterInput);
 
@@ -157,7 +155,7 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
         return filterString;
     }
 
-    private String buildCompoundFilter(LogicalFilter filter) throws Exception {
+    private String buildCompoundFilter(LogicalFilter filter) {
         String logicalOperator;
         switch (filter.getOperator()) {
             case HDOP_AND:
@@ -291,7 +289,6 @@ public class HiveFilterBuilder implements FilterParser.FilterBuilder {
     }
 
     private Object handleLogicalOperation(FilterParser.LogicalOperation operator, Object leftOperand, Object rightOperand) {
-
         List<Object> result = new LinkedList<>();
 
         result.add(leftOperand);

--- a/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3SelectAccessor.java
+++ b/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3SelectAccessor.java
@@ -159,13 +159,7 @@ public class S3SelectAccessor extends BasePlugin implements Accessor {
                 StringUtils.equalsIgnoreCase(FILE_HEADER_INFO_NONE, fileHeaderInfo) ||
                 StringUtils.equalsIgnoreCase(FILE_HEADER_INFO_IGNORE, fileHeaderInfo);
         S3SelectQueryBuilder queryBuilder = new S3SelectQueryBuilder(context, usePositionToIdentifyColumn);
-        String query;
-        try {
-            query = queryBuilder.buildSelectQuery();
-        } catch (ParseException e) {
-            LOG.error("Unable to build S3 SELECT query", e);
-            throw new RuntimeException(e.getMessage(), e);
-        }
+        String query = queryBuilder.buildSelectQuery();
 
         LOG.trace("Select query: {}", query);
 

--- a/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3SelectFilterParser.java
+++ b/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3SelectFilterParser.java
@@ -1,0 +1,308 @@
+package org.greenplum.pxf.plugins.s3;
+
+import org.apache.commons.lang.StringUtils;
+import org.greenplum.pxf.api.BasicFilter;
+import org.greenplum.pxf.api.FilterParser;
+import org.greenplum.pxf.api.LogicalFilter;
+import org.greenplum.pxf.api.io.DataType;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+import org.greenplum.pxf.api.utilities.Utilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class S3SelectFilterParser implements FilterParser.FilterBuilder {
+
+    private Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    private boolean usePositionToIdentifyColumn;
+    private static final EnumSet<FilterParser.Operation> SUPPORTED_OPERATORS =
+            EnumSet.of(
+                    FilterParser.Operation.HDOP_LT,
+                    FilterParser.Operation.HDOP_GT,
+                    FilterParser.Operation.HDOP_LE,
+                    FilterParser.Operation.HDOP_GE,
+                    FilterParser.Operation.HDOP_EQ,
+                    // TODO: LIKE is not supported on the C side
+                    // FilterParser.Operation.HDOP_LIKE,
+                    FilterParser.Operation.HDOP_NE,
+                    FilterParser.Operation.HDOP_IN,
+                    FilterParser.Operation.HDOP_IS_NULL,
+                    FilterParser.Operation.HDOP_IS_NOT_NULL
+            );
+
+    private List<ColumnDescriptor> columnDescriptors;
+
+    @Override
+    public Object build(FilterParser.LogicalOperation op, Object leftOperand, Object rightOperand) {
+        return handleLogicalOperation(op, leftOperand, rightOperand);
+    }
+
+    @Override
+    public Object build(FilterParser.LogicalOperation op, Object filter) {
+        return handleLogicalOperation(op, filter);
+    }
+
+    @Override
+    public Object build(FilterParser.Operation opId, Object leftOperand,
+                        Object rightOperand) {
+        // Assume column is on the left
+        return handleSimpleOperations(opId,
+                (FilterParser.ColumnIndex) leftOperand,
+                (FilterParser.Constant) rightOperand
+        );
+    }
+
+    @Override
+    public Object build(FilterParser.Operation operation, Object operand) throws UnsupportedOperationException {
+        if (operation == FilterParser.Operation.HDOP_IS_NULL || operation == FilterParser.Operation.HDOP_IS_NOT_NULL) {
+            // Use null for the constant value of null comparison
+            return handleSimpleOperations(operation, (FilterParser.ColumnIndex) operand, null);
+        } else {
+            throw new UnsupportedOperationException("Unsupported unary operation '" + operation + "'");
+        }
+    }
+
+    /*
+     * Handles simple column-operator-constant expressions.
+     * Creates a special filter in the case the column is the row key column
+     */
+    private BasicFilter handleSimpleOperations(FilterParser.Operation opId,
+                                               FilterParser.ColumnIndex column,
+                                               FilterParser.Constant constant) {
+        return new BasicFilter(opId, column, constant);
+    }
+
+    private Object handleLogicalOperation(FilterParser.LogicalOperation operator, Object leftOperand, Object rightOperand) {
+        List<Object> result = new LinkedList<>();
+
+        result.add(leftOperand);
+        result.add(rightOperand);
+        return new LogicalFilter(operator, result);
+    }
+
+    private Object handleLogicalOperation(FilterParser.LogicalOperation operator, Object filter) {
+        return new LogicalFilter(operator, Collections.singletonList(filter));
+    }
+
+    /**
+     * Translates a filterString into a {@link BasicFilter} or a
+     * list of such filters.
+     *
+     * @param filterString the string representation of the filter
+     * @return a single {@link BasicFilter}
+     * object or a {@link java.util.List} of
+     * {@link BasicFilter} objects.
+     * @throws Exception if parsing the filter failed or filter is not a basic
+     *                   filter or list of basic filters
+     */
+    private Object getFilterObject(String filterString) throws Exception {
+        FilterParser parser = new FilterParser(this);
+        Object result = parser.parse(filterString.getBytes(FilterParser.DEFAULT_CHARSET));
+
+        if (!(result instanceof LogicalFilter) && !(result instanceof BasicFilter)
+                && !(result instanceof List)) {
+            throw new Exception(String.format("String '%s' resolved to no filter", filterString));
+        }
+
+        return result;
+    }
+
+
+    public String buildWhereClause(String filterInput) throws Exception {
+        LOG.debug("Filter string input: {}", filterInput);
+
+        String filterString;
+        Object filter = getFilterObject(filterInput);
+
+        if (filter instanceof LogicalFilter) {
+            filterString = buildCompoundFilter((LogicalFilter) filter);
+        } else {
+            filterString = buildSingleFilter(filter, null);
+        }
+
+        return StringUtils.isNotBlank(filterString) ? " WHERE " + filterString : "";
+    }
+
+    private String mapValue(Object val, DataType dataType) {
+        switch (dataType) {
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case FLOAT8:
+            case REAL:
+            case BOOLEAN:
+                return val.toString();
+            case TEXT:
+            case VARCHAR:
+            case BPCHAR:
+                return Utilities.toCsvText(val.toString(), '\'', true, true);
+            case DATE:
+            case TIMESTAMP:
+                return "TO_TIMESTAMP('" + val.toString() + "')";
+            default:
+                throw new UnsupportedOperationException(String.format(
+                        "Unsupported column type for filtering '%s' ", dataType.getOID()));
+        }
+    }
+
+
+    private String buildCompoundFilter(LogicalFilter filter) {
+        String logicalOperator;
+        String outputFormat = "(%s)";
+        switch (filter.getOperator()) {
+            case HDOP_AND:
+                logicalOperator = " AND ";
+                break;
+            case HDOP_OR:
+                logicalOperator = " OR ";
+                break;
+            case HDOP_NOT:
+                logicalOperator = " NOT ";
+                outputFormat = "%s";
+                break;
+            default:
+                // should not get here
+                return null;
+        }
+
+        StringBuilder filterString = new StringBuilder();
+        String deserializedFilter;
+        for (Object f : filter.getFilterList()) {
+            if (f instanceof LogicalFilter) {
+                deserializedFilter = buildCompoundFilter((LogicalFilter) f);
+            } else {
+                deserializedFilter = buildSingleFilter(f, filter.getOperator());
+            }
+
+            if (deserializedFilter != null) {
+                if (filter.getOperator() == FilterParser.LogicalOperation.HDOP_NOT) {
+                    filterString
+                            .append("NOT (")
+                            .append(deserializedFilter)
+                            .append(")");
+                } else {
+                    // We only append the operator if there is something on the filterString
+                    if (filterString.length() > 0) {
+                        filterString.append(logicalOperator);
+                    }
+                    filterString.append(deserializedFilter);
+                }
+            }
+        }
+
+        return (filterString.length() > 0) ?
+                String.format(outputFormat, filterString.toString()) : null;
+    }
+
+    private String buildSingleFilter(Object filter, FilterParser.LogicalOperation logicalOperation) {
+
+        // Let's look first at the filter
+        BasicFilter bFilter = (BasicFilter) filter;
+
+        // Extract column name and value
+        int filterColumnIndex = bFilter.getColumn().index();
+        ColumnDescriptor filterColumn = columnDescriptors.get(filterColumnIndex);
+        String filterColumnName = getColumnName(filterColumn);
+        FilterParser.Operation operation = ((BasicFilter) filter).getOperation();
+        DataType dataType = DataType.get(filterColumn.columnTypeCode());
+
+        StringBuilder result = new StringBuilder();
+
+        if (operation == FilterParser.Operation.HDOP_IS_NULL || operation == FilterParser.Operation.HDOP_IS_NOT_NULL) {
+            result.append(filterColumnName);
+        } else {
+            switch (dataType) {
+                case BIGINT:
+                case INTEGER:
+                case SMALLINT:
+                    result.append("CAST (")
+                            .append(filterColumnName)
+                            .append(" AS int)");
+                    break;
+                case BOOLEAN:
+                    result.append("CAST (")
+                            .append(filterColumnName)
+                            .append(" AS bool)");
+                    return result.toString();
+                case FLOAT8:
+                    result.append("CAST (")
+                            .append(filterColumnName)
+                            .append(" AS float)");
+                    break;
+                case REAL:
+                    result.append("CAST (")
+                            .append(filterColumnName)
+                            .append(" AS decimal)");
+                    break;
+                case TEXT:
+                case VARCHAR:
+                case BPCHAR:
+                    result.append(filterColumnName);
+                    break;
+                case DATE:
+                case TIMESTAMP:
+                    result.append("TO_TIMESTAMP(")
+                            .append(filterColumnName)
+                            .append(")");
+                    break;
+                default:
+                    throw new UnsupportedOperationException(String.format("Unsupported column type for filtering '%s'", filterColumn.columnTypeCode()));
+            }
+        }
+
+        if (SUPPORTED_OPERATORS.contains(operation)) {
+            result.append(" ")
+                    .append(operation.getOperator());
+        } else {
+            result.setLength(0);
+            return null;
+        }
+
+        if (operation != FilterParser.Operation.HDOP_IS_NULL && operation != FilterParser.Operation.HDOP_IS_NOT_NULL) {
+
+            // Insert constraint constant
+            Object val = bFilter.getConstant().constant();
+            if (val instanceof Iterable) {
+                Iterable<?> iterable = (Iterable<?>) val;
+                String listValue = StreamSupport.stream(iterable.spliterator(), false)
+                        .map(s -> mapValue(s, dataType))
+                        .collect(Collectors.joining(","));
+                result.append(" (").append(listValue).append(")");
+            } else {
+                result.append(" ").append(mapValue(val, dataType));
+            }
+        }
+
+        return result.toString();
+    }
+
+    public void setColumnDescriptors(List<ColumnDescriptor> columnDescriptors) {
+        this.columnDescriptors = columnDescriptors;
+    }
+
+    public void setUsePositionToIdentifyColumn(boolean usePositionToIdentifyColumn) {
+        this.usePositionToIdentifyColumn = usePositionToIdentifyColumn;
+    }
+
+    /**
+     * Returns the column name. If we use the column position to identify the column
+     * we return the index of the column as the column name. Otherwise, we use
+     * the actual column name
+     *
+     * @param column the column descriptor
+     * @return the column name to use as part of the query
+     */
+    private String getColumnName(ColumnDescriptor column) {
+        // TODO: this code is duplicated in S3SelectQueryBuilder
+        return usePositionToIdentifyColumn ?
+                String.format("%s._%d", S3SelectQueryBuilder.S3_TABLE_ALIAS, column.columnIndex() + 1) :
+                String.format("%s.\"%s\"", S3SelectQueryBuilder.S3_TABLE_ALIAS, column.columnName());
+    }
+}

--- a/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3SelectQueryBuilderTest.java
+++ b/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3SelectQueryBuilderTest.java
@@ -13,8 +13,8 @@ import static org.junit.Assert.assertEquals;
 
 public class S3SelectQueryBuilderTest {
 
-    private static final String SQL_POSITION = "SELECT s._1, s._2, s._3, s._4 FROM S3Object s";
-    private static final String SQL_NO_POSITION = "SELECT s.\"id\", s.\"cdate\", s.\"amt\", s.\"grade\" FROM S3Object s";
+    private static final String SQL_POSITION = "SELECT s._1, s._2, s._3, s._4, s._5, s._6 FROM S3Object s";
+    private static final String SQL_NO_POSITION = "SELECT s.\"id\", s.\"cdate\", s.\"amt\", s.\"grade\", s.\"pass\", s.\"weight\" FROM S3Object s";
 
     private RequestContext context;
     private S3SelectQueryBuilder builderPosition, builderNoPosition;
@@ -28,6 +28,8 @@ public class S3SelectQueryBuilderTest {
         columns.add(new ColumnDescriptor("cdate", DataType.DATE.getOID(), 1, "date", null));
         columns.add(new ColumnDescriptor("amt", DataType.FLOAT8.getOID(), 2, "float8", null));
         columns.add(new ColumnDescriptor("grade", DataType.TEXT.getOID(), 3, "text", null));
+        columns.add(new ColumnDescriptor("pass", DataType.BOOLEAN.getOID(), 4, "boolean", null));
+        columns.add(new ColumnDescriptor("weight", DataType.REAL.getOID(), 5, "float4", null));
         context.setTupleDescription(columns);
 
         builderPosition = new S3SelectQueryBuilder(context, true);
@@ -35,28 +37,28 @@ public class S3SelectQueryBuilderTest {
     }
 
     @Test
-    public void testNoFilterNoProjection() throws Exception {
+    public void testNoFilterNoProjection() {
         assertEquals(SQL_POSITION, builderPosition.buildSelectQuery());
         assertEquals(SQL_NO_POSITION, builderNoPosition.buildSelectQuery());
     }
 
     @Test
-    public void testIdFilter() throws Exception {
+    public void testIdFilter() {
         context.setFilterString("a0c20s1d1o5"); // id = 1
         assertEquals(SQL_POSITION + " WHERE CAST (s._1 AS int) = 1", builderPosition.buildSelectQuery());
         assertEquals(SQL_NO_POSITION + " WHERE CAST (s.\"id\" AS int) = 1", builderNoPosition.buildSelectQuery());
     }
 
     @Test
-    public void testDateAndAmtFilter() throws Exception {
+    public void testDateAndAmtFilter() {
         // cdate > '2008-02-01' and cdate < '2008-12-01' and amt > 1200
         context.setFilterString("a1c25s10d2008-02-01o2a1c25s10d2008-12-01o1l0a2c20s4d1200o2l0");
-        assertEquals(SQL_POSITION + " WHERE TO_TIMESTAMP(s._2) > TO_TIMESTAMP('2008-02-01') AND TO_TIMESTAMP(s._2) < TO_TIMESTAMP('2008-12-01') AND CAST (s._3 AS FLOAT) > 1200", builderPosition.buildSelectQuery());
-        assertEquals(SQL_NO_POSITION + " WHERE TO_TIMESTAMP(s.\"cdate\") > TO_TIMESTAMP('2008-02-01') AND TO_TIMESTAMP(s.\"cdate\") < TO_TIMESTAMP('2008-12-01') AND CAST (s.\"amt\" AS FLOAT) > 1200", builderNoPosition.buildSelectQuery());
+        assertEquals(SQL_POSITION + " WHERE ((TO_TIMESTAMP(s._2) > TO_TIMESTAMP('2008-02-01') AND TO_TIMESTAMP(s._2) < TO_TIMESTAMP('2008-12-01')) AND CAST (s._3 AS float) > 1200)", builderPosition.buildSelectQuery());
+        assertEquals(SQL_NO_POSITION + " WHERE ((TO_TIMESTAMP(s.\"cdate\") > TO_TIMESTAMP('2008-02-01') AND TO_TIMESTAMP(s.\"cdate\") < TO_TIMESTAMP('2008-12-01')) AND CAST (s.\"amt\" AS float) > 1200)", builderNoPosition.buildSelectQuery());
     }
 
     @Test
-    public void testInOperationFilter() throws Exception {
+    public void testInOperationFilter() {
         // a0 IN (194 , 82756)
         context.setFilterString("a0m1016s3d194s5d82756o10");
         assertEquals(SQL_POSITION + " WHERE CAST (s._1 AS int) IN (194,82756)", builderPosition.buildSelectQuery());
@@ -64,7 +66,7 @@ public class S3SelectQueryBuilderTest {
     }
 
     @Test
-    public void testInOperationFilterWithText() throws Exception {
+    public void testInOperationFilterWithText() {
         // a3 IN ('A' , 'B')
         context.setFilterString("a3m1009s1dAs1dBo10");
         assertEquals(SQL_POSITION + " WHERE s._4 IN ('A','B')", builderPosition.buildSelectQuery());
@@ -72,7 +74,7 @@ public class S3SelectQueryBuilderTest {
     }
 
     @Test
-    public void testInOperationFilterWithTextWithSingleQuote() throws Exception {
+    public void testInOperationFilterWithTextWithSingleQuote() {
         // a3 IN ('A' , 'B')
         context.setFilterString("a3m1009s5dA'B'Cs1dBo10");
         assertEquals(SQL_POSITION + " WHERE s._4 IN ('A''B''C','B')", builderPosition.buildSelectQuery());
@@ -80,15 +82,15 @@ public class S3SelectQueryBuilderTest {
     }
 
     @Test
-    public void testUnsupportedLogicalFilter() throws Exception {
-        // cdate > '2008-02-01' or amt < 1200
+    public void testOrFilter() {
+        // cdate > '2008-02-01' or amt > 1200
         context.setFilterString("a1c25s10d2008-02-01o2a2c20s4d1200o2l1");
-        assertEquals(SQL_POSITION, builderPosition.buildSelectQuery());
-        assertEquals(SQL_NO_POSITION, builderNoPosition.buildSelectQuery());
+        assertEquals(SQL_POSITION + " WHERE (TO_TIMESTAMP(s._2) > TO_TIMESTAMP('2008-02-01') OR CAST (s._3 AS float) > 1200)", builderPosition.buildSelectQuery());
+        assertEquals(SQL_NO_POSITION + " WHERE (TO_TIMESTAMP(s.\"cdate\") > TO_TIMESTAMP('2008-02-01') OR CAST (s.\"amt\" AS float) > 1200)", builderNoPosition.buildSelectQuery());
     }
 
     @Test
-    public void testIsNotNullOperator() throws Exception {
+    public void testIsNotNullOperator() {
         // a3 IS NOT NULL
         context.setFilterString("a3o9");
         assertEquals(SQL_POSITION + " WHERE s._4 IS NOT NULL", builderPosition.buildSelectQuery());
@@ -96,11 +98,42 @@ public class S3SelectQueryBuilderTest {
     }
 
     @Test
-    public void testIsNullOperator() throws Exception {
+    public void testIsNullOperator() {
         // a3 IS NULL
         context.setFilterString("a3o8");
         assertEquals(SQL_POSITION + " WHERE s._4 IS NULL", builderPosition.buildSelectQuery());
         assertEquals(SQL_NO_POSITION + " WHERE s.\"grade\" IS NULL", builderNoPosition.buildSelectQuery());
     }
 
+    @Test
+    public void testBoolean() {
+        // a4
+        context.setFilterString("a4c16s4dtrueo0");
+        assertEquals(SQL_POSITION + " WHERE CAST (s._5 AS bool)", builderPosition.buildSelectQuery());
+        assertEquals(SQL_NO_POSITION + " WHERE CAST (s.\"pass\" AS bool)", builderNoPosition.buildSelectQuery());
+    }
+
+    @Test
+    public void testNotBoolean() {
+        // NOT a4
+        context.setFilterString("a4c16s4dtrueo0l2");
+        assertEquals(SQL_POSITION + " WHERE NOT (CAST (s._5 AS bool))", builderPosition.buildSelectQuery());
+        assertEquals(SQL_NO_POSITION + " WHERE NOT (CAST (s.\"pass\" AS bool))", builderNoPosition.buildSelectQuery());
+    }
+
+    @Test
+    public void testReal() {
+        // a5 = 2.0
+        context.setFilterString("a5c701s1d2o5");
+        assertEquals(SQL_POSITION + " WHERE CAST (s._6 AS decimal) = 2.0", builderPosition.buildSelectQuery());
+        assertEquals(SQL_NO_POSITION + " WHERE CAST (s.\"weight\" AS decimal) = 2.0", builderNoPosition.buildSelectQuery());
+    }
+
+    @Test
+    public void testNestedExpressionWithLogicalOperation() {
+        // (a3 = 'foobar' AND a2 <> 999) AND (a1 = '2008-02-01' OR a5 <> 999)
+        context.setFilterString("a3c25s6dfoobaro5a2c23s3d999o6l0a1c25s10d2008-02-01o5a5c20s3d999o6l1l0");
+        assertEquals(SQL_POSITION + " WHERE ((s._4 = 'foobar' AND CAST (s._3 AS float) <> 999) AND (TO_TIMESTAMP(s._2) = TO_TIMESTAMP('2008-02-01') OR CAST (s._6 AS decimal) <> 999))", builderPosition.buildSelectQuery());
+        assertEquals(SQL_NO_POSITION + " WHERE ((s.\"grade\" = 'foobar' AND CAST (s.\"amt\" AS float) <> 999) AND (TO_TIMESTAMP(s.\"cdate\") = TO_TIMESTAMP('2008-02-01') OR CAST (s.\"weight\" AS decimal) <> 999))", builderNoPosition.buildSelectQuery());
+    }
 }


### PR DESCRIPTION
Add support for NOT and OR operators. Added the S3SelectFilterParser class to handle NOTs and ORs. Increase test coverage.

This PR needs to be merged against master and not s3select

Co-authored-by: Raymond Yin <ryin@pivotal.io>
Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>