### PR TITLE
A new UGI is created every time in some cases

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -229,7 +229,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10</version>
+            <version>2.9.10.1</version>
         </dependency>
 
         <dependency>

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
@@ -28,6 +28,25 @@ public class LoginSession {
     private User user;
 
     /**
+     * Creates a new session object with a config directory
+     *
+     * @param configDirectory server configuration directory
+     */
+    public LoginSession(String configDirectory) {
+        this(configDirectory, null, null, null, null, 0L);
+    }
+
+    /**
+     * Creates a new session object with a config directory and a login user
+     *
+     * @param configDirectory server configuration directory
+     * @param loginUser       UserGroupInformation for the given principal after login to Kerberos was performed
+     */
+    public LoginSession(String configDirectory, UserGroupInformation loginUser) {
+        this(configDirectory, null, null, loginUser, null, 0L);
+    }
+
+    /**
      * Creates a new session object.
      *
      * @param configDirectory server configuration directory

--- a/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
+++ b/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
@@ -31,6 +31,30 @@ public class LoginSessionTest {
     }
 
     @Test
+    public void testLoginSessionConfigurationConstructor() {
+        session = new LoginSession("config");
+        assertEquals(0, session.getKerberosMinMillisBeforeRelogin());
+        assertNull(session.getKeytabPath());
+        assertNull(session.getPrincipalName());
+        assertNull(session.getLoginUser());
+        assertNull(session.getSubject());
+        assertNull(session.getUser());
+        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0]", session.toString());
+    }
+
+    @Test
+    public void testLoginSessionConfigurationAndLoginUserConstructor() {
+        session = new LoginSession("config", ugiFoo);
+        assertEquals(0, session.getKerberosMinMillisBeforeRelogin());
+        assertSame(ugiFoo, session.getLoginUser());
+        assertNull(session.getKeytabPath());
+        assertNull(session.getPrincipalName());
+        assertNull(session.getSubject());
+        assertNull(session.getUser());
+        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0]", session.toString());
+    }
+
+    @Test
     public void testLoginSessionShortConstructor() {
         session = new LoginSession("config", "principal", "keytab", 0);
         assertEquals(0, session.getKerberosMinMillisBeforeRelogin());


### PR DESCRIPTION
When security is disabled, a new UserGroupInformation is created every
time when the pxf.service.kerberos.principal or
pxf.service.kerberos.keytab or
hadoop.kerberos.min.seconds.before.relogin properties are set in the
configuration. This can occur when the pxf-site.xml template is copied
into the server configuration of the non-secured server. Even though the
values in these properties are dummy values that take no effect, but
they were still being used by the LoginSession for non-secure servers.