### PR TITLE
Update pxf_pr pipeline to not use Greenplum master

### DIFF
--- a/concourse/pipelines/pxf_pr_pipeline.yml
+++ b/concourse/pipelines/pxf_pr_pipeline.yml
@@ -11,7 +11,7 @@ resources:
 - name: gpdb_src
   type: git
   source:
-    branch: master
+    branch: 6X_STABLE
     uri: https://github.com/greenplum-db/gpdb.git
 
 - name: pxf_src
@@ -103,7 +103,7 @@ jobs:
         GROUP: smoke,proxy
         HADOOP_CLIENT: HDP
         IMPERSONATION: true
-        PGPORT: 7000
+        PGPORT: 6000
         TARGET_OS: centos
         TARGET_OS_VERSION: 6
       run:


### PR DESCRIPTION
We recently merged a PR to Greenplum master which removes the PXF
external table extension in favor of FDW. To continue testing we should
use 6X_STABLE in our pxf_pr pipelines.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>