### PR TITLE
The newest version of PSQL introduces a + in multiline text

### DIFF
--- a/automation/tincrepo/main/pxf/features/hcfs/file_as_row/json/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hcfs/file_as_row/json/expected/query01.ans
@@ -7,77 +7,79 @@
 -- Display on for output consistency between GPDB 5 and 6
 \x on
 Expanded display is on.
+\pset format unaligned
+Output format is unaligned.
 select * from file_as_row_json;
--[ RECORD 1 ]-----------------------------------------------------------------------------------------------------------------------------------------
-json_blob | {
-          |   "root":[
-          |     {
-          |       "record":{
-          |         "created_at":"Fri Jun 07 22:45:02 +0000 2013",
-          |         "id":343136547115253761,
-          |         "id_str":"343136547115253761",
-          |         "text":"text1",
-          |         "source":"<a href=\"http:\/\/twitter.com\/download\/iphone\" rel=\"nofollow\">Twitter for iPhone<\/a>",
-          |         "user":{
-          |           "id":26643566,
-          |           "name":"SpreadButter",
-          |           "screen_name":"SpreadButter",
-          |           "location":"Austin, Texas"
-          |         },
-          |         "entities":{
-          |           "hashtags":[
-          |             "tweetCongress",
-          |             "IRS"
-          |           ]
-          |         }
-          |       }
-          |     },
-          |     {
-          |       "record":{
-          |         "created_at":"Fri Jun 07 22:45:02 +0000 2013",
-          |         "id":343136547123646465,
-          |         "id_str":"343136547123646465",
-          |         "text":"text2",
-          |         "source":"\u003ca href=\"http:\/\/twitter.com\/download\/android\" rel=\"nofollow\"\u003eTwitter for Android\u003c\/a\u003e",
-          |         "user":{
-          |           "id":102904200,
-          |           "id_str":"102904200",
-          |           "name":"Ardianto",
-          |           "screen_name":"patronusdeadly",
-          |           "location":"Bekasi-Surabaya"
-          |         },
-          |         "entities":{
-          |           "hashtags":[
-          | 
-          |           ]
-          |         }
-          |       }
-          |     },
-          |     {
-          |       "record":{
-          |         "created_at":"Fri Jun 07 22:45:02 +0000 2013",
-          |         "id":343136547136233472,
-          |         "id_str":"343136547136233472",
-          |         "text":"text3",
-          |         "source":"\u003ca href=\"http:\/\/www.nosecrets-empregos.com.br\/homologa\" rel=\"nofollow\"\u003eVagas NoSecrets\u003c\/a\u003e",
-          |         "user":{
-          |           "id":287819058,
-          |           "id_str":"287819058",
-          |           "name":"No Secrets Empregos",
-          |           "screen_name":"NoSecrets_Vagas",
-          |           "location":""
-          |         },
-          |         "entities":{
-          |           "hashtags":[
-          | 
-          |           ]
-          |         }
-          |       }
-          |     }
-          |   ]
-          | }
+json_blob|{
+  "root":[
+    {
+      "record":{
+        "created_at":"Fri Jun 07 22:45:02 +0000 2013",
+        "id":343136547115253761,
+        "id_str":"343136547115253761",
+        "text":"text1",
+        "source":"<a href=\"http:\/\/twitter.com\/download\/iphone\" rel=\"nofollow\">Twitter for iPhone<\/a>",
+        "user":{
+          "id":26643566,
+          "name":"SpreadButter",
+          "screen_name":"SpreadButter",
+          "location":"Austin, Texas"
+        },
+        "entities":{
+          "hashtags":[
+            "tweetCongress",
+            "IRS"
+          ]
+        }
+      }
+    },
+    {
+      "record":{
+        "created_at":"Fri Jun 07 22:45:02 +0000 2013",
+        "id":343136547123646465,
+        "id_str":"343136547123646465",
+        "text":"text2",
+        "source":"\u003ca href=\"http:\/\/twitter.com\/download\/android\" rel=\"nofollow\"\u003eTwitter for Android\u003c\/a\u003e",
+        "user":{
+          "id":102904200,
+          "id_str":"102904200",
+          "name":"Ardianto",
+          "screen_name":"patronusdeadly",
+          "location":"Bekasi-Surabaya"
+        },
+        "entities":{
+          "hashtags":[
 
+          ]
+        }
+      }
+    },
+    {
+      "record":{
+        "created_at":"Fri Jun 07 22:45:02 +0000 2013",
+        "id":343136547136233472,
+        "id_str":"343136547136233472",
+        "text":"text3",
+        "source":"\u003ca href=\"http:\/\/www.nosecrets-empregos.com.br\/homologa\" rel=\"nofollow\"\u003eVagas NoSecrets\u003c\/a\u003e",
+        "user":{
+          "id":287819058,
+          "id_str":"287819058",
+          "name":"No Secrets Empregos",
+          "screen_name":"NoSecrets_Vagas",
+          "location":""
+        },
+        "entities":{
+          "hashtags":[
+
+          ]
+        }
+      }
+    }
+  ]
+}
 -- Query JSON using JSON functions
