### PR TITLE
Allow users to set hadoop login user with HADOOP_USER_NAME

### DIFF
--- a/server/pxf-service/src/scripts/pxf-env-default.sh
+++ b/server/pxf-service/src/scripts/pxf-env-default.sh
@@ -73,3 +73,6 @@ export PXF_OOM_KILL=${PXF_OOM_KILL:-true}
 
 # Dump heap on OutOfMemoryError, set to dump path to enable
 # export PXF_OOM_DUMP_PATH=
+
+# Login user for hadoop, defaults to the OS user that started PXF process
+export HADOOP_USER_NAME=${HADOOP_USER_NAME:-$(whoami)}

--- a/server/pxf-service/src/templates/user/conf/pxf-env.sh
+++ b/server/pxf-service/src/templates/user/conf/pxf-env.sh
@@ -39,3 +39,6 @@ PXF_CONF="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 # Dump heap on OutOfMemoryError, set to dump path to enable
 # export PXF_OOM_DUMP_PATH=/tmp/pxf_heap_dump
+
+# Login user for hadoop, defaults to the OS user that started PXF process
+# export HADOOP_USER_NAME=$(whoami)


### PR DESCRIPTION
Allow users to set the HADOOP_USER_NAME environment variable to define
the hadoop login user. By default, hadoop will use the OS user name.
By setting the HADOOP_USER_NAME property in pxf-conf.sh, a different
user can be specified.

When PXF is configured with multiple hadoop environments, this
environment variable will apply to all the non-kerberized environments.
For example, let's say we have 3 servers default (kerberized), hdp1, and
hdp2, and the HADOOP_USER_NAME is set to gpuser. The login user for hdp1
and hdp2 will be gpuser.