### PR TITLE
Rename S3-SELECT option -> S3_SELECT

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/cloud/S3SelectTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/cloud/S3SelectTest.java
@@ -71,7 +71,7 @@ public class S3SelectTest extends BaseFeature {
 
     @Test(groups = {"gpdb", "s3"})
     public void testPlainCsvWithHeaders() throws Exception {
-        String[] userParameters = {"FILE_HEADER=IGNORE", "S3-SELECT=ON"};
+        String[] userParameters = {"FILE_HEADER=IGNORE", "S3_SELECT=ON"};
         runTestScenario("csv", "s3", "csv", s3Path,
                 localDataResourcesFolder + "/s3select/", sampleCsvFile,
                 "|", userParameters);
@@ -79,7 +79,7 @@ public class S3SelectTest extends BaseFeature {
 
     @Test(groups = {"gpdb", "s3"})
     public void testPlainCsvWithHeadersUsingHeaderInfo() throws Exception {
-        String[] userParameters = {"FILE_HEADER=USE", "S3-SELECT=ON"};
+        String[] userParameters = {"FILE_HEADER=USE", "S3_SELECT=ON"};
         runTestScenario("csv_use_headers", "s3", "csv", s3Path,
                 localDataResourcesFolder + "/s3select/", sampleCsvFile,
                 "|", userParameters);
@@ -87,7 +87,7 @@ public class S3SelectTest extends BaseFeature {
 
     @Test(groups = {"gpdb", "s3"})
     public void testPlainCsvWithNoHeaders() throws Exception {
-        String[] userParameters = {"FILE_HEADER=NONE", "S3-SELECT=ON"};
+        String[] userParameters = {"FILE_HEADER=NONE", "S3_SELECT=ON"};
         runTestScenario("csv_noheaders", "s3", "csv", s3Path,
                 localDataResourcesFolder + "/s3select/", sampleCsvNoHeaderFile,
                 "|", userParameters);
@@ -95,7 +95,7 @@ public class S3SelectTest extends BaseFeature {
 
     @Test(groups = {"gpdb", "s3"})
     public void testGzipCsvWithHeadersUsingHeaderInfo() throws Exception {
-        String[] userParameters = {"FILE_HEADER=USE", "S3-SELECT=ON", "COMPRESSION_CODEC=gzip"};
+        String[] userParameters = {"FILE_HEADER=USE", "S3_SELECT=ON", "COMPRESSION_CODEC=gzip"};
         runTestScenario("gzip_csv_use_headers", "s3", "csv", s3Path,
                 localDataResourcesFolder + "/s3select/", sampleGzippedCsvFile,
                 "|", userParameters);
@@ -103,7 +103,7 @@ public class S3SelectTest extends BaseFeature {
 
     @Test(groups = {"gpdb", "s3"})
     public void testBzip2CsvWithHeadersUsingHeaderInfo() throws Exception {
-        String[] userParameters = {"FILE_HEADER=USE", "S3-SELECT=ON", "COMPRESSION_CODEC=bzip2"};
+        String[] userParameters = {"FILE_HEADER=USE", "S3_SELECT=ON", "COMPRESSION_CODEC=bzip2"};
         runTestScenario("bzip2_csv_use_headers", "s3", "csv", s3Path,
                 localDataResourcesFolder + "/s3select/", sampleBzip2CsvFile,
                 "|", userParameters);
@@ -111,7 +111,7 @@ public class S3SelectTest extends BaseFeature {
 
     @Test(groups = {"gpdb", "s3"})
     public void testParquet() throws Exception {
-        String[] userParameters = {"S3-SELECT=ON"};
+        String[] userParameters = {"S3_SELECT=ON"};
         runTestScenario("parquet", "s3", "parquet", s3Path,
                 localDataResourcesFolder + "/s3select/", sampleParquetFile,
                 null, userParameters);
@@ -119,7 +119,7 @@ public class S3SelectTest extends BaseFeature {
 
     @Test(groups = {"gpdb", "s3"})
     public void testSnappyParquet() throws Exception {
-        String[] userParameters = {"S3-SELECT=ON"};
+        String[] userParameters = {"S3_SELECT=ON"};
         runTestScenario("parquet_snappy", "s3", "parquet", s3Path,
                 localDataResourcesFolder + "/s3select/", sampleParquetSnappyFile,
                 null, userParameters);
@@ -127,7 +127,7 @@ public class S3SelectTest extends BaseFeature {
 
     @Test(groups = {"gpdb", "s3"})
     public void testGzipParquet() throws Exception {
-        String[] userParameters = {"S3-SELECT=ON"};
+        String[] userParameters = {"S3_SELECT=ON"};
         runTestScenario("parquet_gzip", "s3", "parquet", s3Path,
                 localDataResourcesFolder + "/s3select/", sampleParquetGzipFile,
                 null, userParameters);

--- a/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3ProtocolHandler.java
+++ b/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3ProtocolHandler.java
@@ -22,7 +22,7 @@ import static org.greenplum.pxf.plugins.s3.S3SelectAccessor.FILE_HEADER_INFO_USE
  */
 public class S3ProtocolHandler implements ProtocolHandler {
 
-    public static final String S3_SELECT_OPTION = "S3-SELECT";
+    public static final String S3_SELECT_OPTION = "S3_SELECT";
 
     private static final Logger LOG = LoggerFactory.getLogger(S3ProtocolHandler.class);
     private static final Set<String> SUPPORTED_FORMATS = Sets.newHashSet("TEXT", "CSV", "PARQUET", "JSON");
@@ -91,7 +91,7 @@ public class S3ProtocolHandler implements ProtocolHandler {
 
         if (!isS3SelectSupportedFormat) {
             if (selectMode == S3Mode.ON) {
-                throw new IllegalArgumentException(String.format("S3-SELECT optimization is not supported for format '%s'. Use S3-SELECT=OFF for this format", format));
+                throw new IllegalArgumentException(String.format("%s optimization is not supported for format '%s'. Use %s=OFF for this format", S3_SELECT_OPTION, format, S3_SELECT_OPTION));
             }
             return false;
         }
@@ -101,7 +101,7 @@ public class S3ProtocolHandler implements ProtocolHandler {
 
         if (!isS3SelectSupportedCompressionType) {
             if (selectMode == S3Mode.ON) {
-                throw new IllegalArgumentException(String.format("S3-SELECT optimization is not supported for compression type '%s'. Use S3-SELECT=OFF for this compression codec", compressionType));
+                throw new IllegalArgumentException(String.format("%s optimization is not supported for compression type '%s'. Use %s=OFF for this compression codec", S3_SELECT_OPTION, compressionType, S3_SELECT_OPTION));
             }
             return false;
         }
@@ -150,51 +150,51 @@ public class S3ProtocolHandler implements ProtocolHandler {
     }
 
     /**
-     * Determines if the using S3-SELECT will be beneficial for performance, such as where there is
+     * Determines if the using S3_SELECT will be beneficial for performance, such as where there is
      * a column projection or a predicate pushdown for the given query
      *
      * @param context request context
-     * @return true if using S3-SELECT will be beneficial, false otherwise
+     * @return true if using S3_SELECT will be beneficial, false otherwise
      */
     private boolean willBenefitFromSelect(RequestContext context) {
         return context.hasFilter() || context.hasColumnProjection();
     }
 
     /**
-     * Determines if the given data format can be retrieved from S3 using S3-SELECT protocol
+     * Determines if the given data format can be retrieved from S3 using S3_SELECT protocol
      * and sent back to Greenplum using given OutputFormat
      *
      * @param outputFormat   output format
      * @param format         data format
-     * @param selectMode     s3-select mode requested by a user
+     * @param selectMode     s3_select mode requested by a user
      * @param raiseException true if an exception needs to be raised if the format is not supported, false otherwise
      * @return true if the data format is supported to be retrieved with s3select protocol
      */
     private boolean formatSupported(OutputFormat outputFormat, String format, S3Mode selectMode, boolean raiseException) {
         boolean supported = SUPPORT_MATRIX.contains(new SupportMatrixEntry(format, outputFormat, selectMode));
         if (!supported && raiseException) {
-            throw new IllegalArgumentException(String.format("S3-SELECT optimization is not supported for format '%s'", format));
+            throw new IllegalArgumentException(String.format("%s optimization is not supported for format '%s'", S3_SELECT_OPTION, format));
         }
 
         return supported;
     }
 
     /**
-     * Enumeration of modes a user can configure for using S3-SELECT optimization
+     * Enumeration of modes a user can configure for using S3_SELECT optimization
      */
     enum S3Mode {
         /**
-         * ON mode will apply S3-SELECT access always, no matter whether it's optimal or not
+         * ON mode will apply S3_SELECT access always, no matter whether it's optimal or not
          */
         ON,
 
         /**
-         * OFF mode will make sure S3-SELECT access is never applied, even if it would be the optimal one
+         * OFF mode will make sure S3_SELECT access is never applied, even if it would be the optimal one
          */
         OFF,
 
         /**
-         * AUTO mode will apply S3-SELECT only if it will result in more optimal execution
+         * AUTO mode will apply S3_SELECT only if it will result in more optimal execution
          */
         AUTO;
 

--- a/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3ProtocolHandlerTest.java
+++ b/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3ProtocolHandlerTest.java
@@ -82,7 +82,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectOnResolver() {
-        context.addOption("S3-SELECT", "on");
+        context.addOption("S3_SELECT", "on");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_ON);
         verifyResolvers(context, EXPECTED_RESOLVER_TEXT_ON);
@@ -91,7 +91,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithBenefitFilterOnlyResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.TEXT);
         context.setFilterString("abc");
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_BENEFIT);
@@ -101,7 +101,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithBenefitProjectionOnlyResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.TEXT);
         context.setNumAttrsProjected(1);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_BENEFIT);
@@ -111,7 +111,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithBenefitFilterAndProjectionResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.TEXT);
         context.setFilterString("abc");
         context.setNumAttrsProjected(1);
@@ -122,7 +122,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithBenefitFilterAndFullProjectionResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.TEXT);
         context.setFilterString("abc");
         context.setNumAttrsProjected(2);
@@ -133,7 +133,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithNoBenefitResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT);
         verifyResolvers(context, EXPECTED_RESOLVER_TEXT_AUTO_NO_BENEFIT);
@@ -142,7 +142,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithNoBenefitResolverWithDelimiterOption() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.addOption("DELIMITER", "|");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT_HAS_FORMAT_OPTIONS);
@@ -152,7 +152,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithNoBenefitResolverWithQuoteCharacterOption() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.addOption("QUOTE", "'");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT_HAS_FORMAT_OPTIONS);
@@ -162,7 +162,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithNoBenefitResolverWithQuoteEscapeCharacterOption() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.addOption("ESCAPE", "\\");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT_HAS_FORMAT_OPTIONS);
@@ -172,7 +172,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithNoBenefitResolverWithRecordDelimiterOption() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.addOption("NEWLINE", "\r");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT_HAS_FORMAT_OPTIONS);
@@ -182,7 +182,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithNoBenefitResolverWithFileHeaderInfoOptionUSE() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.addOption("FILE_HEADER", "USE");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT_HAS_HEADER);
@@ -192,7 +192,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithNoBenefitResolverWithFileHeaderInfoOptionIGNORE() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.addOption("FILE_HEADER", "IGNORE");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT_HAS_HEADER);
@@ -202,7 +202,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithNoBenefitResolverWithFileHeaderInfoOptionNONE() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.addOption("FILE_HEADER", "NONE");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT);
@@ -212,7 +212,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectAutoWithNoBenefitAllProjectedResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.TEXT);
         context.setNumAttrsProjected(2);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT);
@@ -222,7 +222,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectOffResolver() {
-        context.addOption("S3-SELECT", "off");
+        context.addOption("S3_SELECT", "off");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_OFF);
         verifyResolvers(context, EXPECTED_RESOLVER_TEXT_OFF);
@@ -231,7 +231,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testGPDBWritableWithSelectOnResolver() {
-        context.addOption("S3-SELECT", "on");
+        context.addOption("S3_SELECT", "on");
         context.setOutputFormat(OutputFormat.GPDBWritable);
         verifyAccessors(context, EXPECTED_ACCESSOR_GPDB_WRITABLE_ON);
         verifyResolvers(context, EXPECTED_RESOLVER_GPDB_WRITABLE_ON);
@@ -240,7 +240,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testGPDBWritableWithSelectAutoWithBenefitFilterOnlyResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.GPDBWritable);
         context.setFilterString("abc");
         verifyAccessors(context, EXPECTED_ACCESSOR_GPDB_WRITABLE_AUTO);
@@ -250,7 +250,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testGPDBWritableWithSelectAutoWithBenefitProjectionOnlyResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.GPDBWritable);
         context.setNumAttrsProjected(1);
         verifyAccessors(context, EXPECTED_ACCESSOR_GPDB_WRITABLE_AUTO);
@@ -260,7 +260,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testGPDBWritableWithSelectAutoWithBenefitFilterAndProjectionResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.GPDBWritable);
         context.setFilterString("abc");
         context.setNumAttrsProjected(1);
@@ -271,7 +271,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testGPDBWritableWithSelectAutoWithBenefitFilterAndFullProjectionResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.GPDBWritable);
         context.setFilterString("abc");
         context.setNumAttrsProjected(2);
@@ -282,7 +282,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testGPDBWritableWithSelectAutoWithNoBenefitResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.GPDBWritable);
         verifyAccessors(context, EXPECTED_ACCESSOR_GPDB_WRITABLE_AUTO);
         verifyResolvers(context, EXPECTED_RESOLVER_GPDB_WRITABLE_AUTO);
