### PR TITLE
Fix the MapR job

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -98,6 +98,7 @@ symlink_pxf_jars: check-env
 			fi; \
 		done; \
 		touch $(PXF_TMP_LIB)/pxf-extras.jar && \
+		[ -f "/tmp/pxf-extras-1.0.0.jar" ] && cp /tmp/pxf-extras-1.0.0.jar $(PXF_TMP_LIB)/pxf-extras.jar && \
 		rm -rf $(PXF_TMP_LIB)/tmp; \
 	fi
 

--- a/automation/tincrepo/main/pxf/features/cloud_access/server_no_credentials_invalid_config/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/cloud_access/server_no_credentials_invalid_config/sql/query01.sql
@@ -9,9 +9,6 @@
 -- m/PXF server error.*(com.amazonaws.services.s3.model.AmazonS3Exception: Forbidden).*/
 -- s/PXF server error.*/PXF server error : com.amazonaws.services.s3.model.AmazonS3Exception: Forbidden/
 --
--- m/Make sure no configuration files under.*/
--- s|Make sure no configuration files under.*|Make sure no configuration files under 'server-dir' specify the property 'defaultFS' with the value starting with 'hdfs://', which is incompatible with profile filesystem 's3a'. Check the PXF logs located in the 'logs-dir' directory on host 'mdw' or 'set client_min_messages=LOG' for additional details.|
---
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/
 --

--- a/concourse/scripts/test.bash
+++ b/concourse/scripts/test.bash
@@ -120,11 +120,11 @@ function run_pxf_automation() {
 }
 
 function generate_extras_fat_jar() {
-	mkdir -p /tmp/fatjar "${PXF_HOME}/tmp"
+	mkdir -p /tmp/fatjar
 	pushd /tmp/fatjar
 		find "${PXF_CONF_DIR}/lib" -name '*.jar' -exec jar -xf {} \;
-		jar -cf "${PXF_HOME}/lib/pxf-extras-1.0.0.jar" .
-		chown -R gpadmin:gpadmin "${PXF_HOME}/lib/pxf-extras-1.0.0.jar"
+		jar -cf "/tmp/pxf-extras-1.0.0.jar" .
+		chown -R gpadmin:gpadmin "/tmp/pxf-extras-1.0.0.jar"
 	popd
 }
 
@@ -157,7 +157,7 @@ function setup_hadoop() {
 }
 
 function configure_sut() {
-	AMBARI_DIR=$(find /tmp/build/ -name ambari_env_files)
+	[[ -d /tmp/build/ ]] && AMBARI_DIR=$(find /tmp/build/ -name ambari_env_files)
 	if [[ -n $AMBARI_DIR ]]; then
 		REALM=$(< "$AMBARI_DIR"/REALM)
 		HADOOP_IP=$(grep < "$AMBARI_DIR"/etc_hostfile ambari-1 | awk '{print $1}')

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResponse.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/rest/BridgeResponse.java
@@ -92,7 +92,7 @@ public class BridgeResponse implements StreamingResponseBody {
             try {
                 bridge.endIteration();
             } catch (Exception e) {
-                LOG.error("Ignoring error encountered during bridge.endIteration()", e);
+                LOG.warn("Ignoring error encountered during bridge.endIteration()", e);
             }
             if (!threadSafe) {
                 unlock(dataDir);

--- a/server/pxf-service/src/scripts/pxf-env-default.sh
+++ b/server/pxf-service/src/scripts/pxf-env-default.sh
@@ -63,8 +63,8 @@ export PXF_OOM_KILL=${PXF_OOM_KILL:-true}
 # export PXF_OOM_DUMP_PATH=
 
 # Additional locations to be class-loaded by the application
-if [ -n "$PXF_LOADER_PATH" ]; then
-  export LOADER_PATH="$PXF_LOADER_PATH,file:${PXF_CONF}/conf,file:${PXF_HOME}/conf,file:${PXF_CONF}/lib"
+if [[ -n "${PXF_LOADER_PATH}" ]]; then
+  export LOADER_PATH="${PXF_LOADER_PATH},file:${PXF_CONF}/conf,file:${PXF_HOME}/conf,file:${PXF_CONF}/lib"
 else
   export LOADER_PATH="file:${PXF_CONF}/conf,file:${PXF_HOME}/conf,file:${PXF_CONF}/lib"
 fi

--- a/server/pxf-service/src/scripts/pxf-env-default.sh
+++ b/server/pxf-service/src/scripts/pxf-env-default.sh
@@ -63,4 +63,8 @@ export PXF_OOM_KILL=${PXF_OOM_KILL:-true}
 # export PXF_OOM_DUMP_PATH=
 
 # Additional locations to be class-loaded by the application
-export LOADER_PATH="${PXF_LOADER_PATH},file:${PXF_CONF}/conf,file:${PXF_HOME}/conf,file:${PXF_CONF}/lib"
+if [ -n "$PXF_LOADER_PATH" ]; then
+  export LOADER_PATH="$PXF_LOADER_PATH,file:${PXF_CONF}/conf,file:${PXF_HOME}/conf,file:${PXF_CONF}/lib"
+else
+  export LOADER_PATH="file:${PXF_CONF}/conf,file:${PXF_HOME}/conf,file:${PXF_CONF}/lib"
+fi


### PR DESCRIPTION
When doing classloading, the LOADER_PATH is ending up with something
like this:

export LOADER_PATH=,file:/home/gpadmin/pxf/conf,....

Apparently, PropertiesLauncher is parsing the string above and doing a
split, and for them "" (the first element in the array as a result of a split)
means the user wants root of archive but not
current directory. This is making the root archive to be on the
classpath first, then the PXF specific classpath, and then again the
root archive for some reason. This is preventing us to classload the PXF
libraries before the application libraries. This commit checks whether
the PXF_LOADER_PATH environment variable is set, and if it's not, we
don't add the comma at the beginning.

- Fix a test for CloudAccess
- warn instead of error ignored exception
