### PR TITLE
Add JDK11 to PXF docker base dev image

### DIFF
--- a/concourse/docker/pxf-dev-base/Dockerfile
+++ b/concourse/docker/pxf-dev-base/Dockerfile
@@ -13,6 +13,12 @@ RUN cd /tmp && \
     echo >> /etc/bashrc 'export GOPATH=/opt/go' && \
     echo >> /etc/bashrc 'export PATH=${GOPATH}/bin:/usr/local/go/bin:$PATH'
 
+# add Java 11
+RUN wget -q https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz && \
+    mkdir -p /usr/lib/jvm && \
+    tar -C /usr/lib/jvm -xzf openjdk-11+28_linux-x64_bin.tar.gz && \
+    rm -f openjdk-11+28_linux-x64_bin.tar.gz
+
 # add minio software
 RUN useradd -s /sbin/nologin -d /opt/minio minio && \
     mkdir -p /opt/minio/bin && \


### PR DESCRIPTION
Added JDK 11 to the base image, tested locally to make sure it is available in the container under `/usr/lib/jvm/jdk-11`. This JDK, however, will not be set as default JDK since we still want to compile with  JDK 8, but will be available to test jobs , which will set JAVA_HOME in `pxf-env.sh` to this new location.