### PR TITLE
Update nogokiri to version 1.10.8

### DIFF
--- a/docs/book/Gemfile.lock
+++ b/docs/book/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       middleman-livereload
       middleman-sprockets
       middleman-syntax (= 2.1.0)
-      nokogiri (= 1.8.5)
+      nokogiri (= 1.10.8)
       puma
       rack-rewrite
       redcarpet (~> 3.2.3)
@@ -86,7 +86,7 @@ GEM
       multi_json (~> 1.10)
     fog-xml (0.1.3)
       fog-core
-      nokogiri (>= 1.5.11, < 2.0.0)
+      nokogiri (>= 1.10.8, < 2.0.0)
     font-awesome-sass (4.7.0)
       sass (>= 3.2)
     formatador (0.2.5)
@@ -157,7 +157,7 @@ GEM
     multi_json (1.14.1)
     multipart-post (2.0.0)
     nio4r (2.5.2)
-    nokogiri (1.8.5)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.3.0)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)


### PR DESCRIPTION
Nogokiri version 1.10.8 addresses CVE-2020-7595 and CVE-2019-5477