### PR TITLE
Allow short names for text compression codecs

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/profiles/ProfilesTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/profiles/ProfilesTest.java
@@ -306,7 +306,7 @@ public class ProfilesTest extends BaseFeature {
 
         exTable.setProfile(null);
         exTable.setProfile(EnumPxfDefaultProfiles.HdfsTextSimple.toString());
-        exTable.setUserParameters(new String[] { "COMPRESSION_CODEC=org.apache.hadoop.io.compress.BZip2Codec" });
+        exTable.setUserParameters(new String[] { "COMPRESSION_CODEC=bzip2" });
 
         gpdb.createTableAndVerify(exTable);
         runVerificationTinc();

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -155,7 +155,7 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
     @Test(groups = { "features", "gpdb", "hcfs", "security"})
     public void textFormatCopyDefaultCodec() throws Exception {
 
-        writableExTable.setCompressionCodec(COMPRESSION_CODEC);
+        writableExTable.setCompressionCodec("default");
         gpdb.createTableAndVerify(writableExTable);
         insertData(dataTable, writableExTable, InsertionMethod.COPY);
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/CodecFactory.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/CodecFactory.java
@@ -10,10 +10,18 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class CodecFactory {
 
-    private static Logger LOG = LoggerFactory.getLogger(CodecFactory.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CodecFactory.class);
     private static final CodecFactory codecFactoryInstance = new CodecFactory();
+    private static final Map<String, String> codecMap = new HashMap<String, String>() {{
+        put("bzip2", "org.apache.hadoop.io.compress.BZip2Codec");
+        put("default", "org.apache.hadoop.io.compress.DefaultCodec");
+        put("gzip", "org.apache.hadoop.io.compress.GzipCodec");
+    }};
 
     /**
      * Returns the {@link CompressionCodecName} for the given name, or default if name is null
@@ -44,6 +52,9 @@ public class CodecFactory {
      * @return generated CompressionCodec
      */
     public CompressionCodec getCodec(String name, Configuration conf) {
+        if (codecMap.containsKey(name)) {
+            name = codecMap.get(name);
+        }
         return ReflectionUtils.newInstance(getCodecClass(name, conf), conf);
     }
 

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/CodecFactoryTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/CodecFactoryTest.java
@@ -118,4 +118,14 @@ public class CodecFactoryTest {
     private void testIsThreadSafe(String testDescription, String path, String codecStr, boolean expectedResult) {
         assertEquals(testDescription, expectedResult, factory.isCodecThreadSafe(codecStr, path, new Configuration()));
     }
+
+    @Test
+    public void getCodecGzipShortName() {
+        Configuration conf = new Configuration();
+        String name = "gzip";
+
+        CompressionCodec codec = factory.getCodec(name, conf);
+        assertNotNull(codec);
+        assertEquals(".gz", codec.getDefaultExtension());
+    }
 }


### PR DESCRIPTION
 In Parquet and Avro we allow the user to specify COMPRESSION_CODEC by
short names like snappy, gzip, bzip2, deflate, etc. With this change, we
can allow the user to specify one of the three supported codecs for text
data using shortcuts: bzip2, default, gzip.