### PR TITLE
Improve performance of HdfsFileFragmenter

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/Fragment.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/Fragment.java
@@ -19,26 +19,13 @@ package org.greenplum.pxf.api.model;
  * under the License.
  */
 
-import org.greenplum.pxf.api.utilities.Utilities;
-
-import java.io.IOException;
-
 /**
  * Fragment holds a data fragment' information.
  * {@link Fragmenter#getFragments} returns a list of fragments.
  */
 public class Fragment {
-    // The hostname is no longer used, hardcoding it to localhost
-    private static final String[] HOSTS = {"localhost"};
-    private static byte[] EMPTY_METADATA;
 
-    static {
-        try {
-            EMPTY_METADATA = Utilities.writeBaseFragmentInfo(0, 0, HOSTS).toByteArray();
-        } catch (IOException ignored) {
-            // Should not fail
-        }
-    }
+    private static final String[] HOSTS = new String[]{"localhost"};
 
     /**
      * File path+name, table name, etc.
@@ -76,7 +63,7 @@ public class Fragment {
      * @param sourceName the resource uri (File path+name, table name, etc.)
      */
     public Fragment(String sourceName) {
-        this(sourceName, HOSTS, EMPTY_METADATA);
+        this(sourceName, HOSTS, null);
     }
 
     /**

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/Fragment.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/Fragment.java
@@ -19,11 +19,27 @@ package org.greenplum.pxf.api.model;
  * under the License.
  */
 
+import org.greenplum.pxf.api.utilities.Utilities;
+
+import java.io.IOException;
+
 /**
  * Fragment holds a data fragment' information.
  * {@link Fragmenter#getFragments} returns a list of fragments.
  */
 public class Fragment {
+    // The hostname is no longer used, hardcoding it to localhost
+    private static final String[] HOSTS = {"localhost"};
+    private static byte[] EMPTY_METADATA;
+
+    static {
+        try {
+            EMPTY_METADATA = Utilities.writeBaseFragmentInfo(0, 0, HOSTS).toByteArray();
+        } catch (IOException ignored) {
+            // Should not fail
+        }
+    }
+
     /**
      * File path+name, table name, etc.
      */
@@ -58,8 +74,17 @@ public class Fragment {
      * Constructs a Fragment.
      *
      * @param sourceName the resource uri (File path+name, table name, etc.)
-     * @param hosts the replicas
-     * @param metadata the meta data (Starting point + length, region location, etc.).
+     */
+    public Fragment(String sourceName) {
+        this(sourceName, HOSTS, EMPTY_METADATA);
+    }
+
+    /**
+     * Constructs a Fragment.
+     *
+     * @param sourceName the resource uri (File path+name, table name, etc.)
+     * @param hosts      the replicas
+     * @param metadata   the meta data (Starting point + length, region location, etc.).
      */
     public Fragment(String sourceName,
                     String[] hosts,
@@ -73,9 +98,9 @@ public class Fragment {
      * Constructs a Fragment.
      *
      * @param sourceName the resource uri (File path+name, table name, etc.)
-     * @param hosts the replicas
-     * @param metadata the meta data (Starting point + length, region location, etc.).
-     * @param userData third party data added to a fragment.
+     * @param hosts      the replicas
+     * @param metadata   the meta data (Starting point + length, region location, etc.).
+     * @param userData   third party data added to a fragment.
      */
     public Fragment(String sourceName,
                     String[] hosts,
@@ -88,10 +113,10 @@ public class Fragment {
     }
 
     public Fragment(String sourceName,
-            String[] hosts,
-            byte[] metadata,
-            byte[] userData,
-            String profile) {
+                    String[] hosts,
+                    byte[] metadata,
+                    byte[] userData,
+                    String profile) {
         this(sourceName, hosts, metadata, userData);
         this.profile = profile;
     }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/Utilities.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/Utilities.java
@@ -31,9 +31,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
@@ -262,6 +264,26 @@ public class Utilities {
         } catch (IOException | ClassNotFoundException e) {
             throw new RuntimeException("Exception while reading expected fragment metadata", e);
         }
+    }
+
+    /**
+     * Serializes fragment metadata into a ByteArrayOutputStream
+     *
+     * @param start     the fragment metadata start
+     * @param length    the fragment metadata length
+     * @param locations the data node locations for this split
+     * @return byte serialization of the file split
+     * @throws IOException if I/O errors occur while writing to the underlying
+     *                     stream
+     */
+    public static ByteArrayOutputStream writeBaseFragmentInfo(long start, long length, String[] locations)
+            throws IOException {
+        ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
+        ObjectOutputStream objectStream = new ObjectOutputStream(byteArrayStream);
+        objectStream.writeLong(start);
+        objectStream.writeLong(length);
+        objectStream.writeObject(locations);
+        return byteArrayStream;
     }
 
     /**

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
@@ -87,7 +87,7 @@ public class HdfsDataFragmenter extends BaseFragmenter {
     @Override
     public FragmentStats getFragmentStats() throws Exception {
         String absoluteDataPath = hcfsType.getDataUri(jobConf, context);
-        ArrayList<InputSplit> splits = getSplits(new Path(absoluteDataPath));
+        List<InputSplit> splits = getSplits(new Path(absoluteDataPath));
 
         if (splits.isEmpty()) {
             return new FragmentStats(0, 0, 0);
@@ -100,11 +100,11 @@ public class HdfsDataFragmenter extends BaseFragmenter {
         return new FragmentStats(splits.size(), firstSplit.getLength(), totalSize);
     }
 
-    private ArrayList<InputSplit> getSplits(Path path) throws IOException {
-        PxfInputFormat fformat = new PxfInputFormat();
+    protected List<InputSplit> getSplits(Path path) throws IOException {
+        PxfInputFormat pxfInputFormat = new PxfInputFormat();
         PxfInputFormat.setInputPaths(jobConf, path);
-        InputSplit[] splits = fformat.getSplits(jobConf, 1);
-        ArrayList<InputSplit> result = new ArrayList<>();
+        InputSplit[] splits = pxfInputFormat.getSplits(jobConf, 1);
+        List<InputSplit> result = new ArrayList<>();
 
         /*
          * HD-2547: If the file is empty, an empty split is returned: no

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
@@ -102,7 +102,7 @@ public class HdfsUtilities {
     public static byte[] prepareFragmentMetadata(long start, long length, String[] locations)
             throws IOException {
 
-        ByteArrayOutputStream byteArrayStream = Utilities.writeBaseFragmentInfo(start, length, locations);
+        ByteArrayOutputStream byteArrayStream = writeBaseFragmentInfo(start, length, locations);
         return byteArrayStream.toByteArray();
     }
 
@@ -165,5 +165,25 @@ public class HdfsUtilities {
             delim = delimiter;
         }
         return buff.toString();
+    }
+
+    /**
+     * Serializes fragment metadata into a ByteArrayOutputStream
+     *
+     * @param start     the fragment metadata start
+     * @param length    the fragment metadata length
+     * @param locations the data node locations for this split
+     * @return byte serialization of the file split
+     * @throws IOException if I/O errors occur while writing to the underlying
+     *                     stream
+     */
+    private static ByteArrayOutputStream writeBaseFragmentInfo(long start, long length, String[] locations)
+            throws IOException {
+        ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
+        ObjectOutputStream objectStream = new ObjectOutputStream(byteArrayStream);
+        objectStream.writeLong(start);
+        objectStream.writeLong(length);
+        objectStream.writeObject(locations);
+        return byteArrayStream;
     }
 }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
@@ -88,21 +88,22 @@ public class HdfsUtilities {
         return prepareFragmentMetadata(fsp.getStart(), fsp.getLength(), fsp.getLocations());
     }
 
+    /**
+     * Prepares byte serialization of a file split information (start, length,
+     * hosts) using {@link ObjectOutputStream}.
+     *
+     * @param start     the file split start
+     * @param length    the file split length
+     * @param locations the data node locations for this split
+     * @return byte serialization of the file split
+     * @throws IOException if I/O errors occur while writing to the underlying
+     *                     stream
+     */
     public static byte[] prepareFragmentMetadata(long start, long length, String[] locations)
             throws IOException {
 
-        ByteArrayOutputStream byteArrayStream = writeBaseFragmentInfo(start, length, locations);
+        ByteArrayOutputStream byteArrayStream = Utilities.writeBaseFragmentInfo(start, length, locations);
         return byteArrayStream.toByteArray();
-    }
-
-
-    private static ByteArrayOutputStream writeBaseFragmentInfo(long start, long length, String[] locations) throws IOException {
-        ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
-        ObjectOutputStream objectStream = new ObjectOutputStream(byteArrayStream);
-        objectStream.writeLong(start);
-        objectStream.writeLong(length);
-        objectStream.writeObject(locations);
-        return byteArrayStream;
     }
 
     /**
@@ -165,5 +166,4 @@ public class HdfsUtilities {
         }
         return buff.toString();
     }
-
 }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/PxfInputFormat.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/PxfInputFormat.java
@@ -19,7 +19,7 @@ package org.greenplum.pxf.plugins.hdfs.utilities;
  * under the License.
  */
 
-
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -30,6 +30,8 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
+
+import java.io.IOException;
 
 /**
  * PxfInputFormat is not intended to read a specific format, hence it implements
@@ -45,6 +47,11 @@ public class PxfInputFormat extends FileInputFormat {
                                         JobConf conf,
                                         Reporter reporter) {
         throw new UnsupportedOperationException("PxfInputFormat should not be used for reading data, but only for obtaining the splits of a file");
+    }
+
+    @Override
+    public FileStatus[] listStatus(JobConf job) throws IOException {
+        return super.listStatus(job);
     }
 
     /**

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -1,9 +1,12 @@
 package org.greenplum.pxf.plugins.hdfs;
 
+import org.apache.hadoop.mapred.InvalidInputException;
 import org.greenplum.pxf.api.model.Fragment;
 import org.greenplum.pxf.api.model.Fragmenter;
 import org.greenplum.pxf.api.model.RequestContext;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.List;
 
@@ -14,6 +17,26 @@ import static org.junit.Assert.assertNotNull;
  * Test the HdfsFileFragmenter
  */
 public class HdfsFileFragmenterTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testFragmenterErrorsWhenPathDoesNotExist() throws Exception {
+        expectedException.expect(InvalidInputException.class);
+        expectedException.expectMessage("Input path does not exist:");
+
+        String path = this.getClass().getClassLoader().getResource("csv/").getPath();
+
+        RequestContext context = new RequestContext();
+        context.setConfig("default");
+        context.setProfileScheme("localfile");
+        context.setDataSource(path + "non-existent");
+
+        Fragmenter fragmenter = new HdfsFileFragmenter();
+        fragmenter.initialize(context);
+        fragmenter.getFragments();
+    }
 
     @Test
     public void testFragmenterReturnsListOfFiles() throws Exception {
@@ -29,8 +52,7 @@ public class HdfsFileFragmenterTest {
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        // empty files are not returned
-        assertEquals(3, fragmentList.size());
+        assertEquals(4, fragmentList.size());
     }
 
     @Test
@@ -47,7 +69,6 @@ public class HdfsFileFragmenterTest {
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        // empty files are not returned
-        assertEquals(3, fragmentList.size());
+        assertEquals(4, fragmentList.size());
     }
 }

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -29,7 +29,8 @@ public class HdfsFileFragmenterTest {
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        assertEquals(4, fragmentList.size());
+        // empty files are not returned
+        assertEquals(3, fragmentList.size());
     }
 
     @Test
@@ -46,6 +47,7 @@ public class HdfsFileFragmenterTest {
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        assertEquals(4, fragmentList.size());
+        // empty files are not returned
+        assertEquals(3, fragmentList.size());
     }
 }


### PR DESCRIPTION
While trying the current HdfsFileFragmenter code on a directory with
40K+ files, fs.globStatus(...) was taking over 20 minutes before having
to cancel the query. The new code takes a few seconds to load the
metadata, and allows the query to run to completion.