### PR TITLE
Allow configurable PGPORT

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -49,7 +49,11 @@ ifeq "$(JDBC_HOST)" ""
 	JDBC_HOST=localhost
 endif
 ifeq "$(JDBC_PORT)" ""
-	JDBC_PORT=15432
+	ifeq "$(PGPORT)" ""
+		JDBC_PORT=15432
+	else
+		JDBC_PORT=$(PGPORT)
+	endif
 endif
 
 ifeq "$(HIVE_SERVER_HOST)" ""

--- a/concourse/deploy
+++ b/concourse/deploy
@@ -89,7 +89,7 @@ def how_to_use_generated_pipeline_message():
             cmd += '    -v gcs-bucket-resources-prod=pivotal-gpdb-concourse-resources-prod\\\n'
     if ARGS.compile_gpdb:
         cmd += '    -v configure_flags=--enable-cassert -v gpaddon-git-branch=master \\\n'
-    cmd += '    -v gpdb-branch=' + ARGS.actual_gpdb_branch
+    cmd += '    -v gpdb-branch=' + ARGS.actual_gpdb_branch + ' -v pgport=' + ARGS.PGPORT
     if ARGS.pipeline_name:
         cmd += '    -p ' + ARGS.pipeline_name
     else:
@@ -175,6 +175,7 @@ if __name__ == "__main__":
     default_output_filename = "pxf_pipeline-generated.yml"
     PARSER = build_parser(default_output_filename)
     ARGS = PARSER.parse_args()
+    ARGS.PGPORT = '15432'
 
     if ARGS.gpdb_branch == '5x':
         ARGS.gpdb_branch = '5X_STABLE'
@@ -184,6 +185,7 @@ if __name__ == "__main__":
         ARGS.ICW_GREEN_BUCKET = 'gpdb5-assert-concourse-builds'
     elif ARGS.gpdb_branch == 'master':
         ARGS.ICW_GREEN_BUCKET = 'gpdb5-assert-concourse-builds'
+        ARGS.PGPORT = '7000'
     else:
         sys.stderr.write('error: Only master, 6x and 5x branches are supported for GPDB.'
                          'Include --compile_gpdb flag if you intend to compile GPDB from a different branch.\n')

--- a/concourse/pipelines/pxf_pr_pipeline.yml
+++ b/concourse/pipelines/pxf_pr_pipeline.yml
@@ -4,7 +4,7 @@ resource_types:
 - name: pull-request
   type: docker-image
   source:
-    repository: jtarchie/pr
+    repository: teliaoss/github-pr-resource
 
 resources:
 
@@ -17,7 +17,7 @@ resources:
 - name: pxf_src
   type: pull-request
   source:
-    repo: greenplum-db/pxf
+    repository: greenplum-db/pxf
     access_token: {{pxf-bot-access-token}}
 
 - name: gpdb-pxf-dev-centos6
@@ -100,11 +100,12 @@ jobs:
       - name: gpdb_src
       - name: pxf_src
       params:
+        GROUP: smoke,proxy
+        HADOOP_CLIENT: HDP
         IMPERSONATION: true
+        PGPORT: 7000
         TARGET_OS: centos
         TARGET_OS_VERSION: 6
-        HADOOP_CLIENT: HDP
-        GROUP: smoke,proxy
       run:
         path: pxf_src/concourse/scripts/test_pxf.bash
     timeout: 2h

--- a/concourse/pipelines/pxf_pr_pipeline.yml
+++ b/concourse/pipelines/pxf_pr_pipeline.yml
@@ -41,13 +41,13 @@ jobs:
     params:
       path: pxf_src
       status: failure
-      context: $BUILD_JOB_NAME
+      context: compile_pxf
   on_success:
     put: pxf_src
     params:
       path: pxf_src
       status: success
-      context: $BUILD_JOB_NAME
+      context: compile_pxf
   plan:
   - get: pxf_src
     trigger: true
@@ -55,7 +55,7 @@ jobs:
     params:
       path: pxf_src
       status: pending
-      context: $BUILD_JOB_NAME
+      context: compile_pxf
   - in_parallel:
     - get: gpdb_src
     - get: gpdb-pxf-dev-centos6
@@ -70,13 +70,13 @@ jobs:
     params:
       path: pxf_src
       status: failure
-      context: $BUILD_JOB_NAME
+      context: test_pxf
   on_success:
     put: pxf_src
     params:
       path: pxf_src
       status: success
