### PR TITLE
Automation HCFS: remove avroFileNameWithSpaces

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/avro/HdfsReadableAvroTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/avro/HdfsReadableAvroTest.java
@@ -400,7 +400,8 @@ public class HdfsReadableAvroTest extends BaseFeature {
      *
      * @throws Exception
      */
-    @Test(groups = {"features", "gpdb", "hcfs", "security"})
+    // TODO: Add back to HCFS group after updating Google dependency
+    @Test(groups = {"features", "gpdb", "security"})
     public void avroFileNameWithSpaces() throws Exception {
 
         exTable.setName("avro_in_seq_arrays");


### PR DESCRIPTION
Temporarily removing the
HdfsReadableAvroTest#avroFileNameWithSpaces test from the HCFS test
group because for GCS it fails. Later we will update the Google jar that
is causing the failure and then re-enable this test for HCFS.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>