### PR TITLE
CI: Use --max-age flag on dataproc command to destroy clusters

### DIFF
--- a/concourse/pipelines/templates/pxf-tpl.yml
+++ b/concourse/pipelines/templates/pxf-tpl.yml
@@ -151,45 +151,6 @@ dataproc_destroy_anchor: &dataproc_destroy
       get_params:
         action: destroy
 
-dataproc_timed_destroy_anchor: &dataproc_timed_destroy
-  do:
-  - task: debug_sleep
-    image: ccp-7
-    config:
-      run:
-        path: /bin/sleep
-        args: [{{dataproc-destroy-timeout}}]
-      platform: linux
-  - in_parallel:
-    - task: Cleanup Dataproc 1
-      config:
-        run:
-          path: pxf_src/concourse/scripts/cleanup_dataproc_cluster.bash
-        inputs:
-          - name: pxf_src
-          - name: dataproc_env_files
-        platform: linux
-      image: ccp-7
-      params:
-        GOOGLE_CREDENTIALS: {{google-service-account-key}}
-        GOOGLE_PROJECT_ID: {{google-project-id}}
-        GOOGLE_ZONE: {{google-zone}}
-    - task: Cleanup Dataproc 2
-      input_mapping:
-        dataproc_env_files: dataproc_2_env_files
-      config:
-        run:
-          path: pxf_src/concourse/scripts/cleanup_dataproc_cluster.bash
-        inputs:
-          - name: pxf_src
-          - name: dataproc_env_files
-        platform: linux
-      image: ccp-7
-      params:
-        GOOGLE_CREDENTIALS: ((data-gpdb-ud-kerberos-google-service-account-key))
-        GOOGLE_PROJECT_ID: ((data-gpdb-ud-kerberos-google-project-id))
-        GOOGLE_ZONE: ((data-gpdb-ud-kerberos-google-zone))
-
 ## ======================================================================
 ## RESOURCE TYPES
 ## ======================================================================
@@ -1039,6 +1000,7 @@ jobs:
         GOOGLE_ZONE: {{google-zone}}
         IMAGE_VERSION: {{dataproc-image-version}}
         KERBEROS: {{kerberos-enabled}}
+        ccp_reap_minutes: 120
     - task: Generate Hadoop Cluster 2
       file: pxf_src/concourse/tasks/install_dataproc.yml
       image: ccp-7
@@ -1055,6 +1017,7 @@ jobs:
         KERBEROS: {{kerberos-enabled}}
         KEY: dataproc-kerberos-key
         KEYRING: dataproc-kerberos
+        ccp_reap_minutes: 120
         NO_ADDRESS: false
         PROXY_USER: gpuser
         SECRETS_BUCKET: data-gpdb-ud-kerberos-pxf-secrets
@@ -1076,15 +1039,11 @@ jobs:
       KERBEROS: {{kerberos-enabled}}
       PLATFORM: centos7
       PXF_JVM_OPTS: {{pxf-jvm-opts}}
-    on_failure:
-      <<: *dataproc_timed_destroy
   - task: Test PXF Multinode
     input_mapping:
       bin_gpdb: gpdb_binary
     on_success:
       <<: *dataproc_destroy
-    on_failure:
-      <<: *dataproc_timed_destroy
     image: gpdb-pxf-dev-centos6-hdp2-server
     file: pxf_src/concourse/tasks/test_pxf_multinode.yml
     attempts: 2
@@ -1218,15 +1177,11 @@ jobs:
       KERBEROS: {{kerberos-enabled}}
       PLATFORM: centos7
       PXF_JVM_OPTS: {{pxf-jvm-opts}}
-    on_failure:
-      <<: *dataproc_timed_destroy
   - task: Test PXF Multinode
     input_mapping:
       bin_gpdb: gpdb_binary
     on_success:
       <<: *dataproc_destroy
-    on_failure:
-      <<: *dataproc_timed_destroy
     image: gpdb-pxf-dev-centos6-hdp2-server
     file: pxf_src/concourse/tasks/test_pxf_multinode.yml
     attempts: 2

--- a/concourse/scripts/start_dataproc_cluster.bash
+++ b/concourse/scripts/start_dataproc_cluster.bash
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 # defaults
+CCP_REAP_MINUTES=${ccp_reap_minutes:-}
 HADOOP_USER=${HADOOP_USER:-gpadmin}
 IMAGE_VERSION=${IMAGE_VERSION:-1.3}
 INITIALIZATION_SCRIPT=${INITIALIZATION_SCRIPT:-gs://pxf-perf/scripts/initialization-for-kerberos.sh}
@@ -52,6 +53,10 @@ GCLOUD_COMMAND=(gcloud beta dataproc clusters
   "--num-workers=$NUM_WORKERS"
   --image-version "$IMAGE_VERSION"
   --properties "core:hadoop.proxyuser.${PROXY_USER}.hosts=*,core:hadoop.proxyuser.${PROXY_USER}.groups=*")
+
+if [[ -n "$CCP_REAP_MINUTES" ]]; then
+    GCLOUD_COMMAND+=(--max-age "${CCP_REAP_MINUTES}m")
+fi
 
 if [[ $NO_ADDRESS == true ]]; then
     GCLOUD_COMMAND+=(--no-address)

--- a/concourse/settings/pxf-multinode-params.yml
+++ b/concourse/settings/pxf-multinode-params.yml
@@ -4,5 +4,4 @@ tf-bucket-path: clusters-google/
 no_of_files: 10000
 pxf-jvm-opts: "-Xmx512m -Xms512m"
 kerberos-enabled: true
-dataproc-destroy-timeout: 3600
 dataproc-image-version: "1.4.12-debian9"


### PR DESCRIPTION
CCP provisioned clusters integrate to the CCP Reaper, but the kerberized
dataproc clusters are not able to integrate to CCP because of the lack
of support from terraform. We currently use a task to delay cleaning up
dataproc clusters on error. This method of destroying clusters is not
reliable. If someone cancels a concourse job, the cluster will remain
lingering, and manual intervention will be needed.

In this PR, we use the --max-age flag to cleanup clusters. We reuse the
reap time value from CCP as a way to cleanup clusters.