### PR TITLE
Use the first version of Guava that has a stable Cache API

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -86,7 +86,7 @@ allprojects {
             force "org.apache.avro:avro:1.7.7"
             force "org.apache.zookeeper:zookeeper:3.4.6"
             force "junit:junit:${junitVersion}"
-            force "com.google.guava:guava:19.0" // stable cache api
+            force "com.google.guava:guava:28.2-jre"
         }
     }
 
@@ -296,7 +296,7 @@ project('pxf-service') {
         bundleJars "org.apache.hadoop:hadoop-auth:${hadoopVersion}"
         bundleJars "commons-cli:commons-cli:1.2"
         bundleJars "commons-io:commons-io:2.4"
-        bundleJars "com.google.guava:guava:11.0.2"
+        bundleJars "com.google.guava:guava:28.2-jre"
         bundleJars "org.mortbay.jetty:jetty:6.1.26"
         bundleJars "org.mortbay.jetty:jetty-util:6.1.26"
         bundleJars "com.sun.jersey:jersey-server:1.9"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -86,7 +86,7 @@ allprojects {
             force "org.apache.avro:avro:1.7.7"
             force "org.apache.zookeeper:zookeeper:3.4.6"
             force "junit:junit:${junitVersion}"
-            force "com.google.guava:guava:28.2-jre"
+            force "com.google.guava:guava:19.0"
         }
     }
 
@@ -296,7 +296,7 @@ project('pxf-service') {
         bundleJars "org.apache.hadoop:hadoop-auth:${hadoopVersion}"
         bundleJars "commons-cli:commons-cli:1.2"
         bundleJars "commons-io:commons-io:2.4"
-        bundleJars "com.google.guava:guava:28.2-jre"
+        bundleJars "com.google.guava:guava:19.0"
         bundleJars "org.mortbay.jetty:jetty:6.1.26"
         bundleJars "org.mortbay.jetty:jetty-util:6.1.26"
         bundleJars "com.sun.jersey:jersey-server:1.9"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -86,7 +86,7 @@ allprojects {
             force "org.apache.avro:avro:1.7.7"
             force "org.apache.zookeeper:zookeeper:3.4.6"
             force "junit:junit:${junitVersion}"
-            force "com.google.guava:guava:11.0.2" // because this version ships with HDP-2.5.3
+            force "com.google.guava:guava:19.0" // stable cache api
         }
     }
 


### PR DESCRIPTION
Currently, we are using an old version of Guava that does not provide a
stable cache API and warnings are showing in IDE and during compilation.
The API became stable starting version 19.0