### PR TITLE
Log ClientAbortException at debug level

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
@@ -142,7 +142,9 @@ public class BridgeResource extends BaseResource {
                     LOG.debug("Finished streaming fragment {} of resource {}, {} records.", fragment, dataDir, recordCount);
                 } catch (ClientAbortException e) {
                     // Occurs whenever client (GPDB) decides to end the connection
-                    LOG.error("Remote connection closed by GPDB", e);
+                    LOG.error("Remote connection closed by GPDB (Enable debug for additional details)");
+                    // Stacktrace in debug
+                    LOG.debug("Details: Remote connection closed by GPDB", e);
                 } catch (Exception e) {
                     throw new IOException(e.getMessage(), e);
                 } finally {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
@@ -142,9 +142,12 @@ public class BridgeResource extends BaseResource {
                     LOG.debug("Finished streaming fragment {} of resource {}, {} records.", fragment, dataDir, recordCount);
                 } catch (ClientAbortException e) {
                     // Occurs whenever client (GPDB) decides to end the connection
-                    LOG.error("Remote connection closed by GPDB (Enable debug for additional details)");
-                    // Stacktrace in debug
-                    LOG.debug("Details: Remote connection closed by GPDB", e);
+                    if (LOG.isDebugEnabled()) {
+                        // Stacktrace in debug
+                        LOG.debug("Remote connection closed by GPDB", e);
+                    } else {
+                        LOG.error("Remote connection closed by GPDB (Enable debug for stacktrace)");
+                    }
                 } catch (Exception e) {
                     throw new IOException(e.getMessage(), e);
                 } finally {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/ClusterNodesResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/ClusterNodesResource.java
@@ -103,8 +103,11 @@ public class ClusterNodesResource {
             LOG.error("Nodes verification failed", e);
             throw e;
         } catch (ClientAbortException e) {
-            LOG.error("Remote connection closed by GPDB (Enable debug for additional details)");
-            LOG.debug("Details: Remote connection closed by GPDB", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Remote connection closed by GPDB", e);
+            } else {
+                LOG.error("Remote connection closed by GPDB (Enable debug for stacktrace)");
+            }
             throw e;
         } catch (java.io.IOException e) {
             LOG.error("Unhandled exception thrown", e);

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/ClusterNodesResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/ClusterNodesResource.java
@@ -103,7 +103,8 @@ public class ClusterNodesResource {
             LOG.error("Nodes verification failed", e);
             throw e;
         } catch (ClientAbortException e) {
-            LOG.error("Remote connection closed by GPDB", e);
+            LOG.error("Remote connection closed by GPDB (Enable debug for additional details)");
+            LOG.debug("Details: Remote connection closed by GPDB", e);
             throw e;
         } catch (java.io.IOException e) {
             LOG.error("Unhandled exception thrown", e);

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
@@ -96,7 +96,8 @@ public class WritableResource extends BaseResource {
 
     /**
      * Creates an instance of the resource with provided instances of RequestParser and BridgeFactory.
-     * @param parser request parser
+     *
+     * @param parser        request parser
      * @param bridgeFactory bridge factory
      */
     WritableResource(RequestParser<HttpHeaders> parser, BridgeFactory bridgeFactory) {
@@ -161,8 +162,11 @@ public class WritableResource extends BaseResource {
                 ++totalWritten;
             }
         } catch (ClientAbortException cae) {
-            LOG.error("Remote connection closed by GPDB (Enable debug for additional details)");
-            LOG.debug("Details: Remote connection closed by GPDB", cae);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Remote connection closed by GPDB", cae);
+            } else {
+                LOG.error("Remote connection closed by GPDB (Enable debug for stacktrace)");
+            }
         } catch (Exception e) {
             LOG.error("Exception: totalWritten so far " + totalWritten + " to " + path, e);
             ex = e;

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
@@ -161,7 +161,8 @@ public class WritableResource extends BaseResource {
                 ++totalWritten;
             }
         } catch (ClientAbortException cae) {
-            LOG.error("Remote connection closed by GPDB", cae);
+            LOG.error("Remote connection closed by GPDB (Enable debug for additional details)");
+            LOG.debug("Details: Remote connection closed by GPDB", cae);
         } catch (Exception e) {
             LOG.error("Exception: totalWritten so far " + totalWritten + " to " + path, e);
             ex = e;


### PR DESCRIPTION
While running a large cluster and queries fail, ClientAbortExceptions
become intrusive in the error log. To better debug queries while running
on large clusters (10s of segments per segment host), log the stacktrace
at the debug level, and give hints how to surface the exception.