### PR TITLE
pgregress: fix HCFS cleanup script template

### DIFF
--- a/regression/scripts/cleanup_hcfs.bash
+++ b/regression/scripts/cleanup_hcfs.bash
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-{{HCFS_CMD}} dfs -rm -r -f {{HCFS_SCHEME}}{{HCFS_BUCKET}}{{HCFS_LOCATION}}
+'{{ HCFS_CMD }}' dfs -rm -r -f '{{ HCFS_SCHEME }}{{ HCFS_BUCKET }}{{ TEST_LOCATION }}'


### PR DESCRIPTION
It was using HCFS_LOCATION, which is no longer used in the substitution
script, in favor of TEST_LOCATION.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>