### PR TITLE
Clean up unused imports

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.SequenceFile;
-import org.apache.hadoop.io.SequenceFile.Writer;
 
 import org.greenplum.pxf.automation.components.common.BaseSystemObject;
 import org.greenplum.pxf.automation.fileformats.IAvroSchema;

--- a/automation/src/main/java/org/greenplum/pxf/automation/testplugin/ThrowOn10000Accessor.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/testplugin/ThrowOn10000Accessor.java
@@ -3,7 +3,6 @@ package org.greenplum.pxf.automation.testplugin;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.greenplum.pxf.api.OneRow;
-import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.plugins.hdfs.LineBreakAccessor;
 
 import java.io.IOException;

--- a/automation/src/main/java/org/greenplum/pxf/automation/testplugin/ThrowOn10000Resolver.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/testplugin/ThrowOn10000Resolver.java
@@ -4,7 +4,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.greenplum.pxf.api.OneField;
 import org.greenplum.pxf.api.OneRow;
-import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.plugins.hdfs.StringPassResolver;
 
 import java.util.List;

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hbase/HBaseTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hbase/HBaseTest.java
@@ -1,7 +1,6 @@
 package org.greenplum.pxf.automation.features.hbase;
 
 import org.greenplum.pxf.automation.components.hbase.HBase;
-import org.greenplum.pxf.automation.enums.EnumPxfDefaultProfiles;
 import org.greenplum.pxf.automation.structures.tables.hbase.HBaseTable;
 import org.greenplum.pxf.automation.structures.tables.hbase.LookupTable;
 import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/FileAsRowTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/FileAsRowTest.java
@@ -3,7 +3,6 @@ package org.greenplum.pxf.automation.features.hcfs;
 import org.greenplum.pxf.automation.features.BaseFeature;
 import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**

--- a/automation/tincrepo/main/mpp/common/utilities/ccl/connectivity/jdbc/JDBCCommon.java
+++ b/automation/tincrepo/main/mpp/common/utilities/ccl/connectivity/jdbc/JDBCCommon.java
@@ -1,7 +1,6 @@
 import java.sql.Connection;
 import java.sql.Statement;
 import java.sql.SQLException;
-import java.sql.ResultSet;
 
 public class JDBCCommon
 {

--- a/automation/tincrepo/main/mpp/common/utilities/ccl/connectivity/jdbc/TestJDBCCreateAndDropTable.java
+++ b/automation/tincrepo/main/mpp/common/utilities/ccl/connectivity/jdbc/TestJDBCCreateAndDropTable.java
@@ -1,6 +1,3 @@
-import java.sql.Connection;
-import java.sql.Statement;
-import java.sql.SQLException;
 
 public class TestJDBCCreateAndDropTable
 {

--- a/automation/tincrepo/main/mpp/common/utilities/ccl/connectivity/jdbc/TestJDBCInsertSQL.java
+++ b/automation/tincrepo/main/mpp/common/utilities/ccl/connectivity/jdbc/TestJDBCInsertSQL.java
@@ -1,6 +1,3 @@
-import java.sql.Connection;
-import java.sql.Statement;
-import java.sql.SQLException;
 
 public class TestJDBCInsertSQL
 {

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
@@ -7,7 +7,6 @@ import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.el.MethodNotFoundException;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.DirectoryStream;

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BasePlugin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BasePlugin.java
@@ -19,7 +19,6 @@ package org.greenplum.pxf.api.model;
  * under the License.
  */
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/FragmentStatsTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/FragmentStatsTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 
-import org.greenplum.pxf.api.model.FragmentStats;
 import org.greenplum.pxf.api.model.FragmentStats.SizeUnit;
 import org.junit.Test;
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HcfsType.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HcfsType.java
@@ -2,7 +2,6 @@ package org.greenplum.pxf.plugins.hdfs;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/CodecFactoryTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/CodecFactoryTest.java
@@ -2,7 +2,6 @@ package org.greenplum.pxf.plugins.hdfs;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessorTest.java
@@ -4,8 +4,6 @@ import org.apache.parquet.schema.MessageType;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertNull;
 

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
@@ -28,8 +28,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveRCFileAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveRCFileAccessor.java
@@ -20,7 +20,6 @@ package org.greenplum.pxf.plugins.hive;
  */
 
 
-import org.greenplum.pxf.api.model.RequestContext;
 import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
 import org.apache.hadoop.hive.ql.io.RCFileRecordReader;
 import org.apache.hadoop.mapred.FileSplit;

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/utilities/HiveUtilitiesTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/utilities/HiveUtilitiesTest.java
@@ -23,15 +23,11 @@ package org.greenplum.pxf.plugins.hive.utilities;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import com.google.common.base.Joiner;
 
 import org.greenplum.pxf.api.io.DataType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.hadoop.hive.metastore.api.SerDeInfo;
-import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
-import org.apache.hadoop.hive.serde.serdeConstants;
 import org.junit.Test;
 import org.greenplum.pxf.api.model.Metadata;
 import org.greenplum.pxf.api.UnsupportedTypeException;

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
@@ -20,8 +20,6 @@ package org.greenplum.pxf.service.rest;
  */
 
 import org.apache.catalina.connector.ClientAbortException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.utilities.Utilities;
 import org.greenplum.pxf.service.bridge.Bridge;
@@ -29,7 +27,6 @@ import org.greenplum.pxf.service.HttpRequestParser;
 import org.greenplum.pxf.service.RequestParser;
 import org.greenplum.pxf.service.bridge.BridgeFactory;
 import org.greenplum.pxf.service.bridge.SimpleBridgeFactory;
-import org.greenplum.pxf.service.bridge.WriteBridge;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.Consumes;


### PR DESCRIPTION
I came across this python tool[1] that programatically finds unused
imports.

[1]https://gist.github.com/rodrigosetti/4734557

Authored-by: Oliver Albertini <oalbertini@pivotal.io>