### PR TITLE
pxf cluster init: enforce JAVA_HOME is set

### DIFF
--- a/cli/go/src/pxf-cli/cmd/pxf.go
+++ b/cli/go/src/pxf-cli/cmd/pxf.go
@@ -14,8 +14,9 @@ import (
 type envVar string
 
 const (
-	gphome  envVar = "GPHOME"
-	pxfConf envVar = "PXF_CONF"
+	gphome   envVar = "GPHOME"
+	pxfConf  envVar = "PXF_CONF"
+	javaHome envVar = "JAVA_HOME"
 )
 
 type messageType int
@@ -70,6 +71,9 @@ func (cmd *command) GetFunctionToExecute() (func(string) string, error) {
 		if inputs[pxfConf] != "" {
 			pxfCommand += "PXF_CONF=" + inputs[pxfConf] + " "
 		}
+		if inputs[javaHome] != "" {
+			pxfCommand += "JAVA_HOME=" + inputs[javaHome] + " "
+		}
 		pxfCommand += inputs[gphome] + "/pxf/bin/pxf" + " " + string(cmd.name)
 		if cmd.name == reset {
 			pxfCommand += " --force" // there is a prompt for local reset as well
@@ -108,7 +112,7 @@ var (
 			err:     "PXF failed to initialize on %d out of %d hosts\n",
 		},
 		warn:       false,
-		envVars:    []envVar{gphome, pxfConf},
+		envVars:    []envVar{gphome, pxfConf, javaHome},
 		whereToRun: cluster.ON_HOSTS_AND_MASTER,
 	}
 	StartCommand = command{

--- a/cli/go/src/pxf-cli/cmd/pxf_test.go
+++ b/cli/go/src/pxf-cli/cmd/pxf_test.go
@@ -11,16 +11,17 @@ import (
 )
 
 var _ = Describe("CommandFunc", func() {
-	Context("when PXF_CONF and GPHOME are set", func() {
+	Context("when JAVA_HOME, PXF_CONF and GPHOME are set", func() {
 		BeforeEach(func() {
 			_ = os.Setenv("GPHOME", "/test/gphome")
 			_ = os.Setenv("PXF_CONF", "/test/gphome/pxf_conf")
+			_ = os.Setenv("JAVA_HOME", "/etc/java/home")
 		})
 
 		It("successfully generates init command", func() {
 			commandFunc, err := cmd.InitCommand.GetFunctionToExecute()
 			Expect(err).To(BeNil())
-			expected := "PXF_CONF=/test/gphome/pxf_conf /test/gphome/pxf/bin/pxf init"
+			expected := "PXF_CONF=/test/gphome/pxf_conf JAVA_HOME=/etc/java/home /test/gphome/pxf/bin/pxf init"
 			Expect(commandFunc("foo")).To(Equal(expected))
 		})
 	})

--- a/server/pxf-service/src/scripts/pxf-service
+++ b/server/pxf-service/src/scripts/pxf-service
@@ -103,11 +103,11 @@ function get_environment()
 
 }
 
-checkJavaHome()
+function checkJavaHome()
 {
     # validate JAVA_HOME
     if [[ ! -x ${JAVA_HOME}/bin/java ]]; then
-        fail "\$JAVA_HOME=$JAVA_HOME is invalid. Set \$JAVA_HOME in ~/.bashrc or $default_env_script on all Greenplum hosts."
+        fail "\$JAVA_HOME=$JAVA_HOME is invalid. Set \$JAVA_HOME in your environment before initializing PXF."
     fi
 }
 
@@ -370,10 +370,16 @@ function doInit()
     checkJavaHome
     generatePrivateClasspath || return 1
     generateUserConfigs || return 1
+    editPxfEnvSh || return 1
     createInstance || return 1
     deployWebapp || return 1
     createLogsDir || return 1
     createRunDir  || return 1
+}
+
+function editPxfEnvSh()
+{
+	sed -i.bak -e "s|.*JAVA_HOME=.*|JAVA_HOME=${JAVA_HOME}|g" "${PXF_CONF}/conf/pxf-env.sh" && rm "${PXF_CONF}/conf/pxf-env.sh.bak"
 }
 
 #


### PR DESCRIPTION
Sometimes users want to use a specific version of Java with PXF. In the
current world, initializing PXF can become awkward. We would ask the
user to temporarily set `JAVA_HOME` in `~/.bashrc` to perform the init
(or `pxf-env-default.sh`, which users shouldn't touch). Then after init,
we would ask them to manually adjust `JAVA_HOME` in
`$PXF_CONF/conf/pxf-env.sh` for their custom PXF value and optionally
switch back in `~/.bashrc`.

This PR proposes a better scenario where we enforce that `JAVA_HOME` is
valid in `pxf cluster init` by passing from the command's environment to
the remote hosts. Command then looks like this:

`JAVA_HOME=/correct/java/home pxf cluster init`

The `pxf-service` script also edits `$PXF_CONF/conf/pxf-env.sh` to make sure that
PXF will always have the correct value of `JAVA_HOME`. Users can thus have
whatever they like in their startup scripts, etc. for `JAVA_HOME`.

Also `pxf-service` stops telling users to edit `pxf-env-default.sh`.

