### PR TITLE
Log org.apache.parquet at WARN level [ci_skip]

### DIFF
--- a/server/pxf-service/src/templates/user/conf/pxf-log4j.properties
+++ b/server/pxf-service/src/templates/user/conf/pxf-log4j.properties
@@ -27,7 +27,7 @@ log4j.logger.org.apache.hadoop=WARN
 log4j.logger.org.apache.zookeeper=WARN
 log4j.logger.hive.metastore=WARN
 
-log4j.logger.org.apache.parquet.hadoop=WARN
+log4j.logger.org.apache.parquet=WARN
 log4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender
 # use the same value directory as set for $PXF_LOGDIR
 log4j.appender.ROLLINGFILE.File=${pxf.log.dir}/pxf-service.log


### PR DESCRIPTION
After implementing parquet predicate pushdown, an increase of INFO level
log entries are appearing when there is a predicate filter. This commit
defaults the level to WARN for org.apache.parquet in the
pxf-log4j.properties.