### PR TITLE
Fix license-finder in the norsk pipeline

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -5,8 +5,10 @@
 # make TEST=<class>#<method> ===> run specific <method> from <class>.class
 # make OFFLINE=true ===> run using only cache
 
+SHELL := bash
 UNAME_S := $(shell uname -s)
 MAVEN_TEST_OPTS+= -B -e
+PXF_TMP_LIB := $(HOME)/automation_tmp_lib
 
 ifneq "$(TEST)" ""
 	MAVEN_TEST_OPTS+= -Dtest=$(TEST)
@@ -19,7 +21,7 @@ endif
 ifeq "$(PXF_HOME)" ""
 	PXF_HOME=$(GPHOME)/pxf
 endif
-MAVEN_TEST_OPTS+= -DPXF_TMP_LIB=$(PXF_HOME)/tmp "-Djava.awt.headless=true"
+MAVEN_TEST_OPTS+= "-Djava.awt.headless=true"
 
 ifneq "$(OFFLINE)" "true"
 	MAVEN_TEST_OPTS+= -U
@@ -87,13 +89,17 @@ all: test
 
 symlink_pxf_jars:
 	@if [ -d "$(PXF_HOME)/lib" ]; then \
-		rm -rf $(PXF_HOME)/tmp && \
-		mkdir -p $(PXF_HOME)/tmp && \
-		cd $(PXF_HOME)/tmp && \
-		for X in $(PXF_HOME)/lib/pxf-*-[0-9]*.jar; do \
-			ln -sf $$X `echo \`basename $$X\` | sed -e 's/-[a-zA-Z0-9.]*.jar/.jar/'`; \
+		rm -rf $(PXF_TMP_LIB) && \
+		mkdir -p $(PXF_TMP_LIB) && \
+		for jar in $(PXF_HOME)/lib/pxf-*.jar; do \
+			jar_name="$${jar##*/}"; \
+			if [[ $${jar_name} =~ ^pxf-[A-Za-z0-9]+(-[0-9.]+)\.jar$$ ]]; then \
+				link=$(PXF_TMP_LIB)/$${jar_name/$${BASH_REMATCH[1]}/}; \
+				echo "creating link $${link} -> $${jar}"; \
+				ln -sf "$${jar}" "$${link}"; \
+			fi; \
 		done; \
-		touch $(PXF_HOME)/tmp/pxf-extras.jar; \
+		touch $(PXF_TMP_LIB)/pxf-extras.jar; \
 	fi
 
 test: clean-logs symlink_pxf_jars sync_cloud_configs sync_jdbc_config
@@ -101,7 +107,7 @@ test: clean-logs symlink_pxf_jars sync_cloud_configs sync_jdbc_config
 
 clean: clean-logs
 	$(MVN) $(MAVEN_TEST_OPTS) clean
-	@rm -rf $(PXF_HOME)/tmp
+	@rm -rf $(PXF_TMP_LIB)
 
 clean-logs:
 	@rm -rf automation_logs/* tincrepo/main/log/* run-results/*

--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <gphd.home>${GPHD_ROOT}</gphd.home>
-        <pxf.lib>${PXF_TMP_LIB}</pxf.lib>
+        <pxf.lib>${user.home}/automation_tmp_lib</pxf.lib>
         <hdp.hadoop.version>2.9.2</hdp.hadoop.version>
         <hdp.hbase.version>1.1.2</hdp.hbase.version>
         <hdp.hive.version>1.1.0</hdp.hive.version>


### PR DESCRIPTION
Recently we experienced issues with the norsk pipeline for PXF. The
issue is a failure when scanning the `pxf/automation` Maven project.

Within the license finder code, this command is run:

mvn help:evaluate -Dexpression=project.parent -q -D forceStdout

which aims to find the project parent. The correct response is:

null object or invalid expression

because there is no parent to automation/pom.xml.

However, the mvn command fails because mvn expects an environment
variable, PXF_TMP_LIB, to be set. mvn is normally only run from our
automation/Makefile, which sets PXF_TMP_LIB.  For automation it points
to a directory with symlinks to jars from $PXF_HOME/lib. Historically,
PXF_TMP_LIB=$PXF_HOME/tmp.

This commit changes that in favor of a hardcoded value in the user's
home directory: $HOME/pxf_tmp_lib. Symlinks will be created there
linking to jar files in $PXF_HOME/lib. This way mvn will not fail when
the above command is run, because HOME will be defined, and pointing to
an absolute path.
