### PR TITLE
Host information is not needed for the split information

### DIFF
--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/HdfsUtilities.java
@@ -115,7 +115,7 @@ public class HdfsUtilities {
     public static FileSplit parseFileSplit(RequestContext requestContext) {
         FragmentMetadata metadata = Utilities.parseFragmentMetadata(requestContext);
         return new FileSplit(new Path(requestContext.getDataSource()),
-                metadata.getStart(), metadata.getEnd(), metadata.getHosts());
+                metadata.getStart(), metadata.getEnd(), (String[]) null);
     }
 
     /**


### PR DESCRIPTION
This is a minor optimization, no need to get the hosts as they are most likely hardcoded and not needed for the split information