### PR TITLE
Split dependencies tarball into 2 tarballs

### DIFF
--- a/concourse/docker/pxf-build-base/Dockerfile
+++ b/concourse/docker/pxf-build-base/Dockerfile
@@ -28,10 +28,11 @@ RUN export BUILD_PARAMS=-Dorg.gradle.daemon=false && \
       ln -sf $X /root/automation_tmp_lib/`echo \`basename $X\` | sed -e 's/-[a-zA-Z0-9.]*.jar/.jar/'`; \
     done && touch /root/automation_tmp_lib/pxf-extras.jar && \
     cd /tmp/pxf_src/automation && mvn dependency:go-offline -DexcludeGroupIds=org.greenplum && \
-    cd - && mkdir -p /tmp/output/.tomcat && \
+    cd - && mkdir -p /tmp/output/.tomcat && mkdir -p /tmp/automation && \
     mv /tmp/pxf_src/pxf_commit_sha /tmp/output/pxf_commit_sha && \
     mv /tmp/pxf_src/server/tomcat/build/apache-tomcat-*.tar.gz /tmp/output/.tomcat/ && \
     mv /tmp/pxf_src/cli/go/pkg/dep/sources /tmp/output/.go-dep-cached-sources && \
-    mv /root/.gradle /tmp/output && mv /root/.m2 /tmp/output && \
+    mv /root/.gradle /tmp/output && mv /root/.m2 /tmp/automation && \
     cd /tmp/output/ && tar -czf /tmp/pxf-build-dependencies.tar.gz . && \
-    rm -rf /tmp/output /tmp/pxf_src /root/.gradle /root/.m2
+    cd /tmp/automation && tar -czf /tmp/pxf-automation-dependencies.tar.gz . && \
+    rm -rf /tmp/output /tmp/pxf_src /root/.gradle /root/.m2 /tmp/automation

--- a/concourse/docker/pxf-build-base/Dockerfile
+++ b/concourse/docker/pxf-build-base/Dockerfile
@@ -28,9 +28,9 @@ RUN export BUILD_PARAMS=-Dorg.gradle.daemon=false && \
       ln -sf $X /root/automation_tmp_lib/`echo \`basename $X\` | sed -e 's/-[a-zA-Z0-9.]*.jar/.jar/'`; \
     done && touch /root/automation_tmp_lib/pxf-extras.jar && \
     make -C /tmp/pxf_src/automation dev && \
-    cp /tmp/pxf_src/server/pxf-service/src/templates/user/templates/jdbc-site.xml /root/pxf/servers/database/jdbc-site.xml && \
-    cp /tmp/pxf_src/server/pxf-service/src/templates/user/templates/jdbc-site.xml /root/pxf/servers/db-session-params/jdbc-site.xml && \
-    cp /tmp/pxf_src/server/pxf-service/src/templates/user/templates/jdbc-site.xml /root/pxf/servers/db-hive && \
+    mkdir -p /root/pxf/servers/database/ && cp /tmp/pxf_src/server/pxf-service/src/templates/user/templates/jdbc-site.xml /root/pxf/servers/database/ && \
+    mkdir -p /root/pxf/servers/db-session-params/ && cp /tmp/pxf_src/server/pxf-service/src/templates/user/templates/jdbc-site.xml /root/pxf/servers/db-session-params/ && \
+    mkdir -p /root/pxf/servers/db-hive/ && cp /tmp/pxf_src/server/pxf-service/src/templates/user/templates/jdbc-site.xml /root/pxf/servers/db-hive/ && \
     make -C /tmp/pxf_src/automation TEST=HdfsSmokeTest || true && \
     mkdir -p /tmp/output/.tomcat && mkdir -p /tmp/automation && \
     mv /tmp/pxf_src/pxf_commit_sha /tmp/output/pxf_commit_sha && \

