### PR TITLE
docs - more avro compression codecs, more greenplum type certs

### DIFF
--- a/docs/content/hdfs_avro.html.md.erb
+++ b/docs/content/hdfs_avro.html.md.erb
@@ -24,7 +24,7 @@ under the License.
 
 Use the PXF HDFS Connector to read and write Avro-format data. This section describes how to use PXF to read and write Avro data in HDFS, including how to create, query, and insert into an external table that references an Avro file in the HDFS data store.
 
-**Note**: PXF does not support reading or writing compressed Avro files.
+PXF supports reading or writing Avro files compressed with these codecs: `bzip2`, `xz`, `snappy`, and `deflate`.
 
 ## <a id="prereq"></a>Prerequisites
 
@@ -150,7 +150,7 @@ The PXF `hdfs:avro` profile supports encoding- and compression-related write opt
 
 | Write Option  | Value Description |
 |-------|-------------------------------------|
-| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing Avro data include: `snappy`, `deflate`, and `uncompressed` . If this option is not provided, PXF compresses the data using `deflate` compression. |
+| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing Avro data include: `bzip2`, `xz`, `snappy`, `deflate`, and `uncompressed` . If this option is not provided, PXF compresses the data using `deflate` compression. |
 | CODEC_LEVEL    | The compression level (applicable to the `deflate` codec only). This level controls the trade-off between speed and compression. Valid values are 1 (fastest) to 9 (most compressed). The default compression level when using the `deflate` codec is 6. |
 
 ## <a id="avro_example"></a>Example: Reading Avro Data

--- a/docs/content/hdfs_avro.html.md.erb
+++ b/docs/content/hdfs_avro.html.md.erb
@@ -85,7 +85,7 @@ PXF uses the following data type mapping when writing Avro data:
 | array ([]), enum, record | string |
 | date, time, timestamp, timestamptz | string |
 
-</br><sup>1</sup>&nbsp;PXF right-pads <code>char[<i>n</i>]</code> types to length <code><i>n</i> + 1</code>, if required, with white space.
+</br><sup>1</sup>&nbsp;PXF right-pads <code>char[<i>n</i>]</code> types to length <code><i>n</i></code>, if required, with white space.
 </br><sup>2</sup>&nbsp;PXF converts Greenplum <code>smallint</code> types to <code>int</code> before it writes the Avro data. Be sure to read the field into an <code>int</code>.
 
 
@@ -155,7 +155,7 @@ The PXF `hdfs:avro` profile supports encoding- and compression-related write opt
 | Write Option  | Value Description |
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing Avro data include: `bzip2`, `xz`, `snappy`, `deflate`, and `uncompressed` . If this option is not provided, PXF compresses the data using `deflate` compression. |
-| CODEC_LEVEL    | The compression level (applicable to the `deflate` codec only). This level controls the trade-off between speed and compression. Valid values are 1 (fastest) to 9 (most compressed). The default compression level when using the `deflate` codec is 6. |
+| CODEC_LEVEL    | The compression level (applicable to the `deflate` and `xz` codecs only). This level controls the trade-off between speed and compression. Valid values are 1 (fastest) to 9 (most compressed). The default compression level is 6. |
 
 ## <a id="avro_example"></a>Example: Reading Avro Data
 

--- a/docs/content/hdfs_avro.html.md.erb
+++ b/docs/content/hdfs_avro.html.md.erb
@@ -75,14 +75,18 @@ PXF uses the following data type mapping when writing Avro data:
 | boolean | boolean |
 | bytea | bytes |
 | double | double |
+| char<sup>1</sup> | string |
 | enum | string |
 | int |  int |
 | real | float |
-| smallint<sup>1</sup> | int |
+| smallint<sup>2</sup> | int |
 | text | string |
+| varchar | string |
 | array ([]), enum, record | string |
+| date, time, timestamp, timestamptz | string |
 
-</br><sup>1</sup>&nbsp;PXF converts Greenplum <code>smallint</code> types to <code>int</code> before it writes the Avro data. Be sure to read the field into an <code>int</code>.
+</br><sup>1</sup>&nbsp;PXF right-pads <code>char[<i>n</i>]</code> types to length <code><i>n</i> + 1</code>, if required, with white space.
+</br><sup>2</sup>&nbsp;PXF converts Greenplum <code>smallint</code> types to <code>int</code> before it writes the Avro data. Be sure to read the field into an <code>int</code>.
 
 
 ### <a id="topic_tr3_dpg_ts__section_m2p_ztg_ts"></a>Avro Schemas and Data


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/392 (compression support) and https://github.com/greenplum-db/pxf/pull/401 (more greenplum type to avro string certification)

in this PR:
- avro supports bzip2, gz
- more greenplum types certified