@@ -291,7 +291,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testGPDBWritableWithSelectAutoWithNoBenefitAllProjectedResolver() {
-        context.addOption("S3-SELECT", "auto");
+        context.addOption("S3_SELECT", "auto");
         context.setOutputFormat(OutputFormat.GPDBWritable);
         context.setNumAttrsProjected(2);
         verifyAccessors(context, EXPECTED_ACCESSOR_GPDB_WRITABLE_AUTO);
@@ -301,7 +301,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testGPDBWritableWithSelectOffResolver() {
-        context.addOption("S3-SELECT", "off");
+        context.addOption("S3_SELECT", "off");
         context.setOutputFormat(OutputFormat.GPDBWritable);
         verifyAccessors(context, EXPECTED_ACCESSOR_GPDB_WRITABLE_OFF);
         verifyResolvers(context, EXPECTED_RESOLVER_GPDB_WRITABLE_OFF);
@@ -327,23 +327,23 @@ public class S3ProtocolHandlerTest {
     @Test
     public void testSelectInvalid() {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid value 'foo' for S3-SELECT option");
+        thrown.expectMessage("Invalid value 'foo' for S3_SELECT option");
 
         context.setFormat("CSV");
-        context.addOption("S3-SELECT", "foo");
+        context.addOption("S3_SELECT", "foo");
         handler.getAccessorClassName(context);
     }
 
     @Test
     public void testSelectOffMissingFormat() {
-        context.addOption("S3-SELECT", "off");
+        context.addOption("S3_SELECT", "off");
         assertEquals("default-accessor", handler.getAccessorClassName(context));
         assertEquals("default-resolver", handler.getResolverClassName(context));
     }
 
     @Test
     public void testSelectOffUnsupportedFormat() {
-        context.addOption("S3-SELECT", "off");
+        context.addOption("S3_SELECT", "off");
         context.setFormat("custom");
         assertEquals("default-accessor", handler.getAccessorClassName(context));
         assertEquals("default-resolver", handler.getResolverClassName(context));
@@ -352,32 +352,32 @@ public class S3ProtocolHandlerTest {
     @Test
     public void testSelectOnMissingFormat() {
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("S3-SELECT optimization is not supported for format 'null'");
+        thrown.expectMessage("S3_SELECT optimization is not supported for format 'null'");
 
-        context.addOption("S3-SeLeCt", "on");
+        context.addOption("S3_SeLeCt", "on");
         handler.getAccessorClassName(context);
     }
 
     @Test
     public void testSelectOnUnsupportedFormat() {
         thrown.expect(RuntimeException.class);
-        thrown.expectMessage("S3-SELECT optimization is not supported for format 'CUSTOM'");
+        thrown.expectMessage("S3_SELECT optimization is not supported for format 'CUSTOM'");
 
-        context.addOption("S3-SELECT", "on");
+        context.addOption("S3_SELECT", "on");
         context.setFormat("custom");
         handler.getAccessorClassName(context);
     }
 
     @Test
     public void testSelectAutoMissingFormat() {
-        context.addOption("S3-SELECT", "AUTO");
+        context.addOption("S3_SELECT", "AUTO");
         assertEquals("default-accessor", handler.getAccessorClassName(context));
         assertEquals("default-resolver", handler.getResolverClassName(context));
     }
 
     @Test
     public void testSelectAutoUnsupportedFormat() {
-        context.addOption("S3-SELECT", "Auto");
+        context.addOption("S3_SELECT", "Auto");
         context.setFormat("custom");
         assertEquals("default-accessor", handler.getAccessorClassName(context));
         assertEquals("default-resolver", handler.getResolverClassName(context));
@@ -385,7 +385,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectOnAndWithSupportedCompressionType() {
-        context.addOption("S3-SELECT", "on");
+        context.addOption("S3_SELECT", "on");
         context.addOption(S3SelectAccessor.COMPRESSION_TYPE, "gZiP");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_ON);
@@ -395,7 +395,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testTextWithSelectOnAndWithNoSupportedCompressionType() {
-        context.addOption("S3-SELECT", "on");
+        context.addOption("S3_SELECT", "on");
         context.addOption(S3SelectAccessor.COMPRESSION_TYPE, "");
         context.setOutputFormat(OutputFormat.TEXT);
         verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_ON);
@@ -405,7 +405,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testWithSelectOnAndWithUnSupportedCompressionType() {
-        context.addOption("S3-SELECT", "on");
+        context.addOption("S3_SELECT", "on");
         context.addOption(S3SelectAccessor.COMPRESSION_TYPE, "foo");
         // EXPECTED_RESOLVER_GPDB_WRITABLE_ON is used as its values are desirable as expected value
         verifyResolvers(context, EXPECTED_RESOLVER_GPDB_WRITABLE_ON);
@@ -413,7 +413,7 @@ public class S3ProtocolHandlerTest {
 
     @Test
     public void testWithSelectOffAndWithUnSupportedCompressionType() {
-        context.addOption("S3-SELECT", "off");
+        context.addOption("S3_SELECT", "off");
         context.addOption(S3SelectAccessor.COMPRESSION_TYPE, "foo");
         // EXPECTED_RESOLVER_GPDB_WRITABLE_OFF is used as its values are desirable as expected value
         verifyResolvers(context, EXPECTED_RESOLVER_GPDB_WRITABLE_OFF);


### PR DESCRIPTION
Following recommendations from docs team, we will use underscore for
consistency. Even though PXF still mixes between dash and underscore, we
should make an effort to use underscores only. This will align us
better with FDW as well.