### PR TITLE
Build and support hadoop native libraries in PXF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,12 @@ stage:
 	cp -a cli/build/stage/* build/stage/$${PXF_PACKAGE_NAME} ;\
 	cp -a server/build/stage/* build/stage/$${PXF_PACKAGE_NAME} ;\
 	echo $$(git rev-parse --verify HEAD) > build/stage/$${PXF_PACKAGE_NAME}/pxf/commit.sha ;\
-	cp package/install_binary build/stage/$${PXF_PACKAGE_NAME}/install_component
+	cp package/install_binary build/stage/$${PXF_PACKAGE_NAME}/install_component ;\
+	if [ -n "$(HADOOP_NATIVE_LIBRARY_PATH)" ] && [ -d "$(HADOOP_NATIVE_LIBRARY_PATH)" ]; then \
+		mkdir -p build/stage/$${PXF_PACKAGE_NAME}/pxf/lib/shared/native && \
+		rm -rf $(HADOOP_NATIVE_LIBRARY_PATH)/examples && \
+		cp $(HADOOP_NATIVE_LIBRARY_PATH)/* build/stage/$${PXF_PACKAGE_NAME}/pxf/lib/shared/native/; \
+	fi
 
 tar: stage
 	rm -rf build/dist
@@ -76,6 +81,11 @@ rpm:
 	cp -a server/build/stage/pxf/* build/rpmbuild/SOURCES ;\
 	echo $$(git rev-parse --verify HEAD) > build/rpmbuild/SOURCES/commit.sha ;\
 	cp package/*.spec build/rpmbuild/SPECS/ ;\
+	if [ -n "$(HADOOP_NATIVE_LIBRARY_PATH)" ] && [ -d "$(HADOOP_NATIVE_LIBRARY_PATH)" ]; then \
+		mkdir -p build/rpmbuild/SOURCES/lib/shared/native && \
+		rm -rf $(HADOOP_NATIVE_LIBRARY_PATH)/examples && \
+		cp $(HADOOP_NATIVE_LIBRARY_PATH)/* build/rpmbuild/SOURCES/lib/shared/native/; \
+	fi; \
 	rpmbuild \
 	--define "_topdir $${PWD}/build/rpmbuild" \
 	--define "pxf_version $${PXF_MAIN_VERSION}" \

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -198,6 +198,15 @@ singlecluster:
 		-l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
 		-v pxf-git-branch=master -p pxf-singlecluster
 
+
+.PHONY: pxf-native
+pxf-native:
+	fly -t ud set-pipeline \
+		-c ~/workspace/pxf/concourse/pipelines/pxf-native_pipeline.yml \
+		-l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+		--load-vars-from=$(SECRETS_FILE) \
+		-v pxf-git-branch=${BRANCH} -p pxf-native
+
 ## ----------------------------------------------------------------------
 ## List explicit rules
 ## ----------------------------------------------------------------------

--- a/concourse/README.md
+++ b/concourse/README.md
@@ -9,7 +9,7 @@ engine for Python. This allows the generation of portions of the
 pipeline from common blocks of pipeline code. Logic (Python code) can
 be embedded to further manipulate the generated pipeline.
 
-# Deploy the `pxf-build` (release) pipeline
+## Deploy the `pxf-build` (release) pipeline
 
 To deploy the build pipeline for PXF, make sure PXF master branch is currently checked-out and run this command:
 
@@ -17,15 +17,24 @@ To deploy the build pipeline for PXF, make sure PXF master branch is currently c
 make -C "${HOME}/workspace/pxf/concourse" build
 ```
 
-# Deploy the `pxf-certification` (release) pipeline
+## Deploy the `pxf-certification` (release) pipeline
 
-To deploy the certifcation pipeline (forward compatibility) for PXF, make sure PXF master branch is currently checked-out and run this command:
+To deploy the certification pipeline (forward compatibility) for PXF, make sure PXF master branch is currently checked-out and run this command:
 
 ```shell script
 make -C "${HOME}/workspace/pxf/concourse" certification
 ```
 
-# Deploy the singlecluster pipeline
+## Deploy the `pxf-native` pipeline
+
+The `pxf-native` pipeline builds native components to be shipped with PXF, for
+example, it builds the Hadoop Native Libraries to be embedded in the RPM.
+
+```shell script
+make pxf-native
+```
+
+## Deploy the singlecluster pipeline
 
 The singlecluster pipeline generates the singlecluster tarball for CDH, HDP2,
 and HDP3. The generated tarballs are then published to an S3 and GCS bucket.
@@ -35,7 +44,7 @@ The produced tarballs can then be consumed in the pxf-build pipelines.
 make singlecluster
 ```
 
-# Deploy the cloudbuild pipeline
+## Deploy the cloudbuild pipeline
 
 ```shell
 fly -t ud set-pipeline \
@@ -46,13 +55,13 @@ fly -t ud set-pipeline \
     -v pxf-git-branch=master -p cloudbuild
 ```
 
-# Deploy the pull-request pipeline
+## Deploy the pull-request pipeline
 
 ```shell
 make -C "${HOME}/workspace/pxf/concourse" pr
 ```
 
-# Deploy the performance pipelines
+## Deploy the performance pipelines
 
 10G Performance pipeline:
 
@@ -76,7 +85,7 @@ make SCALE=50 perf
 make SCALE=500 perf
 ```
 
-# Deploy a PXF acceptance pipeline
+## Deploy a PXF acceptance pipeline
 Acceptance pipelines can be deployed for feature testing purposes.
 ```shell
 ./deploy dev master -a -n acceptance
@@ -90,7 +99,7 @@ After acceptance, the pipeline can be cleaned up as follows:
 fly -t ud dp -p acceptance
 ```
 
-# Deploy development PXF pipelines
+## Deploy development PXF pipelines
 
 The dev pipeline is an abbreviated version of the `pxf-build` pipeline.
 
@@ -102,7 +111,7 @@ make -C "${HOME}/workspace/pxf/concourse" dev
 
 This command will automatically point the pipeline at your currently checked-out branch of PXF.
 
-# Deploy Longevity Testing PXF pipeline
+## Deploy Longevity Testing PXF pipeline
 The longevity testing pipeline is designed to work off a PXF tag that needs to be provided as a parameter when
 creating the pipeline. The generated pipeline compiles PXF, creates a Greenplum CCP cluster and 2 secure dataproc clusters
 and runs a multi-cluster security test every 15 minutes. CCP cluster is set with expiration time of more than 6 months, so
@@ -123,7 +132,7 @@ fly -t ud set-pipeline \
     -v pxf-tag=<YOUR-TAG> -p dev:longevity_<YOUR-TAG>_6X_STABLE
 ```
 
-# Deploy `pg_regress` pipeline
+## Deploy `pg_regress` pipeline
 
 This pipeline currently runs the smoke test group against the different clouds using `pg_regress` instead of automation.
 It uses both external and foreign tables.
@@ -147,7 +156,7 @@ Expose the `pg_regress` pipeline:
 fly -t ud expose-pipeline -p pg_regress
 ```
 
-# Deploy the PXF CLI pipeline
+## Deploy the PXF CLI pipeline
 
 ```shell
 fly -t ud set-pipeline \

--- a/concourse/docker/pxf-dev-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-dev-base/cloudbuild.yaml
@@ -39,6 +39,18 @@ steps:
   waitFor:
     - gpdb5-centos6-test-pxf-image-cache
 
+- name: 'gcr.io/cloud-builders/docker'
+  id: gpdb5-centos6-build-native-image
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos6-test-pxf:$COMMIT_SHA'
+  - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos6-build-native:$COMMIT_SHA'
+  - '-f'
+  - 'concourse/docker/pxf-native-base/gpdb5/centos6/Dockerfile'
+  - '/workspace/build/'
+  waitFor:
+    - gpdb5-centos6-test-pxf-image
+
 # An image for gpdb5 running on CentOS7
 - name: 'gcr.io/cloud-builders/docker'
   id: gpdb5-centos7-test-pxf-image-cache
@@ -63,6 +75,18 @@ steps:
   - '/workspace/build/'
   waitFor:
     - gpdb5-centos7-test-pxf-image-cache
+
+- name: 'gcr.io/cloud-builders/docker'
+  id: gpdb5-centos7-build-native-image
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf:$COMMIT_SHA'
+  - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-build-native:$COMMIT_SHA'
+  - '-f'
+  - 'concourse/docker/pxf-native-base/gpdb5/centos7/Dockerfile'
+  - '/workspace/build/'
+  waitFor:
+    - gpdb5-centos7-test-pxf-image
 
 ##############################################################################
 # GPDB 6 Images
@@ -92,6 +116,18 @@ steps:
   - '/workspace/build/'
   waitFor:
     - gpdb6-centos7-test-pxf-image-cache
+
+- name: 'gcr.io/cloud-builders/docker'
+  id: gpdb6-centos7-build-native-image
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-test-pxf:$COMMIT_SHA'
+  - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-build-native:$COMMIT_SHA'
+  - '-f'
+  - 'concourse/docker/pxf-native-base/gpdb6/centos7/Dockerfile'
+  - '/workspace/build/'
+  waitFor:
+    - gpdb6-centos7-test-pxf-image
 
 # Corresponds to the docker-gpdb-pxf-dev-ubuntu18 job in the docker pipeline
 - name: 'gcr.io/cloud-builders/docker'
@@ -143,10 +179,13 @@ steps:
   waitFor:
     - gpdb6-oel7-test-pxf-image-cache
 
-# Push images to Cloud Build to Container Registry
+# Push images from Cloud Build to Container Registry
 images:
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos6-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-ubuntu18.04-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-oel7-test-pxf:$COMMIT_SHA'
+- 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos6-build-native:$COMMIT_SHA'
+- 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-build-native:$COMMIT_SHA'
+- 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-build-native:$COMMIT_SHA'

--- a/concourse/docker/pxf-native-base/gpdb5/centos6/Dockerfile
+++ b/concourse/docker/pxf-native-base/gpdb5/centos6/Dockerfile
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE=gpdb-pxf-dev/gpdb5-centos6-test-pxf:latest
+
+FROM ${BASE_IMAGE}
+
+RUN yum install -y -d1 \
+    libzstd \
+    libzstd-devel
+
+######
+# Install Google Protobuf 2.5.0 (2.6.0 ships with Xenial)
+######
+RUN mkdir -p /opt/protobuf-src \
+    && curl -L -s -S \
+      https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz \
+      -o /opt/protobuf.tar.gz \
+    && tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src \
+    && cd /opt/protobuf-src \
+    && ./configure --prefix=/opt/protobuf \
+    && make install \
+    && cd /root \
+    && rm -rf /opt/protobuf-src
+ENV PROTOBUF_HOME /opt/protobuf
+ENV PATH "${PATH}:/opt/protobuf/bin"

--- a/concourse/docker/pxf-native-base/gpdb5/centos7/Dockerfile
+++ b/concourse/docker/pxf-native-base/gpdb5/centos7/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE=gpdb-pxf-dev/gpdb5-centos7-test-pxf:latest
+
+FROM ${BASE_IMAGE}
+
+######
+# Install Google Protobuf 2.5.0 (2.6.0 ships with Xenial)
+######
+RUN mkdir -p /opt/protobuf-src \
+    && curl -L -s -S \
+      https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz \
+      -o /opt/protobuf.tar.gz \
+    && tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src \
+    && cd /opt/protobuf-src \
+    && ./configure --prefix=/opt/protobuf \
+    && make install \
+    && cd /root \
+    && rm -rf /opt/protobuf-src
+ENV PROTOBUF_HOME /opt/protobuf
+ENV PATH "${PATH}:/opt/protobuf/bin"

--- a/concourse/docker/pxf-native-base/gpdb6/centos7/Dockerfile
+++ b/concourse/docker/pxf-native-base/gpdb6/centos7/Dockerfile
@@ -1,0 +1,36 @@
+ARG BASE_IMAGE=gpdb-pxf-dev/gpdb6-centos7-test-pxf:latest
+
+FROM ${BASE_IMAGE}
+
+RUN yum install -y -d1 \
+    libzstd \
+    libzstd-devel \
+    snappy \
+    snappy-devel
+
+######
+# Install Google Protobuf 2.5.0 (2.6.0 ships with Xenial)
+######
+RUN mkdir -p /opt/protobuf-src \
+    && curl -L -s -S \
+      https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz \
+      -o /opt/protobuf.tar.gz \
+    && tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src \
+    && cd /opt/protobuf-src \
+    && ./configure --prefix=/opt/protobuf \
+    && make install \
+    && cd /root \
+    && rm -rf /opt/protobuf-src
+ENV PROTOBUF_HOME /opt/protobuf
+ENV PATH "${PATH}:/opt/protobuf/bin"
+
+######
+# Install cmake 3.1.0 (3.5.1 ships with Xenial)
+######
+RUN mkdir -p /opt/cmake \
+    && curl -L -s -S \
+      https://cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz \
+      -o /opt/cmake.tar.gz \
+    && tar xzf /opt/cmake.tar.gz --strip-components 1 -C /opt/cmake
+ENV CMAKE_HOME /opt/cmake
+ENV PATH "${PATH}:/opt/cmake/bin"

--- a/concourse/pipelines/cloudbuild_pipeline.yml
+++ b/concourse/pipelines/cloudbuild_pipeline.yml
@@ -37,6 +37,7 @@ resources:
       uri: https://github.com/greenplum-db/pxf.git
       paths:
         - concourse/docker/pxf-dev-base
+        - concourse/docker/pxf-native-base
 
   - name: dockerfile-gpdb-pxf-mapr
     type: git
@@ -103,7 +104,7 @@ jobs:
         GOOGLE_CREDENTIALS: {{google-service-account-key}}
         GOOGLE_PROJECT_ID: {{google-project-id}}
         GOOGLE_ZONE: {{google-zone}}
-        IMAGE_LIST: "gpdb5-centos6-test-pxf gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf"
+        IMAGE_LIST: "gpdb5-centos6-test-pxf gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf gpdb5-centos6-build-native gpdb5-centos7-build-native gpdb6-centos7-build-native"
       config:
         platform: linux
         inputs:

--- a/concourse/pipelines/perf_pipeline.yml
+++ b/concourse/pipelines/perf_pipeline.yml
@@ -168,6 +168,14 @@ resources:
     json_key: ((pxf-storage-service-account-key))
     versioned_file: build-dependencies/pxf-build-dependencies.tar.gz
 
+- name: hadoop_gp6_tarball_rhel7
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: data-gpdb-ud-pxf-build-resources
+    json_key: ((pxf-storage-service-account-key))
+    versioned_file: hadoop-native/hadoop-gp6.el7.tar.gz
+
 - name: timed-trigger
   type: time
   icon: timer
@@ -189,6 +197,8 @@ jobs:
     - get: gpdb_package
       resource: gpdb6_rhel7
     - get: pxf-build-dependencies
+    - get: hadoop-native-libraries
+      resource: hadoop_gp6_tarball_rhel7
   - task: Build PXF-GP6 on RHEL7
     image: gpdb6-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/build.yml

--- a/concourse/pipelines/pxf-native_pipeline.yml
+++ b/concourse/pipelines/pxf-native_pipeline.yml
@@ -1,0 +1,141 @@
+
+## ======================================================================
+## RESOURCE TYPES
+## ======================================================================
+resource_types:
+
+- name: gcs
+  type: registry-image
+  source:
+    repository: frodenas/gcs-resource
+
+resources:
+## ---------- Build Resources -------
+- name: hadoop-build-dependencies
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: data-gpdb-ud-pxf-build-resources
+    json_key: ((pxf-storage-service-account-key))
+    versioned_file: build-dependencies/hadoop-native-build-dependencies.tar.gz
+
+## ---------- Github Repos ----------
+- name: pxf_src
+  type: git
+  icon: git
+  source:
+    branch: ((pxf-git-branch))
+    uri: ((pxf-git-remote))
+
+- name: hadoop_src
+  type: git
+  icon: git
+  source:
+    uri: https://github.com/apache/hadoop.git
+    tag_filter: rel/release-2.9.2
+
+## ---------- Docker Images ----------
+- name: gpdb5-pxf-dev-centos6-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: gcr.io/data-gpdb-ud/gpdb-pxf-dev/gpdb5-centos6-build-native
+    tag: latest
+    username: _json_key
+    password: ((pxf-cloudbuild-service-account-key))
+
+- name: gpdb5-pxf-dev-centos7-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: gcr.io/data-gpdb-ud/gpdb-pxf-dev/gpdb5-centos7-build-native
+    tag: latest
+    username: _json_key
+    password: ((pxf-cloudbuild-service-account-key))
+
+- name: gpdb6-pxf-dev-centos7-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: gcr.io/data-gpdb-ud/gpdb-pxf-dev/gpdb6-centos7-build-native
+    tag: latest
+    username: _json_key
+    password: ((pxf-cloudbuild-service-account-key))
+
+## ---------- Hadoop Native Build Artifacts ----------
+- name: hadoop_gp5_tarball_rhel6
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: data-gpdb-ud-pxf-build-resources
+    json_key: ((pxf-storage-service-account-key))
+    versioned_file: hadoop-native/hadoop-gp5.el6.tar.gz
+
+- name: hadoop_gp5_tarball_rhel7
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: data-gpdb-ud-pxf-build-resources
+    json_key: ((pxf-storage-service-account-key))
+    versioned_file: hadoop-native/hadoop-gp5.el7.tar.gz
+
+- name: hadoop_gp6_tarball_rhel7
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: data-gpdb-ud-pxf-build-resources
+    json_key: ((pxf-storage-service-account-key))
+    versioned_file: hadoop-native/hadoop-gp6.el7.tar.gz
+
+## ---------- Centos 6 Swimlane ----------
+jobs:
+- name: Build Hadoop-GP5 on RHEL6
+  plan:
+    - in_parallel:
+      - get: pxf_src
+      - get: hadoop_src
+      - get: gpdb5-pxf-dev-centos6-image
+      - get: hadoop-build-dependencies
+    - task: Build Hadoop Native-GP5 on RHEL6
+      image: gpdb5-pxf-dev-centos6-image
+      file: pxf_src/concourse/tasks/build-hadoop-native.yml
+      params:
+        TARGET_OS: rhel6
+    - put: hadoop_gp5_tarball_rhel6
+      params:
+        file: dist/hadoop-2.9.2.tar.gz
+
+- name: Build Hadoop-GP5 on RHEL7
+  plan:
+    - in_parallel:
+      - get: pxf_src
+      - get: hadoop_src
+      - get: gpdb5-pxf-dev-centos7-image
+      - get: hadoop-build-dependencies
+    - task: Build Hadoop Native-GP5 on RHEL7
+      image: gpdb5-pxf-dev-centos7-image
+      file: pxf_src/concourse/tasks/build-hadoop-native.yml
+      params:
+        TARGET_OS: rhel7
+    - put: hadoop_gp5_tarball_rhel7
+      params:
+        file: dist/hadoop-2.9.2.tar.gz
+
+- name: Build Hadoop-GP6 on RHEL7
+  plan:
+    - in_parallel:
+      - get: pxf_src
+      - get: hadoop_src
+      - get: gpdb6-pxf-dev-centos7-image
+      - get: hadoop-build-dependencies
+    - task: Build Hadoop Native-GP6 on RHEL7
+      image: gpdb6-pxf-dev-centos7-image
+      file: pxf_src/concourse/tasks/build-hadoop-native.yml
+      params:
+        TARGET_OS: rhel7
+    - put: hadoop_gp6_tarball_rhel7
+      params:
+        file: dist/hadoop-2.9.2.tar.gz
+    - put: hadoop-build-dependencies
+      params:
+        file: dist/hadoop-native-build-dependencies.tar.gz

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -419,6 +419,14 @@ resources:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
     versioned_file: prod/snapshots/pxf-gp[[gp_ver]].el6.tar.gz
+
+- name: hadoop_gp[[gp_ver]]_tarball_rhel6
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: data-gpdb-ud-pxf-build-resources
+    json_key: ((pxf-storage-service-account-key))
+    versioned_file: hadoop-native/hadoop-gp[[gp_ver]].el6.tar.gz
 {% set gp_ver = None %}
 
 {% for gp_ver in range(5, 7) %}
@@ -429,6 +437,14 @@ resources:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
     versioned_file: prod/snapshots/pxf-gp[[gp_ver]].el7.tar.gz
+
+- name: hadoop_gp[[gp_ver]]_tarball_rhel7
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: data-gpdb-ud-pxf-build-resources
+    json_key: ((pxf-storage-service-account-key))
+    versioned_file: hadoop-native/hadoop-gp[[gp_ver]].el7.tar.gz
 {% endfor %}
 
 {% if build_deb %}
@@ -484,6 +500,8 @@ jobs:
       resource: gpdb[[gp_ver]]_rhel6_rpm_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-centos6-image
     - get: pxf-build-dependencies
+    - get:  hadoop-native-libraries
+      resource: hadoop_gp[[gp_ver]]_tarball_rhel6
   - task: Build PXF on RHEL6
     image: gpdb[[gp_ver]]-pxf-dev-centos6-image
     file: pxf_src/concourse/tasks/build.yml
@@ -535,6 +553,8 @@ jobs:
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-build-dependencies
+    - get: hadoop-native-libraries
+      resource: hadoop_gp[[gp_ver]]_tarball_rhel7
   - task: Build PXF-GP[[gp_ver]] on RHEL7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/build.yml

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -271,6 +271,14 @@ resources:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
     versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf-gp[[gp_ver]].el6.tar.gz
+
+- name: hadoop_gp[[gp_ver]]_tarball_rhel6
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: data-gpdb-ud-pxf-build-resources
+    json_key: ((pxf-storage-service-account-key))
+    versioned_file: hadoop-native/hadoop-gp[[gp_ver]].el6.tar.gz
 {% set gp_ver = None %}
 
 {% for gp_ver in range(5, 7) %}
@@ -281,6 +289,14 @@ resources:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
     versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf-gp[[gp_ver]].el7.tar.gz
+
+- name: hadoop_gp[[gp_ver]]_tarball_rhel7
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: data-gpdb-ud-pxf-build-resources
+    json_key: ((pxf-storage-service-account-key))
+    versioned_file: hadoop-native/hadoop-gp[[gp_ver]].el7.tar.gz
 {% endfor %}
 
 {% if build_deb %}
@@ -330,6 +346,8 @@ jobs:
       resource: gpdb[[gp_ver]]_rhel6_rpm_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-centos6-image
     - get: pxf-build-dependencies
+    - get:  hadoop-native-libraries
+      resource: hadoop_gp[[gp_ver]]_tarball_rhel6
   - task: Build PXF on RHEL6
     image: gpdb[[gp_ver]]-pxf-dev-centos6-image
     file: pxf_src/concourse/tasks/build.yml
@@ -384,6 +402,8 @@ jobs:
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-build-dependencies
+    - get: hadoop-native-libraries
+      resource: hadoop_gp[[gp_ver]]_tarball_rhel7
   - task: Build PXF-GP[[gp_ver]] on RHEL7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/build.yml

--- a/concourse/scripts/build-hadoop-native.bash
+++ b/concourse/scripts/build-hadoop-native.bash
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eox pipefail
+
+CWDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${CWDIR}/pxf_common.bash"
+source ~/.pxfrc
+
+if [[ -f hadoop-build-dependencies/hadoop-native-build-dependencies.tar.gz ]]; then
+	tar -xzf "hadoop-build-dependencies/hadoop-native-build-dependencies.tar.gz" -C ~root
+fi
+
+pushd hadoop_src
+mvn package \
+	-Pdist,native \
+	-DskipTests \
+	-Drequire.zlib \
+	-Drequire.snappy \
+	-Drequire.zstd \
+	-Drequire.lz4 \
+	-Drequire.bzip2 \
+	-Dtar
+popd
+
+cp hadoop_src/hadoop-dist/target/hadoop-*.tar.gz dist
+
+# tar .m2 cache
+tar -czf dist/hadoop-native-build-dependencies.tar.gz -C ~ .m2

--- a/concourse/scripts/install_pxf.bash
+++ b/concourse/scripts/install_pxf.bash
@@ -133,6 +133,10 @@ function create_pxf_installer_scripts() {
 		  echo 'export JAVA_HOME=/usr/lib/jvm/jre' | sudo tee -a ~centos/.bashrc
 		}
 
+		function install_snappy() {
+		  yum install -y -q -e 0 snappy
+		}
+
 		function install_hadoop_client() {
 		  cat > /etc/yum.repos.d/hdp.repo <<EOF
 		[HDP-2.6.5.0]
@@ -151,6 +155,8 @@ function create_pxf_installer_scripts() {
 
 		function main() {
 		  install_java
+		  # required for native snappy compression support
+		  install_snappy
 		  if [[ $INSTALL_GPHDFS == true ]]; then
 		    install_hadoop_client
 		  fi

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -31,8 +31,12 @@ function inflate_dependencies() {
 		files_to_link+=(~gpadmin/.{tomcat,go-dep-cached-sources,gradle})
 	fi
 	if [[ -f pxf-automation-dependencies/pxf-automation-dependencies.tar.gz ]]; then
-		tarballs+=pxf-automation-dependencies/pxf-automation-dependencies.tar.gz
+		tarballs+=(pxf-automation-dependencies/pxf-automation-dependencies.tar.gz)
 		files_to_link+=(~gpadmin/.m2)
+	fi
+	local hadoop_tarball=$(find hadoop-native-libraries -name 'hadoop-gp*.el*.tar.gz')
+	if [[ -f ${hadoop_tarball} ]]; then
+		tarballs+=("${hadoop_tarball}")
 	fi
 	(( ${#tarballs[@]} == 0 )) && return
 	for t in "${tarballs[@]}"; do
@@ -40,6 +44,11 @@ function inflate_dependencies() {
 	done
 	ln -s "${files_to_link[@]}" ~root
 	chown -R gpadmin:gpadmin ~gpadmin
+
+	if [[ -f ${hadoop_tarball} ]]; then
+		local hadoop_native_lib_path=$(find ~gpadmin/hadoop-*/ -name native)
+		export HADOOP_NATIVE_LIBRARY_PATH=${hadoop_native_lib_path}
+	fi
 }
 
 function inflate_singlecluster() {

--- a/concourse/tasks/build-hadoop-native.yml
+++ b/concourse/tasks/build-hadoop-native.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+
+inputs:
+  - name: hadoop_src
+  - name: pxf_src
+  - name: hadoop-build-dependencies
+    optional: true
+
+outputs:
+  - name: dist
+
+params:
+  TARGET_OS:
+
+run:
+  path: pxf_src/concourse/scripts/build-hadoop-native.bash

--- a/concourse/tasks/build.yml
+++ b/concourse/tasks/build.yml
@@ -9,6 +9,8 @@ inputs:
   optional: true
 - name: pxf_src
 - name: gpdb_package
+- name: hadoop-native-libraries
+  optional: true
 
 outputs:
 - name: dist

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/servlet/ServletLifecycleListener.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/servlet/ServletLifecycleListener.java
@@ -20,6 +20,14 @@ package org.greenplum.pxf.service.servlet;
  */
 
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.crypto.OpensslCipher;
+import org.apache.hadoop.io.compress.Lz4Codec;
+import org.apache.hadoop.io.compress.SnappyCodec;
+import org.apache.hadoop.io.compress.ZStandardCodec;
+import org.apache.hadoop.io.compress.bzip2.Bzip2Factory;
+import org.apache.hadoop.io.compress.zlib.ZlibFactory;
+import org.apache.hadoop.util.NativeCodeLoader;
 import org.greenplum.pxf.service.utilities.Log4jConfigure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +53,8 @@ public class ServletLifecycleListener implements ServletContextListener {
 		Log4jConfigure.configure(event);
 
 		LOG.info("PXF server webapp initialized");
+
+		checkNativeLibraries();
 	}
 
 	/**
@@ -53,5 +63,68 @@ public class ServletLifecycleListener implements ServletContextListener {
 	@Override
 	public void contextDestroyed(ServletContextEvent event) {
 		LOG.info("PXF server webapp is about to go down");
+	}
+
+	/**
+	 * Checks whether native libraries are loaded and logs details of the
+	 * loaded libraries
+	 */
+	private void checkNativeLibraries() {
+		boolean nativeHadoopLoaded = NativeCodeLoader.isNativeCodeLoaded();
+
+		if (nativeHadoopLoaded) {
+			Configuration conf = new Configuration();
+			boolean zlibLoaded;
+			boolean snappyLoaded;
+			boolean zStdLoaded;
+			boolean bzip2Loaded = Bzip2Factory.isNativeBzip2Loaded(conf);
+			boolean openSslLoaded;
+
+			String openSslDetail;
+			String hadoopLibraryName;
+			String zlibLibraryName = "";
+			String snappyLibraryName = "";
+			String zstdLibraryName = "";
+			String lz4LibraryName;
+			String bzip2LibraryName = "";
+
+			hadoopLibraryName = NativeCodeLoader.getLibraryName();
+			zlibLoaded = ZlibFactory.isNativeZlibLoaded(conf);
+			if (zlibLoaded) {
+				zlibLibraryName = ZlibFactory.getLibraryName();
+			}
+			snappyLoaded = NativeCodeLoader.buildSupportsSnappy() &&
+					SnappyCodec.isNativeCodeLoaded();
+			if (snappyLoaded && NativeCodeLoader.buildSupportsSnappy()) {
+				snappyLibraryName = SnappyCodec.getLibraryName();
+			}
+			zStdLoaded = NativeCodeLoader.buildSupportsZstd() &&
+					ZStandardCodec.isNativeCodeLoaded();
+			if (zStdLoaded && NativeCodeLoader.buildSupportsZstd()) {
+				zstdLibraryName = ZStandardCodec.getLibraryName();
+			}
+			if (OpensslCipher.getLoadingFailureReason() != null) {
+				openSslDetail = OpensslCipher.getLoadingFailureReason();
+				openSslLoaded = false;
+			} else {
+				openSslDetail = OpensslCipher.getLibraryName();
+				openSslLoaded = true;
+			}
+			lz4LibraryName = Lz4Codec.getLibraryName();
+			if (bzip2Loaded) {
+				bzip2LibraryName = Bzip2Factory.getLibraryName(conf);
+			}
+
+			LOG.info("Hadoop native library : {} {}", true, hadoopLibraryName);
+			LOG.info("zlib library          : {} {}", zlibLoaded, zlibLibraryName);
+			LOG.info("snappy library        : {} {}", snappyLoaded, snappyLibraryName);
+			LOG.info("zstd library          : {} {}", zStdLoaded, zstdLibraryName);
+			// lz4 is linked within libhadoop
+			LOG.info("lz4 library           : {} {}", true, lz4LibraryName);
+			LOG.info("bzip2 library         : {} {}", bzip2Loaded, bzip2LibraryName);
+			LOG.info("openssl library       : {} {}", openSslLoaded, openSslDetail);
+		} else {
+			LOG.info("Hadoop native library not loaded");
+		}
 	}
 }