-      context: $BUILD_JOB_NAME
+      context: test_pxf
   plan:
   - get: pxf_src
     passed:
@@ -86,7 +86,7 @@ jobs:
     params:
       path: pxf_src
       status: pending
-      context: $BUILD_JOB_NAME
+      context: test_pxf
   - in_parallel:
     - get: gpdb_src
       passed:

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -574,12 +574,13 @@ jobs:
     image: gpdb-pxf-dev-centos6-hdp2-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       GROUP: gpdb,proxy,profile
-      TEST_ENV: {{test-env}}
       HADOOP_CLIENT: HDP
+      PGPORT: {{pgport}}
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: centos
       TARGET_OS_VERSION: 6
+      TEST_ENV: {{test-env}}
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -615,10 +616,11 @@ jobs:
     image: gpdb-pxf-dev-centos6-mapr-image
     params:
       GROUP: hcfs,jdbc
-      TEST_ENV: {{test-env}}
       HADOOP_CLIENT: MAPR
+      PGPORT: {{pgport}}
       TARGET_OS: centos
       TARGET_OS_VERSION: 6
+      TEST_ENV: {{test-env}}
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -656,12 +658,13 @@ jobs:
     image: gpdb-pxf-dev-centos7-hdp3-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       GROUP: gpdb,proxy,profile
-      TEST_ENV: {{test-env}}
       HADOOP_CLIENT: HDP
+      PGPORT: {{pgport}}
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: centos
       TARGET_OS_VERSION: 7
+      TEST_ENV: {{test-env}}
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -699,13 +702,14 @@ jobs:
     image: gpdb-pxf-dev-centos7-hdp2-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       GROUP: cloud-access-and-hdfs,hbase,hcfs,jdbc,profile,pushdown
-      TEST_ENV: {{test-env}}
       HADOOP_CLIENT: HDP
+      PGPORT: {{pgport}}
+      RUN_JDK_VERSION: 11
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: centos
       TARGET_OS_VERSION: 7
-      RUN_JDK_VERSION: 11
+      TEST_ENV: {{test-env}}
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -733,13 +737,14 @@ jobs:
     image: gpdb-pxf-dev-ubuntu16-hdp2-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       GROUP: gpdb,proxy,profile
-      TEST_ENV: {{test-env}}
       HADOOP_CLIENT: HDP
+      PGPORT: {{pgport}}
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TEST_OS: ubuntu
       TARGET_OS: ubuntu
       TARGET_OS_VERSION: 16
+      TEST_ENV: {{test-env}}
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -766,13 +771,14 @@ jobs:
     image: gpdb-pxf-dev-ubuntu18-hdp2-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       GROUP: gpdb,proxy,profile
-      TEST_ENV: {{test-env}}
       HADOOP_CLIENT: HDP
-      TEST_OS: ubuntu
+      PGPORT: {{pgport}}
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: ubuntu
       TARGET_OS_VERSION: 18
+      TEST_ENV: {{test-env}}
+      TEST_OS: ubuntu
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -813,6 +819,7 @@ jobs:
       AWS_DEFAULT_REGION: {{aws-region}}
       GROUP: gpdb,proxy
       IMPERSONATION: true
+      PGPORT: {{pgport}}
       TEST_ENV: {{test-env}}
       TARGET_OS: centos
 {% if acceptance %}
@@ -855,6 +862,7 @@ jobs:
       AWS_DEFAULT_REGION: {{aws-region}}
       GROUP: gpdb,proxy
       IMPERSONATION: false
+      PGPORT: {{pgport}}
       TEST_ENV: {{test-env}}
       TARGET_OS: centos
 {% if acceptance %}
@@ -954,10 +962,11 @@ jobs:
     file: pxf_src/concourse/tasks/test_pxf_multinode.yml
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
-      IMPERSONATION: {{enable-impersonation-multinode}}
       GROUP: gpdb,proxy
+      IMPERSONATION: {{enable-impersonation-multinode}}
+      PGPORT: {{pgport}}
       PXF_JVM_OPTS: {{pxf-jvm-opts}}
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: centos
 {% if acceptance %}
       ACCEPTANCE: true
@@ -1101,11 +1110,12 @@ jobs:
     attempts: 2
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       GROUP: gpdb,proxy,profile
-      TEST_ENV: {{test-env}}
-      TARGET_OS: centos
       HADOOP_CLIENT: CDH
