### PR TITLE
Add Support for Kerberized Hive 3

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -141,7 +141,7 @@ sync_jdbc_config:
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_PASSWORD||" $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml; \
 	fi
 	@if [ ! -f $(PXF_CONF_SERVERS)/db-hive/hive-report.sql ]; then \
-		@cp src/test/resources/hive-report.sql $(PXF_CONF_SERVERS)/db-hive; \
+		cp src/test/resources/hive-report.sql $(PXF_CONF_SERVERS)/db-hive; \
 	fi
 
 sync_cloud_configs:

--- a/automation/Makefile
+++ b/automation/Makefile
@@ -110,7 +110,7 @@ dev: symlink_pxf_jars
 
 sync_jdbc_config:
 	@mkdir -p $(PXF_CONF_SERVERS)/database
-	@if [ ! -f "$(PXF_CONF_SERVERS)/database/jdbc-site.xml" ]; then \
+	@if [ ! -f $(PXF_CONF_SERVERS)/database/jdbc-site.xml ]; then \
 		cp $(PXF_HOME)/templates/user/templates/jdbc-site.xml $(PXF_CONF_SERVERS)/database/; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.postgresql.Driver|" $(PXF_CONF_SERVERS)/database/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_URL|jdbc:postgresql://$(JDBC_HOST):$(JDBC_PORT)/pxfautomation|" $(PXF_CONF_SERVERS)/database/jdbc-site.xml; \
@@ -122,7 +122,7 @@ sync_jdbc_config:
 	@cp src/test/resources/report.sql $(PXF_CONF_SERVERS)/database
 
 	@mkdir -p $(PXF_CONF_SERVERS)/db-session-params
-	@if [ ! -f "$(PXF_CONF_SERVERS)/db-session-params/jdbc-site.xml" ]; then \
+	@if [ ! -f $(PXF_CONF_SERVERS)/db-session-params/jdbc-site.xml ]; then \
 		cp $(PXF_HOME)/templates/user/templates/jdbc-site.xml $(PXF_CONF_SERVERS)/db-session-params/; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.postgresql.Driver|" $(PXF_CONF_SERVERS)/db-session-params/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_URL|jdbc:postgresql://$(JDBC_HOST):$(JDBC_PORT)/pxfautomation|" $(PXF_CONF_SERVERS)/db-session-params/jdbc-site.xml; \
@@ -133,14 +133,16 @@ sync_jdbc_config:
 	fi
 
 	@mkdir -p $(PXF_CONF_SERVERS)/db-hive
-	@if [ ! -f "$(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml" ]; then \
+	@if [ ! -f $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml ]; then \
 		cp $(PXF_HOME)/templates/user/templates/jdbc-site.xml $(PXF_CONF_SERVERS)/db-hive/; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.apache.hive.jdbc.HiveDriver|" $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_URL|jdbc:hive2://$(HIVE_SERVER_HOST):$(HIVE_SERVER_PORT)/default|" $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_USER||" $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_PASSWORD||" $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml; \
 	fi
-	@cp src/test/resources/hive-report.sql $(PXF_CONF_SERVERS)/db-hive
+	@if [ ! -f $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml ]; then \
+		@cp src/test/resources/hive-report.sql $(PXF_CONF_SERVERS)/db-hive; \
+	fi
 
 sync_cloud_configs:
 ifneq "$(PROTOCOL)" ""

--- a/automation/Makefile
+++ b/automation/Makefile
@@ -140,7 +140,7 @@ sync_jdbc_config:
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_USER||" $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_PASSWORD||" $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml; \
 	fi
-	@if [ ! -f $(PXF_CONF_SERVERS)/db-hive/jdbc-site.xml ]; then \
+	@if [ ! -f $(PXF_CONF_SERVERS)/db-hive/hive-report.sql ]; then \
 		@cp src/test/resources/hive-report.sql $(PXF_CONF_SERVERS)/db-hive; \
 	fi
 

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/cluster/SingleCluster.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/cluster/SingleCluster.java
@@ -40,7 +40,9 @@ public class SingleCluster extends PhdCluster {
         runCommand("cd " + getPhdRoot());
 
         // set hive base hdfs directory for SC cluster
-        setHiveBaseHdfsDirectory("/hive/warehouse/");
+        if (StringUtils.isEmpty(getHiveBaseHdfsDirectory())) {
+            setHiveBaseHdfsDirectory("/hive/warehouse/");
+        }
     }
 
     @Override

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.SequenceFile;
-import org.apache.hadoop.io.SequenceFile.Writer;
 
 import org.greenplum.pxf.automation.components.common.BaseSystemObject;
 import org.greenplum.pxf.automation.fileformats.IAvroSchema;

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
@@ -201,7 +201,7 @@ public class HiveTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = {"features", "security"})
+    @Test(groups = {"features", "multi-cluster-security"})
     public void testTwoSecuredServers() throws Exception {
 
         Hdfs hdfs2 = (Hdfs) systemManager.

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
@@ -201,7 +201,7 @@ public class HiveTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = {"features", "multi-cluster-security"})
+    @Test(groups = {"features", "multiClusterSecurity"})
     public void testTwoSecuredServers() throws Exception {
 
         Hdfs hdfs2 = (Hdfs) systemManager.

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTextTest.java
@@ -111,7 +111,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "features", "gpdb", "security"})
     public void mismatchedTypes() throws Exception {
 
         // Hive column is SMALLINT, expected GPDB type is SMALLINT(int2), but actual is INTEGER(int4)
@@ -167,7 +167,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "features", "gpdb", "security"})
     public void hiveTextTable() throws Exception {
 
         exTable = TableFactory.getPxfHiveTextReadableTable(HIVE_TEXT_TABLE,
@@ -183,7 +183,7 @@ public class HiveTextTest extends HiveBaseTest {
             gpdb.runQuery(createCmd);
         } catch (Exception e) {
             ExceptionUtils.validate(null, e, new Exception(
-                            "nonstandard use of escape in a string literal"), true,true);
+                    "nonstandard use of escape in a string literal"), true, true);
         }
         Assert.assertTrue("Table " + exTable.getName() + " was not created", gpdb.checkTableExists(exTable));
 
