### PR TITLE
Bump com.fasterxml.jackson.core:jackson-* version from 2.9.x to 2.11.0

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -223,19 +223,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.10</version>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.10</version>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -147,8 +147,8 @@ project('pxf-api') {
         compile "commons-codec:commons-codec:1.4"
         compile "com.sun.jersey:jersey-core:1.9"
         compile "org.apache.hadoop:hadoop-common:${hadoopVersion}"
-        compile "com.fasterxml.jackson.core:jackson-core:2.9.10"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.9.10.4"
+        compile "com.fasterxml.jackson.core:jackson-core:2.11.0"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.11.0"
 
         bundleJars "asm:asm:3.2"
     }
@@ -172,9 +172,9 @@ project('pxf-hdfs') {
     dependencies {
         compile(project(':pxf-api'))
         compile "org.apache.avro:avro-mapred:1.7.7"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.9.10.4"
-        compile "com.fasterxml.jackson.core:jackson-core:2.9.10"
-        compile "com.fasterxml.jackson.core:jackson-annotations:2.9.10"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.11.0"
+        compile "com.fasterxml.jackson.core:jackson-core:2.11.0"
+        compile "com.fasterxml.jackson.core:jackson-annotations:2.11.0"
         compile "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}"
         compile "org.apache.hadoop:hadoop-yarn-api:${hadoopVersion}" // Kerberos dependency
         compile "org.apache.hadoop:hadoop-yarn-client:${hadoopVersion}" // Kerberos dependency


### PR DESCRIPTION
This addresses the following:

CVE-2020-14195 (moderate severity)
FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the
interaction between serialization gadgets and typing, related to
org.jsecurity.realm.jndi.JndiRealmFactory (aka org.jsecurity).

CVE-2020-14062 (high severity)
FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the
interaction between serialization gadgets and typing, related to
com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool (aka
xalan2).

CVE-2020-14061 (high severity)
FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the
interaction between serialization gadgets and typing, related to
oracle.jms.AQjmsQueueConnectionFactory,
oracle.jms.AQjmsXATopicConnectionFactory,
oracle.jms.AQjmsTopicConnectionFactory,
oracle.jms.AQjmsXAQueueConnectionFactory, and
oracle.jms.AQjmsXAConnectionFactory (aka weblogic/oracle-aqjms).

CVE-2020-14060 (high severity)
FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the
interaction between serialization gadgets and typing, related to
oadd.org.apache.xalan.lib.sql.JNDIConnectionPool (aka apache/drill).

These are the versions that are coming up in the Spring Boot branch,
where all the tests are passing. Take this opportunity to use the
versions that will end up being used in the near future.