### PR TITLE
Additional clean up for the thread safe option

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
@@ -127,10 +127,6 @@ public class RequestContext {
      */
     private String serverName = "default";
     private int totalSegments;
-    /**
-     * When false the bridge has to run in synchronized mode. default value is true.
-     */
-    private boolean threadSafe = true;
 
     private List<ColumnDescriptor> tupleDescription = new ArrayList<>();
     private String user;
@@ -513,20 +509,6 @@ public class RequestContext {
      */
     public String getSecret() {
         return remoteSecret;
-    }
-
-    /**
-     * Returns whether this request is thread safe.
-     * If it is not, request will be handled consequentially and not in parallel.
-     *
-     * @return whether the request is thread safe
-     */
-    public boolean isThreadSafe() {
-        return threadSafe;
-    }
-
-    public void setThreadSafe(boolean threadSafe) {
-        this.threadSafe = threadSafe;
     }
 
     /**

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
@@ -151,11 +151,6 @@ public class HttpRequestParser implements RequestParser<HttpHeaders> {
             context.setStatsSampleRatio(Float.parseFloat(sampleRatioStr));
         }
 
-        String threadSafeStr = params.removeUserProperty("THREAD-SAFE");
-        if (!StringUtils.isBlank(threadSafeStr)) {
-            context.setThreadSafe(parseBooleanValue(threadSafeStr));
-        }
-
         context.setTotalSegments(params.removeIntProperty("SEGMENT-COUNT"));
         context.setTransactionId(params.removeProperty("XID"));
 

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
@@ -241,44 +241,6 @@ public class HttpRequestParserTest {
     }
 
     @Test
-    public void threadSafeTrue() {
-        parameters.putSingle("X-GP-OPTIONS-THREAD-SAFE", "TRUE");
-        RequestContext context = parser.parseRequest(mockRequestHeaders, RequestType.FRAGMENTER);
-        assertTrue(context.isThreadSafe());
-
-        parameters.putSingle("X-GP-OPTIONS-THREAD-SAFE", "true");
-        context = new HttpRequestParser().parseRequest(mockRequestHeaders, RequestType.FRAGMENTER);
-        assertTrue(context.isThreadSafe());
-    }
-
-    @Test
-    public void threadSafeFalse() {
-        parameters.putSingle("X-GP-OPTIONS-THREAD-SAFE", "False");
-        RequestContext context = new HttpRequestParser().parseRequest(mockRequestHeaders, RequestType.FRAGMENTER);
-        assertFalse(context.isThreadSafe());
-
-        parameters.putSingle("X-GP-OPTIONS-THREAD-SAFE", "falSE");
-        context = new HttpRequestParser().parseRequest(mockRequestHeaders, RequestType.FRAGMENTER);
-        assertFalse(context.isThreadSafe());
-    }
-
-    @Test
-    public void threadSafeMaybe() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Illegal boolean value 'maybe'. Usage: [TRUE|FALSE]");
-
-        parameters.putSingle("X-GP-OPTIONS-THREAD-SAFE", "maybe");
-        parser.parseRequest(mockRequestHeaders, RequestType.FRAGMENTER);
-    }
-
-    @Test
-    public void threadSafeDefault() {
-        parameters.remove("X-GP-OPTIONS-THREAD-SAFE");
-        RequestContext context = parser.parseRequest(mockRequestHeaders, RequestType.FRAGMENTER);
-        assertTrue(context.isThreadSafe());
-    }
-
-    @Test
     public void getFragmentMetadata() {
         RequestContext context = parser.parseRequest(mockRequestHeaders, RequestType.FRAGMENTER);
         byte[] location = context.getFragmentMetadata();


### PR DESCRIPTION
Remove the thread safe option from the request context as it serves no
purpose anymore