--- a/concourse/docker/pxf-build-base/Dockerfile
+++ b/concourse/docker/pxf-build-base/Dockerfile
@@ -27,7 +27,11 @@ RUN export BUILD_PARAMS=-Dorg.gradle.daemon=false && \
     for X in /tmp/pxf_src/server/build/stage/lib/pxf-*-[0-9]*.jar; do \
       ln -sf $X /root/automation_tmp_lib/`echo \`basename $X\` | sed -e 's/-[a-zA-Z0-9.]*.jar/.jar/'`; \
     done && touch /root/automation_tmp_lib/pxf-extras.jar && \
-    make -C /tmp/pxf_src/automation dev && make -C /tmp/pxf_src/automation TEST=HdfsSmokeTest || true && \
+    make -C /tmp/pxf_src/automation dev && \
+    cp /tmp/pxf_src/server/pxf-service/src/templates/user/templates/jdbc-site.xml /root/pxf/servers/database/jdbc-site.xml && \
+    cp /tmp/pxf_src/server/pxf-service/src/templates/user/templates/jdbc-site.xml /root/pxf/servers/db-session-params/jdbc-site.xml && \
+    cp /tmp/pxf_src/server/pxf-service/src/templates/user/templates/jdbc-site.xml /root/pxf/servers/db-hive && \
+    make -C /tmp/pxf_src/automation TEST=HdfsSmokeTest || true && \
     mkdir -p /tmp/output/.tomcat && mkdir -p /tmp/automation && \
     mv /tmp/pxf_src/pxf_commit_sha /tmp/output/pxf_commit_sha && \
     mv /tmp/pxf_src/server/tomcat/build/apache-tomcat-*.tar.gz /tmp/output/.tomcat/ && \

--- a/concourse/docker/pxf-build-base/Dockerfile
+++ b/concourse/docker/pxf-build-base/Dockerfile
@@ -27,8 +27,8 @@ RUN export BUILD_PARAMS=-Dorg.gradle.daemon=false && \
     for X in /tmp/pxf_src/server/build/stage/lib/pxf-*-[0-9]*.jar; do \
       ln -sf $X /root/automation_tmp_lib/`echo \`basename $X\` | sed -e 's/-[a-zA-Z0-9.]*.jar/.jar/'`; \
     done && touch /root/automation_tmp_lib/pxf-extras.jar && \
-    cd /tmp/pxf_src/automation && mvn dependency:go-offline -DexcludeGroupIds=org.greenplum && \
-    cd - && mkdir -p /tmp/output/.tomcat && mkdir -p /tmp/automation && \
+    make -C /tmp/pxf_src/automation dev && \
+    mkdir -p /tmp/output/.tomcat && mkdir -p /tmp/automation && \
     mv /tmp/pxf_src/pxf_commit_sha /tmp/output/pxf_commit_sha && \
     mv /tmp/pxf_src/server/tomcat/build/apache-tomcat-*.tar.gz /tmp/output/.tomcat/ && \
     mv /tmp/pxf_src/cli/go/pkg/dep/sources /tmp/output/.go-dep-cached-sources && \

--- a/concourse/docker/pxf-build-base/Dockerfile
+++ b/concourse/docker/pxf-build-base/Dockerfile
@@ -27,7 +27,7 @@ RUN export BUILD_PARAMS=-Dorg.gradle.daemon=false && \
     for X in /tmp/pxf_src/server/build/stage/lib/pxf-*-[0-9]*.jar; do \
       ln -sf $X /root/automation_tmp_lib/`echo \`basename $X\` | sed -e 's/-[a-zA-Z0-9.]*.jar/.jar/'`; \
     done && touch /root/automation_tmp_lib/pxf-extras.jar && \
-    make -C /tmp/pxf_src/automation dev && \
+    make -C /tmp/pxf_src/automation dev && make -C /tmp/pxf_src/automation TEST=HdfsSmokeTest || true && \
     mkdir -p /tmp/output/.tomcat && mkdir -p /tmp/automation && \
     mv /tmp/pxf_src/pxf_commit_sha /tmp/output/pxf_commit_sha && \
     mv /tmp/pxf_src/server/tomcat/build/apache-tomcat-*.tar.gz /tmp/output/.tomcat/ && \