--- a/server/pxf-service/src/scripts/pxf-env-default.sh
+++ b/server/pxf-service/src/scripts/pxf-env-default.sh
@@ -29,9 +29,6 @@ export PXF_CONF=${PXF_CONF:-NOT_INITIALIZED}
 # Default PXF_HOME
 export PXF_HOME=${PXF_HOME:=${PARENT_SCRIPT_DIR}}
 
-# Path to HDFS native libraries
-export LD_LIBRARY_PATH=/usr/lib/hadoop/lib/native:${LD_LIBRARY_PATH}
-
 # Path to JAVA
 export JAVA_HOME=${JAVA_HOME:=/usr/java/default}
 
@@ -49,6 +46,13 @@ export PXF_SHUTDOWN_PORT=${PXF_SHUTDOWN_PORT:=5889}
 
 # Memory
 export PXF_JVM_OPTS=${PXF_JVM_OPTS:='-Xmx2g -Xms1g'}
+
+# Path to native libraries
+if [[ -d ${PXF_HOME}/lib/shared/native ]]; then
+  export LD_LIBRARY_PATH=${PXF_HOME}/lib/shared/native:${LD_LIBRARY_PATH}
+
+  PXF_JVM_OPTS="-Djava.library.path=${PXF_HOME}/lib/shared/native ${PXF_JVM_OPTS}"
+fi
 
 # Threads
 export PXF_MAX_THREADS=${PXF_MAX_THREADS:=200}


### PR DESCRIPTION
Build Hadoop Native Libraries from source for all the supported
platforms for PXF and add these libraries to the build process. Add the
native libraries to the RPMs produced during the build process. Ensure
that the native libraries are added to the java.library.path during PXF
start up.