### PR TITLE
Update jackson-databind version to 2.9.10

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.2</version>
+            <version>2.9.10</version>
         </dependency>
 
         <dependency>

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -148,7 +148,7 @@ project('pxf-api') {
         compile "com.sun.jersey:jersey-core:1.9"
         compile "org.apache.hadoop:hadoop-common:${hadoopVersion}"
         compile "com.fasterxml.jackson.core:jackson-core:2.9.9"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.9.9"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.10"
 
         bundleJars "asm:asm:3.2"
     }
@@ -172,7 +172,7 @@ project('pxf-hdfs') {
     dependencies {
         compile(project(':pxf-api'))
         compile "org.apache.avro:avro-mapred:1.7.7"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.9.9"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.10"
         compile "com.fasterxml.jackson.core:jackson-core:2.9.9"
         compile "com.fasterxml.jackson.core:jackson-annotations:2.9.9"
         compile "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}"

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
@@ -20,21 +20,16 @@ package org.greenplum.pxf.plugins.hdfs;
  */
 
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapreduce.MRJobConfig;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.greenplum.pxf.api.model.BaseFragmenter;
 import org.greenplum.pxf.api.model.Fragment;
 import org.greenplum.pxf.api.model.FragmentStats;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.plugins.hdfs.utilities.HdfsUtilities;
 import org.greenplum.pxf.plugins.hdfs.utilities.PxfInputFormat;
-import org.mortbay.util.StringUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;


### PR DESCRIPTION
There are two CVEs impacting com.fasterxml.jackson.core:jackson-databind
versions < 2.9.10

CVE-2019-14540 More information (critical severity)
Vulnerable versions: < 2.9.10
Patched version: 2.9.10
A Polymorphic Typing issue was discovered in FasterXML jackson-databind
before 2.9.10. It is related to com.zaxxer.hikari.HikariConfig.

CVE-2019-16335 More information (critical severity)
Vulnerable versions: < 2.9.10
Patched version: 2.9.10
A Polymorphic Typing issue was discovered in FasterXML jackson-databind
before 2.9.10. It is related to com.zaxxer.hikari.HikariDataSource. This
is a different vulnerability than CVE-2019-14540.