### PR TITLE
Fix regression in *:text:multi profiles when using wildcards

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/cloud/S3SelectTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/cloud/S3SelectTest.java
@@ -108,7 +108,7 @@ public class S3SelectTest extends BaseFeature {
     public void testCsvWithHeadersUsingHeaderInfoWithWrongColumnNames() throws Exception {
         String[] userParameters = {"FILE_HEADER=USE", "S3_SELECT=ON"};
         runTestScenario("errors.", "csv_use_headers_with_wrong_col_names", "s3", "csv", s3Path,
-                localDataResourcesFolder + "/s3select/", sampleCsvFile,
+                localDataResourcesFolder + "/s3select/", sampleCsvFile, "/" + s3Path + sampleCsvFile,
                 "|", userParameters, PXF_S3_SELECT_INVALID_COLS);
     }
 
@@ -145,6 +145,14 @@ public class S3SelectTest extends BaseFeature {
     }
 
     @Test(groups = {"gpdb", "s3", "pushdown"})
+    public void testParquetWildcardLocation() throws Exception {
+        String[] userParameters = {"S3_SELECT=ON"};
+        runTestScenario("", "parquet", "s3", "parquet", s3Path,
+                localDataResourcesFolder + "/s3select/", sampleParquetFile, "/" + s3Path + "*e.parquet",
+                null, userParameters, PXF_S3_SELECT_COLS);
+    }
+
+    @Test(groups = {"gpdb", "s3", "pushdown"})
     public void testSnappyParquet() throws Exception {
         String[] userParameters = {"S3_SELECT=ON"};
         runTestScenario("parquet_snappy", "s3", "parquet", s3Path,
@@ -178,6 +186,7 @@ public class S3SelectTest extends BaseFeature {
                 s3Path,
                 srcPath,
                 filename,
+                "/" + s3Path + filename,
                 delimiter,
                 userParameters,
                 PXF_S3_SELECT_COLS);
@@ -191,6 +200,7 @@ public class S3SelectTest extends BaseFeature {
             String s3Path,
             String srcPath,
             String filename,
+            String locationPath,
             String delimiter,
             String[] userParameters,
             String[] fields)
@@ -201,7 +211,7 @@ public class S3SelectTest extends BaseFeature {
 
         s3Server.copyFromLocal(srcPath + filename, PROTOCOL_S3 + s3Path + filename);
 
-        exTable = new ReadableExternalTable(tableName, fields, "/" + s3Path + filename, "CSV");
+        exTable = new ReadableExternalTable(tableName, fields, locationPath, "CSV");
         exTable.setProfile("s3:" + format);
         exTable.setServer(serverParam);
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/FileAsRowTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/FileAsRowTest.java
@@ -96,6 +96,18 @@ public class FileAsRowTest extends BaseFeature {
                 hdfsBasePath + "multi/", hdfsBasePath + "multi/*line", srcPaths);
     }
 
+    @Test(groups = {"gpdb", "hcfs", "security"})
+    public void testMultilineWithDirectoryWildcardPathLocation() throws Exception {
+        String hdfsBasePath = hdfs.getWorkingDirectory() + "/file_as_row/";
+        String[] srcPaths = {
+                localDataResourcesFolder + "/text/" + multiLineTextFile,
+                localDataResourcesFolder + "/text/" + singleLineTextFile,
+                localDataResourcesFolder + "/text/" + twoLineTextFile};
+
+        runTestScenario("multi_files", PXF_MULTILINE_COLS,
+                hdfsBasePath + "multi/", hdfsBasePath + "m*ti/*line", srcPaths);
+    }
+
     private void runTestScenario(String name, String[] fields, String hdfsPath, String[] srcPaths) throws Exception {
         runTestScenario(name, fields, hdfsPath, hdfsPath, srcPaths);
     }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/FileAsRowTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/FileAsRowTest.java
@@ -19,8 +19,9 @@ public class FileAsRowTest extends BaseFeature {
 
     private static final String[] PXF_MULTILINE_COLS = {"text_blob text"};
 
-    @AfterClass
-    protected void cleanupData() throws Exception {
+    @Override
+    protected void afterClass() throws Exception {
+        super.afterClass();
         hdfs.removeDirectory(hdfs.getWorkingDirectory() + "/file_as_row/");
     }
 
@@ -80,11 +81,26 @@ public class FileAsRowTest extends BaseFeature {
                 localDataResourcesFolder + "/text/" + twoLineTextFile};
 
         runTestScenario("multi_files", PXF_MULTILINE_COLS,
-                hdfsBasePath + "foo/", srcPaths);
+                hdfsBasePath + "multi/", srcPaths);
     }
 
-    private void runTestScenario(String name, String[] fields,
-                                 String hdfsPath, String[] srcPaths) throws Exception {
+    @Test(groups = {"gpdb", "hcfs", "security"})
+    public void testMultilineWithDirectoryWildcardLocation() throws Exception {
+        String hdfsBasePath = hdfs.getWorkingDirectory() + "/file_as_row/";
+        String[] srcPaths = {
+                localDataResourcesFolder + "/text/" + multiLineTextFile,
+                localDataResourcesFolder + "/text/" + singleLineTextFile,
+                localDataResourcesFolder + "/text/" + twoLineTextFile};
+
+        runTestScenario("multi_files", PXF_MULTILINE_COLS,
+                hdfsBasePath + "multi/", hdfsBasePath + "multi/*line", srcPaths);
+    }
+
+    private void runTestScenario(String name, String[] fields, String hdfsPath, String[] srcPaths) throws Exception {
+        runTestScenario(name, fields, hdfsPath, hdfsPath, srcPaths);
+    }
+
+    private void runTestScenario(String name, String[] fields, String hdfsPath, String locationPath, String[] srcPaths) throws Exception {
 
         if (srcPaths != null) {
             for (String srcPath : srcPaths) {
@@ -99,7 +115,7 @@ public class FileAsRowTest extends BaseFeature {
         }
 
         String tableName = "file_as_row_" + name;
-        exTable = new ReadableExternalTable(tableName, fields, hdfsPath, "CSV");
+        exTable = new ReadableExternalTable(tableName, fields, locationPath, "CSV");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":text:multi");
         exTable.setUserParameters(new String[]{"FILE_AS_ROW=true"});
         gpdb.createTableAndVerify(exTable);

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -1,12 +1,12 @@
 package org.greenplum.pxf.plugins.hdfs;
 
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 import org.greenplum.pxf.api.model.Fragment;
 import org.greenplum.pxf.plugins.hdfs.utilities.HdfsUtilities;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
@@ -18,6 +18,18 @@ import java.util.List;
  */
 public class HdfsFileFragmenter extends HdfsDataFragmenter {
 
+    // The hostname is no longer used, hardcoding it to localhost
+    private static final String[] HOSTS = {"localhost"};
+    private static byte[] DUMMY_METADATA;
+
+    static {
+        try {
+            DUMMY_METADATA = HdfsUtilities.prepareFragmentMetadata(0, 0, HOSTS);
+        } catch (IOException ignored) {
+            // Should not fail
+        }
+    }
+
     /**
      * Gets the fragments for a data source URI that can appear as a file name,
      * a directory name or a wildcard. Returns the data fragments in JSON
@@ -27,23 +39,36 @@ public class HdfsFileFragmenter extends HdfsDataFragmenter {
     public List<Fragment> getFragments() throws Exception {
         String fileName = hcfsType.getDataUri(jobConf, context);
         Path path = new Path(fileName);
-        // The hostname is no longer used, hardcoding it to localhost
-        String[] hosts = {"localhost"};
-        byte[] dummyMetadata = HdfsUtilities
-                .prepareFragmentMetadata(0, 0, hosts);
 
         FileSystem fs = FileSystem.get(URI.create(fileName), configuration);
-        RemoteIterator<LocatedFileStatus> fileStatusListIterator =
-                fs.listFiles(path, false);
+        FileStatus[] fileStatusList = fs.globStatus(path);
 
-        while (fileStatusListIterator.hasNext()) {
-            LocatedFileStatus fileStatus = fileStatusListIterator.next();
-            String sourceName = fileStatus.getPath().toUri().toString();
-            Fragment fragment = new Fragment(sourceName, hosts, dummyMetadata);
-            fragments.add(fragment);
+        for (FileStatus fileStatus : fileStatusList) {
+            listFragments(fs, fileStatus.getPath());
         }
         LOG.debug("Total number of fragments = {}", fragments.size());
 
         return fragments;
+    }
+
+    /**
+     * List fragments recursively, if a directory is found, recursively
+     * list the files
+     *
+     * @param fs   the filesystem
+     * @param path the path to list
+     * @throws IOException for any IO error
+     */
+    private void listFragments(FileSystem fs, Path path) throws IOException {
+        FileStatus[] fileStatusList = fs.listStatus(path);
+        for (FileStatus fileStatus : fileStatusList) {
+            if (fileStatus.isDirectory()) {
+                listFragments(fs, fileStatus.getPath());
+            } else {
+                String sourceName = fileStatus.getPath().toUri().toString();
+                Fragment fragment = new Fragment(sourceName, HOSTS, DUMMY_METADATA);
+                fragments.add(fragment);
+            }
+        }
     }
 }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -44,7 +44,7 @@ public class HdfsFileFragmenter extends HdfsDataFragmenter {
         FileStatus[] fileStatusList = fs.globStatus(path);
 
         for (FileStatus fileStatus : fileStatusList) {
-            listFragments(fs, fileStatus.getPath());
+            listFragments(fs, fileStatus.getPath(), 0);
         }
         LOG.debug("Total number of fragments = {}", fragments.size());
 
@@ -55,15 +55,21 @@ public class HdfsFileFragmenter extends HdfsDataFragmenter {
      * List fragments recursively, if a directory is found, recursively
      * list the files
      *
-     * @param fs   the filesystem
-     * @param path the path to list
+     * @param fs    the filesystem
+     * @param path  the path to list
+     * @param depth recursion depth
      * @throws IOException for any IO error
      */
-    private void listFragments(FileSystem fs, Path path) throws IOException {
+    private void listFragments(FileSystem fs, Path path, int depth) throws IOException {
+
+        if (depth >= 32) {
+            throw new IOException("Exceeded depth for recursion");
+        }
+
         FileStatus[] fileStatusList = fs.listStatus(path);
         for (FileStatus fileStatus : fileStatusList) {
             if (fileStatus.isDirectory()) {
-                listFragments(fs, fileStatus.getPath());
+                listFragments(fs, fileStatus.getPath(), depth + 1);
             } else {
                 String sourceName = fileStatus.getPath().toUri().toString();
                 Fragment fragment = new Fragment(sourceName, HOSTS, DUMMY_METADATA);

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
@@ -7,13 +7,9 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
-/**
- * Test the HdfsFileFragmenter
- */
-public class HdfsFileFragmenterTest {
+public class HdfsDataFragmenterTest {
 
     @Test
     public void testFragmenterReturnsListOfFiles() throws Exception {
@@ -24,12 +20,13 @@ public class HdfsFileFragmenterTest {
         context.setProfileScheme("localfile");
         context.setDataSource(path);
 
-        Fragmenter fragmenter = new HdfsFileFragmenter();
+        Fragmenter fragmenter = new HdfsDataFragmenter();
         fragmenter.initialize(context);
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        assertEquals(4, fragmentList.size());
+        // empty.csv gets ignored
+        assertEquals(3, fragmentList.size());
     }
 
     @Test
@@ -41,11 +38,12 @@ public class HdfsFileFragmenterTest {
         context.setProfileScheme("localfile");
         context.setDataSource(path + "*.csv");
 
-        Fragmenter fragmenter = new HdfsFileFragmenter();
+        Fragmenter fragmenter = new HdfsDataFragmenter();
         fragmenter.initialize(context);
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        assertEquals(4, fragmentList.size());
+        // empty.csv gets ignored
+        assertEquals(3, fragmentList.size());
     }
 }


### PR DESCRIPTION
The HdfsFileFragmenter did not support wildcards and it caused
regressions in *:text:multi profiles because the HdfsFileFragmenter was
used for this profiles in favor of HdfsDataFragmenter.

Also, when using S3 Select, wildcards were not supported in the location
path of the create external table definition.