### PR TITLE
Server: Upgrade com.fasterxml.jackson.core:jackson-databind jar to 2.9.9.2

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -148,7 +148,7 @@ project('pxf-api') {
         compile "com.sun.jersey:jersey-core:1.9"
         compile "org.apache.hadoop:hadoop-common:${hadoopVersion}"
         compile "com.fasterxml.jackson.core:jackson-core:2.9.9"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.9.9"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.9.2"
 
         bundleJars "asm:asm:3.2"
     }
@@ -172,7 +172,7 @@ project('pxf-hdfs') {
     dependencies {
         compile(project(':pxf-api'))
         compile "org.apache.avro:avro-mapred:1.7.7"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.9.9"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.9.2"
         compile "com.fasterxml.jackson.core:jackson-core:2.9.9"
         compile "com.fasterxml.jackson.core:jackson-annotations:2.9.9"
         compile "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}"


### PR DESCRIPTION
The jar addresses 2 CVE:
CVE-2019-14379: SubTypeValidator.java in FasterXML jackson-databind
before 2.9.9.2 mishandles default typing when ehcache is used, leading
to remote code execution.

CVE-2019-14439: A Polymorphic Typing issue was discovered in FasterXML
jackson-databind 2.x before 2.9.9.2. This occurs when Default Typing is
enabled (either globally or for a specific property) for an externally
exposed JSON endpoint and the service has the logback jar in the
classpath.