### PR TITLE
Use Zonal DNS when accessing GCP servers

### DIFF
--- a/concourse/scripts/cleanup_dataproc_cluster.bash
+++ b/concourse/scripts/cleanup_dataproc_cluster.bash
@@ -13,8 +13,8 @@ gcloud auth activate-service-account --key-file=<(echo "$GOOGLE_CREDENTIALS")
 
 set -x
 
-PETNAME=$(< "${ENV_FILES_DIR}/name")
+PETNAME=$(awk -F'.' '{print $1}' < "${ENV_FILES_DIR}/name")
 # --quiet to avoid interactive prompts
 gcloud beta dataproc clusters --quiet \
-  "--region=$REGION" delete "${PETNAME%-m}" # lop off trailing '-m'
+  "--region=$REGION" delete "${PETNAME%-m*}" # lop off trailing '-m'
 

--- a/concourse/scripts/install_pxf.bash
+++ b/concourse/scripts/install_pxf.bash
@@ -9,13 +9,14 @@ MASTER_HOSTNAME=$(grep < cluster_env_files/etc_hostfile '\bmdw' | awk '{print $2
 REALM=${REALM:-}
 REALM_2=${REALM_2:-}
 GOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID:-data-gpdb-ud}
+GOOGLE_ZONE=${GOOGLE_ZONE:-us-central1-a}
 KERBEROS=${KERBEROS:-false}
 if [[ -f terraform_dataproc/name ]]; then
 	HADOOP_HOSTNAME=ccp-$(< terraform_dataproc/name)-m
-	HADOOP_IP=$(getent hosts "${HADOOP_HOSTNAME}.c.${GOOGLE_PROJECT_ID}.internal" | awk '{ print $1 }')
+	HADOOP_IP=$(getent hosts "${HADOOP_HOSTNAME}.${GOOGLE_ZONE}.c.${GOOGLE_PROJECT_ID}.internal" | awk '{ print $1 }')
 elif [[ -f dataproc_env_files/name ]]; then
 	HADOOP_HOSTNAME=$(< dataproc_env_files/name)
-	HADOOP_IP=$(getent hosts "${HADOOP_HOSTNAME}.c.${GOOGLE_PROJECT_ID}.internal" | awk '{ print $1 }')
+	HADOOP_IP=$(getent hosts "${HADOOP_HOSTNAME}" | awk '{ print $1 }')
 	REALM=$(< dataproc_env_files/REALM)
 else
 	HADOOP_HOSTNAME=hadoop

--- a/concourse/scripts/load_data.bash
+++ b/concourse/scripts/load_data.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 GOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID:-data-gpdb-ud}
+GOOGLE_ZONE=${GOOGLE_ZONE:-us-central1-a}
 
 yum install -y -d1 openssh openssh-clients
 mkdir -p ~/.ssh/
@@ -22,5 +23,5 @@ gcloud compute instances add-metadata "${HADOOP_HOSTNAME}" \
   --zone "us-central1-a"
 
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  -t -i ~/.ssh/google_compute_engine "ccp-ci-service@${HADOOP_HOSTNAME}.c.${GOOGLE_PROJECT_ID}.internal" \
+  -t -i ~/.ssh/google_compute_engine "ccp-ci-service@${HADOOP_HOSTNAME}.${GOOGLE_ZONE}.c.${GOOGLE_PROJECT_ID}.internal" \
   "hadoop distcp gs://data-gpdb-ud-tpch/${SCALE}/lineitem_data/*.tbl /tmp/lineitem_read/" || exit 1

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -7,6 +7,7 @@ PXF_COMMON_SRC_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROXY_USER=${PROXY_USER:-pxfuser}
 PROTOCOL=${PROTOCOL:-}
 GOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID:-data-gpdb-ud}
+GOOGLE_ZONE=${GOOGLE_ZONE:-us-central1-a}
 
 # on purpose do not call this PXF_CONF so that it is not set during pxf operations
 PXF_CONF_DIR=~gpadmin/pxf
@@ -512,7 +513,7 @@ function configure_pxf_default_server() {
 
 			REALM=$(cat "$AMBARI_DIR"/REALM)
 			HIVE_HOSTNAME=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-2 | awk '{print $2}')
