### PR TITLE
Add missing dependency for Hive profile when accessing CSV files

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveBaseTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveBaseTest.java
@@ -99,6 +99,12 @@ public class HiveBaseTest extends BaseFeature {
             "num1  INTEGER",
             "dub1  DOUBLE PRECISION"
     };
+    static final String[] PXF_HIVE_SMALLDATA_AS_TEXT_COLS = {
+            "t1    TEXT",
+            "t2    TEXT",
+            "num1  TEXT",
+            "dub1  TEXT"
+    };
     static final String[] PXF_HIVE_SUBSET_COLS = {
             "dub1  DOUBLE PRECISION",
             "t2    TEXT"
@@ -186,6 +192,7 @@ public class HiveBaseTest extends BaseFeature {
     static final String HIVE_PARQUET_TABLE = "hive_parquet_table";
     static final String HIVE_PARQUET_FOR_ALTER_TABLE = "hive_parquet_alter_table";
     static final String HIVE_SEQUENCE_TABLE = "hive_sequence_table";
+    static final String HIVE_OPEN_CSV_TABLE = "hive_open_csv_table";
     static final String HIVE_PARTITIONED_TABLE = "hive_partitioned_table";
     static final String HIVE_PARTITIONED_PPD_TABLE = "hive_partitioned_ppd_table";
     static final String HIVE_REG_HETEROGEN_TABLE = "reg_heterogen";
@@ -204,6 +211,7 @@ public class HiveBaseTest extends BaseFeature {
 
     static final String HIVE_SCHEMA = "userdb";
     static final String AVRO = "AVRO";
+    static final String OPEN_CSV_INPUT_OUTPUT_FORMAT = "INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'";
     static final String ORC = "ORC";
     static final String PARQUET = "PARQUET";
     static final String RCFILE = "RCFILE";
@@ -232,6 +240,7 @@ public class HiveBaseTest extends BaseFeature {
     HiveTable hiveBinaryTable;
     HiveTable hiveCollectionTable;
     HiveTable hiveNonDefaultSchemaTable;
+    HiveTable hiveOpenCsvTable;
     Table comparisonDataTable;
 
     String configuredNameNodeAddress;
@@ -446,6 +455,18 @@ public class HiveBaseTest extends BaseFeature {
                 HIVE_SMALL_DATA_TABLE, HIVE_SCHEMA, new String[]{"id INT", "name STRING"});
         hive.createDataBase(HIVE_SCHEMA, true);
         hive.createTableAndVerify(hiveNonDefaultSchemaTable);
+    }
+
+    void prepareOpenCsvData() throws Exception {
+
+        if (hiveOpenCsvTable != null)
+            return;
+        hiveOpenCsvTable = new HiveTable(HIVE_OPEN_CSV_TABLE, HIVE_RC_COLS);
+        hiveOpenCsvTable.setFormat("ROW");
+        hiveOpenCsvTable.setStoredAs(OPEN_CSV_INPUT_OUTPUT_FORMAT);
+        hiveOpenCsvTable.setSerde("org.apache.hadoop.hive.serde2.OpenCSVSerde");
+        hive.createTableAndVerify(hiveOpenCsvTable);
+        hive.insertData(hiveSmallDataTable, hiveOpenCsvTable);
     }
 
     void addHivePartition(String hiveTable, String partition, String location) throws Exception {

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveTest.java
@@ -48,8 +48,6 @@ public class HiveTest extends HiveBaseTest {
     private HiveTable hivePartitionedSkewedTable;
     private HiveTable hivePartitionedSkewedStoredAsDirsTable;
 
-    private Hive hiveNonSecure;
-
     private void preparePartitionedClusteredSortedData() throws Exception {
 
         if (hivePartitionedClusteredSortedTable != null)
@@ -171,7 +169,7 @@ public class HiveTest extends HiveBaseTest {
     public void testSecureServerAndNonSecuredServer() throws Exception {
         if (hdfsNonSecure == null) return;
 
-        hiveNonSecure = (Hive) SystemManagerImpl.getInstance().getSystemObject("hiveNonSecure");
+        Hive hiveNonSecure = (Hive) SystemManagerImpl.getInstance().getSystemObject("hiveNonSecure");
 
         HiveTable hiveSmallDataTable3 =
                 prepareSmallData(hdfsNonSecure, hiveNonSecure, null, HIVE_SMALL_DATA_TABLE, HIVE_SMALLDATA_COLS, HIVE_DATA_FILE_NAME_3);
@@ -331,6 +329,21 @@ public class HiveTest extends HiveBaseTest {
 
         runTincTest("pxf.features.hive.small_data.runTest");
         runTincTest("pxf.features.hcatalog.small_data_parquet.runTest");
+    }
+
+    /**
+     * PXF on Hive OpenCSV format table
+     *
+     * @throws Exception if test fails to run
+     */
+    @Test(groups = {"hive", "features", "gpdb", "security"})
+    public void storeAsHiveOpenCsv() throws Exception {
+
+        prepareOpenCsvData();
+        createExternalTable(PXF_HIVE_SMALL_DATA_TABLE,
+                PXF_HIVE_SMALLDATA_AS_TEXT_COLS, hiveOpenCsvTable);
+
+        runTincTest("pxf.features.hive.small_data_as_text.runTest");
     }
 
     /**

--- a/automation/tincrepo/main/pxf/features/hive/small_data_as_text/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hive/small_data_as_text/expected/query01.ans
@@ -1,0 +1,16 @@
+-- @description query01 for PXF Hive Small Data cases
+
+SELECT t1, t2, num1::int, dub1::double precision from pxf_hive_small_data where num1::int <= 10 ORDER BY t1;
+  t1   |  t2  | num1 | dub1 
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+(10 rows)

--- a/automation/tincrepo/main/pxf/features/hive/small_data_as_text/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/features/hive/small_data_as_text/expected/query02.ans
@@ -1,0 +1,14 @@
+-- @description query02 query with complex WHERE clause and some projected columns
+-- two queries with the same WHERE clause but different columns selected
+-- number of rows should be the same
+SELECT t1, t2 FROM pxf_hive_small_data WHERE to_timestamp(1505056530 + num1::int*86400)::DATE = '2017-09-15'::DATE AND t2 = 's_10';
+  t1  |  t2  
+------+------
+ row5 | s_10
+(1 row)
+
+SELECT t1, t2, num1 FROM pxf_hive_small_data WHERE to_timestamp(1505056530 + num1::int*86400)::DATE = '2017-09-15'::DATE AND t2 = 's_10';
+  t1  |  t2  | num1 
+------+------+------
+ row5 | s_10 |    5
+(1 row)

--- a/automation/tincrepo/main/pxf/features/hive/small_data_as_text/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hive/small_data_as_text/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLTestCase
+from mpp.models import SQLConcurrencyTestCase
+
+class PxfHiveSmallData(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hive/small_data_as_text/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/small_data_as_text/sql/query01.sql
@@ -1,0 +1,3 @@
+-- @description query01 for PXF Hive Small Data cases
+
+SELECT t1, t2, num1::int, dub1::double precision from pxf_hive_small_data where num1::int <= 10 ORDER BY t1;

--- a/automation/tincrepo/main/pxf/features/hive/small_data_as_text/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/features/hive/small_data_as_text/sql/query02.sql
@@ -1,0 +1,6 @@
+-- @description query02 query with complex WHERE clause and some projected columns
+
+-- two queries with the same WHERE clause but different columns selected
+-- number of rows should be the same
+SELECT t1, t2 FROM pxf_hive_small_data WHERE to_timestamp(1505056530 + num1::int*86400)::DATE = '2017-09-15'::DATE AND t2 = 's_10';
+SELECT t1, t2, num1 FROM pxf_hive_small_data WHERE to_timestamp(1505056530 + num1::int*86400)::DATE = '2017-09-15'::DATE AND t2 = 's_10';

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -244,6 +244,12 @@ project('pxf-hive') {
          * Transitive dependencies for hive-exec-core until here
          * */
 
+        /*
+         * Transitive dependency required for reading Hive tables with
+         * SerDe 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
+         */
+        bundleJars "net.sf.opencsv:opencsv:2.3"
+
         /* Transitive dependency required by MapR */
         bundleJars "org.json:json:20090211"
     }


### PR DESCRIPTION
To reproduce this issue:

In Hive:

```
CREATE EXTERNAL TABLE hive_csv_table(
`timestamp` string COMMENT 'from deserializer',
`hitstime` string COMMENT 'from deserializer',
`hostname` string COMMENT 'from deserializer',
`productsku` string COMMENT 'from deserializer',
`country` string COMMENT 'from deserializer',
`flow_id` string COMMENT 'from deserializer',
`request_id` string COMMENT 'from deserializer')
PARTITIONED BY (
`year` int,
`month` int,
`day` int)
ROW FORMAT SERDE
'org.apache.hadoop.hive.serde2.OpenCSVSerde'
WITH SERDEPROPERTIES (
'quoteChar'='\"',
'separatorChar'=',')
STORED AS INPUTFORMAT
'org.apache.hadoop.mapred.TextInputFormat'
OUTPUTFORMAT
'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';

insert into hive_csv_table partition(year=2020, month=6, day=15)
values ('2423423', '5', 'foo.com', 'abc', 'ec', '123', '123');
```

In Greenplum:

```
create external table ext_hive_svc_table
(
timestamp text,
hitstime text,
hostname text,
productsku text,
country text,
flow_id text,
request_id text,
year integer,
month integer,
day integer
)
location ('pxf://hive_csv_table?PROFILE=Hive&SERVER=default-hdfs')
format 'custom' (formatter = 'pxfwritable_import');
```