### PR TITLE
Docker pipeline: use Dockerfile that triggered build

### DIFF
--- a/concourse/pipelines/docker-images.yml
+++ b/concourse/pipelines/docker-images.yml
@@ -176,7 +176,7 @@ resources:
       username: {{docker-username}}
       password: {{docker-password}}
 
-  - name: dockerfile-gpdb-dev-centos6-hdp-secure
+  - name: dockerfile-gpdb-pxf-dev-centos6-hdp-secure
     type: git
     source:
       branch: {{pxf-git-branch}}
@@ -362,11 +362,11 @@ jobs:
   - name: docker-gpdb-pxf-dev-centos6
     plan:
       - aggregate:
-          - get: pxf_src
           - get: dockerfile-gpdb-dev-centos6
             passed: [docker-gpdb-dev-centos6]
             trigger: true
-          - get: dockerfile-gpdb-pxf-dev-base
+          - get: pxf_src
+            resource: dockerfile-gpdb-pxf-dev-base
             trigger: true
           - get: gpdb-dev-centos6-image
             passed: [docker-gpdb-dev-centos6]
@@ -393,11 +393,11 @@ jobs:
   - name: docker-gpdb-pxf-dev-centos7
     plan:
       - aggregate:
-          - get: pxf_src
           - get: dockerfile-gpdb-dev-centos7
             passed: [docker-gpdb-dev-centos7]
             trigger: true
-          - get: dockerfile-gpdb-pxf-dev-base
+          - get: pxf_src
+            resource: dockerfile-gpdb-pxf-dev-base
             trigger: true
           - get: gpdb-dev-centos7-image
             passed: [docker-gpdb-dev-centos7]
@@ -426,11 +426,11 @@ jobs:
   - name: docker-gpdb-pxf-dev-ubuntu16
     plan:
       - aggregate:
-          - get: pxf_src
           - get: dockerfile-gpdb-dev-ubuntu
             passed: [docker-gpdb-dev-ubuntu16]
             trigger: true
-          - get: dockerfile-gpdb-pxf-dev-base
+          - get: pxf_src
+            resource: dockerfile-gpdb-pxf-dev-base
             trigger: true
           - get: gpdb-dev-ubuntu16-image
             passed: [docker-gpdb-dev-ubuntu16]
@@ -459,11 +459,11 @@ jobs:
   - name: docker-gpdb-pxf-dev-ubuntu18
     plan:
       - aggregate:
-          - get: pxf_src
           - get: dockerfile-gpdb-dev-ubuntu
             passed: [docker-gpdb-dev-ubuntu18]
             trigger: true
-          - get: dockerfile-gpdb-pxf-dev-base
+          - get: pxf_src
+            resource: dockerfile-gpdb-pxf-dev-base
             trigger: true
           - get: gpdb-dev-ubuntu18-image
             passed: [docker-gpdb-dev-ubuntu18]
@@ -481,14 +481,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-centos6-mapr-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-centos6
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
-      - get: dockerfile-gpdb-pxf-mapr
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-mapr
         trigger: true
       - get: gpdb-pxf-dev-centos6-image
         passed: [docker-gpdb-pxf-dev-centos6]
@@ -506,14 +506,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-centos7-mapr-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-centos7
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
-      - get: dockerfile-gpdb-pxf-mapr
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-mapr
         trigger: true
       - get: gpdb-pxf-dev-centos7-image
         passed: [docker-gpdb-pxf-dev-centos7]
@@ -531,12 +531,11 @@ jobs:
   - name: docker-gpdb-dev-centos6-hdp-secure
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-centos6
         passed: [docker-gpdb-dev-centos6]
         trigger: true
-      - get: dockerfile
-        resource: dockerfile-gpdb-dev-centos6-hdp-secure
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-dev-centos6-hdp-secure
         trigger: true
       - get: gpdb-dev-centos6-image
         passed: [docker-gpdb-dev-centos6]
@@ -607,14 +606,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-centos6-cdh-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-centos6
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
-      - get: dockerfile-gpdb-pxf-dev-server
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-dev-server
         trigger: true
       - get: singlecluster
         resource: singlecluster-CDH
@@ -636,14 +635,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-centos7-cdh-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-centos7
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
-      - get: dockerfile-gpdb-pxf-dev-server
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-dev-server
         trigger: true
       - get: singlecluster
         resource: singlecluster-CDH
@@ -665,14 +664,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-centos6-hdp-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-centos6
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
-      - get: dockerfile-gpdb-pxf-dev-server
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-dev-server
         trigger: true
       - get: singlecluster
         resource: singlecluster-HDP
@@ -694,14 +693,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-centos7-hdp-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-centos7
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
-      - get: dockerfile-gpdb-pxf-dev-server
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-dev-server
         trigger: true
       - get: singlecluster
         resource: singlecluster-HDP
@@ -723,14 +722,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-ubuntu16-cdh-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
-      - get: dockerfile-gpdb-pxf-dev-server
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-dev-server
         trigger: true
       - get: singlecluster
         resource: singlecluster-CDH
@@ -752,14 +751,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-ubuntu16-hdp-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
-      - get: dockerfile-gpdb-pxf-dev-server
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-dev-server
         trigger: true
       - get: singlecluster
         resource: singlecluster-HDP
@@ -781,14 +780,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-ubuntu18-cdh-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu18]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-ubuntu18]
         trigger: true
-      - get: dockerfile-gpdb-pxf-dev-server
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-dev-server
         trigger: true
       - get: singlecluster
         resource: singlecluster-CDH
@@ -810,14 +809,14 @@ jobs:
   - name: docker-gpdb-pxf-dev-ubuntu18-hdp-server
     plan:
     - aggregate:
-      - get: pxf_src
       - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu18]
         trigger: true
       - get: dockerfile-gpdb-pxf-dev-base
         passed: [docker-gpdb-pxf-dev-ubuntu18]
         trigger: true
-      - get: dockerfile-gpdb-pxf-dev-server
+      - get: pxf_src
+        resource: dockerfile-gpdb-pxf-dev-server
         trigger: true
       - get: singlecluster
         resource: singlecluster-HDP


### PR DESCRIPTION
Previously we were `get`ing the `pxf_src` and Dockerfile resources
separately, and using the Dockerfile from `pxf_src`. This allowed
situations where the Dockerfile being used in the task was not the one
that actually triggered the build.

With the approach used in this commit, the pipeline task always uses the
Dockerfile that triggers it. The downside is that if you want to
re-trigger the docker image manually (to re-cache stuff on the image)
you will either need to temporarily change the pipeline to use the
Dockerfile from `pxf_src`, or push some change to the Dockerfile.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>