### PR TITLE
SecureLoginTest: Fix test pollution

### DIFF
--- a/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
+++ b/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
@@ -1,7 +1,9 @@
 package org.apache.hadoop.security;
 
 import com.google.common.collect.Sets;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.security.auth.Subject;
@@ -17,6 +19,24 @@ public class LoginSessionTest {
     private UserGroupInformation ugiFoo, ugiBar;
     private Subject subjectFoo, subjectBar;
     private User userFoo, userBar;
+
+    private static final String PROPERTY_KEY_KERBEROS_KDC = "java.security.krb5.kdc";
+    private static final String PROPERTY_KEY_KERBEROS_REALM = "java.security.krb5.realm";
+    private static String kdcDefault;
+    private static String realmDefault;
+
+    @BeforeClass
+    public static void setProperties() {
+        // simulate presence of krb.conf file, important for prevention of test pollution when creating Users
+        kdcDefault = System.setProperty(PROPERTY_KEY_KERBEROS_KDC, "localhost");
+        realmDefault = System.setProperty(PROPERTY_KEY_KERBEROS_REALM, "DEFAULT_REALM");
+    }
+
+    @AfterClass
+    public static void resetProperties() {
+        resetProperty(PROPERTY_KEY_KERBEROS_KDC, kdcDefault);
+        resetProperty(PROPERTY_KEY_KERBEROS_REALM, realmDefault);
+    }
 
     @Before
     public void setup() {
@@ -109,4 +129,11 @@ public class LoginSessionTest {
         assertEquals("LoginSession[config=config,principal=principal,keytab=keytab,kerberosMinMillisBeforeRelogin=1]", session.toString());
     }
 
+    private static void resetProperty(String key, String val) {
+        if (val != null) {
+            System.setProperty(key, val);
+            return;
+        }
+        System.clearProperty(key);
+    }
 }

--- a/server/pxf-api/src/test/java/org/apache/hadoop/security/PxfUserGroupInformationTest.java
+++ b/server/pxf-api/src/test/java/org/apache/hadoop/security/PxfUserGroupInformationTest.java
@@ -3,7 +3,9 @@ package org.apache.hadoop.security;
 import com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -50,6 +52,24 @@ public class PxfUserGroupInformationTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    private static final String PROPERTY_KEY_KERBEROS_KDC = "java.security.krb5.kdc";
+    private static final String PROPERTY_KEY_KERBEROS_REALM = "java.security.krb5.realm";
+    private static String kdcDefault;
+    private static String realmDefault;
+
+    @BeforeClass
+    public static void setProperties() {
+        // simulate presence of krb.conf file, important for prevention of test pollution when creating Users
+        kdcDefault = System.setProperty(PROPERTY_KEY_KERBEROS_KDC, "localhost");
+        realmDefault = System.setProperty(PROPERTY_KEY_KERBEROS_REALM, "DEFAULT_REALM");
+    }
+
+    @AfterClass
+    public static void resetProperties() {
+        resetProperty(PROPERTY_KEY_KERBEROS_KDC, kdcDefault);
+        resetProperty(PROPERTY_KEY_KERBEROS_REALM, realmDefault);
+    }
 
     @Before
     public void setup() throws Exception {
@@ -318,4 +338,11 @@ public class PxfUserGroupInformationTest {
         PxfUserGroupInformation.reloginFromKeytab(serverName, session);
     }
 
+    private static void resetProperty(String key, String val) {
+        if (val != null) {
+            System.setProperty(key, val);
+            return;
+        }
+        System.clearProperty(key);
+    }
 }


### PR DESCRIPTION
SecureLoginTest has been failing sporadically on centos7 in Concourse
during the compile_pxf job. It turns out that if one of these tests:

* org.apache.hadoop.security.LoginSessionTest
* org.apache.hadoop.security.PxfUserGroupInformationTest

runs before SecureLoginTest, we get an error when SecureLogin tries to
get the default realm when looking up the user. This has to do with
test pollution when newing up Hadoop `User`s, which end up
setting the default Kerberos realm for the JVM. This is the Hadoop code
that up does that[0].

This commit makes sure that

* if we change system properties, we change them back after the tests
* we have default realm set to something so that we don't get empty
  string

[0] https://github.com/apache/hadoop/blob/826afbeae31ca687bc2f8471dc841b66ed2c6704/hadoop-common-project/hadoop-auth/src/main/java/org/apache/hadoop/security/authentication/util/KerberosName.java#L86

Co-authored-by: Oliver Albertini <oalbertini@pivotal.io>
Co-authored-by: Alex Denissov <adenissov@pivotal.io>

