### PR TITLE
Update GCS connector jar in automation/prod

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -254,7 +254,7 @@
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcs-connector</artifactId>
-            <version>1.9.2-hadoop2</version>
+            <version>hadoop2-1.9.17</version>
             <classifier>shaded</classifier>
             <!--The block below excludes all transitive dependencies for the gcs-connector jar-->
             <exclusions>

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/avro/HdfsReadableAvroTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/avro/HdfsReadableAvroTest.java
@@ -437,8 +437,7 @@ public class HdfsReadableAvroTest extends BaseFeature {
      *
      * @throws Exception
      */
-    // TODO: Add back to HCFS group after updating Google dependency
-    @Test(groups = {"features", "gpdb", "security"})
+    @Test(groups = {"features", "gpdb", "hcfs", "security"})
     public void avroFileNameWithSpacesOnHcfs() throws Exception {
 
         hdfs.copyFromLocal(resourcePath + avroInSequenceArraysSchemaFileWithSpaces, hdfsPath + avroInSequenceArraysSchemaFileWithSpaces);

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -134,7 +134,7 @@ project('pxf') {
         bundleJars "org.apache.hadoop:hadoop-azure-datalake:${hadoopVersion}"
         bundleJars "com.microsoft.azure:azure-data-lake-store-sdk:2.2.3"
         // GCS jars and dependencies
-        bundleJars "com.google.cloud.bigdataoss:gcs-connector:1.9.2-hadoop2:shaded"
+        bundleJars "com.google.cloud.bigdataoss:gcs-connector:hadoop2-1.9.17:shaded"
     }
 }
 


### PR DESCRIPTION
This updated version handles filenames with spaces inside correctly.
The error that the old connector gives looks like this:

java.net.URISyntaxException: Illegal character in path

Authored-by: Oliver Albertini <oalbertini@pivotal.io>