### PR TITLE
Prefix tag names with `release-`

### DIFF
--- a/.github/workflows/create-release-on-tag.yml
+++ b/.github/workflows/create-release-on-tag.yml
@@ -2,7 +2,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - '*' # match on any tag
+      - 'release-*' # match on release tags
 
 name: Create Release
 

--- a/concourse/scripts/promote_pxf_artifacts.bash
+++ b/concourse/scripts/promote_pxf_artifacts.bash
@@ -77,9 +77,10 @@ git -C pxf_src remote set-url origin "${GIT_REMOTE_URL}"
 # avoid detached HEAD state from Concourse checking out a SHA
 git -C pxf_src checkout "${GIT_BRANCH}"
 
-echo "Creating new tag ${pxf_version}..."
+TAG=release-${pxf_version}
+echo "Creating new tag ${TAG}..."
 # create annotated tag
-git -C pxf_src tag -am "PXF Version ${pxf_version}" "${pxf_version}"
+git -C pxf_src tag -am "PXF Version ${TAG}" "${TAG}"
 
 patch=${pxf_version##*.}
 # bump patch and add -SNAPSHOT
@@ -90,5 +91,5 @@ echo "${SNAPSHOT_VERSION}" > pxf_src/version
 git -C pxf_src add version
 git -C pxf_src commit -m "Bump version to ${SNAPSHOT_VERSION} [skip ci]"
 
-echo "Pushing new tag ${pxf_version} and new SNAPSHOT version ${SNAPSHOT_VERSION}"
+echo "Pushing new tag ${TAG} and new SNAPSHOT version ${SNAPSHOT_VERSION}"
 git -C pxf_src push --follow-tags


### PR DESCRIPTION
This allows being more selective on which tags to create releases on.
For example tags like docs-v1.2.3 will not trigger a release.

Authored-by: Oliver Albertini <oalbertini@vmware.com>