### PR TITLE
pipelines: switch aggregate for newer in_parallel

### DIFF
--- a/concourse/pipelines/5x-release_pipeline-generated.yml
+++ b/concourse/pipelines/5x-release_pipeline-generated.yml
@@ -93,7 +93,7 @@ ccp_destroy_anchor: &ccp_destroy
 
 dataproc_destroy_anchor: &dataproc_destroy
   do:
-  - aggregate:
+  - in_parallel:
     - task: cleanup_dataproc
       config:
         run:
@@ -301,7 +301,7 @@ jobs:
 
 - name: compile_pxf
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
     - get: pxf_src
       trigger: true
@@ -315,7 +315,7 @@ jobs:
 
 - name: test_pxf_hdp2_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -344,7 +344,7 @@ jobs:
 
 - name: test_pxf_mapr_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -372,7 +372,7 @@ jobs:
 
 - name: test_pxf_hdp3_centos7
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -401,7 +401,7 @@ jobs:
 
 - name: test_pxf_hdp2_centos7_java11
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -431,7 +431,7 @@ jobs:
 
 - name: test_pxf_hdp2_ubuntu16
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -461,7 +461,7 @@ jobs:
 
 - name: test_pxf_hdp2_secure_with_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -492,7 +492,7 @@ jobs:
 
 - name: test_pxf_hdp2_secure_no_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -567,7 +567,7 @@ jobs:
       BUCKET_NAME: {{tf-bucket-name}}
       PLATFORM: centos7
       CLOUD_PROVIDER: google
-  - aggregate:
+  - in_parallel:
     - task: intialize_greenplum
       file: ccp_src/ci/tasks/gpinitsystem.yml
     - task: install_hadoop
@@ -612,7 +612,7 @@ jobs:
 - name: test_pxf_secure_multinode_gpdb
   max_in_flight: 2
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ccp_src
     - get: gpdb_src
       passed:
@@ -629,7 +629,7 @@ jobs:
       trigger: true
     - get: ccp-7
     - get: gpdb-pxf-dev-centos6-hdp2-server
-  - aggregate:
+  - in_parallel:
     - do:
       - put: terraform_gpdb
         resource: terraform
@@ -709,7 +709,7 @@ jobs:
 
 - name: test_pxf_cdh_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -738,7 +738,7 @@ jobs:
 
 - name: test_pxf_s3_no_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -768,7 +768,7 @@ jobs:
 
 - name: test_pxf_s3_with_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -798,7 +798,7 @@ jobs:
 
 - name: test_pxf_minio
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -826,7 +826,7 @@ jobs:
 
 - name: test_pxf_adl
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -858,7 +858,7 @@ jobs:
 
 - name: test_pxf_gs
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -887,7 +887,7 @@ jobs:
 
 - name: test_pxf_no_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf

--- a/concourse/pipelines/6x-release_pipeline-generated.yml
+++ b/concourse/pipelines/6x-release_pipeline-generated.yml
@@ -93,7 +93,7 @@ ccp_destroy_anchor: &ccp_destroy
 
 dataproc_destroy_anchor: &dataproc_destroy
   do:
-  - aggregate:
+  - in_parallel:
     - task: cleanup_dataproc
       config:
         run:
@@ -298,7 +298,7 @@ jobs:
 
 - name: compile_pxf
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
     - get: pxf_src
       trigger: true
@@ -312,7 +312,7 @@ jobs:
 
 - name: test_pxf_hdp2_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -341,7 +341,7 @@ jobs:
 
 - name: test_pxf_mapr_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -369,7 +369,7 @@ jobs:
 
 - name: test_pxf_hdp3_centos7
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -398,7 +398,7 @@ jobs:
 
 - name: test_pxf_hdp2_centos7_java11
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -428,7 +428,7 @@ jobs:
 
 - name: test_pxf_hdp2_ubuntu18
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -458,7 +458,7 @@ jobs:
 
 - name: test_pxf_hdp2_secure_with_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -489,7 +489,7 @@ jobs:
 
 - name: test_pxf_hdp2_secure_no_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -564,7 +564,7 @@ jobs:
       BUCKET_NAME: {{tf-bucket-name}}
       PLATFORM: centos7
       CLOUD_PROVIDER: google
