### PR TITLE
Allow skipping the header for *:text profiles

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hdfs/HdfsReadableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hdfs/HdfsReadableTextTest.java
@@ -170,6 +170,14 @@ public class HdfsReadableTextTest extends BaseFeature {
         hdfs.copyFromLocal(tempLocalDataPath, hdfsFilePath);
         // verify results
         runTincTest("pxf.features.hdfs.readable.text.small_data.runTest");
+
+        // create a new table with the SKIP_HEADER_COUNT parameter
+        exTable.setName("pxf_hdfs_small_data_with_skip");
+        exTable.setUserParameters(new String[]{"SKIP_HEADER_COUNT=10"});
+        // create external table
+        gpdb.createTableAndVerify(exTable);
+        // run the query skipping the first 10 lines of the text
+        runTincTest("pxf.features.hdfs.readable.text.small_data_with_skip.runTest");
     }
 
     /**

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/GreenplumCSV.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/GreenplumCSV.java
@@ -136,8 +136,9 @@ public class GreenplumCSV {
     public GreenplumCSV withNewline(String newline) {
         if (StringUtils.isNotEmpty(newline)) {
             // validate that it is \n or \r or \r\n
-            // Greenplum only support LF (Line feed, 0x0A), CR (Carriage return, 0x0D), or
-            // CRLF (Carriage return plus line feed, 0x0D 0x0A) as newline character
+            // Greenplum only supports LF (Line feed, 0x0A), CR
+            // (Carriage return, 0x0D), or CRLF (Carriage return plus line
+            // feed, 0x0D 0x0A) as newline characters
             if (newline.equals("\n") || newline.equals("\r") || newline.equals("\r\n")) {
                 this.newline = newline;
             } else {

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -41,11 +41,12 @@ import java.net.URI;
  * A PXF Accessor for reading delimited plain text records.
  */
 public class LineBreakAccessor extends HdfsSplittableDataAccessor {
+    private int skipHeaderCount;
     private DataOutputStream dos;
     private FSDataOutputStream fsdos;
     private FileSystem fs;
     private Path file;
-    private CodecFactory codecFactory;
+    private final CodecFactory codecFactory;
 
     /**
      * Constructs a LineBreakAccessor.
@@ -56,17 +57,20 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
     }
 
     @Override
-    public void initialize(RequestContext requestContext) {
-        super.initialize(requestContext);
+    public void initialize(RequestContext context) {
+        super.initialize(context);
         ((TextInputFormat) inputFormat).configure(jobConf);
+        skipHeaderCount = context.getFragmentIndex() != 0 ? 0 :
+                context.getOption("SKIP_HEADER_COUNT", 0, true);
     }
 
     @Override
     protected Object getReader(JobConf jobConf, InputSplit split)
             throws IOException {
 
+        // when the file has header use LineReaderReader to read one line at at time
         // for HDFS, try to use ChunkRecordReader, if possible (not reading from encrypted zone)
-        if (hcfsType == HcfsType.HDFS) {
+        if (skipHeaderCount == 0 && hcfsType == HcfsType.HDFS) {
             try {
                 return new ChunkRecordReader(jobConf, (FileSplit) split);
             } catch (IncompatibleInputStreamException e) {
@@ -75,6 +79,16 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
             }
         }
         return new LineRecordReader(jobConf, (FileSplit) split);
+    }
+
+    @Override
+    public OneRow readNextObject() throws IOException {
+        while (skipHeaderCount > 0) {
+            if (super.readNextObject() == null)
+                return null;
+            skipHeaderCount--;
+        }
+        return super.readNextObject();
     }
 
     /**
@@ -95,21 +109,6 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
         // create output stream - do not allow overwriting existing file
         createOutputStream(file, codec);
         return true;
-    }
-
-    /*
-     * Creates output stream from given file. If compression codec is provided,
-     * wrap it around stream.
-     */
-    private void createOutputStream(Path file, CompressionCodec codec)
-            throws IOException {
-        fsdos = fs.create(file, false);
-        if (codec != null) {
-            dos = new DataOutputStream(codec.createOutputStream(fsdos));
-        } else {
-            dos = fsdos;
-        }
-
     }
 
     /**
@@ -139,5 +138,20 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
             fsdos.hsync();
             dos.close();
         }
+    }
+
+    /*
+     * Creates output stream from given file. If compression codec is provided,
+     * wrap it around stream.
+     */
+    private void createOutputStream(Path file, CompressionCodec codec)
+            throws IOException {
+        fsdos = fs.create(file, false);
+        if (codec != null) {
+            dos = new DataOutputStream(codec.createOutputStream(fsdos));
+        } else {
+            dos = fsdos;
+        }
+
     }
 }

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
@@ -34,7 +34,7 @@ public class HdfsDataFragmenterTest {
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
         // empty.csv gets ignored
-        assertEquals(3, fragmentList.size());
+        assertEquals(7, fragmentList.size());
     }
 
     @Test
