### PR TITLE
Parquet Filter: Pad the predicate value to the length of the char field

### DIFF
--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/parquet/ParquetTypeConverter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/parquet/ParquetTypeConverter.java
@@ -270,7 +270,7 @@ public enum ParquetTypeConverter {
      * Converts a "timestamp with time zone" string to a INT96 byte array.
      * Supports microseconds for timestamps
      *
-     * @param timestampWithTimeZoneString the greenplum string of the timestamp with the time zone
+     * @param timestampWithTimeZoneString the greenplum string representation of the timestamp with timezone
      * @return Binary format of the timestamp with time zone string
      */
     public static Binary getBinaryFromTimestampWithTimeZone(String timestampWithTimeZoneString) {


### PR DESCRIPTION
While querying parquet files generated by PXF, and in the presence of a
predicate for a char field type, the predicate does not match the value
when the predicate value has length < char field length. When these
predicates are present, the query does not return any results.

To illustrate the issue, let's consider the following example:

```
CREATE WRITABLE EXTERNAL TABLE foo_w (a char(3))
LOCATION ('pxf://tmp/foo/?PROFILE=hdfs:parquet&SERVER=local')
FORMAT 'CUSTOM' (formatter='pxfwritable_export');

INSERT INTO foo_w VALUES ('s');
```

The commands above will generate a parquet file with a field of value
's  ' (with 2 blank characters at the end). When we query this data we
get the following:

```
CREATE EXTERNAL TABLE foo_r (a char(3))
LOCATION ('pxf://tmp/foo/?PROFILE=hdfs:parquet&SERVER=local')
FORMAT 'CUSTOM' (formatter='pxfwritable_import');

SELECT * FROM foo_r; -- Produces 1 row

SELECT * FROM foo_r WHERE a = 's'; -- Produces 0 rows

SELECT * FROM foo_r WHERE a = 's  '; -- Produces 1 row
```

To mantain consistency with Greenplum's behavior we need to pad the
predicate value for char fields with a defined length to match the
length of the field.