+\pset format aligned
+Output format is aligned.
 select
        json_array_elements(json_blob->'root')->'record'->'created_at' as created_at,
        json_array_elements(json_blob->'root')->'record'->'text' as text,

--- a/automation/tincrepo/main/pxf/features/hcfs/file_as_row/json/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hcfs/file_as_row/json/sql/query01.sql
@@ -5,11 +5,12 @@
 
 -- Display on for output consistency between GPDB 5 and 6
 \x on
+\pset format unaligned
 select * from file_as_row_json;
 
 
 -- Query JSON using JSON functions
-
+\pset format aligned
 select
        json_array_elements(json_blob->'root')->'record'->'created_at' as created_at,
        json_array_elements(json_blob->'root')->'record'->'text' as text,

--- a/automation/tincrepo/main/pxf/features/hcfs/file_as_row/multi_files/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hcfs/file_as_row/multi_files/expected/query01.ans
@@ -13,36 +13,36 @@ select count(*) from file_as_row_multi_files;
 -- Display on for output consistency between GPDB 5 and 6
 \x on
 Expanded display is on.
+\pset format unaligned
+Output format is unaligned.
 select * from file_as_row_multi_files order by text_blob;
--[ RECORD 1 ]-----------------------------------------------------------
-text_blob | ""Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-          | sed do eiusmod tempor incididunt ut labore et dolore magna
-          | aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-          | ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          | Duis aute irure dolor in reprehenderit in voluptate velit
-          | esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-          | occaecat cupidatat non proident, sunt in culpa qui officia
-          | deserunt mollit anim id est laborum.""
-          | 
-          | "Sed ut perspiciatis unde omnis iste natus error sit
-          | voluptatem accusantium doloremque laudantium, totam rem
-          | aperiam, eaque ipsa quae ab illo inventore veritatis et
-          | quasi architecto beatae vitae dicta sunt explicabo. Nemo
-          | enim ipsam voluptatem quia voluptas sit aspernatur aut odit
-          | aut fugit, sed quia consequuntur magni dolores eos qui
-          | ratione voluptatem sequi nesciunt. Neque porro quisquam est,
-          | qui dolorem ipsum quia dolor sit amet, consectetur,
-          | adipisci velit, sed quia non numquam eius modi tempora
-          | incidunt ut labore et dolore magnam aliquam quaerat
-          | voluptatem. Ut enim ad minima veniam, quis nostrum
-          | exercitationem ullam corporis suscipit laboriosam, nisi ut
-          | aliquid ex ea commodi consequatur? Quis autem vel eum iure
-          | reprehenderit qui in ea voluptate velit esse quam nihil
-          | molestiae consequatur, vel illum qui dolorem eum fugiat quo
-          | voluptas nulla pariatur?\"
--[ RECORD 2 ]-----------------------------------------------------------
-text_blob | there are two lines in this file
-          | 
--[ RECORD 3 ]-----------------------------------------------------------
-text_blob | this is a single line file
+text_blob|""Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum.""
 
+"Sed ut perspiciatis unde omnis iste natus error sit
+voluptatem accusantium doloremque laudantium, totam rem
+aperiam, eaque ipsa quae ab illo inventore veritatis et
+quasi architecto beatae vitae dicta sunt explicabo. Nemo
+enim ipsam voluptatem quia voluptas sit aspernatur aut odit
+aut fugit, sed quia consequuntur magni dolores eos qui
+ratione voluptatem sequi nesciunt. Neque porro quisquam est,
+qui dolorem ipsum quia dolor sit amet, consectetur,
+adipisci velit, sed quia non numquam eius modi tempora
+incidunt ut labore et dolore magnam aliquam quaerat
+voluptatem. Ut enim ad minima veniam, quis nostrum
+exercitationem ullam corporis suscipit laboriosam, nisi ut
+aliquid ex ea commodi consequatur? Quis autem vel eum iure
+reprehenderit qui in ea voluptate velit esse quam nihil
+molestiae consequatur, vel illum qui dolorem eum fugiat quo
+voluptas nulla pariatur?\"
+
+text_blob|there are two lines in this file
+
+
+text_blob|this is a single line file