@@ -53,7 +53,7 @@ public class HdfsDataFragmenterTest {
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
         // empty.csv gets ignored
-        assertEquals(3, fragmentList.size());
+        assertEquals(7, fragmentList.size());
     }
 
     @Test

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -54,7 +54,7 @@ public class HdfsFileFragmenterTest {
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        assertEquals(4, fragmentList.size());
+        assertEquals(8, fragmentList.size());
     }
 
     @Test
@@ -72,7 +72,7 @@ public class HdfsFileFragmenterTest {
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        assertEquals(4, fragmentList.size());
+        assertEquals(8, fragmentList.size());
     }
 
     @Test

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessorTest.java
@@ -1,0 +1,233 @@
+package org.greenplum.pxf.plugins.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+import org.greenplum.pxf.api.OneRow;
+import org.greenplum.pxf.api.model.Accessor;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.plugins.hdfs.utilities.HdfsUtilities;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class LineBreakAccessorTest {
+
+    private Accessor accessor;
+    private RequestContext context;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        accessor = new LineBreakAccessor();
+
+        context = new RequestContext();
+        context.setConfig("default");
+        context.setProfileScheme("localfile");
+        context.setUser("test-user");
+    }
+
+    @Test
+    public void testLineFeedForNewLineCharacter() throws Exception {
+        prepareTest("csv/csv_with_line_feed.csv");
+        context.getGreenplumCSV().withNewline("\n");
+
+        accessor.initialize(context);
+        accessor.openForRead();
+
+        OneRow oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("this,file", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("has,line feeds", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("as,new line delimiter", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("LF,0x0A", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNull(oneRow);
+
+        accessor.closeForRead();
+    }
+
+    @Test
+    public void testCarriageReturnLineFeedForNewLineCharacter() throws Exception {
+        prepareTest("csv/csv_with_carriage_return_line_feed.csv");
+        context.getGreenplumCSV().withNewline("\r\n");
+
+        accessor.initialize(context);
+        accessor.openForRead();
+
+        OneRow oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("this,file", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("has,line feeds", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("as,new line delimiter", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("CRLF,0x0D 0x0A", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNull(oneRow);
+
+        accessor.closeForRead();
+    }
+
+    @Test
+    public void testCarriageReturnForNewLineCharacter() throws Exception {
+        prepareTest("csv/csv_with_carriage_return.csv");
+        context.getGreenplumCSV().withNewline("\r");
+
+        accessor.initialize(context);
+        accessor.openForRead();
+
+        OneRow oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("this,file", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("has,line feeds", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("as,new line delimiter", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("CR,0x0D", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNull(oneRow);
+
+        accessor.closeForRead();
+    }
+
+    @Test
+    public void testSkipHeaderCountIsNotANumber() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Property SKIP_HEADER_COUNT has incorrect value foo : must be a non-negative integer");
+
+        context.addOption("SKIP_HEADER_COUNT", "foo");
+        accessor.initialize(context);
+    }
+
+    @Test
+    public void testSkipHeaderCountIsNotANaturalNumber() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Property SKIP_HEADER_COUNT has incorrect value -5 : must be a non-negative integer");
+
+        context.addOption("SKIP_HEADER_COUNT", "-5");
+        accessor.initialize(context);
+    }
+
+    @Test
+    public void testDontSkipHeaders() throws Exception {
+        prepareTest("csv/csv_with_header.csv");
+        accessor.initialize(context);
+        accessor.openForRead();
+
+        OneRow oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("line1,header1,header2,header3", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("line2,header1,header2,header3", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("line3,value1,value2,value3", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNull(oneRow);
+
+        accessor.closeForRead();
+    }
+
+    @Test
+    public void testSkipHeaderCountOne() throws Exception {
+        prepareTest("csv/csv_with_header.csv");
+        context.addOption("SKIP_HEADER_COUNT", "1");
+        accessor.initialize(context);
+        accessor.openForRead();
+
+        OneRow oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("line2,header1,header2,header3", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("line3,value1,value2,value3", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNull(oneRow);
+
+        accessor.closeForRead();
+    }
+
+    @Test
+    public void testSkipHeaderCountTwo() throws Exception {
+        prepareTest("csv/csv_with_header.csv");
+        context.addOption("SKIP_HEADER_COUNT", "2");
+        accessor.initialize(context);
+        accessor.openForRead();
+
+        OneRow oneRow = accessor.readNextObject();
+        assertEquals("line3,value1,value2,value3", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNull(oneRow);
+
+        accessor.closeForRead();
+    }
+
+    @Test
+    public void testSkipHeaderCountTen() throws Exception {
+        prepareTest("csv/csv_with_header.csv");
+        context.addOption("SKIP_HEADER_COUNT", "10");
+        accessor.initialize(context);
+        accessor.openForRead();
+
+        OneRow oneRow = accessor.readNextObject();
+        assertNull(oneRow);
+
+        accessor.closeForRead();
+    }
+
+    private void prepareTest(String resourceName) throws IOException, URISyntaxException {
+        String filepath = this.getClass().getClassLoader()
+                .getResource(resourceName).toURI().toString();
+        Path path = new Path(filepath);
+        long length = path.getFileSystem(new Configuration()).getContentSummary(path).getLength();
+        FileSplit split = new FileSplit(path, 0, length, (String[]) null);
+
+        context.setDataSource(filepath);
+        context.setFragmentMetadata(HdfsUtilities.prepareFragmentMetadata(split));
+    }
+
+}

--- a/server/pxf-hdfs/src/test/resources/csv/csv_with_carriage_return.csv
+++ b/server/pxf-hdfs/src/test/resources/csv/csv_with_carriage_return.csv
@@ -1,0 +1,1 @@
+this,filehas,line feedsas,new line delimiterCR,0x0D

--- a/server/pxf-hdfs/src/test/resources/csv/csv_with_carriage_return_line_feed.csv
+++ b/server/pxf-hdfs/src/test/resources/csv/csv_with_carriage_return_line_feed.csv
@@ -1,0 +1,4 @@
+this,file
+has,line feeds
+as,new line delimiter
+CRLF,0x0D 0x0A

--- a/server/pxf-hdfs/src/test/resources/csv/csv_with_header.csv
+++ b/server/pxf-hdfs/src/test/resources/csv/csv_with_header.csv
@@ -1,0 +1,3 @@
+line1,header1,header2,header3
+line2,header1,header2,header3
+line3,value1,value2,value3

--- a/server/pxf-hdfs/src/test/resources/csv/csv_with_line_feed.csv
+++ b/server/pxf-hdfs/src/test/resources/csv/csv_with_line_feed.csv
@@ -1,0 +1,4 @@
+this,file
+has,line feeds
+as,new line delimiter
+LF,0x0A


### PR DESCRIPTION
We introduce a new parameter "SKIP_HEADER_COUNT", which when provided
for *:text profiles, it will skip the N first lines of the first split
of each file. For example, SKIP_HEADER_COUNT=2 will skip the first 2
lines of each remote file and will only stream back starting from the
3rd line. If SKIP_HEADER_COUNT is greater than the number of lines of a
file, no data will be streamed back to the client.