### PR TITLE
CVE-2020-8184: Bump rack version in book/Gemfile.lock to >= 2.1.4

### DIFF
--- a/docs/book/Gemfile.lock
+++ b/docs/book/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       memoist (~> 0.14)
       padrino-helpers (~> 0.13.0)
       parallel
-      rack (>= 1.4.5, < 2.0)
+      rack (>= 2.1.4)
       sass (>= 3.4)
       servolux
       tilt (~> 1.4.1)
@@ -169,7 +169,7 @@ GEM
     public_suffix (3.0.3)
     puma (4.3.5)
       nio4r (~> 2.0)
-    rack (1.6.13)
+    rack (2.1.4)
     rack-livereload (0.3.17)
       rack
     rack-rewrite (1.5.1)
@@ -183,7 +183,7 @@ GEM
     servolux (0.13.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.1.4, < 3)
     temple (0.8.0)
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)


### PR DESCRIPTION
Addresses CVE-2020-8184

> A reliance on cookies without validation/integrity check security vulnerability exists in rack < 2.2.3, rack < 2.1.4 that makes it is possible for an attacker to forge a secure or host-only cookie prefix.