### PR TITLE
CI: Ignore some paths for pxf_src

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -245,6 +245,11 @@ resources:
   source:
     branch: ((pxf-git-branch))
     uri: ((pxf-git-remote))
+    ignore_paths:
+      - docs/**
+      - singlecluster/**
+      - NOTICE
+      - README.md
 
 - name: ccp_src
   type: git


### PR DESCRIPTION
Don't trigger the build pipeline when we have changes on docs/**,
singlecluster/**, NOTICE, REAME.md as they don't affect the result of
the build