### PR TITLE
Add custom license-finder configuration

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -17,14 +17,6 @@
  * under the License.
  */
 
-plugins {
-  id "com.github.hierynomus.license-report" version"0.15.0"
-}
-
-downloadLicenses {
-    dependencyConfiguration = 'bundleJars'
-}
-
 wrapper {
     gradleVersion = '4.10.3'
 }

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -28,3 +28,4 @@ parquetVersion=1.10.1
 awsJavaSdk=1.11.490
 org.gradle.daemon=true
 org.gradle.parallel=false
+lfScanConfiguration=bundleJars


### PR DESCRIPTION
This avoids using the default runtimeClasspath configuration, which may
over-report dependencies.

Authored-by: Oliver Albertini <oalbertini@vmware.com>