-  - aggregate:
+  - in_parallel:
     - task: intialize_greenplum
       file: ccp_src/ci/tasks/gpinitsystem.yml
     - task: install_hadoop
@@ -609,7 +609,7 @@ jobs:
 - name: test_pxf_secure_multinode_gpdb
   max_in_flight: 2
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ccp_src
     - get: gpdb_src
       passed:
@@ -626,7 +626,7 @@ jobs:
       trigger: true
     - get: ccp-7
     - get: gpdb-pxf-dev-centos6-hdp2-server
-  - aggregate:
+  - in_parallel:
     - do:
       - put: terraform_gpdb
         resource: terraform
@@ -706,7 +706,7 @@ jobs:
 
 - name: test_pxf_cdh_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -735,7 +735,7 @@ jobs:
 
 - name: test_pxf_s3_no_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -765,7 +765,7 @@ jobs:
 
 - name: test_pxf_s3_with_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -795,7 +795,7 @@ jobs:
 
 - name: test_pxf_minio
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -823,7 +823,7 @@ jobs:
 
 - name: test_pxf_adl
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -855,7 +855,7 @@ jobs:
 
 - name: test_pxf_gs
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -884,7 +884,7 @@ jobs:
 
 - name: test_pxf_no_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf

--- a/concourse/pipelines/docker-images.yml
+++ b/concourse/pipelines/docker-images.yml
@@ -384,7 +384,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-centos6
     plan:
-      - aggregate:
+      - in_parallel:
           - get: dockerfile-gpdb-dev-centos6
             passed: [docker-gpdb-dev-centos6]
             trigger: true
@@ -415,7 +415,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-centos7
     plan:
-      - aggregate:
+      - in_parallel:
           - get: dockerfile-gpdb-dev-centos7
             passed: [docker-gpdb-dev-centos7]
             trigger: true
@@ -448,7 +448,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-ubuntu16
     plan:
-      - aggregate:
+      - in_parallel:
           - get: dockerfile-gpdb-dev-ubuntu
             passed: [docker-gpdb-dev-ubuntu16]
             trigger: true
@@ -481,7 +481,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-ubuntu18
     plan:
-      - aggregate:
+      - in_parallel:
           - get: dockerfile-gpdb-dev-ubuntu
             passed: [docker-gpdb-dev-ubuntu18]
             trigger: true
@@ -503,7 +503,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-centos6-mapr-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-centos6
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
@@ -528,7 +528,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-centos7-mapr-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-centos7
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
@@ -553,7 +553,7 @@ jobs:
 
   - name: docker-gpdb-dev-centos6-hdp2-secure
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-centos6
         passed: [docker-gpdb-dev-centos6]
         trigger: true
@@ -574,7 +574,7 @@ jobs:
 
 #  - name: docker-gpdb-dev-centos7-hdp-secure
 #    plan:
-#    - aggregate:
+#    - in_parallel:
 #      - get: pxf_src
 #      - get: dockerfile-gpdb-dev-centos7
 #        passed: [docker-gpdb-dev-centos7]
@@ -590,7 +590,7 @@ jobs:
 
   - name: singlecluster_noarch_cdh
     plan:
-    - aggregate:
+    - in_parallel:
       - get: cdh_tars_tarball
         trigger: true
       - get: jdbc
@@ -609,7 +609,7 @@ jobs:
 
   - name: singlecluster_noarch_hdp2
     plan:
-    - aggregate:
+    - in_parallel:
       - get: hdp_tars_tarball
         resource: hdp2_tars_tarball
         trigger: true
@@ -629,7 +629,7 @@ jobs:
 
   - name: singlecluster_noarch_hdp3
     plan:
-    - aggregate:
+    - in_parallel:
       - get: hdp_tars_tarball
         resource: hdp3_tars_tarball
         trigger: true
