### PR TITLE
dockerfiles and cloudbuild files for rpmrebuild tool

### DIFF
--- a/concourse/docker/rpmrebuild/centos/Dockerfile
+++ b/concourse/docker/rpmrebuild/centos/Dockerfile
@@ -1,0 +1,6 @@
+ARG BASE_IMAGE=centos:6
+
+FROM ${BASE_IMAGE}
+
+RUN yum install -y epel-release
+RUN yum install -y rpmrebuild

--- a/concourse/docker/rpmrebuild/centos/cloudbuild.yaml
+++ b/concourse/docker/rpmrebuild/centos/cloudbuild.yaml
@@ -1,0 +1,34 @@
+# In this directory, run the following command to build this builder.
+# $ gcloud builds submit . --config=cloudbuild.yaml
+
+steps:
+
+# Builds the rpmrebuild-centos6 image
+- name: 'gcr.io/cloud-builders/docker'
+  id: rpmrebuild-centos6-image
+  args:
+    - 'build'
+    - '--build-arg=BASE_IMAGE=centos:6'
+    - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-centos6:latest'
+    - '-f'
+    - 'concourse/docker/rpmrebuild/centos/Dockerfile'
+    - 'build/'
+  waitFor: ['-']
+
+# Builds the rpmrebuild-centos7 image
+- name: 'gcr.io/cloud-builders/docker'
+  id: rpmrebuild-centos7-image
+  args:
+    - 'build'
+    - '--build-arg=BASE_IMAGE=centos:7'
+    - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
+    - '-f'
+    - 'concourse/docker/rpmrebuild/centos/Dockerfile'
+    - 'build/'
+  waitFor: ['-']
+
+# Push images from Cloud Build to Container Registry
+images:
+  - 'gcr.io/$PROJECT_ID/rpmrebuild-centos6:latest'
+  - 'gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
+

--- a/concourse/docker/rpmrebuild/centos/cloudbuild.yaml
+++ b/concourse/docker/rpmrebuild/centos/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
     - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-centos6:latest'
     - '-f'
     - 'concourse/docker/rpmrebuild/centos/Dockerfile'
-    - '/workspace/none'
+    - 'concourse/docker/rpmrebuild/centos'
   waitFor: ['-']
 
 # Builds the rpmrebuild-centos7 image
@@ -24,7 +24,7 @@ steps:
     - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
     - '-f'
     - 'concourse/docker/rpmrebuild/centos/Dockerfile'
-    - '/workspace/none'
+    - 'concourse/docker/rpmrebuild/centos'
   waitFor: ['-']
 
 # Push images from Cloud Build to Container Registry

--- a/concourse/docker/rpmrebuild/centos/cloudbuild.yaml
+++ b/concourse/docker/rpmrebuild/centos/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
     - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-centos6:latest'
     - '-f'
     - 'concourse/docker/rpmrebuild/centos/Dockerfile'
-    - 'build/'
+    - '/workspace/none'
   waitFor: ['-']
 
 # Builds the rpmrebuild-centos7 image
@@ -24,7 +24,7 @@ steps:
     - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
     - '-f'
     - 'concourse/docker/rpmrebuild/centos/Dockerfile'
-    - 'build/'
+    - '/workspace/none'
   waitFor: ['-']
 
 # Push images from Cloud Build to Container Registry


### PR DESCRIPTION
Want to keep it simple and not cache anything during cloudbuild. This will not be re-built again once built.