### PR TITLE
CLI: update error message for `pxf init`

### DIFF
--- a/server/pxf-service/src/scripts/pxf-service
+++ b/server/pxf-service/src/scripts/pxf-service
@@ -336,7 +336,7 @@ function doReset()
     fi
 
     if doStatus >/dev/null; then
-        echo "PXF is running. Please stop PXF before running 'pxf reset'"
+        echo "PXF is running. Please stop PXF before running 'pxf [cluster] reset'"
         return 1
     fi
 
@@ -358,7 +358,7 @@ function doReset()
 function doInit()
 {
     if instanceExists; then
-        echo "Instance already exists. Cleanup $instance if you wish to re-initialize"
+        echo "Instance already exists. Use 'pxf [cluster] reset' before attempting to re-initialize PXF"
         return 1
     fi
 


### PR DESCRIPTION
If the instance already exists, we should tell users to use `pxf reset`,
not to manually delete `pxf-service/`.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>