### PR TITLE
pxf-dev-base: add LANG to all images

### DIFF
--- a/concourse/docker/pxf-dev-base/gpdb5/centos6/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb5/centos6/Dockerfile
@@ -47,6 +47,7 @@ RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nproc 131072' \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nofile 65536' \
     # create .pxfrc
+    && echo >> ~gpadmin/.pxfrc 'export LANG=en_US.UTF-8' \
     && echo >> ~gpadmin/.pxfrc 'export PGPORT=5432' \
     && echo >> ~gpadmin/.pxfrc 'export GOPATH=/opt/go' \
     && echo >> ~gpadmin/.pxfrc 'export GPHOME=$(find /usr/local/ -name greenplum-db* -type d | head -n1)' \

--- a/concourse/docker/pxf-dev-base/gpdb5/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb5/centos7/Dockerfile
@@ -53,6 +53,7 @@ RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nproc 131072' \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nofile 65536' \
     # create .pxfrc
+    && echo >> ~gpadmin/.pxfrc 'export LANG=en_US.UTF-8' \
     && echo >> ~gpadmin/.pxfrc 'export PGPORT=5432' \
     && echo >> ~gpadmin/.pxfrc 'export GOPATH=/opt/go' \
     && echo >> ~gpadmin/.pxfrc 'export GPHOME=$(find /usr/local/ -name greenplum-db* -type d | head -n1)' \

--- a/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
@@ -64,6 +64,7 @@ RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nproc 131072' \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nofile 65536' \
     # create .pxfrc
+    && echo >> ~gpadmin/.pxfrc 'export LANG=en_US.UTF-8' \
     && echo >> ~gpadmin/.pxfrc 'export PGPORT=5432' \
     && echo >> ~gpadmin/.pxfrc 'export GOPATH=/opt/go' \
     && echo >> ~gpadmin/.pxfrc 'export GPHOME=$(find /usr/local/ -name greenplum-db* -type d | head -n1)' \


### PR DESCRIPTION
This prevents failures on unit tests like
BridgeOutputBuilder#convertTextDataToLines() where the text contains
special characters.

Authored-by: Oliver Albertini <oalbertini@vmware.com>