### PR TITLE
Preserve error when re-throwing IOException

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
@@ -146,7 +146,6 @@ public class BridgeResource extends BaseResource {
                     // Occurs whenever client (GPDB) decides the end the connection
                     LOG.error("Remote connection closed by GPDB", e);
                 } catch (Exception e) {
-                    LOG.error("Exception thrown when streaming", e);
                     throw new IOException(e.getMessage(), e);
                 } finally {
                     LOG.debug("Stopped streaming fragment {} of resource {}, {} records.", fragment, dataDir, recordCount);

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
@@ -147,7 +147,7 @@ public class BridgeResource extends BaseResource {
                     LOG.error("Remote connection closed by GPDB", e);
                 } catch (Exception e) {
                     LOG.error("Exception thrown when streaming", e);
-                    throw new IOException(e.getMessage());
+                    throw new IOException(e.getMessage(), e);
                 } finally {
                     LOG.debug("Stopped streaming fragment {} of resource {}, {} records.", fragment, dataDir, recordCount);
                     try {


### PR DESCRIPTION
When the read bridge encounters an error, it catches the exception and
rethrows as an IOException. However, the IOException is not preserving
the causing exception which is not letting us debug errors during bridge
read.

Co-authored-by: Oliver Albertini <oalbertini@pivotal.io>
Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>