--- a/automation/tincrepo/main/pxf/features/hcfs/file_as_row/multi_files/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hcfs/file_as_row/multi_files/sql/query01.sql
@@ -7,4 +7,5 @@ select count(*) from file_as_row_multi_files;
 
 -- Display on for output consistency between GPDB 5 and 6
 \x on
+\pset format unaligned
 select * from file_as_row_multi_files order by text_blob;

--- a/automation/tincrepo/main/pxf/features/hcfs/file_as_row/text/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hcfs/file_as_row/text/expected/query01.ans
@@ -7,31 +7,31 @@
 -- Display on for output consistency between GPDB 5 and 6
 \x on
 Expanded display is on.
+\pset format unaligned
+Output format is unaligned.
 select * from file_as_row_text;
--[ RECORD 1 ]-----------------------------------------------------------
-text_blob | ""Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-          | sed do eiusmod tempor incididunt ut labore et dolore magna
-          | aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-          | ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          | Duis aute irure dolor in reprehenderit in voluptate velit
-          | esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-          | occaecat cupidatat non proident, sunt in culpa qui officia
-          | deserunt mollit anim id est laborum.""
-          | 
-          | "Sed ut perspiciatis unde omnis iste natus error sit
-          | voluptatem accusantium doloremque laudantium, totam rem
-          | aperiam, eaque ipsa quae ab illo inventore veritatis et
-          | quasi architecto beatae vitae dicta sunt explicabo. Nemo
-          | enim ipsam voluptatem quia voluptas sit aspernatur aut odit
-          | aut fugit, sed quia consequuntur magni dolores eos qui
-          | ratione voluptatem sequi nesciunt. Neque porro quisquam est,
-          | qui dolorem ipsum quia dolor sit amet, consectetur,
-          | adipisci velit, sed quia non numquam eius modi tempora
-          | incidunt ut labore et dolore magnam aliquam quaerat
-          | voluptatem. Ut enim ad minima veniam, quis nostrum
-          | exercitationem ullam corporis suscipit laboriosam, nisi ut
-          | aliquid ex ea commodi consequatur? Quis autem vel eum iure
-          | reprehenderit qui in ea voluptate velit esse quam nihil
-          | molestiae consequatur, vel illum qui dolorem eum fugiat quo
-          | voluptas nulla pariatur?\"
+text_blob|""Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum.""
 
+"Sed ut perspiciatis unde omnis iste natus error sit
+voluptatem accusantium doloremque laudantium, totam rem
+aperiam, eaque ipsa quae ab illo inventore veritatis et
+quasi architecto beatae vitae dicta sunt explicabo. Nemo
+enim ipsam voluptatem quia voluptas sit aspernatur aut odit
+aut fugit, sed quia consequuntur magni dolores eos qui
+ratione voluptatem sequi nesciunt. Neque porro quisquam est,
+qui dolorem ipsum quia dolor sit amet, consectetur,
+adipisci velit, sed quia non numquam eius modi tempora
+incidunt ut labore et dolore magnam aliquam quaerat
+voluptatem. Ut enim ad minima veniam, quis nostrum
+exercitationem ullam corporis suscipit laboriosam, nisi ut
+aliquid ex ea commodi consequatur? Quis autem vel eum iure
+reprehenderit qui in ea voluptate velit esse quam nihil
+molestiae consequatur, vel illum qui dolorem eum fugiat quo
+voluptas nulla pariatur?\"

--- a/automation/tincrepo/main/pxf/features/hcfs/file_as_row/text/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hcfs/file_as_row/text/sql/query01.sql
@@ -5,4 +5,5 @@
 
 -- Display on for output consistency between GPDB 5 and 6
 \x on
+\pset format unaligned
 select * from file_as_row_text;

--- a/automation/tincrepo/main/pxf/features/hcfs/file_as_row/twoline_text/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hcfs/file_as_row/twoline_text/expected/query01.ans
@@ -8,8 +8,8 @@
 -- Display on for output consistency between GPDB 5 and 6
 \x on
 Expanded display is on.
+\pset format unaligned
+Output format is unaligned.
 select * from file_as_row_twoline_text;
--[ RECORD 1 ]-------------------------------
-text_blob | there are two lines in this file
-          | 
+text_blob|there are two lines in this file
 

--- a/automation/tincrepo/main/pxf/features/hcfs/file_as_row/twoline_text/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hcfs/file_as_row/twoline_text/sql/query01.sql
@@ -6,4 +6,5 @@
 
 -- Display on for output consistency between GPDB 5 and 6
 \x on
+\pset format unaligned
 select * from file_as_row_twoline_text;


### PR DESCRIPTION
To make the output consistent accross all versions of GPDB we add \pset
format unaligned