### PR TITLE
docs - add deprecation notice to THREAD-SAFE custom option

### DIFF
--- a/docs/content/hdfs_seqfile.html.md.erb
+++ b/docs/content/hdfs_seqfile.html.md.erb
@@ -72,7 +72,6 @@ The `hdfs:SequenceFile` profile supports the following custom options:
 | COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | DATA-SCHEMA    | The name of the writer serialization/deserialization class. The jar file in which this class resides must be in the PXF classpath. This option is required for the `hdfs:SequenceFile` profile and has no default value. |
-| THREAD-SAFE | Boolean value determining if a table query or write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, all operations are thread-safe. |
 | IGNORE_MISSING_PATH | A Boolean value that specifies the action to take when \<path-to-hdfs-dir\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 

--- a/docs/content/hdfs_seqfile.html.md.erb
+++ b/docs/content/hdfs_seqfile.html.md.erb
@@ -72,7 +72,7 @@ The `hdfs:SequenceFile` profile supports the following custom options:
 | COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | DATA-SCHEMA    | The name of the writer serialization/deserialization class. The jar file in which this class resides must be in the PXF classpath. This option is required for the `hdfs:SequenceFile` profile and has no default value. |
-| THREAD-SAFE | Boolean value determining if a table query can run in multi-threaded mode. The default value is `TRUE`. Set this option to `FALSE` to handle all requests in a single thread for operations that are not thread-safe (for example, compression). |
+| THREAD-SAFE | Boolean value determining if a table write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, write compression is always thread-safe. |
 | IGNORE_MISSING_PATH | A Boolean value that specifies the action to take when \<path-to-hdfs-dir\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 

--- a/docs/content/hdfs_seqfile.html.md.erb
+++ b/docs/content/hdfs_seqfile.html.md.erb
@@ -72,7 +72,7 @@ The `hdfs:SequenceFile` profile supports the following custom options:
 | COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | DATA-SCHEMA    | The name of the writer serialization/deserialization class. The jar file in which this class resides must be in the PXF classpath. This option is required for the `hdfs:SequenceFile` profile and has no default value. |
-| THREAD-SAFE | Boolean value determining if a table write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, write compression is always thread-safe. |
+| THREAD-SAFE | Boolean value determining if a table query or write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, all operations are thread-safe. |
 | IGNORE_MISSING_PATH | A Boolean value that specifies the action to take when \<path-to-hdfs-dir\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -253,7 +253,6 @@ You specify the compression codec via custom options in the `CREATE EXTERNAL TAB
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
-| THREAD-SAFE | Boolean value determining if a table query or write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, all operations are thread-safe. |
 
 ### <a id="write_hdfstextsimple_example"></a>Example: Writing Text Data to HDFS
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -253,7 +253,7 @@ You specify the compression codec via custom options in the `CREATE EXTERNAL TAB
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
-| THREAD-SAFE | Boolean value determining if a table query can run in multi-threaded mode. The default value is `TRUE`. Set this option to `FALSE` to handle all requests in a single thread for operations that are not thread-safe (for example, compression). |
+| THREAD-SAFE | Boolean value determining if a table write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, write compression is always thread-safe. |
 
 ### <a id="write_hdfstextsimple_example"></a>Example: Writing Text Data to HDFS
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -253,7 +253,7 @@ You specify the compression codec via custom options in the `CREATE EXTERNAL TAB
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
-| THREAD-SAFE | Boolean value determining if a table write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, write compression is always thread-safe. |
+| THREAD-SAFE | Boolean value determining if a table query or write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, all operations are thread-safe. |
 
 ### <a id="write_hdfstextsimple_example"></a>Example: Writing Text Data to HDFS
 

--- a/docs/content/objstore_text.html.md.erb
+++ b/docs/content/objstore_text.html.md.erb
@@ -283,7 +283,6 @@ You specify the compression codec via custom options in the `CREATE EXTERNAL TAB
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
-| THREAD-SAFE | Boolean value determining if a table query or write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, all operations are thread-safe. |
 
 If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 

--- a/docs/content/objstore_text.html.md.erb
+++ b/docs/content/objstore_text.html.md.erb
@@ -283,7 +283,7 @@ You specify the compression codec via custom options in the `CREATE EXTERNAL TAB
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
-| THREAD-SAFE | Boolean value determining if a table query can run in multi-threaded mode. The default value is `TRUE`. Set this option to `FALSE` to handle all requests in a single thread for operations that are not thread-safe (for example, compression). |
+| THREAD-SAFE | Boolean value determining if a table write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, write compression is always thread-safe. |
 
 If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 

--- a/docs/content/objstore_text.html.md.erb
+++ b/docs/content/objstore_text.html.md.erb
@@ -283,7 +283,7 @@ You specify the compression codec via custom options in the `CREATE EXTERNAL TAB
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
-| THREAD-SAFE | Boolean value determining if a table write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, write compression is always thread-safe. |
+| THREAD-SAFE | Boolean value determining if a table query or write can run in multi-threaded mode. The default value is `TRUE`. *Deprecated*; PXF ignores this option, all operations are thread-safe. |
 
 If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 


### PR DESCRIPTION
some docs for https://github.com/greenplum-db/pxf/pull/421.

the PR deprecates and ignores the THREAD-SAFE custom option.  the docs mentioned this option in the write sections of the text and sequencefile formats.

in this PR:
- note in descriptions of the THREAD-SAFE option that it is deprecated.

(the 5.15 release notes will mention the locking change, and the deprecation - this will be a separate PR.)