@@ -196,7 +196,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "features", "gpdb", "security"})
     public void severalTextPartitions() throws Exception {
 
         createExternalTable(PXF_HIVE_HETEROGEN_TABLE,
@@ -216,7 +216,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "features", "gpdb", "security"})
     public void severalTextPartitionsNoPartitonColumInGpdb() throws Exception {
 
         hiveTable = new HiveExternalTable(HIVE_REG_HETEROGEN_TABLE, HIVE_RC_COLS);
@@ -247,7 +247,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "features", "gpdb", "security"})
     public void partitionFilterPushDown() throws Exception {
 
         hiveTable = new HiveExternalTable(HIVE_REG_HETEROGEN_TABLE, HIVE_RC_COLS);
@@ -319,12 +319,12 @@ public class HiveTextTest extends HiveBaseTest {
         exTable.setDelimiter("E'\\x01'");
         exTable.setUserParameters(hiveTestFilter(filterString));
         createTable(exTable);
-        gpdb.queryResults(exTable,"SELECT * FROM " + exTable.getName()
-                        + " WHERE t1='row6' AND t2='s_11' AND num1='6' AND dub1='11' ORDER BY fmt, t1");
+        gpdb.queryResults(exTable, "SELECT * FROM " + exTable.getName()
+                + " WHERE t1='row6' AND t2='s_11' AND num1='6' AND dub1='11' ORDER BY fmt, t1");
 
         // Prepare expected data
         Table dataCompareTable = new Table("dataTable", null);
-        dataCompareTable.addRow(new String[] { "row6", "s_11", "6", "11", "rc3", "c" });
+        dataCompareTable.addRow(new String[]{"row6", "s_11", "6", "11", "rc3", "c"});
         ComparisonUtils.compareTables(exTable, dataCompareTable, null);
 
         // Mixed filter with partition and non partition fields, partition filtering: fmt ='rc3'
@@ -332,14 +332,14 @@ public class HiveTextTest extends HiveBaseTest {
         exTable.setDelimiter("E'\\x01'");
         exTable.setUserParameters(hiveTestFilter(filterString));
         createTable(exTable);
-        gpdb.queryResults(exTable,"SELECT * FROM " + exTable.getName()
-                        + " WHERE t1='row6' AND t2='s_11' AND num1='6' AND dub1='11' ORDER BY fmt, t1, prt");
+        gpdb.queryResults(exTable, "SELECT * FROM " + exTable.getName()
+                + " WHERE t1='row6' AND t2='s_11' AND num1='6' AND dub1='11' ORDER BY fmt, t1, prt");
 
         // Prepare expected data
         dataCompareTable = new Table("dataTable", null);
-        dataCompareTable.addRow(new String[] { "row6", "s_11", "6", "11", "rc3", "a" });
-        dataCompareTable.addRow(new String[] { "row6", "s_11", "6", "11", "rc3", "c" });
-        dataCompareTable.addRow(new String[] { "row6", "s_11", "6", "11", "rc3", "f" });
+        dataCompareTable.addRow(new String[]{"row6", "s_11", "6", "11", "rc3", "a"});
+        dataCompareTable.addRow(new String[]{"row6", "s_11", "6", "11", "rc3", "c"});
+        dataCompareTable.addRow(new String[]{"row6", "s_11", "6", "11", "rc3", "f"});
         ComparisonUtils.compareTables(exTable, dataCompareTable, null);
 
         // Mixed filter with partition and non partition fields, partition filtering: part='a'
@@ -347,13 +347,13 @@ public class HiveTextTest extends HiveBaseTest {
         exTable.setDelimiter("E'\\x01'");
         exTable.setUserParameters(hiveTestFilter(filterString));
         createTable(exTable);
-        gpdb.queryResults(exTable,"SELECT * FROM " + exTable.getName()
-                        + " WHERE t1='row5' AND t2='s_10' AND num1='5' AND dub1='10' ORDER BY fmt, t1, prt");
+        gpdb.queryResults(exTable, "SELECT * FROM " + exTable.getName()
+                + " WHERE t1='row5' AND t2='s_10' AND num1='5' AND dub1='10' ORDER BY fmt, t1, prt");
 
         // prepare expected data
         dataCompareTable = new Table("dataTable", null);
-        dataCompareTable.addRow(new String[] { "row5", "s_10", "5", "10", "rc1", "a" });
-        dataCompareTable.addRow(new String[] { "row5", "s_10", "5", "10", "rc3", "a" });
+        dataCompareTable.addRow(new String[]{"row5", "s_10", "5", "10", "rc1", "a"});
+        dataCompareTable.addRow(new String[]{"row5", "s_10", "5", "10", "rc3", "a"});
         ComparisonUtils.compareTables(exTable, dataCompareTable, null);
     }
 
@@ -362,7 +362,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "features", "gpdb", "security"})
     public void filterNonePartitions() throws Exception {
 
         // Create PXF Table using Hive profile
@@ -374,9 +374,9 @@ public class HiveTextTest extends HiveBaseTest {
 
         // prepare expected data
         Table dataCompareTable = new Table("dataTable", null);
-        dataCompareTable.addRow(new String[] { "row6", "s_11", "6", "11", "rc1", "a" });
-        dataCompareTable.addRow(new String[] { "row6", "s_11", "6", "11", "rc2", "b" });
-        dataCompareTable.addRow(new String[] { "row6", "s_11", "6", "11", "rc3", "c" });
+        dataCompareTable.addRow(new String[]{"row6", "s_11", "6", "11", "rc1", "a"});
+        dataCompareTable.addRow(new String[]{"row6", "s_11", "6", "11", "rc2", "b"});
+        dataCompareTable.addRow(new String[]{"row6", "s_11", "6", "11", "rc3", "c"});
 
         ComparisonUtils.compareTables(exTable, dataCompareTable, null);
     }
@@ -386,7 +386,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "features", "gpdb", "security"})
     public void filterBetweenPartitions() throws Exception {
 
         // Create PXF Table using Hive profile
@@ -409,7 +409,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "hcatalog", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "hcatalog", "features", "gpdb", "security"})
     public void hiveTextTableCustomDelimiter() throws Exception {
 
         //hive text table with custom delimiter
@@ -429,7 +429,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "hcatalog", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "hcatalog", "features", "gpdb", "security"})
     public void hiveTextTableOptimizedProfile() throws Exception {
 
         runTincTest("pxf.features.hcatalog.heterogeneous_table_three_text_partitions.runTest");
@@ -440,7 +440,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "hcatalog", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "hcatalog", "features", "gpdb", "security"})
     public void aggregateQueries() throws Exception {
 
         //hive text table with nulls
@@ -462,7 +462,7 @@ public class HiveTextTest extends HiveBaseTest {
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = { "hive", "features", "gpdb", "security" })
+    @Test(groups = {"hive", "features", "gpdb", "security"})
     public void hiveTableWithSkipHeader() throws Exception {
         List<List<String>> tableProperties = new ArrayList<>();
         tableProperties.add(Arrays.asList("skip.header.line.count", "3"));
@@ -490,8 +490,8 @@ public class HiveTextTest extends HiveBaseTest {
         comparisonDataTable.pumpUpTableData(pumpAmount, true);
 
         // extra field to add
-        String[] arr1 = { "rc1", "rc2", "rc3" };
-        String[] arr2 = { "a", "b", "c" };
+        String[] arr1 = {"rc1", "rc2", "rc3"};
+        String[] arr2 = {"a", "b", "c"};
 
         int lastIndex = 0;
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTextTest.java
@@ -81,7 +81,7 @@ public class HiveTextTest extends HiveBaseTest {
         hive.createTableAndVerify(hiveTextPartitionTable);
 
         String tableName = hiveTextPartitionTable.getName();
-        String location = "'hdfs:" + hdfsBaseDir + hiveTextTable.getName() + "'";
+        String location = String.format("'%s%s'", hdfsBaseDir, hiveTextTable.getName());
         addHivePartition(tableName, "fmt = 'rc1'", location);
         addHivePartition(tableName, "fmt = 'rc2'", location);
         addHivePartition(tableName, "fmt = 'rc3'", location);

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcHiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcHiveTest.java
@@ -140,7 +140,7 @@ public class JdbcHiveTest extends BaseFeature {
         runTincTest("pxf.features.jdbc.hive.runTest");
     }
 
-    @Test(groups = {"features", "security"})
+    @Test(groups = {"features", "multi-cluster-security"})
     public void jdbcHiveReadFromTwoSecuredServers() throws Exception {
         // Initialize an additional HDFS system object (optional system object)
         hdfs2 = (Hdfs) systemManager.
@@ -158,7 +158,7 @@ public class JdbcHiveTest extends BaseFeature {
         runTincTest("pxf.features.jdbc.two_secured_hive.runTest");
     }
 
-    @Test(groups = {"features", "security"})
+    @Test(groups = {"features", "multi-cluster-security"})
     public void jdbcHiveReadFromSecureServerAndNonSecuredServer() throws Exception {
         if (hdfsNonSecure == null) return;
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcHiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcHiveTest.java
@@ -140,7 +140,7 @@ public class JdbcHiveTest extends BaseFeature {
         runTincTest("pxf.features.jdbc.hive.runTest");
     }
 
-    @Test(groups = {"features", "multi-cluster-security"})
+    @Test(groups = {"features", "multiClusterSecurity"})
     public void jdbcHiveReadFromTwoSecuredServers() throws Exception {
         // Initialize an additional HDFS system object (optional system object)
         hdfs2 = (Hdfs) systemManager.
@@ -158,7 +158,7 @@ public class JdbcHiveTest extends BaseFeature {
         runTincTest("pxf.features.jdbc.two_secured_hive.runTest");
     }
 
-    @Test(groups = {"features", "multi-cluster-security"})
+    @Test(groups = {"features", "multiClusterSecurity"})
     public void jdbcHiveReadFromSecureServerAndNonSecuredServer() throws Exception {
         if (hdfsNonSecure == null) return;
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
@@ -435,5 +435,4 @@ public class JdbcTest extends BaseFeature {
     public void jdbcNamedQuery() throws Exception {
         runTincTest("pxf.features.jdbc.named_query.runTest");
     }
-
 }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/multiserver/MultiServerTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/multiserver/MultiServerTest.java
@@ -161,17 +161,17 @@ public class MultiServerTest extends BaseFeature {
         runTincTest("pxf.features.multi_server.hdfs_and_cloud.runTest");
     }
 
-    @Test(groups = {"features", "multi-cluster-security"})
+    @Test(groups = {"features", "multiClusterSecurity"})
     public void testTwoSecuredServers() throws Exception {
         runTincTest("pxf.features.multi_server.two_secure_hdfs.runTest");
     }
 
-    @Test(groups = {"features", "multi-cluster-security"})
+    @Test(groups = {"features", "multiClusterSecurity"})
     public void testSecureServerAndNonSecuredServer() throws Exception {
         runTincTest("pxf.features.multi_server.secure_hdfs_and_non_secure_hdfs.runTest");
     }
 
-    @Test(groups = {"features", "multi-cluster-security"})
+    @Test(groups = {"features", "multiClusterSecurity"})
     public void testTwoSecuredServersNonSecureServerAndCloudServer() throws Exception {
         runTincTest("pxf.features.multi_server.test_all.runTest");
     }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/multiserver/MultiServerTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/multiserver/MultiServerTest.java
@@ -161,17 +161,17 @@ public class MultiServerTest extends BaseFeature {
         runTincTest("pxf.features.multi_server.hdfs_and_cloud.runTest");
     }
 
-    @Test(groups = {"features", "security"})
+    @Test(groups = {"features", "multi-cluster-security"})
     public void testTwoSecuredServers() throws Exception {
         runTincTest("pxf.features.multi_server.two_secure_hdfs.runTest");
     }
 
-    @Test(groups = {"features", "security"})
+    @Test(groups = {"features", "multi-cluster-security"})
     public void testSecureServerAndNonSecuredServer() throws Exception {
         runTincTest("pxf.features.multi_server.secure_hdfs_and_non_secure_hdfs.runTest");
     }
 
-    @Test(groups = {"features", "security"})
+    @Test(groups = {"features", "multi-cluster-security"})
     public void testTwoSecuredServersNonSecureServerAndCloudServer() throws Exception {
         runTincTest("pxf.features.multi_server.test_all.runTest");
     }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/security/SecuredServerTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/security/SecuredServerTest.java
@@ -10,7 +10,7 @@ import org.testng.annotations.Test;
  */
 public class SecuredServerTest extends BaseFeature {
 
-    @Test(groups = {"features", "security"})
+    @Test(groups = {"features", "multiClusterSecurity"})
     public void testSecuredServerFailsWithInvalidPrincipalName() throws Exception {
 
         exTable = TableFactory.getPxfReadableTextTable("pxf_secured_invalid_principal", new String[] {
@@ -29,7 +29,7 @@ public class SecuredServerTest extends BaseFeature {
         runTincTest("pxf.features.general.secured.errors.invalid_principal.runTest");
     }
 
-    @Test(groups = {"features", "security"})
+    @Test(groups = {"features", "multiClusterSecurity"})
     public void testSecuredServerFailsWithInvalidKeytabPath() throws Exception {
 
         exTable = TableFactory.getPxfReadableTextTable("pxf_secured_invalid_keytab", new String[] {

--- a/automation/src/test/java/org/greenplum/pxf/automation/proxy/HdfsProxySmokeTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/proxy/HdfsProxySmokeTest.java
@@ -66,7 +66,7 @@ public class HdfsProxySmokeTest extends BaseSmoke {
         runTincTest("pxf.proxy.small_data.runTest");
     }
 
-    @Test(groups = { "proxy", "hdfs", "proxy-security" })
+    @Test(groups = { "proxy", "hdfs", "proxySecurity" })
     public void test() throws Exception {
         runTest();
     }

--- a/automation/src/test/java/org/greenplum/pxf/automation/proxy/HdfsProxySmokeTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/proxy/HdfsProxySmokeTest.java
@@ -66,7 +66,7 @@ public class HdfsProxySmokeTest extends BaseSmoke {
         runTincTest("pxf.proxy.small_data.runTest");
     }
 
-    @Test(groups = { "proxy", "hdfs", "security" })
+    @Test(groups = { "proxy", "hdfs", "proxy-security" })
     public void test() throws Exception {
         runTest();
     }

--- a/automation/src/test/java/org/greenplum/pxf/automation/proxy/HiveProxySmokeTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/proxy/HiveProxySmokeTest.java
@@ -94,7 +94,7 @@ public class HiveProxySmokeTest extends BaseSmoke {
         runTincTest("pxf.proxy.hive_small_data.runTest");
     }
 
-    @Test(groups = { "proxy", "hive", "proxy-security" })
+    @Test(groups = { "proxy", "hive", "proxySecurity" })
     public void test() throws Exception {
         runTest();
     }

--- a/automation/src/test/java/org/greenplum/pxf/automation/proxy/HiveProxySmokeTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/proxy/HiveProxySmokeTest.java
@@ -94,7 +94,7 @@ public class HiveProxySmokeTest extends BaseSmoke {
         runTincTest("pxf.proxy.hive_small_data.runTest");
     }
 
-    @Test(groups = { "proxy", "hive", "security" })
+    @Test(groups = { "proxy", "hive", "proxy-security" })
     public void test() throws Exception {
         runTest();
     }

--- a/automation/src/test/resources/sut/MultiHadoopMultiNodesCluster.xml
+++ b/automation/src/test/resources/sut/MultiHadoopMultiNodesCluster.xml
@@ -46,7 +46,7 @@
         <class>org.greenplum.pxf.automation.components.hdfs.Hdfs</class>
         <host>hadoop</host>
         <port>8020</port>
-        <workingDirectory>tmp/pxf_automation_data</workingDirectory>
+        <workingDirectory>tmp/pxf_automation_data/__UUID__</workingDirectory>
         <haNameservice></haNameservice>
     </hdfs>
     <hdfs2>

--- a/automation/src/test/resources/sut/MultiNodesCluster.xml
+++ b/automation/src/test/resources/sut/MultiNodesCluster.xml
@@ -38,7 +38,7 @@
 		<class>org.greenplum.pxf.automation.components.hdfs.Hdfs</class>
 		<host>hadoop</host>
 		<port>8020</port>
-		<workingDirectory>tmp/pxf_automation_data</workingDirectory>
+		<workingDirectory>tmp/pxf_automation_data/__UUID__</workingDirectory>
 		<haNameservice></haNameservice>
 	</hdfs>
 	<hbase>

--- a/automation/src/test/resources/sut/default.xml
+++ b/automation/src/test/resources/sut/default.xml
@@ -15,7 +15,7 @@
         <class>org.greenplum.pxf.automation.components.hdfs.Hdfs</class>
         <host>localhost</host>
         <port>8020</port>
-        <workingDirectory>tmp/pxf_automation_data</workingDirectory>
+        <workingDirectory>tmp/pxf_automation_data/__UUID__</workingDirectory>
         <scheme>hdfs</scheme>
     </hdfs>
 

--- a/automation/tincrepo/main/pxf/features/general/secured/errors/invalid_keytab/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/general/secured/errors/invalid_keytab/expected/query01.ans
@@ -21,8 +21,8 @@
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/
 --
--- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- m/pxf:\/\/(.*)\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/general/secured/errors/invalid_keytab/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/general/secured/errors/invalid_keytab/sql/query01.sql
@@ -21,8 +21,8 @@
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/
 --
--- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- m/pxf:\/\/(.*)\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/general/secured/errors/invalid_principal/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/general/secured/errors/invalid_principal/expected/query01.ans
@@ -21,8 +21,8 @@
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/
 --
--- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- m/pxf:\/\/(.*)\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/general/secured/errors/invalid_principal/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/general/secured/errors/invalid_principal/sql/query01.sql
@@ -21,8 +21,8 @@
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/
 --
--- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- m/pxf:\/\/(.*)\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/duplicateProfileParametersCheck/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/duplicateProfileParametersCheck/expected/query01.ans
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/duplicateProfileParametersCheck/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/duplicateProfileParametersCheck/sql/query01.sql
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/emptyProfile/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/emptyProfile/expected/query01.ans
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/emptyProfile/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/emptyProfile/sql/query01.sql
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/malformedXmlFile/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/malformedXmlFile/expected/query01.ans
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/malformedXmlFile/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/malformedXmlFile/sql/query01.sql
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/missingPlugin/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/missingPlugin/expected/query01.ans
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/missingPlugin/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/missingPlugin/sql/query01.sql
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/missingProfile/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/missingProfile/expected/query01.ans
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/features/profiles/errors/missingProfile/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/profiles/errors/missingProfile/sql/query01.sql
@@ -22,7 +22,7 @@
 -- s/DETAIL/CONTEXT/
 --
 -- m/pxf:\/\/(.*)\/pxf_automation_data/
--- s/pxf:\/\/.*\/pxf_automation_data/pxf:\/\/pxf_automation_data/
+-- s/pxf:\/\/.*\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/pxf:\/\/pxf_automation_data/
 --
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g

--- a/automation/tincrepo/main/pxf/proxy/small_data/expected/query03.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data/expected/query03.ans
@@ -13,8 +13,8 @@
 -- m/.*inode=.*/
 -- s/inode=.*?:-rwx/inode=SOME_PATH:-rwx/g
 --
--- m/pxf:\/\/(.*)\/pxf_automation_data\/proxy\/([0-9a-zA-Z]).*\/data.txt/
--- s/pxf:\/\/(.*)\/pxf_automation_data\/proxy\/([0-9a-zA-Z]).*\/data.txt/pxf:\/\/pxf_automation_data\/proxy\/OTHER_USER\/data.txt/
+-- m/pxf:\/\/(.*)\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\/proxy\/([0-9a-zA-Z]).*\/data.txt/
+-- s/pxf:\/\/(.*)\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\/proxy\/([0-9a-zA-Z]).*\/data.txt/pxf:\/\/pxf_automation_data\/proxy\/OTHER_USER\/data.txt/
 --
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/

--- a/automation/tincrepo/main/pxf/proxy/small_data/sql/query03.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data/sql/query03.sql
@@ -13,8 +13,8 @@
 -- m/.*inode=.*/
 -- s/inode=.*?:-rwx/inode=SOME_PATH:-rwx/g
 --
--- m/pxf:\/\/(.*)\/pxf_automation_data\/proxy\/([0-9a-zA-Z]).*\/data.txt/
--- s/pxf:\/\/(.*)\/pxf_automation_data\/proxy\/([0-9a-zA-Z]).*\/data.txt/pxf:\/\/pxf_automation_data\/proxy\/OTHER_USER\/data.txt/
+-- m/pxf:\/\/(.*)\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\/proxy\/([0-9a-zA-Z]).*\/data.txt/
+-- s/pxf:\/\/(.*)\/pxf_automation_data\/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\/proxy\/([0-9a-zA-Z]).*\/data.txt/pxf:\/\/pxf_automation_data\/proxy\/OTHER_USER\/data.txt/
 --
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -15,7 +15,7 @@ groups:
       - test_pxf_hdp2_ubuntu18
 {% endif %}
       - test_pxf_hdp2_multinode_gpdb
-      - test_pxf_secure_multinode_gpdb
+      - test_pxf_dataproc_multinode_with_impersonation
       - test_pxf_s3_no_impersonation
       - test_pxf_s3_with_impersonation
       - test_pxf_no_impersonation
@@ -25,6 +25,7 @@ groups:
       - test_pxf_hdp3_centos7
 {% if pipeline_type == "release" %}
       - test_pxf_hdp3_secure_with_impersonation
+      - test_pxf_dataproc_multinode_no_impersonation
       - test_pxf_hdp2_centos6
       - test_pxf_adl
       - test_pxf_gs
@@ -48,11 +49,12 @@ groups:
       - test_pxf_hdp2_ubuntu18
 {% endif %}
       - test_pxf_hdp2_multinode_gpdb
-      - test_pxf_secure_multinode_gpdb
+      - test_pxf_dataproc_multinode_with_impersonation
       - test_pxf_mapr_centos6
       - test_pxf_hdp3_centos7
 {% if pipeline_type == "release" %}
       - test_pxf_hdp2_centos6
+      - test_pxf_dataproc_multinode_no_impersonation
 {% endif %}
 
   - name: cloud
@@ -77,8 +79,9 @@ groups:
 {% endif %}
 {% if pipeline_type == "release" %}
       - test_pxf_hdp3_secure_with_impersonation
+      - test_pxf_dataproc_multinode_no_impersonation
 {% endif %}
-      - test_pxf_secure_multinode_gpdb
+      - test_pxf_dataproc_multinode_with_impersonation
 
   - name: no_impersonation
     jobs:
@@ -961,7 +964,7 @@ jobs:
       ACCEPTANCE: true
 {% endif %}
 
-- name: test_pxf_secure_multinode_gpdb
+- name: test_pxf_dataproc_multinode_with_impersonation
   max_in_flight: 2
   plan:
   - in_parallel:
@@ -1099,6 +1102,145 @@ jobs:
       TARGET_OS: centos
 {% if acceptance %}
       ACCEPTANCE: true
+{% endif %}
+
+{% if pipeline_type == "release" %}
+- name: test_pxf_dataproc_multinode_no_impersonation
+  max_in_flight: 2
+  plan:
+  - in_parallel:
+    - get: ccp_src
+    - get: gpdb_src
+      passed:
+      - compile_pxf
+{% if compile_gpdb %}
+      - compile_gpdb_centos6
+{% endif %}
+    - get: gpdb_binary
+      resource: bin_gpdb_centos6
+{% if compile_gpdb %}
+      passed:
+      - compile_gpdb_centos6
+{% endif %}
+    - get: pxf_src
+      passed:
+      - compile_pxf
+      trigger: true
+    - get: pxf_tarball
+      passed:
+      - compile_pxf
+      trigger: true
+    - get: ccp-7
+    - get: gpdb-pxf-dev-centos6-hdp2-server
+  - in_parallel:
+    - do:
+      - put: terraform_gpdb
+        resource: terraform
+        params:
+          action: create
+          delete_on_failure: true
+          generate_random_name: true
+          terraform_source: ccp_src/google/
+          vars:
+            PLATFORM: centos7
+            number_of_nodes: {{number_of_gpdb_nodes}}
+            extra_nodes: 1
+            segments_per_host: 4
+            instance_type: n1-standard-4
+            ccp_reap_minutes: 120
+      - task: Generate Greenplum Cluster
+        input_mapping:
+          terraform: terraform_gpdb
+        file: ccp_src/ci/tasks/gen_cluster.yml
+        image: ccp-7
+        params:
+          AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+          AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+          AWS_DEFAULT_REGION: {{aws-region}}
+          BUCKET_PATH: {{tf-bucket-path}}
+          BUCKET_NAME: {{tf-bucket-name}}
+          PLATFORM: centos7
+          CLOUD_PROVIDER: google
+      - in_parallel:
+        - task: Initialize Greenplum
+          file: ccp_src/ci/tasks/gpinitsystem.yml
+        - task: Install Hadoop
+          file: pxf_src/concourse/tasks/install_hadoop.yml
+          image: gpdb-pxf-dev-centos6-hdp2-server
+          params:
+            ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+            SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+            IMPERSONATION: {{enable-impersonation-multinode}}
+    {% if pipeline_type == "pxf" %}
+            TARGET_OS: centos
+    {% endif %}
+    - task: Generate Hadoop Cluster 1
+      file: pxf_src/concourse/tasks/install_dataproc.yml
+      image: ccp-7
+      params:
+        GOOGLE_CREDENTIALS: {{google-service-account-key}}
+        GOOGLE_PROJECT_ID: {{google-project-id}}
+        GOOGLE_ZONE: {{google-zone}}
+        IMAGE_VERSION: {{dataproc-image-version}}
+        KERBEROS: {{kerberos-enabled}}
+    - task: Generate Hadoop Cluster 2
+      file: pxf_src/concourse/tasks/install_dataproc.yml
+      image: ccp-7
+      output_mapping:
+        dataproc_env_files: dataproc_2_env_files
+      params:
+        GOOGLE_CREDENTIALS: ((data-gpdb-ud-kerberos-google-service-account-key))
+        GOOGLE_PROJECT_ID: ((data-gpdb-ud-kerberos-google-project-id))
+        GOOGLE_ZONE: ((data-gpdb-ud-kerberos-google-zone))
+        HADOOP_USER: gpuser
+        IMAGE_VERSION: {{dataproc-image-version}}
+        INITIALIZATION_SCRIPT: gs://data-gpdb-ud-kerberos-scripts/scripts/initialization-for-kerberos.sh
+        INSTANCE_TAGS: bosh-network,data-gpdb-ud-access
+        KERBEROS: {{kerberos-enabled}}
+        KEY: dataproc-kerberos-key
+        KEYRING: dataproc-kerberos
+        NO_ADDRESS: false
+        PROXY_USER: gpuser
+        SECRETS_BUCKET: data-gpdb-ud-kerberos-pxf-secrets
+  - task: Setup PXF
+    input_mapping:
+      terraform: terraform_gpdb
+      bin_gpdb: gpdb_binary
+    file: pxf_src/concourse/tasks/install_pxf.yml
+    image: ccp-7
+    params:
+      AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+      AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+      AWS_DEFAULT_REGION: {{aws-region}}
+      BUCKET_PATH: {{tf-bucket-path}}
+      BUCKET_NAME: {{tf-bucket-name}}
+      CLOUD_PROVIDER: google
+      IMPERSONATION: {{enable-impersonation-multinode}}
+      INSTALL_GPHDFS: false
+      KERBEROS: {{kerberos-enabled}}
+      PLATFORM: centos7
+      PXF_JVM_OPTS: {{pxf-jvm-opts}}
+    on_failure:
+      <<: *dataproc_timed_destroy
+  - task: Test PXF Multinode
+    input_mapping:
+      bin_gpdb: gpdb_binary
+    on_success:
+      <<: *dataproc_destroy
+    on_failure:
+      <<: *dataproc_timed_destroy
+    image: gpdb-pxf-dev-centos6-hdp2-server
+    file: pxf_src/concourse/tasks/test_pxf_multinode.yml
+    params:
+      ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
+      HIVE_VERSION: 2
+      IMPERSONATION: false
+      KERBEROS: {{kerberos-enabled}}
+      GOOGLE_PROJECT_ID: {{google-project-id}}
+      GROUP: security,multiClusterSecurity
+      PXF_JVM_OPTS: {{pxf-jvm-opts}}
+      TARGET_OS: centos
 {% endif %}
 
 - name: test_pxf_cdh_centos6
@@ -1403,7 +1545,7 @@ jobs:
     - test_pxf_s3_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
-    - test_pxf_secure_multinode_gpdb
+    - test_pxf_dataproc_multinode_with_impersonation
     trigger: true
   - put: pxf_tarball_stable
     params:
@@ -1433,7 +1575,8 @@ jobs:
     - test_pxf_hdp3_secure_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
-    - test_pxf_secure_multinode_gpdb
+    - test_pxf_dataproc_multinode_with_impersonation
+    - test_pxf_dataproc_multinode_no_impersonation
     trigger: true
   - get: gpdb_release
   - get: pxf_src
@@ -1456,7 +1599,8 @@ jobs:
     - test_pxf_hdp3_secure_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
-    - test_pxf_secure_multinode_gpdb
+    - test_pxf_dataproc_multinode_with_impersonation
+    - test_pxf_dataproc_multinode_no_impersonation
   - task: package_pxf_rc
     config:
       inputs:

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -18,7 +18,7 @@ groups:
       - test_pxf_secure_multinode_gpdb
       - test_pxf_s3_no_impersonation
       - test_pxf_s3_with_impersonation
-      - test_pxf_hdp2_secure_with_impersonation
+      - test_pxf_hdp3_secure_with_impersonation
       - test_pxf_no_impersonation
       - test_pxf_hdp2_multinode_gpdb
       - test_pxf_hdp2_centos7_java11
@@ -29,7 +29,6 @@ groups:
       - test_pxf_adl
       - test_pxf_gs
       - test_pxf_minio
-      - test_pxf_hdp2_secure_no_impersonation
       - build_release_candidate_centos
 {% elif pipeline_type == "pxf" and not acceptance %}
       - promote_pxf_artifact
@@ -76,10 +75,8 @@ groups:
 {% if compile_gpdb %}
       - compile_gpdb_centos6
 {% endif %}
-      - test_pxf_hdp2_secure_with_impersonation
-{% if pipeline_type == "release" %}
-      - test_pxf_hdp2_secure_no_impersonation
-{% endif %}
+      - test_pxf_hdp3_secure_with_impersonation
+      - test_pxf_secure_multinode_gpdb
 
   - name: no_impersonation
     jobs:
@@ -93,7 +90,6 @@ groups:
       - test_pxf_adl
       - test_pxf_gs
       - test_pxf_minio
-      - test_pxf_hdp2_secure_no_impersonation
 {% endif %}
 
 ## ======================================================================
@@ -293,12 +289,6 @@ resources:
     repository: pivotaldata/gpdb-pxf-dev
     tag: ubuntu18-hdp2-server
 {% endif %}
-
-- name: gpdb-pxf-dev-centos6-hdp2-secure
-  type: docker-image
-  source:
-    repository: pivotaldata/gpdb-pxf-dev
-    tag: centos6-hdp2-secure
 
 - name: ccp-7
   type: docker-image
@@ -817,7 +807,7 @@ jobs:
 {% endif %}
 {% endif %}
 
-- name: test_pxf_hdp2_secure_with_impersonation
+- name: test_pxf_hdp3_secure_with_impersonation
   plan:
   - in_parallel:
     - get: gpdb_src
@@ -840,67 +830,21 @@ jobs:
       passed:
       - compile_pxf
       trigger: true
-    - get: gpdb-pxf-dev-centos6-hdp2-secure
-  - task: test_pxf_secure
-    file: pxf_src/concourse/tasks/test_pxf_secure.yml
-    image: gpdb-pxf-dev-centos6-hdp2-secure
-    privileged: true
+    - get: gpdb-pxf-dev-centos6-cdh-server
+  - task: test_pxf
+    file: pxf_src/concourse/tasks/test_pxf.yml
+    image: gpdb-pxf-dev-centos6-cdh-server
     attempts: 2
     params:
-      AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
-      AWS_DEFAULT_REGION: {{aws-region}}
-      GROUP: gpdb,proxy
-      IMPERSONATION: true
+      ACCESS_KEY_ID: {{tf-machine-access-key-id}}
+      GROUP: gpdb
+      HADOOP_CLIENT: CDH
       PGPORT: {{pgport}}
-      TEST_ENV: {{test-env}}
+      SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: centos
+      TEST_ENV: {{test-env}}
 {% if acceptance %}
       ACCEPTANCE: true
-{% endif %}
-
-{% if pipeline_type == "release" %}
-- name: test_pxf_hdp2_secure_no_impersonation
-  plan:
-  - in_parallel:
-    - get: gpdb_src
-      passed:
-      - compile_pxf
-{% if compile_gpdb %}
-      - compile_gpdb_centos6
-{% endif %}
-    - get: bin_gpdb
-      resource: bin_gpdb_centos6
-{% if compile_gpdb %}
-      passed:
-      - compile_gpdb_centos6
-{% endif %}
-    - get: pxf_src
-      passed:
-      - compile_pxf
-      trigger: true
-    - get: pxf_tarball
-      passed:
-      - compile_pxf
-      trigger: true
-    - get: gpdb-pxf-dev-centos6-hdp2-secure
-  - task: test_pxf_secure
-    file: pxf_src/concourse/tasks/test_pxf_secure.yml
-    image: gpdb-pxf-dev-centos6-hdp2-secure
-    privileged: true
-    attempts: 2
-    params:
-      AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
-      AWS_DEFAULT_REGION: {{aws-region}}
-      GROUP: gpdb,proxy
-      IMPERSONATION: false
-      PGPORT: {{pgport}}
-      TEST_ENV: {{test-env}}
-      TARGET_OS: centos
-{% if acceptance %}
-      ACCEPTANCE: true
-{% endif %}
 {% endif %}
 
 - name: test_pxf_hdp2_multinode_gpdb
@@ -1445,7 +1389,7 @@ jobs:
 {% endif %}
     - test_pxf_s3_no_impersonation
     - test_pxf_s3_with_impersonation
-    - test_pxf_hdp2_secure_with_impersonation
+    - test_pxf_hdp3_secure_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
     - test_pxf_secure_multinode_gpdb
@@ -1475,8 +1419,7 @@ jobs:
     - test_pxf_minio
     - test_pxf_s3_no_impersonation
     - test_pxf_s3_with_impersonation
-    - test_pxf_hdp2_secure_with_impersonation
-    - test_pxf_hdp2_secure_no_impersonation
+    - test_pxf_hdp3_secure_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
     - test_pxf_secure_multinode_gpdb
@@ -1499,8 +1442,7 @@ jobs:
     - test_pxf_minio
     - test_pxf_s3_no_impersonation
     - test_pxf_s3_with_impersonation
-    - test_pxf_hdp2_secure_with_impersonation
-    - test_pxf_hdp2_secure_no_impersonation
+    - test_pxf_hdp3_secure_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
     - test_pxf_secure_multinode_gpdb

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -830,11 +830,17 @@ jobs:
       passed:
       - compile_pxf
       trigger: true
-    - get: gpdb-pxf-dev-centos6-cdh-server
+    - get: gpdb-pxf-dev-centos6-hdp2-server
+  - task: load_config_for_ambari
+    file: pxf_src/concourse/tasks/load_ambari_config.yml
+    image: ccp-7
+    params:
+      GOOGLE_CREDENTIALS: {{google-service-account-key}}
+      GOOGLE_PROJECT_ID: {{google-project-id}}
+      GOOGLE_ZONE: {{google-zone}}
   - task: test_pxf
     file: pxf_src/concourse/tasks/test_pxf.yml
-    image: gpdb-pxf-dev-centos6-cdh-server
-    attempts: 2
+    image: gpdb-pxf-dev-centos6-hdp2-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
       GROUP: gpdb

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -831,6 +831,7 @@ jobs:
       - compile_pxf
       trigger: true
     - get: gpdb-pxf-dev-centos6-hdp2-server
+    - get: ccp-7
   - task: load_config_for_ambari
     file: pxf_src/concourse/tasks/load_ambari_config.yml
     image: ccp-7
@@ -845,6 +846,7 @@ jobs:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
       GROUP: gpdb
       HADOOP_CLIENT: HDP_KERBEROS
+      IMPERSONATION: false
       PGPORT: {{pgport}}
       SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: centos

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -844,9 +844,9 @@ jobs:
     image: gpdb-pxf-dev-centos6-hdp2-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      GROUP: hcfs,hive
+      GROUP: security
       HADOOP_CLIENT: HDP_KERBEROS
-      IMPERSONATION: false
+      IMPERSONATION: true
       PGPORT: {{pgport}}
       SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: centos
@@ -1090,7 +1090,7 @@ jobs:
       IMPERSONATION: {{enable-impersonation-multinode}}
       KERBEROS: {{kerberos-enabled}}
       GOOGLE_PROJECT_ID: {{google-project-id}}
-      GROUP: security
+      GROUP: security,proxy-security,multi-cluster-security
       PXF_JVM_OPTS: {{pxf-jvm-opts}}
       TARGET_OS: centos
 {% if acceptance %}

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -838,7 +838,7 @@ jobs:
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
       GROUP: gpdb
-      HADOOP_CLIENT: CDH
+      HADOOP_CLIENT: HDP_KERBEROS
       PGPORT: {{pgport}}
       SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: centos

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -18,13 +18,13 @@ groups:
       - test_pxf_secure_multinode_gpdb
       - test_pxf_s3_no_impersonation
       - test_pxf_s3_with_impersonation
-      - test_pxf_hdp3_secure_with_impersonation
       - test_pxf_no_impersonation
       - test_pxf_hdp2_multinode_gpdb
       - test_pxf_hdp2_centos7_java11
       - test_pxf_mapr_centos6
       - test_pxf_hdp3_centos7
 {% if pipeline_type == "release" %}
+      - test_pxf_hdp3_secure_with_impersonation
       - test_pxf_hdp2_centos6
       - test_pxf_adl
       - test_pxf_gs
@@ -75,7 +75,9 @@ groups:
 {% if compile_gpdb %}
       - compile_gpdb_centos6
 {% endif %}
+{% if pipeline_type == "release" %}
       - test_pxf_hdp3_secure_with_impersonation
+{% endif %}
       - test_pxf_secure_multinode_gpdb
 
   - name: no_impersonation
@@ -807,6 +809,7 @@ jobs:
 {% endif %}
 {% endif %}
 
+{% if pipeline_type == "release" %}
 - name: test_pxf_hdp3_secure_with_impersonation
   plan:
   - in_parallel:
@@ -853,6 +856,7 @@ jobs:
       TEST_ENV: {{test-env}}
 {% if acceptance %}
       ACCEPTANCE: true
+{% endif %}
 {% endif %}
 
 - name: test_pxf_hdp2_multinode_gpdb
@@ -1397,7 +1401,6 @@ jobs:
 {% endif %}
     - test_pxf_s3_no_impersonation
     - test_pxf_s3_with_impersonation
-    - test_pxf_hdp3_secure_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
     - test_pxf_secure_multinode_gpdb

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -844,7 +844,7 @@ jobs:
     image: gpdb-pxf-dev-centos6-hdp2-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
-      GROUP: gpdb
+      GROUP: hcfs,hive
       HADOOP_CLIENT: HDP_KERBEROS
       IMPERSONATION: false
       PGPORT: {{pgport}}

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -1090,7 +1090,7 @@ jobs:
       IMPERSONATION: {{enable-impersonation-multinode}}
       KERBEROS: {{kerberos-enabled}}
       GOOGLE_PROJECT_ID: {{google-project-id}}
-      GROUP: security,proxySecurity,multi-cluster-security
+      GROUP: security,proxySecurity,multiClusterSecurity
       PXF_JVM_OPTS: {{pxf-jvm-opts}}
       TARGET_OS: centos
 {% if acceptance %}

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -15,7 +15,7 @@ groups:
       - test_pxf_hdp2_ubuntu18
 {% endif %}
       - test_pxf_hdp2_multinode_gpdb
-      - test_pxf_dataproc_multinode_with_impersonation
+      - test_pxf_secure_dataproc_multinode_with_impersonation
       - test_pxf_s3_no_impersonation
       - test_pxf_s3_with_impersonation
       - test_pxf_no_impersonation
@@ -25,7 +25,7 @@ groups:
       - test_pxf_hdp3_centos7
 {% if pipeline_type == "release" %}
       - test_pxf_hdp3_secure_with_impersonation
-      - test_pxf_dataproc_multinode_no_impersonation
+      - test_pxf_secure_dataproc_multinode_no_impersonation
       - test_pxf_hdp2_centos6
       - test_pxf_adl
       - test_pxf_gs
@@ -49,12 +49,12 @@ groups:
       - test_pxf_hdp2_ubuntu18
 {% endif %}
       - test_pxf_hdp2_multinode_gpdb
-      - test_pxf_dataproc_multinode_with_impersonation
+      - test_pxf_secure_dataproc_multinode_with_impersonation
       - test_pxf_mapr_centos6
       - test_pxf_hdp3_centos7
 {% if pipeline_type == "release" %}
       - test_pxf_hdp2_centos6
-      - test_pxf_dataproc_multinode_no_impersonation
+      - test_pxf_secure_dataproc_multinode_no_impersonation
 {% endif %}
 
   - name: cloud
@@ -79,9 +79,9 @@ groups:
 {% endif %}
 {% if pipeline_type == "release" %}
       - test_pxf_hdp3_secure_with_impersonation
-      - test_pxf_dataproc_multinode_no_impersonation
+      - test_pxf_secure_dataproc_multinode_no_impersonation
 {% endif %}
-      - test_pxf_dataproc_multinode_with_impersonation
+      - test_pxf_secure_dataproc_multinode_with_impersonation
 
   - name: no_impersonation
     jobs:
@@ -964,7 +964,7 @@ jobs:
       ACCEPTANCE: true
 {% endif %}
 
-- name: test_pxf_dataproc_multinode_with_impersonation
+- name: test_pxf_secure_dataproc_multinode_with_impersonation
   max_in_flight: 2
   plan:
   - in_parallel:
@@ -1105,7 +1105,7 @@ jobs:
 {% endif %}
 
 {% if pipeline_type == "release" %}
-- name: test_pxf_dataproc_multinode_no_impersonation
+- name: test_pxf_secure_dataproc_multinode_no_impersonation
   max_in_flight: 2
   plan:
   - in_parallel:
@@ -1545,7 +1545,7 @@ jobs:
     - test_pxf_s3_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
-    - test_pxf_dataproc_multinode_with_impersonation
+    - test_pxf_secure_dataproc_multinode_with_impersonation
     trigger: true
   - put: pxf_tarball_stable
     params:
@@ -1575,8 +1575,8 @@ jobs:
     - test_pxf_hdp3_secure_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
-    - test_pxf_dataproc_multinode_with_impersonation
-    - test_pxf_dataproc_multinode_no_impersonation
+    - test_pxf_secure_dataproc_multinode_with_impersonation
+    - test_pxf_secure_dataproc_multinode_no_impersonation
     trigger: true
   - get: gpdb_release
   - get: pxf_src
@@ -1599,8 +1599,8 @@ jobs:
     - test_pxf_hdp3_secure_with_impersonation
     - test_pxf_no_impersonation
     - test_pxf_hdp2_multinode_gpdb
-    - test_pxf_dataproc_multinode_with_impersonation
-    - test_pxf_dataproc_multinode_no_impersonation
+    - test_pxf_secure_dataproc_multinode_with_impersonation
+    - test_pxf_secure_dataproc_multinode_no_impersonation
   - task: package_pxf_rc
     config:
       inputs:

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -1090,7 +1090,7 @@ jobs:
       IMPERSONATION: {{enable-impersonation-multinode}}
       KERBEROS: {{kerberos-enabled}}
       GOOGLE_PROJECT_ID: {{google-project-id}}
-      GROUP: security,proxy-security,multi-cluster-security
+      GROUP: security,proxySecurity,multi-cluster-security
       PXF_JVM_OPTS: {{pxf-jvm-opts}}
       TARGET_OS: centos
 {% if acceptance %}

--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -836,7 +836,7 @@ jobs:
       passed:
       - compile_pxf
       trigger: true
-    - get: gpdb-pxf-dev-centos6-hdp2-server
+    - get: gpdb-pxf-dev-centos7-hdp3-server
     - get: ccp-7
   - task: load_config_for_ambari
     file: pxf_src/concourse/tasks/load_ambari_config.yml
@@ -847,7 +847,7 @@ jobs:
       GOOGLE_ZONE: {{google-zone}}
   - task: test_pxf
     file: pxf_src/concourse/tasks/test_pxf.yml
-    image: gpdb-pxf-dev-centos6-hdp2-server
+    image: gpdb-pxf-dev-centos7-hdp3-server
     params:
       ACCESS_KEY_ID: {{tf-machine-access-key-id}}
       GROUP: security
@@ -857,9 +857,6 @@ jobs:
       SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
       TARGET_OS: centos
       TEST_ENV: {{test-env}}
-{% if acceptance %}
-      ACCEPTANCE: true
-{% endif %}
 {% endif %}
 
 - name: test_pxf_hdp2_multinode_gpdb

--- a/concourse/scripts/load_ambari_config.bash
+++ b/concourse/scripts/load_ambari_config.bash
@@ -8,6 +8,7 @@
 # - REALM (a file with the name of the REALM for this kerberized cluster)
 # - HADOOP_USER (a file with the name of the hadoop user)
 # - etc_hostfile (a file with the /etc/hosts configuration for this cluster)
+# - krb5.conf
 # To load the static configuration, prepare all the files above and
 #    gsutil cp -r configuration gs://data-gpdb-ud/configuration/ambari-cloud/
 

--- a/concourse/scripts/load_ambari_config.bash
+++ b/concourse/scripts/load_ambari_config.bash
@@ -7,4 +7,4 @@ PROJECT=${GOOGLE_PROJECT_ID:-}
 gcloud config set project "$PROJECT"
 gcloud auth activate-service-account --key-file=<(echo "$GOOGLE_CREDENTIALS")
 
-gsutil cp -r gs://data-gpdb-ud/configuration/ambari-cloud/ ambari_env_files
+gsutil cp -r gs://data-gpdb-ud/configuration/ambari-cloud/* ambari_env_files

--- a/concourse/scripts/load_ambari_config.bash
+++ b/concourse/scripts/load_ambari_config.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PROJECT=${GOOGLE_PROJECT_ID:-}
+
+gcloud config set project "$PROJECT"
+gcloud auth activate-service-account --key-file=<(echo "$GOOGLE_CREDENTIALS")
+
+gsutil cp -r gs://data-gpdb-ud/configuration/ambari-cloud/ ambari_env_files

--- a/concourse/scripts/load_ambari_config.bash
+++ b/concourse/scripts/load_ambari_config.bash
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# The ambari configuration is a static configuration residing on a google cloud
+# bucket. All the required configuration resides in the bucket including:
+# - /etc/hadoop/conf/*-site.xml
+# - /etc/hive/conf/*-site.xml
+# - keytab
+# - REALM
+# To load the static configuration, prepare all the files above and
+#    gsutil cp -r configuration gs://data-gpdb-ud/configuration/ambari-cloud/
+
 set -euo pipefail
 
 PROJECT=${GOOGLE_PROJECT_ID:-}

--- a/concourse/scripts/load_ambari_config.bash
+++ b/concourse/scripts/load_ambari_config.bash
@@ -5,7 +5,9 @@
 # - /etc/hadoop/conf/*-site.xml
 # - /etc/hive/conf/*-site.xml
 # - keytab
-# - REALM
+# - REALM (a file with the name of the REALM for this kerberized cluster)
+# - HADOOP_USER (a file with the name of the hadoop user)
+# - etc_hostfile (a file with the /etc/hosts configuration for this cluster)
 # To load the static configuration, prepare all the files above and
 #    gsutil cp -r configuration gs://data-gpdb-ud/configuration/ambari-cloud/
 

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -516,6 +516,7 @@ function configure_pxf_default_server() {
 				-e "s|YOUR_DATABASE_JDBC_URL|jdbc:hive2://${HIVE_HOSTNAME}:10000/default;principal=${KERBERIZED_HADOOP_URI}|" \
 				-e 's|YOUR_DATABASE_JDBC_USER||' \
 				-e 's|YOUR_DATABASE_JDBC_PASSWORD||' \
+				-e 's|</configuration>|<property><name>hadoop.security.authentication</name><value>kerberos</value></property></configuration>|g' \
 				${PXF_CONF_DIR}/servers/db-hive/jdbc-site.xml
 
 			PXF_SRC_DIR=$(find /tmp/build/ -name pxf_src)

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -488,26 +488,26 @@ function configure_pxf_wasbs_server() {
 }
 
 function configure_pxf_default_server() {
-	# copy hadoop config files to PXF_CONF_DIR/servers/default
-	if [[ -d /etc/hadoop/conf/ ]]; then
-		cp /etc/hadoop/conf/*-site.xml "${PXF_CONF_DIR}/servers/default"
-	fi
-	if [[ -d /etc/hive/conf/ ]]; then
-		cp /etc/hive/conf/*-site.xml "${PXF_CONF_DIR}/servers/default"
-	fi
-	if [[ -d /etc/hbase/conf/ ]]; then
-		cp /etc/hbase/conf/*-site.xml "${PXF_CONF_DIR}/servers/default"
-	fi
-
 	AMBARI_DIR=$(find /tmp/build/ -name ambari_env_files)
 	if [[ -n $AMBARI_DIR  ]]; then
 	  AMBARI_KEYTAB_FILE=$(find "$AMBARI_DIR" -name "*.keytab")
-		cp "${AMBARI_DIR}/conf/*-site.xml" "${PXF_CONF_DIR}/servers/default"
+		cp "${AMBARI_DIR}"/conf/*-site.xml "${PXF_CONF_DIR}/servers/default"
 
 		if [[ -n $AMBARI_KEYTAB_FILE ]]; then
 			cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|gpadmin/_HOST@EXAMPLE.COM|pxfuser@C.AMBARI.INTERNAL|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|\${pxf.conf}/keytabs/pxf.service.keytab|$AMBARI_KEYTAB_FILE|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
+		fi
+	else
+		# copy hadoop config files to PXF_CONF_DIR/servers/default
+		if [[ -d /etc/hadoop/conf/ ]]; then
+			cp /etc/hadoop/conf/*-site.xml "${PXF_CONF_DIR}/servers/default"
+		fi
+		if [[ -d /etc/hive/conf/ ]]; then
+			cp /etc/hive/conf/*-site.xml "${PXF_CONF_DIR}/servers/default"
+		fi
+		if [[ -d /etc/hbase/conf/ ]]; then
+			cp /etc/hbase/conf/*-site.xml "${PXF_CONF_DIR}/servers/default"
 		fi
 	fi
 }

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -499,6 +499,7 @@ function configure_pxf_default_server() {
 			cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|gpadmin/_HOST@EXAMPLE.COM|${HADOOP_USER}@${REALM}|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|\${pxf.conf}/keytabs/pxf.service.keytab|$AMBARI_KEYTAB_FILE|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
+			sudo mkdir -p /etc/security/keytabs/
 			sudo cp "$AMBARI_KEYTAB_FILE" /etc/security/keytabs/"${HADOOP_USER}".headless.keytab
 			sudo chown gpadmin:gpadmin /etc/security/keytabs/"${HADOOP_USER}".headless.keytab
 		fi

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -325,7 +325,7 @@ function init_and_configure_pxf_server() {
 		# Copy pxf-site.xml to the server configuration and update the
 		# pxf.service.user.name property value to use the PROXY_USER
 		# Only copy this file when testing against non-cloud
-		if [[ ! -f ${PXF_CONF_DIR}/templates/pxf-site.xml ]]; then
+		if [[ ! -f ${PXF_CONF_DIR}/servers/default/pxf-site.xml ]]; then
 			cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|\${user.name}|${PROXY_USER}|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 		fi

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -494,9 +494,12 @@ function configure_pxf_default_server() {
 		cp "${AMBARI_DIR}"/conf/*-site.xml "${PXF_CONF_DIR}/servers/default"
 
 		if [[ -n $AMBARI_KEYTAB_FILE ]]; then
+			REALM=$(cat "$AMBARI_DIR"/REALM)
+			HADOOP_USER=$(cat "$AMBARI_DIR"/HADOOP_USER)
 			cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
-			sed -i -e "s|gpadmin/_HOST@EXAMPLE.COM|pxfuser@C.AMBARI.INTERNAL|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
+			sed -i -e "s|gpadmin/_HOST@EXAMPLE.COM|${HADOOP_USER}@${REALM}|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|\${pxf.conf}/keytabs/pxf.service.keytab|$AMBARI_KEYTAB_FILE|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
+			cp "$AMBARI_KEYTAB_FILE" /etc/security/keytabs/"${HADOOP_USER}".headless.keytab
 		fi
 	else
 		# copy hadoop config files to PXF_CONF_DIR/servers/default

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -500,6 +500,7 @@ function configure_pxf_default_server() {
 			cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|gpadmin/_HOST@EXAMPLE.COM|${HADOOP_USER}@${REALM}|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|\${pxf.conf}/keytabs/pxf.service.keytab|$AMBARI_KEYTAB_FILE|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
+			sed -i -e "s|\${user.name}||g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sudo mkdir -p /etc/security/keytabs/
 			sudo cp "$AMBARI_KEYTAB_FILE" /etc/security/keytabs/"${HADOOP_USER}".headless.keytab
 			sudo chown gpadmin:gpadmin /etc/security/keytabs/"${HADOOP_USER}".headless.keytab

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -496,6 +496,7 @@ function configure_pxf_default_server() {
 		if [[ -n $AMBARI_KEYTAB_FILE ]]; then
 			REALM=$(cat "$AMBARI_DIR"/REALM)
 			HADOOP_USER=$(cat "$AMBARI_DIR"/HADOOP_USER)
+			cp ${PXF_CONF_DIR}/templates/mapred-site.xml ${PXF_CONF_DIR}/servers/default/mapred1-site.xml
 			cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|gpadmin/_HOST@EXAMPLE.COM|${HADOOP_USER}@${REALM}|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|\${pxf.conf}/keytabs/pxf.service.keytab|$AMBARI_KEYTAB_FILE|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -499,7 +499,8 @@ function configure_pxf_default_server() {
 			cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|gpadmin/_HOST@EXAMPLE.COM|${HADOOP_USER}@${REALM}|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 			sed -i -e "s|\${pxf.conf}/keytabs/pxf.service.keytab|$AMBARI_KEYTAB_FILE|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
-			cp "$AMBARI_KEYTAB_FILE" /etc/security/keytabs/"${HADOOP_USER}".headless.keytab
+			sudo cp "$AMBARI_KEYTAB_FILE" /etc/security/keytabs/"${HADOOP_USER}".headless.keytab
+			sudo chown gpadmin:gpadmin /etc/security/keytabs/"${HADOOP_USER}".headless.keytab
 		fi
 	else
 		# copy hadoop config files to PXF_CONF_DIR/servers/default

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -144,6 +144,7 @@ function configure_sut() {
 			-e "/<hive>/,/<\/hive/ s|<host>localhost</host>|<host>${HIVE_IP}</host>|g" \
 			-e "/<hbase>/,/<\/hbase/ s|<host>localhost</host>|<host>${HBASE_IP}</host>|g" \
 			-e "s|</hdfs>|<hadoopRoot>$AMBARI_DIR</hadoopRoot></hdfs>|g" \
+			-e "s|</hbase>|<hbaseRoot>$AMBARI_DIR</hbaseRoot></hbase>|g" \
 			-e "s|</cluster>|<hiveBaseHdfsDirectory>/user/hive/warehouse/</hiveBaseHdfsDirectory><testKerberosPrincipal>${HADOOP_USER}@${REALM}</testKerberosPrincipal></cluster>|g" \
 			-e "s|</hive>|<kerberosPrincipal>${KERBERIZED_HADOOP_URI}</kerberosPrincipal><userName>hive</userName></hive>|g" \
 			pxf_src/automation/src/test/resources/sut/default.xml

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -145,7 +145,7 @@ function configure_sut() {
 			-e "/<hbase>/,/<\/hbase/ s|<host>localhost</host>|<host>${HBASE_IP}</host>|g" \
 			-e "s|</hdfs>|<hadoopRoot>$AMBARI_DIR</hadoopRoot></hdfs>|g" \
 			-e "s|</hbase>|<hbaseRoot>$AMBARI_DIR</hbaseRoot></hbase>|g" \
-			-e "s|</cluster>|<hiveBaseHdfsDirectory>/user/hive/warehouse/</hiveBaseHdfsDirectory><testKerberosPrincipal>${HADOOP_USER}@${REALM}</testKerberosPrincipal></cluster>|g" \
+			-e "s|</cluster>|<hiveBaseHdfsDirectory>/warehouse/tablespace/managed/hive/</hiveBaseHdfsDirectory><testKerberosPrincipal>${HADOOP_USER}@${REALM}</testKerberosPrincipal></cluster>|g" \
 			-e "s|</hive>|<kerberosPrincipal>${KERBERIZED_HADOOP_URI}</kerberosPrincipal><userName>hive</userName></hive>|g" \
 			pxf_src/automation/src/test/resources/sut/default.xml
 	fi

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -134,7 +134,7 @@ function configure_sut() {
 		HBASE_IP=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-3 | awk '{print $1}')
 		HIVE_IP=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-2 | awk '{print $1}')
 		HIVE_HOSTNAME=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-2 | awk '{print $2}')
-		KERBERIZED_HADOOP_URI="hive/${HIVE_HOSTNAME}.${REALM,,}@${REALM};saslQop=auth" # quoted because of semicolon
+		KERBERIZED_HADOOP_URI="hive/${HIVE_HOSTNAME}.c.data-gpdb-ud@${REALM};saslQop=auth" # quoted because of semicolon
 		# Add ambari hostfile to /etc/hosts
 		sudo tee --append /etc/hosts < "$AMBARI_DIR"/etc_hostfile
 		sudo cp "$AMBARI_DIR"/krb5.conf /etc/krb5.conf

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -135,6 +135,7 @@ function configure_sut() {
 		KERBERIZED_HADOOP_URI="hive/${HADOOP_HOSTNAME}.${REALM,,}@${REALM};saslQop=auth" # quoted because of semicolon
 		# Add ambari hostfile to /etc/hosts
 		sudo tee --append /etc/hosts < "$AMBARI_DIR"/etc_hostfile
+		sudo cp "$AMBARI_DIR"/krb5.conf /etc/krb5.conf
 		sed -i \
 			-e "s/>hadoop</>${HADOOP_IP}</g" \
 			-e "s|</hdfs>|<hadoopRoot>$AMBARI_DIR</hadoopRoot></hdfs>|g" \

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -146,7 +146,7 @@ function _main() {
 	install_pxf_client
 	install_pxf_server
 
-	if [[ -z ${PROTOCOL} && ${HADOOP_CLIENT} != MAPR ]]; then
+	if [[ -z ${PROTOCOL} && ${HADOOP_CLIENT} != MAPR && ${HADOOP_CLIENT} != HDP_KERBEROS ]]; then
 		# Setup Hadoop before creating GPDB cluster to use system python for yum install
 		# Must be after installing GPDB to transfer hbase jar
 		setup_hadoop "${GPHD_ROOT}"

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -133,6 +133,8 @@ function configure_sut() {
 		HADOOP_HOSTNAME=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-2 | awk '{print $2}')
 		HADOOP_IP=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-1 | awk '{print $1}')
 		KERBERIZED_HADOOP_URI="hive/${HADOOP_HOSTNAME}.${REALM,,}@${REALM};saslQop=auth" # quoted because of semicolon
+		# Add ambari hostfile to /etc/hosts
+		sudo tee --append /etc/hosts < "$AMBARI_DIR"/etc_hostfile
 		sed -i \
 			-e "s/>hadoop</>${HADOOP_IP}</g" \
 			-e "s|</hdfs>|<hadoopRoot>$AMBARI_DIR</hadoopRoot></hdfs>|g" \

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -130,8 +130,8 @@ function configure_sut() {
 	if [[ -n $AMBARI_DIR  ]]; then
 		REALM=$(cat "$AMBARI_DIR"/REALM)
 		HADOOP_USER=$(cat "$AMBARI_DIR"/HADOOP_USER)
-		HADOOP_HOSTNAME=$(grep < cluster_env_files/etc_hostfile ambari-2 | awk '{print $2}')
-		HADOOP_IP=$(grep < cluster_env_files/etc_hostfile ambari-1 | awk '{print $1}')
+		HADOOP_HOSTNAME=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-2 | awk '{print $2}')
+		HADOOP_IP=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-1 | awk '{print $1}')
 		KERBERIZED_HADOOP_URI="hive/${HADOOP_HOSTNAME}.${REALM,,}@${REALM};saslQop=auth" # quoted because of semicolon
 		sed -i \
 			-e "s/>hadoop</>${HADOOP_IP}</g" \

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -134,7 +134,7 @@ function configure_sut() {
 		HBASE_IP=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-3 | awk '{print $1}')
 		HIVE_IP=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-2 | awk '{print $1}')
 		HIVE_HOSTNAME=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-2 | awk '{print $2}')
-		KERBERIZED_HADOOP_URI="hive/${HIVE_HOSTNAME}.c.data-gpdb-ud@${REALM};saslQop=auth" # quoted because of semicolon
+		KERBERIZED_HADOOP_URI="hive/${HIVE_HOSTNAME}.c.data-gpdb-ud.internal@${REALM};saslQop=auth" # quoted because of semicolon
 		# Add ambari hostfile to /etc/hosts
 		sudo tee --append /etc/hosts < "$AMBARI_DIR"/etc_hostfile
 		sudo cp "$AMBARI_DIR"/krb5.conf /etc/krb5.conf

--- a/concourse/tasks/load_ambari_config.yml
+++ b/concourse/tasks/load_ambari_config.yml
@@ -1,0 +1,12 @@
+platform: linux
+image_resource:
+  type: docker-image
+outputs:
+  - name: ambari_env_files
+params:
+  GOOGLE_CREDENTIALS:
+  GOOGLE_PROJECT_ID:
+  GOOGLE_ZONE:
+  GOOGLE_SERVICE_ACCOUNT:
+run:
+  path: pxf_src/concourse/scripts/load_ambari_config.bash

--- a/concourse/tasks/load_ambari_config.yml
+++ b/concourse/tasks/load_ambari_config.yml
@@ -1,6 +1,8 @@
 platform: linux
 image_resource:
   type: docker-image
+inputs:
+  - name: pxf_src
 outputs:
   - name: ambari_env_files
 params:

--- a/concourse/tasks/test_pxf.yml
+++ b/concourse/tasks/test_pxf.yml
@@ -7,6 +7,8 @@ inputs:
   - name: bin_gpdb
   - name: pxf_tarball
     optional: true
+  - name: ambari_env_files
+    optional: true
 params:
   ACCESS_KEY_ID:
   GROUP: smoke


### PR DESCRIPTION
- Test against a static kerberized ambari server running HDFS 3.1.1 and Hive 3.1.0
- Add groups: multiClusterSecurity, proxySecurity for finer grain test grouping
- Remove `test_pxf_hdp2_secure_no_impersonation` and `test_pxf_hdp2_secure_with_impersonation` jobs from the pipeline as they were running a very basic test with Kerberos. These jobs are now replaced with `test_pxf_dataproc_multinode_with_impersonation` and `test_pxf_dataproc_multinode_no_impersonation`
- Add __UUID__ to the workingDirectory for hdfs

Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>
Co-authored-by: Alexander Denissov <adenissov@pivotal.io>