### PR TITLE
Replace toolsmiths/ccp with pivotaldata/ccp

### DIFF
--- a/concourse/pipelines/perf_pipeline.yml
+++ b/concourse/pipelines/perf_pipeline.yml
@@ -31,7 +31,7 @@ set_failed_gpdb_anchor: &set_failed
         image_resource:
           type: docker-image
           source:
-            repository: toolsmiths/ccp
+            repository: pivotaldata/ccp
             tag: "7"
         inputs:
         - name: ccp_src
@@ -57,7 +57,7 @@ set_failed_gpdb_anchor: &set_failed
         image_resource:
           type: docker-image
           source:
-            repository: toolsmiths/ccp
+            repository: pivotaldata/ccp
             tag: "7"
         inputs:
         - name: ccp_src
@@ -209,7 +209,7 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: toolsmiths/ccp
+            repository: pivotaldata/ccp
             tag: "7"
         run:
           path: aws


### PR DESCRIPTION
The toolsmiths DockerHub repository is deprecated and replaced by pivotaldata.