### PR TITLE
CI: Do not trigger pxf build on every commit to gpdb master [ci_skip]

### DIFF
--- a/concourse/README.md
+++ b/concourse/README.md
@@ -159,11 +159,11 @@ For example, you may want to work off of a development branch for PXF or Greenpl
 
 ```
 fly -t ud set-pipeline -p pg_regress \
-	-c ~/workspace/pxf/concourse/pipelines/pg_regress_pipeline.yml \
-	-l ~/workspace/gp-continuous-integration/secrets/gpdb6-integration-testing.dev.yml \
-	-l ~/workspace/gp-continuous-integration/secrets/ccp-integration-pipelne-secrets.yml \
-	-l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-	-v "folder-prefix=dev/${USER}" -v gpdb-branch=master -v pgport=7000 \
-	-v gpdb-git-branch=master -v gpdb-git-remote=https://github.com/greenplum-db/gpdb \
-	-v pxf-git-branch=master -v pxf-git-remote=https://github.com/greenplum-db/pxf
+    -c ~/workspace/pxf/concourse/pipelines/pg_regress_pipeline.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb6-integration-testing.dev.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/ccp-integration-pipelne-secrets.yml \
+    -l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+    -v "folder-prefix=dev/${USER}" -v gpdb-branch=master -v pgport=7000 \
+    -v gpdb-git-branch=master -v gpdb-git-remote=https://github.com/greenplum-db/gpdb \
+    -v pxf-git-branch=master -v pxf-git-remote=https://github.com/greenplum-db/pxf
 ```

--- a/concourse/pipelines/pg_regress_pipeline.yml
+++ b/concourse/pipelines/pg_regress_pipeline.yml
@@ -13,6 +13,21 @@ resources:
     branch: {{gpdb-git-branch}}
     uri: {{gpdb-git-remote}}
 
+- name: gpdb_pxf_trigger
+  type: git
+  source:
+    branch: {{gpdb-branch}}
+    uri: {{gpdb-git-remote}}
+    paths:
+      - gpcontrib/pxf_fdw
+      - src/backend/foreign
+      - src/backend/commands/copy.c
+      - src/include/commands/copy.h
+      - src/include/catalog/pg_foreign_server.h
+      - src/include/catalog/pg_foreign_data_wrapper.h
+      - src/backend/executor/nodeForeignscan.c
+      - src/include/executor/nodeForeignscan.h
+
 - name: pxf_src
   type: git
   source:
@@ -92,6 +107,7 @@ jobs:
     - get: pxf_src
       trigger: true
     - get: gpdb_src
+    - get: gpdb_pxf_trigger
       trigger: true
     - get: gpdb-pxf-dev-centos7
   - task: compile_pxf


### PR DESCRIPTION
Currently, we trigger a PXF build for the pg_regress pipeline on every
commit to GPDB. Adding a trigger to execute on changes to gpcontrib/pxf_fdw.

We still trigger a build on GPDB for every commit, but it should be
limited to changes to FDW and Copy in the future.