### PR TITLE
Merge pxf impersonation jdbc

### DIFF
--- a/concourse/scripts/test_pxf_multinode.bash
+++ b/concourse/scripts/test_pxf_multinode.bash
@@ -193,6 +193,7 @@ function run_pxf_automation() {
 				cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/db-hive-kerberos/pxf-site.xml &&
 				sed -i 's|gpadmin/_HOST@EXAMPLE.COM|${HADOOP_2_USER}/_HOST@${REALM2}|g' ${PXF_CONF_DIR}/servers/db-hive-kerberos/pxf-site.xml &&
 				sed -i -e 's|/pxf.service.keytab<|/pxf.service.2.keytab<|g' ${PXF_CONF_DIR}/servers/db-hive-kerberos/pxf-site.xml &&
+				sed -i -e 's|\${pxf.service.user.impersonation.enabled}|false|g' ${PXF_CONF_DIR}/servers/db-hive-kerberos/pxf-site.xml &&
 				sed -i 's|</configuration>|<property><name>hadoop.security.authentication</name><value>kerberos</value></property></configuration>|g' \
 					${PXF_CONF_DIR}/servers/db-hive-kerberos/jdbc-site.xml &&
 				${GPHOME}/pxf/bin/pxf cluster sync

--- a/server/pxf-jdbc/README.md
+++ b/server/pxf-jdbc/README.md
@@ -568,7 +568,7 @@ Follow these steps to enable connectivity to Hive:
             2) enable PXF JDBC impersonation so that PXF will automatically use Greenplum's user name to connect to Hive:
             ```
             <property>
-                <name>pxf.impersonation.jdbc</name>
+                <name>pxf.service.user.impersonation</name>
                 <value>true</value>
             </property>
             ```
