### PR TITLE
Fix queries with limit

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
@@ -67,23 +67,6 @@ public class BridgeResource extends BaseResource {
     @GetMapping(value = "/Bridge", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public ResponseEntity<StreamingResponseBody> read(
             @RequestHeader MultiValueMap<String, String> headers) throws IOException, InterruptedException {
-        try {
-            return readInternal(headers);
-        } catch (ClientAbortException e) {
-            // Occurs whenever client (GPDB) decides to end the connection
-            if (LOG.isDebugEnabled()) {
-                // Stacktrace in debug
-                LOG.debug("Remote connection closed by GPDB", e);
-            } else {
-                LOG.error("Remote connection closed by GPDB (Enable debug for stacktrace)");
-            }
-        }
-        // Return an empty outputStream on error
-        return new ResponseEntity<>(outputStream -> {
-        }, HttpStatus.OK);
-    }
-
-    private ResponseEntity<StreamingResponseBody> readInternal(MultiValueMap<String, String> headers) throws IOException, InterruptedException {
 
         RequestContext context = parseRequest(headers);
         // THREAD-SAFE parameter has precedence

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResource.java
@@ -19,7 +19,6 @@ package org.greenplum.pxf.service.rest;
  * under the License.
  */
 
-import org.apache.catalina.connector.ClientAbortException;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.service.bridge.Bridge;
 import org.greenplum.pxf.service.bridge.BridgeFactory;

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResponse.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResponse.java
@@ -73,24 +73,20 @@ public class BridgeResponse implements StreamingResponseBody {
                 ++recordCount;
             }
             LOG.debug("Finished streaming fragment {} of resource {}, {} records.", fragment, dataDir, recordCount);
-        } catch (Exception e) {
-            IOException ioe;
-            if (e instanceof ClientAbortException) {
-                // Occurs whenever client (GPDB) decides to end the connection
-                if (LOG.isDebugEnabled()) {
-                    // Stacktrace in debug
-                    LOG.debug("Remote connection closed by GPDB", e);
-                } else {
-                    LOG.error("Remote connection closed by GPDB (Enable debug for stacktrace)");
-                }
-                ioe = (ClientAbortException) e;
-            } else if (e instanceof IOException) {
-                ioe = (IOException) e;
+        } catch (ClientAbortException e) {
+            // Occurs whenever client (GPDB) decides to end the connection
+            if (LOG.isDebugEnabled()) {
+                // Stacktrace in debug
+                LOG.debug("Remote connection closed by GPDB", e);
             } else {
-                ioe = new IOException(e.getMessage(), e);
+                LOG.warn("Remote connection closed by GPDB (Enable debug for stacktrace)");
             }
             // Re-throw the exception so Spring MVC is aware that an IO error has occurred
-            throw ioe;
+            throw e;
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e.getMessage(), e);
         } finally {
             LOG.debug("Stopped streaming fragment {} of resource {}, {} records.", fragment, dataDir, recordCount);
             try {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/FragmentsResponse.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/FragmentsResponse.java
@@ -76,24 +76,20 @@ public class FragmentsResponse implements StreamingResponseBody {
     public void writeTo(OutputStream output) throws IOException {
         try {
             writeToInternal(output);
-        } catch (Exception e) {
-            IOException ioe;
-            if (e instanceof ClientAbortException) {
-                // Occurs whenever client (GPDB) decides to end the connection
-                if (LOG.isDebugEnabled()) {
-                    // Stacktrace in debug
-                    LOG.debug("Remote connection closed by GPDB", e);
-                } else {
-                    LOG.error("Remote connection closed by GPDB (Enable debug for stacktrace)");
-                }
-                ioe = (ClientAbortException) e;
-            } else if (e instanceof IOException) {
-                ioe = (IOException) e;
+        } catch (ClientAbortException e) {
+            // Occurs whenever client (GPDB) decides to end the connection
+            if (LOG.isDebugEnabled()) {
+                // Stacktrace in debug
+                LOG.debug("Remote connection closed by GPDB", e);
             } else {
-                ioe = new IOException(e.getMessage(), e);
+                LOG.warn("Remote connection closed by GPDB (Enable debug for stacktrace)");
             }
             // Re-throw the exception so Spring MVC is aware that an IO error has occurred
-            throw ioe;
+            throw e;
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e.getMessage(), e);
         }
     }
 

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
@@ -160,13 +160,16 @@ public class WritableResource extends BaseResource {
                     ++totalWritten;
                 }
             } catch (ClientAbortException cae) {
+                // Occurs whenever client (GPDB) decides to end the connection
                 if (LOG.isDebugEnabled()) {
+                    // Stacktrace in debug
                     LOG.debug("Remote connection closed by GPDB", cae);
                 } else {
-                    LOG.error("Remote connection closed by GPDB (Enable debug for stacktrace)");
+                    LOG.warn("Remote connection closed by GPDB (Enable debug for stacktrace)");
                 }
                 ex = cae;
-                throw ex;
+                // Re-throw the exception so Spring MVC is aware that an IO error has occurred
+                throw cae;
             } catch (Exception e) {
                 LOG.error(String.format("Exception: totalWritten so far %d to %s", totalWritten, path), e);
                 ex = e;

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/WritableResource.java
@@ -165,6 +165,8 @@ public class WritableResource extends BaseResource {
                 } else {
                     LOG.error("Remote connection closed by GPDB (Enable debug for stacktrace)");
                 }
+                ex = cae;
+                throw ex;
             } catch (Exception e) {
                 LOG.error(String.format("Exception: totalWritten so far %d to %s", totalWritten, path), e);
                 ex = e;


### PR DESCRIPTION
There is an issue with async threads, where we are swallowing the
ClientAbortException when Greenplum closes the connection. This lack of
communication that an IOException has occurred is causing problems with
subsequent requests. Re-throwing the exception allows Spring MVC to
catch it and mark the connection as broken so it stops writing.

The short version of what happens is:
- client drops connection async thread is writing to
- Tomcat cleans this up
- Request/Response/Processor gets put back in pool
- New connections come in
- Processor above gets allocated to one of them
- Original async thread tries writing again, fails and puts the processor into an error state
- Tomcat tries to process the new connection
- Processor is in an error state so the connection is closed before the request is even read

Co-authored-by: Mark Thomas <thomasma@vmware.com>
Co-authored-by: Francisco Guerrero <aguerrero@pivotal.io>