### PR TITLE
pxf-cli: set GOPATH using direnv

### DIFF
--- a/cli/go/src/pxf-cli/.envrc
+++ b/cli/go/src/pxf-cli/.envrc
@@ -1,0 +1,2 @@
+GOPATH=$(cd ../.. && echo "$PWD")
+export GOPATH


### PR DESCRIPTION
.envrc will be sourced if user has direnv.

Authored-by: Oliver Albertini <oalbertini@vmware.com>