@@ -614,7 +614,7 @@ Follow these steps to enable connectivity to Hive:
         3) enable PXF JDBC impersonation in `jdbc-site.xml` so that PXF will automatically use Greenplum's user name to connect to Hive:
             ```
             <property>
-                <name>pxf.impersonation.jdbc</name>
+                <name>pxf.service.user.impersonation</name>
                 <value>true</value>
             </property>
             ```

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -157,6 +157,12 @@ public class JdbcBasePlugin extends BasePlugin {
 
     private ConnectionManager connectionManager;
 
+    static {
+        // Deprecated as of Oct 22, 2019 in version 5.9.2+
+        Configuration.addDeprecation("pxf.impersonation.jdbc",
+                CONFIG_KEY_SERVICE_USER_IMPERSONATION,
+                "The property \"pxf.impersonation.jdbc\" has been deprecated in favor of \"pxf.service.user.impersonation\".");
+    }
 
     /**
      * Creates a new instance with default (singleton) instance of ConnectionManager.

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -78,7 +78,7 @@ public class JdbcBasePlugin extends BasePlugin {
     private static final String FORBIDDEN_SESSION_PROPERTY_CHARACTERS = ";\n\b\0";
     private static final String QUERY_NAME_PREFIX = "query:";
     private static final int QUERY_NAME_PREFIX_LENGTH = QUERY_NAME_PREFIX.length();
-    private static final String PXF_IMPERSONATION_JDBC_PROPERTY_NAME = "pxf.impersonation.jdbc";
+    private static final String PXF_IMPERSONATION_JDBC_PROPERTY_NAME = "pxf.service.user.impersonation";
 
     private static final String HIVE_URL_PREFIX = "jdbc:hive2://";
     private static final String HIVE_DEFAULT_DRIVER_CLASS = "org.apache.hive.jdbc.HiveDriver";

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -23,8 +23,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.greenplum.pxf.api.model.BasePlugin;
 import org.greenplum.pxf.api.model.RequestContext;
-import org.greenplum.pxf.api.utilities.ColumnDescriptor;
 import org.greenplum.pxf.api.security.SecureLogin;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
 import org.greenplum.pxf.api.utilities.Utilities;
 import org.greenplum.pxf.plugins.jdbc.utils.ConnectionManager;
 import org.greenplum.pxf.plugins.jdbc.utils.DbProduct;
@@ -33,9 +33,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.security.PrivilegedExceptionAction;
-import java.sql.*;
-import java.util.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
+
+import static org.greenplum.pxf.api.security.SecureLogin.CONFIG_KEY_SERVICE_USER_IMPERSONATION;
 
 /**
  * JDBC tables plugin (base class)
@@ -78,7 +88,6 @@ public class JdbcBasePlugin extends BasePlugin {
     private static final String FORBIDDEN_SESSION_PROPERTY_CHARACTERS = ";\n\b\0";
     private static final String QUERY_NAME_PREFIX = "query:";
     private static final int QUERY_NAME_PREFIX_LENGTH = QUERY_NAME_PREFIX.length();
-    private static final String PXF_IMPERSONATION_JDBC_PROPERTY_NAME = "pxf.service.user.impersonation";
 
     private static final String HIVE_URL_PREFIX = "jdbc:hive2://";
     private static final String HIVE_DEFAULT_DRIVER_CLASS = "org.apache.hive.jdbc.HiveDriver";
@@ -271,7 +280,7 @@ public class JdbcBasePlugin extends BasePlugin {
 
         // Set optional user parameter, taking into account impersonation setting for the server.
         String jdbcUser = configuration.get(JDBC_USER_PROPERTY_NAME);
-        boolean impersonationEnabledForServer = configuration.getBoolean(PXF_IMPERSONATION_JDBC_PROPERTY_NAME, false);
+        boolean impersonationEnabledForServer = configuration.getBoolean(CONFIG_KEY_SERVICE_USER_IMPERSONATION, false);
         LOG.debug("JDBC impersonation is {}enabled for server {}", impersonationEnabledForServer ? "" : "not ", context.getServerName());
         if (impersonationEnabledForServer) {
             if (Utilities.isSecurityEnabled(configuration) && StringUtils.startsWith(jdbcUrl, HIVE_URL_PREFIX)) {
@@ -280,11 +289,15 @@ public class JdbcBasePlugin extends BasePlugin {
                 LOG.debug("Replaced JDBC URL {} with {}", jdbcUrl, updatedJdbcUrl);
                 jdbcUrl = updatedJdbcUrl;
             } else {
+                // the jdbcUser is the GPDB user
                 jdbcUser = context.getUser();
             }
         }
         if (jdbcUser != null) {
+            LOG.debug("Effective JDBC user {}", jdbcUser);
             connectionConfiguration.setProperty("user", jdbcUser);
+        } else {
+            LOG.debug("JDBC user has not been set");
         }
 
         if (LOG.isDebugEnabled()) {

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTestInitialize.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTestInitialize.java
@@ -440,7 +440,7 @@ public class JdbcBasePluginTestInitialize {
     public void testUserWithImpersonation() throws Exception {
         // Configuration
         Configuration configuration = makeConfiguration();
-        configuration.set("pxf.impersonation.jdbc", "true");
+        configuration.set("pxf.service.user.impersonation", "true");
 
         // Context
         RequestContext context = makeContext();
@@ -462,7 +462,7 @@ public class JdbcBasePluginTestInitialize {
         // Configuration
         Configuration configuration = makeConfiguration();
         configuration.set(CONFIG_USER, "user");
-        configuration.set("pxf.impersonation.jdbc", "true");
+        configuration.set("pxf.service.user.impersonation", "true");
 
         // Context
         RequestContext context = makeContext();
@@ -484,7 +484,7 @@ public class JdbcBasePluginTestInitialize {
         // Configuration
         Configuration configuration = makeConfiguration();
         configuration.set(CONFIG_USER, "user");
-        configuration.set("pxf.impersonation.jdbc", "false");
+        configuration.set("pxf.service.user.impersonation", "false");
 
         // Context
         RequestContext context = makeContext();

--- a/server/pxf-service/src/templates/user/templates/jdbc-site.xml
+++ b/server/pxf-service/src/templates/user/templates/jdbc-site.xml
@@ -114,7 +114,7 @@
     <!--
     <property>
         <name>pxf.service.user.impersonation</name>
-        <value>true</value>
+        <value>${pxf.service.user.impersonation.enabled}</value>
         <description>Impersonate Greenplum user when connecting to the remote database (previously known as pxf.impersonation.jdbc)</description>
     </property>
     -->

--- a/server/pxf-service/src/templates/user/templates/jdbc-site.xml
+++ b/server/pxf-service/src/templates/user/templates/jdbc-site.xml
@@ -114,7 +114,7 @@
     <!--
     <property>
         <name>pxf.service.user.impersonation</name>
-        <value>${pxf.service.user.impersonation.enabled}</value>
+        <value>false</value>
         <description>Impersonate Greenplum user when connecting to the remote database (previously known as pxf.impersonation.jdbc)</description>
     </property>
     -->

--- a/server/pxf-service/src/templates/user/templates/jdbc-site.xml
+++ b/server/pxf-service/src/templates/user/templates/jdbc-site.xml
@@ -113,9 +113,9 @@
 
     <!--
     <property>
-        <name>pxf.impersonation.jdbc</name>
+        <name>pxf.service.user.impersonation</name>
         <value>true</value>
-        <description>Impersonate Greenplum user when connecting to the remote database</description>
+        <description>Impersonate Greenplum user when connecting to the remote database (previously known as pxf.impersonation.jdbc)</description>
     </property>
     -->
 


### PR DESCRIPTION
- Rename pxf.impersonation.jdbc to pxf.service.user.impersonation for JDBC
- Add deprecated property pxf.impersonation.jdbc to the Configuration

Co-authored-by: Alexander Denissov <adenissov@pivotal.io>
Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>