@@ -649,7 +649,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-centos6-cdh-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-centos6
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
@@ -678,7 +678,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-centos7-cdh-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-centos7
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
@@ -707,7 +707,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-centos6-hdp2-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-centos6
         passed: [docker-gpdb-pxf-dev-centos6]
         trigger: true
@@ -736,7 +736,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-centos7-hdp2-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-centos7
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
@@ -765,7 +765,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-centos7-hdp3-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-centos7
         passed: [docker-gpdb-pxf-dev-centos7]
         trigger: true
@@ -794,7 +794,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-ubuntu16-cdh-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
@@ -823,7 +823,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-ubuntu16-hdp2-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu16]
         trigger: true
@@ -852,7 +852,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-ubuntu18-cdh-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu18]
         trigger: true
@@ -881,7 +881,7 @@ jobs:
 
   - name: docker-gpdb-pxf-dev-ubuntu18-hdp2-server
     plan:
-    - aggregate:
+    - in_parallel:
       - get: dockerfile-gpdb-dev-ubuntu
         passed: [docker-gpdb-pxf-dev-ubuntu18]
         trigger: true

--- a/concourse/pipelines/perf_pipeline.yml
+++ b/concourse/pipelines/perf_pipeline.yml
@@ -1,6 +1,6 @@
 dataproc_destroy_anchor: &ccp_destroy
   do:
-  - aggregate:
+  - in_parallel:
     - put: terraform_gpdb
       resource: terraform
       params:
@@ -22,7 +22,7 @@ dataproc_destroy_anchor: &ccp_destroy
 
 set_failed_gpdb_anchor: &set_failed
   do:
-  - aggregate:
+  - in_parallel:
     - task: on_failure_set_failed_gpdb
       input_mapping:
         terraform: terraform_gpdb
@@ -168,7 +168,7 @@ jobs:
   plan:
   - get: timed-trigger
     trigger: true
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
     - get: pxf_src
     - get: gpdb-pxf-dev-centos6
@@ -202,7 +202,7 @@ jobs:
   - get: ccp-7
   - get: gpdb-pxf-dev-centos6-hdp2-server
 
-  - aggregate:
+  - in_parallel:
     - task: clean_up_s3
       config:
         platform: linux
@@ -256,7 +256,7 @@ jobs:
           initialization_script_timeout: {{perf-hadoop-initialization-script-timeout}}
           disk_size: {{perf-hadoop-disk-size}}
 
-  - aggregate:
+  - in_parallel:
       - do:
         - task: gen_gpdb_cluster
           input_mapping:

--- a/concourse/pipelines/pg_regress_pipeline.yml
+++ b/concourse/pipelines/pg_regress_pipeline.yml
@@ -90,7 +90,7 @@ jobs:
   plan:
   - get: pxf_src
     trigger: true
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       trigger: true
     - get: gpdb-pxf-dev-centos7
@@ -102,7 +102,7 @@ jobs:
 
 - name: compile_gpdb
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       params: { submodules: all, submodules_recursive: true }
       trigger: true
@@ -129,7 +129,7 @@ jobs:
 
 - name: test_pxf
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pxf_src
       passed:
         - compile_pxf
@@ -169,7 +169,7 @@ jobs:
 
 - name: test_pxf_s3
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pxf_src
       passed:
         - compile_pxf
@@ -213,7 +213,7 @@ jobs:
 
 - name: test_pxf_gcs
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pxf_src
       passed:
         - compile_pxf
@@ -256,7 +256,7 @@ jobs:
 
 - name: test_pxf_wasbs
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pxf_src
       passed:
         - compile_pxf
@@ -300,7 +300,7 @@ jobs:
 
 - name: test_pxf_adl
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pxf_src
       passed:
         - compile_pxf
@@ -346,7 +346,7 @@ jobs:
 
 - name: test_pxf_minio
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pxf_src
       passed:
         - compile_pxf

