### PR TITLE
server/Makefile: Allow running single unit test

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -42,8 +42,23 @@ all:
 compile:
 	./gradlew compileJava
 
+GRADLEW_TEST_PARAMS = test
+ifneq "$(TEST)" ""
+	# find test file, remove leading "./" and trailing ".java"
+	TEST_FILE = $(shell : "$$(find . -name $(TEST).java)"; : "$${_%.java}"; echo "$${_\#./}")
+	# parse out the gradle project by grabbing top-level dir name
+	PROJECT   = $(shell : '${TEST_FILE}'; echo "$${_%%/*}")
+	# get java-style path with dots, starting at "org"
+	TEST_PATH = $(shell : '${TEST_FILE}'; : "$${_\#${PROJECT}/src/test/java/}"; echo "$${_//\//.}")
+	GRADLEW_TEST_PARAMS = :$(PROJECT):test --rerun-tasks --tests $(TEST_PATH)
+endif
+
 test unittest:
-	./gradlew test
+	@if [ -n '$(TEST)' ] && [ -z '${TEST_FILE}' ]; then \
+		echo 'Test $(TEST) was not found'; \
+		exit 1; \
+	fi
+	./gradlew ${GRADLEW_TEST_PARAMS}
 
 tar: tomcat
 	./gradlew tar ${BUILD_PARAMS}


### PR DESCRIPTION
In dev environments (like CI, especially) it is sometimes useful to run
one-off unit tests from the command line. This commit introduces this
behavior via an environment variable. The gradlew --rerun-tasks flag is
included to enforce that the test is always re-run.

Here's an example of the usage/behavior:

When `TEST` points to a valid test in any gradle project:

```
$ TEST=ParquetResolverTest make -C server test
./gradlew :pxf-hdfs:test --rerun-tasks --tests org.greenplum.pxf.plugins.hdfs.ParquetResolverTest

BUILD SUCCESSFUL in 3s
6 actionable tasks: 6 executed

$ TEST=UtilitiesTest make -C server test
./gradlew :pxf-api:test --rerun-tasks --tests org.greenplum.pxf.api.utilities.UtilitiesTest

BUILD SUCCESSFUL in 1s
4 actionable tasks: 4 executed
```

When `TEST` points to an invalid test:

```
$ TEST=FooTest make -C server test
Test FooTest was not found
make: *** [test] Error 1
```

When `TEST` is empty or unset, all tests run, as usual:

```
$ TEST= make -C server test
./gradlew test

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 14s
36 actionable tasks: 5 executed, 31 up-to-date
$ make -C server test
./gradlew test

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2s
36 actionable tasks: 3 executed, 33 up-to-date
```

Authored-by: Oliver Albertini <oalbertini@pivotal.io>