### PR TITLE
Use custom user identity per Hadoop server (non-secure)

### DIFF
--- a/concourse/scripts/install_pxf.bash
+++ b/concourse/scripts/install_pxf.bash
@@ -20,6 +20,7 @@ else
 	HADOOP_HOSTNAME=hadoop
 	HADOOP_IP=$(grep < cluster_env_files/etc_hostfile edw0 | awk '{print $1}')
 fi
+PROXY_USER=${PROXY_USER:-pxfuser}
 PXF_CONF_DIR=~gpadmin/pxf
 INSTALL_GPHDFS=${INSTALL_GPHDFS:-true}
 
@@ -88,8 +89,9 @@ function create_pxf_installer_scripts() {
 		    # required for recursive directories tests
 		    cp "\$PXF_CONF/templates/mapred-site.xml" "\$PXF_CONF/servers/default/mapred1-site.xml"
 		  else
-		    cp \$PXF_CONF/templates/{hdfs,mapred,yarn,core,hbase,hive}-site.xml "\$PXF_CONF/servers/default"
+		    cp \$PXF_CONF/templates/{hdfs,mapred,yarn,core,hbase,hive,pxf}-site.xml "\$PXF_CONF/servers/default"
 		    sed -i -e 's/\(0.0.0.0\|localhost\|127.0.0.1\)/${HADOOP_IP}/g' \$PXF_CONF/servers/default/*-site.xml
+		    sed -i -e 's|\${user.name}|${PROXY_USER}|g' \$PXF_CONF/servers/default/pxf-site.xml
 		  fi
 		  setup_pxf_env
 		}

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -4,6 +4,7 @@ GPHOME=/usr/local/greenplum-db-devel
 PXF_HOME=${GPHOME}/pxf
 MDD_VALUE=/data/gpdata/master/gpseg-1
 PXF_COMMON_SRC_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROXY_USER=${PROXY_USER:-pxfuser}
 
 # on purpose do not call this PXF_CONF so that it is not set during pxf operations
 PXF_CONF_DIR=~gpadmin/pxf
@@ -319,6 +320,9 @@ function init_and_configure_pxf_server() {
 	if [[ ! ${IMPERSONATION} == true ]]; then
 		echo 'Impersonation is disabled, updating pxf-env.sh property'
 		su gpadmin -c "echo 'export PXF_USER_IMPERSONATION=false' >> ${PXF_CONF_DIR}/conf/pxf-env.sh"
+	else
+		cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
+		sed -i -e "s|\${user.name}|${PROXY_USER}|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 	fi
 
 	# update runtime JDK value based on CI parameter

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -5,6 +5,7 @@ PXF_HOME=${GPHOME}/pxf
 MDD_VALUE=/data/gpdata/master/gpseg-1
 PXF_COMMON_SRC_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROXY_USER=${PROXY_USER:-pxfuser}
+PROTOCOL=${PROTOCOL:-}
 
 # on purpose do not call this PXF_CONF so that it is not set during pxf operations
 PXF_CONF_DIR=~gpadmin/pxf
@@ -201,11 +202,11 @@ function setup_impersonation() {
 		echo 'Impersonation is enabled, adding support for gpadmin proxy user'
 		cat > proxy-config.xml <<-EOF
 			<property>
-			  <name>hadoop.proxyuser.pxfuser.hosts</name>
+			  <name>hadoop.proxyuser.${PROXY_USER}.hosts</name>
 			  <value>*</value>
 			</property>
 			<property>
-			  <name>hadoop.proxyuser.pxfuser.groups</name>
+			  <name>hadoop.proxyuser.${PROXY_USER}.groups</name>
 			  <value>*</value>
 			</property>
 			<property>
@@ -320,7 +321,10 @@ function init_and_configure_pxf_server() {
 	if [[ ! ${IMPERSONATION} == true ]]; then
 		echo 'Impersonation is disabled, updating pxf-env.sh property'
 		su gpadmin -c "echo 'export PXF_USER_IMPERSONATION=false' >> ${PXF_CONF_DIR}/conf/pxf-env.sh"
-	else
+	elif [[ -z ${PROTOCOL} ]]; then
+		# Copy pxf-site.xml to the server configuration and update the
+		# pxf.service.user.name property value to use the PROXY_USER
+		# Only copy this file when testing against non-cloud
 		cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 		sed -i -e "s|\${user.name}|${PROXY_USER}|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 	fi

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -200,11 +200,11 @@ function setup_impersonation() {
 		echo 'Impersonation is enabled, adding support for gpadmin proxy user'
 		cat > proxy-config.xml <<-EOF
 			<property>
-			  <name>hadoop.proxyuser.gpadmin.hosts</name>
+			  <name>hadoop.proxyuser.pxfuser.hosts</name>
 			  <value>*</value>
 			</property>
 			<property>
-			  <name>hadoop.proxyuser.gpadmin.groups</name>
+			  <name>hadoop.proxyuser.pxfuser.groups</name>
 			  <value>*</value>
 			</property>
 			<property>

--- a/concourse/scripts/test_pxf_multinode.bash
+++ b/concourse/scripts/test_pxf_multinode.bash
@@ -10,6 +10,7 @@ SSH_OPTS=(-i cluster_env_files/private_key.pem -o 'StrictHostKeyChecking=no')
 HADOOP_SSH_OPTS=(-o 'StrictHostKeyChecking=no')
 
 LOCAL_GPHD_ROOT=/singlecluster
+PROXY_USER=${PROXY_USER:-pxfuser}
 
 function configure_local_hdfs() {
 	sed -i -e "s|hdfs://0.0.0.0:8020|hdfs://${HADOOP_HOSTNAME}:8020|" \
@@ -243,8 +244,9 @@ function run_pxf_automation() {
 				${PXF_CONF_DIR}/servers/db-hive-non-secure/jdbc-site.xml &&
 			cp ~gpadmin/hive-report.sql ${PXF_CONF_DIR}/servers/db-hive-non-secure &&
 			mkdir -p ${PXF_CONF_DIR}/servers/hdfs-non-secure &&
-			cp ${PXF_CONF_DIR}/templates/{hdfs,mapred,yarn,core,hbase,hive}-site.xml ${PXF_CONF_DIR}/servers/hdfs-non-secure &&
+			cp ${PXF_CONF_DIR}/templates/{hdfs,mapred,yarn,core,hbase,hive,pxf}-site.xml ${PXF_CONF_DIR}/servers/hdfs-non-secure &&
 			sed -i -e 's/\(0.0.0.0\|localhost\|127.0.0.1\)/${NON_SECURE_HADOOP_IP}/g' ${PXF_CONF_DIR}/servers/hdfs-non-secure/*-site.xml &&
+			sed -i -e 's|\${user.name}|${PROXY_USER}|g' ${PXF_CONF_DIR}/servers/hdfs-non-secure/pxf-site.xml &&
 			${GPHOME}/pxf/bin/pxf cluster sync
 		"
 		sed -i "s/>non-secure-hadoop</>${NON_SECURE_HADOOP_IP}</g" "$multiNodesCluster"

--- a/concourse/scripts/test_pxf_secure.bash
+++ b/concourse/scripts/test_pxf_secure.bash
@@ -151,6 +151,9 @@ function _main() {
 	configure_pxf_default_server
 	secure_pxf
 
+	# clean up pxf-site.xml
+	rm "${PXF_CONF_DIR}/servers/default/pxf-site.xml"
+
 	create_gpdb_cluster
 	add_remote_user_access_for_gpdb testuser
 	start_pxf_server

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
@@ -122,7 +122,8 @@ public class SecureLogin {
                         // Remote user specified in config file, or defaults to user running pxf service
                         String remoteUser = configuration.get(CONFIG_KEY_SERVICE_USER_NAME, System.getProperty("user.name"));
 
-                        loginSession = new LoginSession(configDirectory, null, null, UserGroupInformation.createRemoteUser(remoteUser), null, 0L);
+                        UserGroupInformation loginUser = UserGroupInformation.createRemoteUser(remoteUser);
+                        loginSession = new LoginSession(configDirectory, null, null, loginUser, null, 0L);
                     }
                     loginMap.put(serverName, loginSession);
                 }
@@ -208,8 +209,8 @@ public class SecureLogin {
         if (currentSession == null)
             return null;
 
-        long kerberosMinMillisBeforeReloginkerberosMinMillisBeforeRelogin =
-                PxfUserGroupInformation.getKerberosMinMillisBeforeRelogin(serverName, configuration);
+        long kerberosMinMillisBeforeReloginkerberosMinMillisBeforeRelogin = Utilities.isSecurityEnabled(configuration) ?
+                PxfUserGroupInformation.getKerberosMinMillisBeforeRelogin(serverName, configuration) : 0L;
         LoginSession expectedLoginSession = new LoginSession(
                 configDirectory,
                 SecureLogin.getServicePrincipal(serverName, configuration),

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
@@ -209,13 +209,13 @@ public class SecureLogin {
         if (currentSession == null)
             return null;
 
-        long kerberosMinMillisBeforeReloginkerberosMinMillisBeforeRelogin = Utilities.isSecurityEnabled(configuration) ?
+        long kerberosMinMillisBeforeRelogin = Utilities.isSecurityEnabled(configuration) ?
                 PxfUserGroupInformation.getKerberosMinMillisBeforeRelogin(serverName, configuration) : 0L;
         LoginSession expectedLoginSession = new LoginSession(
                 configDirectory,
                 SecureLogin.getServicePrincipal(serverName, configuration),
                 SecureLogin.getServiceKeytab(serverName, configuration),
-                kerberosMinMillisBeforeReloginkerberosMinMillisBeforeRelogin);
+                kerberosMinMillisBeforeRelogin);
         if (!currentSession.equals(expectedLoginSession)) {
             LOG.warn("LoginSession has changed for server {} : existing {} expected {}", serverName, currentSession, expectedLoginSession);
             return null;

--- a/server/pxf-service/src/templates/user/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/user/templates/pxf-site.xml
@@ -12,7 +12,7 @@
     </property>
     <property>
         <name>pxf.service.user.name</name>
-        <value>${user}</value>
+        <value>${user.name}</value>
         <description>Login user for remote system, defaults to the OS user that started PXF process</description>
     </property>
     <property>


### PR DESCRIPTION
Allow users to set the `pxf.service.user.name` property to define
the hadoop login user on a per server basis. By default, hadoop
will use the OS user name.

PXF provides a template `$PXF_CONF/templates/pxf-site.xml`.
To configure the `pxf.service.user.name` property follow these
steps:

1. Copy the pxf-site.xml template to your non-secure hadoop
server configuration

        cp $PXF_CONF/templates/pxf-site.xml $PXF_CONF/servers/non-secure-hadoop-server

2. Edit $PXF_CONF/servers/non-secure-hadoop-server-configuration/pxf-site.xml
by replacing the value for the `pxf.service.user.name` property
to your hadoop user.