--- a/concourse/docker/pxf-build-base/Dockerfile
+++ b/concourse/docker/pxf-build-base/Dockerfile
@@ -39,4 +39,4 @@ RUN export BUILD_PARAMS=-Dorg.gradle.daemon=false && \
     mv /root/.gradle /tmp/output && mv /root/.m2 /tmp/automation && \
     cd /tmp/output/ && tar -czf /tmp/pxf-build-dependencies.tar.gz . && \
     cd /tmp/automation && tar -czf /tmp/pxf-automation-dependencies.tar.gz . && \
-    rm -rf /tmp/output /tmp/pxf_src /root/.gradle /root/.m2 /tmp/automation
+    rm -rf /tmp/output /tmp/pxf_src /root/.gradle /root/.m2 /tmp/automation /root/pxf

--- a/concourse/docker/pxf-build-base/README.md
+++ b/concourse/docker/pxf-build-base/README.md
@@ -1,7 +1,8 @@
 # How to generate a tarball with PXF dependencies locally
 
-You can generate the tarball with all the dependencies for PXF (`.m2` cache,
-`.gradle` cache, `.tomcat` directory, go dependencies).
+You can generate the tarball with all the build dependencies for PXF
+(`.gradle` cache, `.tomcat` directory, go dependencies), and the tarball
+with all the automation dependencies (`.m2` cache).
 
 ### Requirements
 
@@ -21,7 +22,7 @@ docker build --tag=pxf-build-dev \
 
 docker run --rm \
   -v ~/workspace/build:/tmp/build/ \
-  pxf-build-dev /bin/bash -c "cp /tmp/pxf-build-dependencies.tar.gz /tmp/build/"
+  pxf-build-dev /bin/bash -c "cp /tmp/pxf-*-dependencies.tar.gz /tmp/build/"
 
 ```
 
@@ -39,6 +40,7 @@ gcloud builds submit . --config=cloudbuild.yaml \
 
 ```
 
-The dependencies will be stored in Google Cloud Storage in the
-`gs://${_PXF_BUILD_BUCKET}/build-dependencies/pxf-build-dependencies.tar.gz`
-path.
+The dependencies will be stored in Google Cloud Storage in:
+
+- `gs://${_PXF_BUILD_BUCKET}/build-dependencies/pxf-build-dependencies.tar.gz` for build dependencies
+- `gs://${_PXF_BUILD_BUCKET}/automation-dependencies/pxf-automation-dependencies.tar.gz` for automation dependencies

--- a/concourse/docker/pxf-build-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-build-base/cloudbuild.yaml
@@ -31,9 +31,14 @@ steps:
   - '-c'
   - |
     mkdir /workspace/build
-    docker run --rm -v /workspace/build:/tmp/build/ pxf-build-dev /bin/bash -c "cp /tmp/pxf-build-dependencies.tar.gz /tmp/build/"
+    docker run --rm -v /workspace/build:/tmp/build/ pxf-build-dev /bin/bash -c "cp /tmp/pxf-*-dependencies.tar.gz /tmp/build/"
 
 # Push the pxf-build-dependencies.tar.gz tarball to Google Cloud Storage
 - name: 'gcr.io/cloud-builders/gsutil'
   id: pxf-build-dependencies-tarball
   args: ['cp', '/workspace/build/pxf-build-dependencies.tar.gz', 'gs://${_PXF_BUILD_BUCKET}/build-dependencies/pxf-build-dependencies.tar.gz']
+
+# Push the pxf-automation-dependencies.tar.gz tarball to Google Cloud Storage
+- name: 'gcr.io/cloud-builders/gsutil'
+  id: pxf-automation-dependencies-tarball
+  args: ['cp', '/workspace/build/pxf-automation-dependencies.tar.gz', 'gs://${_PXF_BUILD_BUCKET}/automation-dependencies/pxf-automation-dependencies.tar.gz']


### PR DESCRIPTION
- 1 tarball for .gradle, .tomcat, .go
- 1 tarball for .m2 (includes all dependencies / allows for offline mode)

These tarballs will be used in different jobs in different parts of the
pipeline