-			KERBERIZED_HADOOP_URI="hive/${HIVE_HOSTNAME}.c.${GOOGLE_PROJECT_ID}.internal@${REALM};saslQop=auth" # quoted because of semicolon
+			KERBERIZED_HADOOP_URI="hive/${HIVE_HOSTNAME}.${GOOGLE_ZONE}.c.${GOOGLE_PROJECT_ID}.internal@${REALM};saslQop=auth" # quoted because of semicolon
 			sed -i -e 's|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.apache.hive.jdbc.HiveDriver|' \
 				-e "s|YOUR_DATABASE_JDBC_URL|jdbc:hive2://${HIVE_HOSTNAME}:10000/default;principal=${KERBERIZED_HADOOP_URI}|" \
 				-e 's|YOUR_DATABASE_JDBC_USER||' \

--- a/concourse/scripts/start_dataproc_cluster.bash
+++ b/concourse/scripts/start_dataproc_cluster.bash
@@ -98,10 +98,10 @@ do
     --format='get(networkInterfaces[0].networkIP)' \
     --zone "$ZONE")
 
-  echo "${HADOOP_IP_ADDRESS} ${CLUSTER_NAME}-w-${i} ${CLUSTER_NAME}-w-${i}.c.${PROJECT}.internal" >> dataproc_env_files/etc_hostfile
+  echo "${HADOOP_IP_ADDRESS} ${CLUSTER_NAME}-w-${i} ${CLUSTER_NAME}-w-${i}.${ZONE}.c.${PROJECT}.internal" >> dataproc_env_files/etc_hostfile
 done
 
-echo "$HADOOP_HOSTNAME" > "dataproc_env_files/name"
+echo "$HADOOP_HOSTNAME.${ZONE}.c.${PROJECT}.internal" > "dataproc_env_files/name"
 
 mkdir -p "dataproc_env_files/conf"
 
@@ -111,7 +111,7 @@ HADOOP_IP_ADDRESS=$(gcloud compute instances describe "${HADOOP_HOSTNAME}" \
   --format='get(networkInterfaces[0].networkIP)' \
   --zone "$ZONE")
 
-echo "${HADOOP_IP_ADDRESS} ${HADOOP_HOSTNAME} ${HADOOP_HOSTNAME}.c.${PROJECT}.internal" >> dataproc_env_files/etc_hostfile
+echo "${HADOOP_IP_ADDRESS} ${HADOOP_HOSTNAME} ${HADOOP_HOSTNAME}.${ZONE}.c.${PROJECT}.internal" >> dataproc_env_files/etc_hostfile
 
 scp "${SSH_OPTS[@]}" \
   "${HADOOP_USER}@${HADOOP_IP_ADDRESS}:/etc/hadoop/conf/*-site.xml" \

--- a/concourse/scripts/test_pxf.bash
+++ b/concourse/scripts/test_pxf.bash
@@ -7,6 +7,7 @@ source "${CWDIR}/pxf_common.bash"
 PG_REGRESS=${PG_REGRESS:-false}
 
 export GOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID:-data-gpdb-ud}
+export GOOGLE_ZONE=${GOOGLE_ZONE:-us-central1-a}
 export GPHOME=${GPHOME:-/usr/local/greenplum-db-devel}
 export PXF_HOME=${GPHOME}/pxf
 export JAVA_HOME=${JAVA_HOME}
@@ -147,7 +148,7 @@ function configure_sut() {
 		HBASE_IP=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-3 | awk '{print $1}')
 		HIVE_IP=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-2 | awk '{print $1}')
 		HIVE_HOSTNAME=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-2 | awk '{print $2}')
-		KERBERIZED_HADOOP_URI="hive/${HIVE_HOSTNAME}.c.${GOOGLE_PROJECT_ID}.internal@${REALM};saslQop=auth" # quoted because of semicolon
+		KERBERIZED_HADOOP_URI="hive/${HIVE_HOSTNAME}.${GOOGLE_ZONE}.c.${GOOGLE_PROJECT_ID}.internal@${REALM};saslQop=auth" # quoted because of semicolon
 		# Add ambari hostfile to /etc/hosts
 		sudo tee --append /etc/hosts < "$AMBARI_DIR"/etc_hostfile
 		sudo cp "$AMBARI_DIR"/krb5.conf /etc/krb5.conf


### PR DESCRIPTION
Our GCP dataproc instances are being deployed with `VmDnsSetting= ZonalOnly`, but our scripts are using `Global (project wide) DNS`.
https://cloud.google.com/compute/docs/internal-dns