### PR TITLE
Log information about loaded hadoop native libraries during startup

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/servlet/ServletLifecycleListener.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/servlet/ServletLifecycleListener.java
@@ -21,6 +21,7 @@ package org.greenplum.pxf.service.servlet;
 
 
 import org.greenplum.pxf.service.utilities.Log4jConfigure;
+import org.greenplum.pxf.service.utilities.NativeLibraryChecker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,7 @@ import javax.servlet.ServletContextListener;
  */
 public class ServletLifecycleListener implements ServletContextListener {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ServletContextListener.class);
+	private static final Logger LOG = LoggerFactory.getLogger(ServletContextListener.class);
 
 	/**
 	 * Called after the webapp has been initialized.
@@ -43,6 +44,9 @@ public class ServletLifecycleListener implements ServletContextListener {
 	public void contextInitialized(ServletContextEvent event) {
 		// 1. Initialize log4j:
 		Log4jConfigure.configure(event);
+
+		// 2. Check native libraries that have been loaded by PXF
+		NativeLibraryChecker.checkNativeLibraries();
 
 		LOG.info("PXF server webapp initialized");
 	}

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/NativeLibraryChecker.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/NativeLibraryChecker.java
@@ -1,0 +1,84 @@
+package org.greenplum.pxf.service.utilities;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.crypto.OpensslCipher;
+import org.apache.hadoop.io.compress.Lz4Codec;
+import org.apache.hadoop.io.compress.SnappyCodec;
+import org.apache.hadoop.io.compress.ZStandardCodec;
+import org.apache.hadoop.io.compress.bzip2.Bzip2Factory;
+import org.apache.hadoop.io.compress.zlib.ZlibFactory;
+import org.apache.hadoop.util.NativeCodeLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class that checks whether native libraries have been loaded and logs
+ * information about the loaded native libraries
+ */
+public class NativeLibraryChecker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NativeLibraryChecker.class);
+
+    /**
+     * Checks whether native libraries are loaded and logs details of the
+     * loaded libraries
+     */
+    public static void checkNativeLibraries() {
+        boolean nativeHadoopLoaded = NativeCodeLoader.isNativeCodeLoaded();
+
+        if (nativeHadoopLoaded) {
+            Configuration conf = new Configuration();
+            boolean zlibLoaded;
+            boolean snappyLoaded;
+            boolean zStdLoaded;
+            boolean bzip2Loaded = Bzip2Factory.isNativeBzip2Loaded(conf);
+            boolean openSslLoaded;
+
+            String openSslDetail;
+            String hadoopLibraryName;
+            String zlibLibraryName = "";
+            String snappyLibraryName = "";
+            String zstdLibraryName = "";
+            String lz4LibraryName;
+            String bzip2LibraryName = "";
+
+            hadoopLibraryName = NativeCodeLoader.getLibraryName();
+            zlibLoaded = ZlibFactory.isNativeZlibLoaded(conf);
+            if (zlibLoaded) {
+                zlibLibraryName = ZlibFactory.getLibraryName();
+            }
+            snappyLoaded = NativeCodeLoader.buildSupportsSnappy() &&
+                    SnappyCodec.isNativeCodeLoaded();
+            if (snappyLoaded && NativeCodeLoader.buildSupportsSnappy()) {
+                snappyLibraryName = SnappyCodec.getLibraryName();
+            }
+            zStdLoaded = NativeCodeLoader.buildSupportsZstd() &&
+                    ZStandardCodec.isNativeCodeLoaded();
+            if (zStdLoaded && NativeCodeLoader.buildSupportsZstd()) {
+                zstdLibraryName = ZStandardCodec.getLibraryName();
+            }
+            if (OpensslCipher.getLoadingFailureReason() != null) {
+                openSslDetail = OpensslCipher.getLoadingFailureReason();
+                openSslLoaded = false;
+            } else {
+                openSslDetail = OpensslCipher.getLibraryName();
+                openSslLoaded = true;
+            }
+            lz4LibraryName = Lz4Codec.getLibraryName();
+            if (bzip2Loaded) {
+                bzip2LibraryName = Bzip2Factory.getLibraryName(conf);
+            }
+
+            LOG.info("Hadoop native library : {} {}", true, hadoopLibraryName);
+            LOG.info("zlib library          : {} {}", zlibLoaded, zlibLibraryName);
+            LOG.info("snappy library        : {} {}", snappyLoaded, snappyLibraryName);
+            LOG.info("zstd library          : {} {}", zStdLoaded, zstdLibraryName);
+            // lz4 is linked within libhadoop
+            LOG.info("lz4 library           : {} {}", true, lz4LibraryName);
+            LOG.info("bzip2 library         : {} {}", bzip2Loaded, bzip2LibraryName);
+            LOG.info("openssl library       : {} {}", openSslLoaded, openSslDetail);
+        } else {
+            LOG.info("Hadoop native library not loaded");
+        }
+    }
+}

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/NativeLibraryChecker.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/NativeLibraryChecker.java
@@ -26,59 +26,60 @@ public class NativeLibraryChecker {
     public static void checkNativeLibraries() {
         boolean nativeHadoopLoaded = NativeCodeLoader.isNativeCodeLoaded();
 
-        if (nativeHadoopLoaded) {
-            Configuration conf = new Configuration();
-            boolean zlibLoaded;
-            boolean snappyLoaded;
-            boolean zStdLoaded;
-            boolean bzip2Loaded = Bzip2Factory.isNativeBzip2Loaded(conf);
-            boolean openSslLoaded;
-
-            String openSslDetail;
-            String hadoopLibraryName;
-            String zlibLibraryName = "";
-            String snappyLibraryName = "";
-            String zstdLibraryName = "";
-            String lz4LibraryName;
-            String bzip2LibraryName = "";
-
-            hadoopLibraryName = NativeCodeLoader.getLibraryName();
-            zlibLoaded = ZlibFactory.isNativeZlibLoaded(conf);
-            if (zlibLoaded) {
-                zlibLibraryName = ZlibFactory.getLibraryName();
-            }
-            snappyLoaded = NativeCodeLoader.buildSupportsSnappy() &&
-                    SnappyCodec.isNativeCodeLoaded();
-            if (snappyLoaded && NativeCodeLoader.buildSupportsSnappy()) {
-                snappyLibraryName = SnappyCodec.getLibraryName();
-            }
-            zStdLoaded = NativeCodeLoader.buildSupportsZstd() &&
-                    ZStandardCodec.isNativeCodeLoaded();
-            if (zStdLoaded && NativeCodeLoader.buildSupportsZstd()) {
-                zstdLibraryName = ZStandardCodec.getLibraryName();
-            }
-            if (OpensslCipher.getLoadingFailureReason() != null) {
-                openSslDetail = OpensslCipher.getLoadingFailureReason();
-                openSslLoaded = false;
-            } else {
-                openSslDetail = OpensslCipher.getLibraryName();
-                openSslLoaded = true;
-            }
-            lz4LibraryName = Lz4Codec.getLibraryName();
-            if (bzip2Loaded) {
-                bzip2LibraryName = Bzip2Factory.getLibraryName(conf);
-            }
-
-            LOG.info("Hadoop native library : {} {}", true, hadoopLibraryName);
-            LOG.info("zlib library          : {} {}", zlibLoaded, zlibLibraryName);
-            LOG.info("snappy library        : {} {}", snappyLoaded, snappyLibraryName);
-            LOG.info("zstd library          : {} {}", zStdLoaded, zstdLibraryName);
-            // lz4 is linked within libhadoop
-            LOG.info("lz4 library           : {} {}", true, lz4LibraryName);
-            LOG.info("bzip2 library         : {} {}", bzip2Loaded, bzip2LibraryName);
-            LOG.info("openssl library       : {} {}", openSslLoaded, openSslDetail);
-        } else {
+        if (!nativeHadoopLoaded) {
             LOG.info("Hadoop native library not loaded");
+            return;
         }
+
+        Configuration conf = new Configuration();
+        boolean zlibLoaded;
+        boolean snappyLoaded;
+        boolean zStdLoaded;
+        boolean bzip2Loaded = Bzip2Factory.isNativeBzip2Loaded(conf);
+        boolean openSslLoaded;
+
+        String openSslDetail;
+        String hadoopLibraryName;
+        String zlibLibraryName = "";
+        String snappyLibraryName = "";
+        String zstdLibraryName = "";
+        String lz4LibraryName;
+        String bzip2LibraryName = "";
+
+        hadoopLibraryName = NativeCodeLoader.getLibraryName();
+        zlibLoaded = ZlibFactory.isNativeZlibLoaded(conf);
+        if (zlibLoaded) {
+            zlibLibraryName = ZlibFactory.getLibraryName();
+        }
+        snappyLoaded = NativeCodeLoader.buildSupportsSnappy() &&
+                SnappyCodec.isNativeCodeLoaded();
+        if (snappyLoaded && NativeCodeLoader.buildSupportsSnappy()) {
+            snappyLibraryName = SnappyCodec.getLibraryName();
+        }
+        zStdLoaded = NativeCodeLoader.buildSupportsZstd() &&
+                ZStandardCodec.isNativeCodeLoaded();
+        if (zStdLoaded && NativeCodeLoader.buildSupportsZstd()) {
+            zstdLibraryName = ZStandardCodec.getLibraryName();
+        }
+        if (OpensslCipher.getLoadingFailureReason() != null) {
+            openSslDetail = OpensslCipher.getLoadingFailureReason();
+            openSslLoaded = false;
+        } else {
+            openSslDetail = OpensslCipher.getLibraryName();
+            openSslLoaded = true;
+        }
+        lz4LibraryName = Lz4Codec.getLibraryName();
+        if (bzip2Loaded) {
+            bzip2LibraryName = Bzip2Factory.getLibraryName(conf);
+        }
+
+        LOG.info("Hadoop native library : {} {}", true, hadoopLibraryName);
+        LOG.info("zlib library          : {} {}", zlibLoaded, zlibLibraryName);
+        LOG.info("snappy library        : {} {}", snappyLoaded, snappyLibraryName);
+        LOG.info("zstd library          : {} {}", zStdLoaded, zstdLibraryName);
+        // lz4 is linked within libhadoop
+        LOG.info("lz4 library           : {} {}", true, lz4LibraryName);
+        LOG.info("bzip2 library         : {} {}", bzip2Loaded, bzip2LibraryName);
+        LOG.info("openssl library       : {} {}", openSslLoaded, openSslDetail);
     }
 }


### PR DESCRIPTION
Log at INFO level information about hadoop native libraries and native
hadoop codecs available for PXF during startup. This allows displaying
important information for PXF that can help in debugging issues with
different compression codecs used for hadoop. Some compression codecs
require native libraries, for example snappy, while others have both
native and java-based implementations of the compression codecs.