--- a/concourse/pipelines/pxf_pr_pipeline.yml
+++ b/concourse/pipelines/pxf_pr_pipeline.yml
@@ -56,7 +56,7 @@ jobs:
       path: pxf_src
       status: pending
       context: $BUILD_JOB_NAME
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
     - get: gpdb-pxf-dev-centos6
   - task: compile_pxf
@@ -87,7 +87,7 @@ jobs:
       path: pxf_src
       status: pending
       context: $BUILD_JOB_NAME
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -112,7 +112,7 @@ ccp_destroy_anchor: &ccp_destroy
 
 dataproc_destroy_anchor: &dataproc_destroy
   do:
-  - aggregate:
+  - in_parallel:
     - task: cleanup_dataproc
       config:
         run:
@@ -484,7 +484,7 @@ jobs:
 {% if compile_gpdb %}
 - name: compile_gpdb_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
     - get: gpdb-centos6-build
 {% if gpdb_branch == '5X_STABLE' %}
@@ -528,7 +528,7 @@ jobs:
 {% endif %}
 - name: compile_pxf
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
 {% if pipeline_type == "pxf" %}
     - get: gpdb_pxf_trigger
@@ -547,7 +547,7 @@ jobs:
 {% if pipeline_type == "release" %}
 - name: test_pxf_hdp2_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -587,7 +587,7 @@ jobs:
 
 - name: test_pxf_mapr_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -625,7 +625,7 @@ jobs:
 
 - name: test_pxf_hdp3_centos7
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -668,7 +668,7 @@ jobs:
 
 - name: test_pxf_hdp2_centos7_java11
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -713,7 +713,7 @@ jobs:
 {% if gpdb_type == "5X_STABLE" %}
 - name: test_pxf_hdp2_ubuntu16
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -746,7 +746,7 @@ jobs:
 {% else %}
 - name: test_pxf_hdp2_ubuntu18
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -780,7 +780,7 @@ jobs:
 
 - name: test_pxf_hdp2_secure_with_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -822,7 +822,7 @@ jobs:
 {% if pipeline_type == "release" %}
 - name: test_pxf_hdp2_secure_no_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -915,7 +915,7 @@ jobs:
       BUCKET_NAME: {{tf-bucket-name}}
       PLATFORM: centos7
       CLOUD_PROVIDER: google
-  - aggregate:
+  - in_parallel:
     - task: intialize_greenplum
       file: ccp_src/ci/tasks/gpinitsystem.yml
     - task: install_hadoop
@@ -966,7 +966,7 @@ jobs:
 - name: test_pxf_secure_multinode_gpdb
   max_in_flight: 2
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ccp_src
     - get: gpdb_src
       passed:
@@ -990,7 +990,7 @@ jobs:
       trigger: true
     - get: ccp-7
     - get: gpdb-pxf-dev-centos6-hdp2-server
-  - aggregate:
+  - in_parallel:
     - do:
       - put: terraform_gpdb
         resource: terraform
@@ -1073,7 +1073,7 @@ jobs:
 
 - name: test_pxf_cdh_centos6
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -1112,7 +1112,7 @@ jobs:
 
 - name: test_pxf_s3_no_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -1152,7 +1152,7 @@ jobs:
 
 - name: test_pxf_s3_with_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -1193,7 +1193,7 @@ jobs:
 {% if pipeline_type == "release" %}
 - name: test_pxf_minio
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -1231,7 +1231,7 @@ jobs:
 
 - name: test_pxf_adl
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -1273,7 +1273,7 @@ jobs:
 
 - name: test_pxf_gs
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf
@@ -1313,7 +1313,7 @@ jobs:
 
 - name: test_pxf_no_impersonation
   plan:
-  - aggregate:
+  - in_parallel:
     - get: gpdb_src
       passed:
       - compile_pxf


### PR DESCRIPTION
We recently updgraded Concourse to 5.6.0 and to avoid seeing a
deprecation warning from the fly command, we should start using
`in_parallel` instead of the older `aggregate`.

https://concourse-ci.org/aggregate-step.html
https://concourse-ci.org/in-parallel-step.html

Authored-by: Oliver Albertini <oalbertini@pivotal.io>