+      PGPORT: {{pgport}}
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+      TARGET_OS: centos
+      TEST_ENV: {{test-env}}
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -1139,13 +1149,14 @@ jobs:
     image: gpdb-pxf-dev-centos6-cdh-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       GROUP: hcfs,s3
       IMPERSONATION: false
+      PGPORT: {{pgport}}
       PROTOCOL: s3
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+      TARGET_OS: centos
       TEST_ENV: {{test-env}}
       TEST_OS: centos
-      TARGET_OS: centos
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -1179,13 +1190,14 @@ jobs:
     image: gpdb-pxf-dev-centos6-hdp2-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       GROUP: hcfs,s3
       IMPERSONATION: true
+      PGPORT: {{pgport}}
       PROTOCOL: s3
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+      TARGET_OS: centos
       TEST_ENV: {{test-env}}
       TEST_OS: centos
-      TARGET_OS: centos
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -1221,10 +1233,11 @@ jobs:
     params:
       GROUP: hcfs
       IMPERSONATION: false
+      PGPORT: {{pgport}}
       PROTOCOL: minio
+      TARGET_OS: centos
       TEST_ENV: {{test-env}}
       TEST_OS: centos
-      TARGET_OS: centos
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -1263,10 +1276,11 @@ jobs:
       ADL_REFRESH_URL: {{adl-refresh-url}}
       GROUP: hcfs
       IMPERSONATION: false
+      PGPORT: {{pgport}}
       PROTOCOL: adl
+      TARGET_OS: centos
       TEST_ENV: {{test-env}}
       TEST_OS: centos
-      TARGET_OS: centos
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -1302,10 +1316,11 @@ jobs:
       GOOGLE_CREDENTIALS: {{data-gpdb-ud-google-json-key}}
       GROUP: hcfs
       IMPERSONATION: false
+      PGPORT: {{pgport}}
       PROTOCOL: gs
+      TARGET_OS: centos
       TEST_ENV: {{test-env}}
       TEST_OS: centos
-      TARGET_OS: centos
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}
@@ -1340,8 +1355,9 @@ jobs:
     image: gpdb-pxf-dev-centos6-hdp2-server
     params:
       IMPERSONATION: false
-      TEST_ENV: {{test-env}}
+      PGPORT: {{pgport}}
       TARGET_OS: centos
+      TEST_ENV: {{test-env}}
 {% if acceptance %}
       ACCEPTANCE: true
 {% endif %}

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -16,6 +16,7 @@ export GPHD_ROOT=/singlecluster
 if [[ ${HADOOP_CLIENT} == MAPR ]]; then
 	export GPHD_ROOT=/opt/mapr
 fi
+export PGPORT=${PGPORT:-15432}
 
 function run_pg_regress() {
 	# run desired groups (below we replace commas with spaces in $GROUPS)
@@ -27,7 +28,7 @@ function run_pg_regress() {
 
 		export GPHD_ROOT=${GPHD_ROOT}
 		export PXF_HOME=${PXF_HOME} PXF_CONF=${PXF_CONF_DIR}
-		export PGPORT=15432
+		export PGPORT=${PGPORT}
 		export HCFS_CMD=${GPHD_ROOT}/bin/hdfs
 		export HCFS_PROTOCOL=${PROTOCOL}
 		export HBASE_CMD=${GPHD_ROOT}/bin/hbase
@@ -62,7 +63,7 @@ function run_pxf_automation() {
 
 	su gpadmin -c "
 		source '${GPHOME}/greenplum_path.sh' &&
-		psql -p 15432 -d template1 -c 'CREATE EXTENSION PXF'
+		psql -p ${PGPORT} -d template1 -c 'CREATE EXTENSION PXF'
 	"
 
 	cat > ~gpadmin/run_pxf_automation_test.sh <<-EOF
@@ -73,7 +74,7 @@ function run_pxf_automation() {
 		export PATH=\$PATH:${GPHD_ROOT}/bin
 		export GPHD_ROOT=${GPHD_ROOT}
 		export PXF_HOME=${PXF_HOME}
-		export PGPORT=15432
+		export PGPORT=${PGPORT}
 
 		# JAVA_HOME is from pxf_common.bash
 		export JAVA_HOME=${JAVA_HOME}


### PR DESCRIPTION
In GPDB, a PORT_BASE [was introduced](https://github.com/greenplum-db/gpdb/commit/704d2bdcab3b3ba413abb1aaebbb365e487ca79c)
for demo cluster. In GPDB 7 base port is 7000.

This commit allows pipelines to define a base port for the GPDB cluster and
default to 15432.