### PR TITLE
CI: Disable the HiveMultiClusterSecurityTest.testTwoSecuredServers test

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveMultiClusterSecurityTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveMultiClusterSecurityTest.java
@@ -25,12 +25,15 @@ import org.testng.annotations.Test;
         return false;
     }
 
+    // TODO: this test is being ignored because the reverse DNS lookup seems
+    // TODO: to cause issues when accessing the metastore on the second dataproc
+    // TODO: environment
     /**
      * query for small data hive table against two kerberized hive servers
      *
      * @throws Exception if test fails to run
      */
-    @Test(groups = {"features", "multiClusterSecurity"})
+    @Test(groups = {"features", "multiClusterSecurity"}, enabled = false)
     public void testTwoSecuredServers() throws Exception {
 
         createExternalTable(PXF_HIVE_SMALL_DATA_TABLE, PXF_HIVE_SMALLDATA_COLS, hiveSmallDataTable);


### PR DESCRIPTION
The HiveMultiClusterSecurityTest.testTwoSecuredServers started failing
in our CI, and it looks like the root cause is that reverse DNS lookup
started failing at some point on June 8th. It looks like something on
GCP has changed that caused the issue to begin. We are disabling the
test until a fix for the infrastructure is found.