### PR TITLE
Add User Option to allow invalid input paths

### DIFF
--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
@@ -20,9 +20,11 @@ package org.greenplum.pxf.plugins.hdfs;
  */
 
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.InvalidInputException;
 import org.apache.hadoop.mapred.JobConf;
 import org.greenplum.pxf.api.model.BaseFragmenter;
 import org.greenplum.pxf.api.model.Fragment;
@@ -64,7 +66,16 @@ public class HdfsDataFragmenter extends BaseFragmenter {
     @Override
     public List<Fragment> getFragments() throws Exception {
         Path path = new Path(hcfsType.getDataUri(jobConf, context));
-        List<InputSplit> splits = getSplits(path);
+        List<InputSplit> splits;
+        try {
+            splits = getSplits(path);
+        } catch (InvalidInputException e) {
+            if (StringUtils.equalsIgnoreCase("true", context.getOption("IGNORE_INVALID_INPUT"))) {
+                LOG.debug("Ignoring InvalidInputException", e);
+                return fragments;
+            }
+            throw e;
+        }
 
         LOG.debug("Total number of fragments = {}", splits.size());
         for (InputSplit split : splits) {

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenter.java
@@ -46,6 +46,8 @@ import java.util.List;
  */
 public class HdfsDataFragmenter extends BaseFragmenter {
 
+    protected static final String IGNORE_MISSING_PATH_OPTION = "IGNORE_MISSING_PATH";
+
     protected JobConf jobConf;
     protected HcfsType hcfsType;
 
@@ -70,7 +72,7 @@ public class HdfsDataFragmenter extends BaseFragmenter {
         try {
             splits = getSplits(path);
         } catch (InvalidInputException e) {
-            if (StringUtils.equalsIgnoreCase("true", context.getOption("IGNORE_INVALID_INPUT"))) {
+            if (StringUtils.equalsIgnoreCase("true", context.getOption(IGNORE_MISSING_PATH_OPTION))) {
                 LOG.debug("Ignoring InvalidInputException", e);
                 return fragments;
             }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -37,7 +37,7 @@ public class HdfsFileFragmenter extends HdfsDataFragmenter {
         try {
             fileStatusArray = pxfInputFormat.listStatus(jobConf);
         } catch (InvalidInputException e) {
-            if (StringUtils.equalsIgnoreCase("true", context.getOption("IGNORE_INVALID_INPUT"))) {
+            if (StringUtils.equalsIgnoreCase("true", context.getOption(IGNORE_MISSING_PATH_OPTION))) {
                 LOG.debug("Ignoring InvalidInputException", e);
                 return fragments;
             }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -1,6 +1,9 @@
 package org.greenplum.pxf.plugins.hdfs;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.InvalidInputException;
 import org.greenplum.pxf.api.model.Fragment;
 import org.greenplum.pxf.plugins.hdfs.utilities.PxfInputFormat;
 
@@ -29,7 +32,19 @@ public class HdfsFileFragmenter extends HdfsDataFragmenter {
         PxfInputFormat pxfInputFormat = new PxfInputFormat();
         PxfInputFormat.setInputPaths(jobConf, path);
 
-        fragments = Arrays.stream(pxfInputFormat.listStatus(jobConf))
+        FileStatus[] fileStatusArray;
+
+        try {
+            fileStatusArray = pxfInputFormat.listStatus(jobConf);
+        } catch (InvalidInputException e) {
+            if (StringUtils.equalsIgnoreCase("true", context.getOption("IGNORE_INVALID_INPUT"))) {
+                LOG.debug("Ignoring InvalidInputException", e);
+                return fragments;
+            }
+            throw e;
+        }
+
+        fragments = Arrays.stream(fileStatusArray)
                 .map(fileStatus -> new Fragment(fileStatus.getPath().toUri().toString()))
                 .collect(Collectors.toList());
         LOG.debug("Total number of fragments = {}", fragments.size());

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
@@ -78,7 +78,7 @@ public class HdfsDataFragmenterTest {
         context.setConfig("default");
         context.setUser("test-user");
         context.setProfileScheme("localfile");
-        context.addOption("IGNORE_INVALID_INPUT", "true");
+        context.addOption("IGNORE_MISSING_PATH", "true");
         context.setDataSource("/tmp/non-existent-path-on-disk/*.csv");
 
         Fragmenter fragmenter = new HdfsDataFragmenter();

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
@@ -1,9 +1,12 @@
 package org.greenplum.pxf.plugins.hdfs;
 
+import org.apache.hadoop.mapred.InvalidInputException;
 import org.greenplum.pxf.api.model.Fragment;
 import org.greenplum.pxf.api.model.Fragmenter;
 import org.greenplum.pxf.api.model.RequestContext;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.List;
 
@@ -11,6 +14,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class HdfsDataFragmenterTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testFragmenterReturnsListOfFiles() throws Exception {
@@ -48,5 +54,38 @@ public class HdfsDataFragmenterTest {
         assertNotNull(fragmentList);
         // empty.csv gets ignored
         assertEquals(3, fragmentList.size());
+    }
+
+    @Test
+    public void testInvalidInputPath() throws Exception {
+        thrown.expect(InvalidInputException.class);
+        thrown.expectMessage("Input Pattern file:/tmp/non-existent-path-on-disk/*.csv matches 0 files");
+
+        RequestContext context = new RequestContext();
+        context.setConfig("default");
+        context.setUser("test-user");
+        context.setProfileScheme("localfile");
+        context.setDataSource("/tmp/non-existent-path-on-disk/*.csv");
+
+        Fragmenter fragmenter = new HdfsDataFragmenter();
+        fragmenter.initialize(context);
+        fragmenter.getFragments();
+    }
+
+    @Test
+    public void testInvalidInputPathIgnored() throws Exception {
+        RequestContext context = new RequestContext();
+        context.setConfig("default");
+        context.setUser("test-user");
+        context.setProfileScheme("localfile");
+        context.addOption("IGNORE_INVALID_INPUT", "true");
+        context.setDataSource("/tmp/non-existent-path-on-disk/*.csv");
+
+        Fragmenter fragmenter = new HdfsDataFragmenter();
+        fragmenter.initialize(context);
+
+        List<Fragment> fragmentList = fragmenter.getFragments();
+        assertNotNull(fragmentList);
+        assertEquals(0, fragmentList.size());
     }
 }

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -74,4 +74,37 @@ public class HdfsFileFragmenterTest {
         assertNotNull(fragmentList);
         assertEquals(4, fragmentList.size());
     }
+
+    @Test
+    public void testInvalidInputPath() throws Exception {
+        expectedException.expect(InvalidInputException.class);
+        expectedException.expectMessage("Input Pattern file:/tmp/non-existent-path-on-disk/*.csv matches 0 files");
+
+        RequestContext context = new RequestContext();
+        context.setConfig("default");
+        context.setUser("test-user");
+        context.setProfileScheme("localfile");
+        context.setDataSource("/tmp/non-existent-path-on-disk/*.csv");
+
+        Fragmenter fragmenter = new HdfsFileFragmenter();
+        fragmenter.initialize(context);
+        fragmenter.getFragments();
+    }
+
+    @Test
+    public void testInvalidInputPathIgnored() throws Exception {
+        RequestContext context = new RequestContext();
+        context.setConfig("default");
+        context.setUser("test-user");
+        context.setProfileScheme("localfile");
+        context.addOption("IGNORE_INVALID_INPUT", "true");
+        context.setDataSource("/tmp/non-existent-path-on-disk/*.csv");
+
+        Fragmenter fragmenter = new HdfsFileFragmenter();
+        fragmenter.initialize(context);
+
+        List<Fragment> fragmentList = fragmenter.getFragments();
+        assertNotNull(fragmentList);
+        assertEquals(0, fragmentList.size());
+    }
 }

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -97,7 +97,7 @@ public class HdfsFileFragmenterTest {
         context.setConfig("default");
         context.setUser("test-user");
         context.setProfileScheme("localfile");
-        context.addOption("IGNORE_INVALID_INPUT", "true");
+        context.addOption("IGNORE_MISSING_PATH", "true");
         context.setDataSource("/tmp/non-existent-path-on-disk/*.csv");
 
         Fragmenter fragmenter = new HdfsFileFragmenter();


### PR DESCRIPTION
While running performance tests, some external tables did not have any
data, and when writting data to the partition, they did not create the
expected path while reading. To illustrate this better, this is a sample
code of what happened:

    CREATE TABLE foo (id int, some_date date)
    DISTRIBUTED BY (id)
    PARTITION BY RANGE (some_date)
    (start('1992-01-01') INCLUSIVE end ('1998-12-31') INCLUSIVE every
    (30), default partition others);

The stamement above will create 87 partitions. In our experiment, some
of the partitions did not have any data (there were no records for some
date ranges).

We then replace the internal partition with an external partition, as
illustrated below:

    CREATE EXTERNAL TABLE replace_partition_87 (id int, some_date date)
    LOCATION (
    'pxf://bucket/non-existent-path/?PROFILE=s3:parquet&SERVER=s3'
    ) FORMAT 'CUSTOM' (formatter = 'pxfwritable_import');

    ALTER TABLE foo
    EXCHANGE PARTITION FOR (RANK(87)) WITH TABLE replace_partition_87
    WITHOUT VALIDATION;

Because some of the external tables end up with no data, queries fail
when reading the original partitioned table `foo`. This commit
introduces a new user property `IGNORE_INVALID_INPUT`, which when set to
true, it will ignore the error and return an empty list of fragments.
The new table definition would look like this:

    CREATE EXTERNAL TABLE replace_partition_87(id int, some_date date)
    LOCATION (
    'pxf://bucket/non-existent-path/?PROFLE=s3:parquet&IGNORE_INVALID_INPUT=true'
    ) FORMAT 'CUSTOM' (formatter = 'pxfwritable_import');

This commit does not change the default behaviour of erroring out when
the partition is missing, but rather gives users an option to not error
out when the input path is missing.