### PR TITLE
Parquet Write: Fix physical and logical storage for DATE types

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/GreenplumDateTime.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/GreenplumDateTime.java
@@ -9,21 +9,33 @@ import java.time.temporal.ChronoField;
  */
 public class GreenplumDateTime {
 
+    public static final String DATE_FORMATTER_BASE_PATTERN = "yyyy-MM-dd";
+
     public static final String DATETIME_FORMATTER_BASE_PATTERN = "yyyy-MM-dd HH:mm:ss";
+
+    /**
+     * The date formatter for Greenplum values
+     */
+    public static final DateTimeFormatter DATE_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .appendPattern(DATE_FORMATTER_BASE_PATTERN)
+                    .toFormatter();
 
     /**
      * Supports date times with the format yyyy-MM-dd HH:mm:ss and
      * optional microsecond
      */
     public static final DateTimeFormatter DATETIME_FORMATTER =
-            new DateTimeFormatterBuilder().appendPattern(DATETIME_FORMATTER_BASE_PATTERN)
+            new DateTimeFormatterBuilder()
+                    .appendPattern(DATETIME_FORMATTER_BASE_PATTERN)
                     // Parsing nanos in strict mode, the number of parsed digits must be between 0 and 6 (microsecond support)
-                    .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true).toFormatter();
+                    .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
+                    .toFormatter();
 
     /**
      * Supports date times with timezone and optional microsecond
      */
-    private static DateTimeFormatter optionalFormatter = new DateTimeFormatterBuilder().appendOffset("+HH:mm", "Z").toFormatter();
+    private static final DateTimeFormatter optionalFormatter = new DateTimeFormatterBuilder().appendOffset("+HH:mm", "Z").toFormatter();
     public static final DateTimeFormatter DATETIME_WITH_TIMEZONE_FORMATTER =
             new DateTimeFormatterBuilder()
                     .parseCaseInsensitive()

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessor.java
@@ -85,6 +85,7 @@ import static org.apache.parquet.hadoop.ParquetOutputFormat.PAGE_SIZE;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.WRITER_VERSION;
 import static org.apache.parquet.hadoop.api.ReadSupport.PARQUET_READ_SCHEMA;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 
@@ -506,6 +507,13 @@ public class ParquetFileAccessor extends BasePlugin implements Accessor {
                     builder = Types.optional(PrimitiveTypeName.INT96);
                     break;
                 case DATE:
+                    // DATE is used to for a logical date type, without a time
+                    // of day. It must annotate an int32 that stores the number
+                    // of days from the Unix epoch, 1 January 1970. The sort
+                    // order used for DATE is signed.
+                    builder = Types.optional(PrimitiveTypeName.INT32)
+                            .as(dateType());
+                    break;
                 case TIME:
                 case VARCHAR:
                 case BPCHAR:

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/parquet/ParquetTypeConverter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/parquet/ParquetTypeConverter.java
@@ -18,6 +18,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -258,6 +259,15 @@ public enum ParquetTypeConverter {
                     timestamp, julianDay, timeOfDayNanos, unixTimeMs);
         }
         return timestamp;
+    }
+
+    /**
+     * Parses the dateString and returns the number of days between the unix
+     * epoch (1 January 1970) until the given date in the dateString
+     */
+    public static int getDaysFromEpochFromDateString(String dateString) {
+        LocalDate date = LocalDate.parse(dateString, GreenplumDateTime.DATE_FORMATTER);
+        return (int) date.toEpochDay();
     }
 
     /**

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetResolverTest.java
@@ -107,8 +107,8 @@ public class ParquetResolverTest {
         schema = getParquetSchemaForPrimitiveTypes(Type.Repetition.OPTIONAL, false);
         // schema has changed, set metadata again
         context.setMetadata(schema);
-        resolver.initialize(context);
         context.setTupleDescription(getColumnDescriptorsFromSchema(schema));
+        resolver.initialize(context);
 
         Instant timestamp = Instant.parse("2013-07-14T04:00:05Z"); // UTC
         ZonedDateTime localTime = timestamp.atZone(ZoneId.systemDefault());

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetWriteTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/ParquetWriteTest.java
@@ -49,6 +49,7 @@ import static org.apache.parquet.hadoop.ParquetOutputFormat.DICTIONARY_PAGE_SIZE
 import static org.apache.parquet.hadoop.ParquetOutputFormat.ENABLE_DICTIONARY;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.PAGE_SIZE;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.WRITER_VERSION;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.IntLogicalTypeAnnotation;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
@@ -328,22 +329,24 @@ public class ParquetWriteTest {
                 .withConf(configuration)
                 .build();
 
-        // Physical type is binary, logical type is Date
+        // Physical type is INT32, logical type is DATE
         assertNotNull(schema.getColumns());
         assertEquals(1, schema.getColumns().size());
         Type type = schema.getType(0);
-        assertEquals(PrimitiveType.PrimitiveTypeName.BINARY, type.asPrimitiveType().getPrimitiveTypeName());
-        assertTrue(type.getLogicalTypeAnnotation() instanceof StringLogicalTypeAnnotation);
-        assertEquals("2020-08-01", fileReader.read().getString(0, 0));
-        assertEquals("2020-08-02", fileReader.read().getString(0, 0));
-        assertEquals("2020-08-03", fileReader.read().getString(0, 0));
-        assertEquals("2020-08-04", fileReader.read().getString(0, 0));
-        assertEquals("2020-08-05", fileReader.read().getString(0, 0));
-        assertEquals("2020-08-06", fileReader.read().getString(0, 0));
-        assertEquals("2020-08-07", fileReader.read().getString(0, 0));
-        assertEquals("2020-08-08", fileReader.read().getString(0, 0));
-        assertEquals("2020-08-09", fileReader.read().getString(0, 0));
-        assertEquals("2020-08-10", fileReader.read().getString(0, 0));
+        assertEquals(PrimitiveType.PrimitiveTypeName.INT32, type.asPrimitiveType().getPrimitiveTypeName());
+        assertTrue(type.getLogicalTypeAnnotation() instanceof DateLogicalTypeAnnotation);
+
+        // Days since epoch: 18475 days from 1970-01-01 -> 2020-08-01
+        assertEquals(18475, fileReader.read().getInteger(0, 0));
+        assertEquals(18476, fileReader.read().getInteger(0, 0));
+        assertEquals(18477, fileReader.read().getInteger(0, 0));
+        assertEquals(18478, fileReader.read().getInteger(0, 0));
+        assertEquals(18479, fileReader.read().getInteger(0, 0));
+        assertEquals(18480, fileReader.read().getInteger(0, 0));
+        assertEquals(18481, fileReader.read().getInteger(0, 0));
+        assertEquals(18482, fileReader.read().getInteger(0, 0));
+        assertEquals(18483, fileReader.read().getInteger(0, 0));
+        assertEquals(18484, fileReader.read().getInteger(0, 0));
         assertNull(fileReader.read());
         fileReader.close();
     }


### PR DESCRIPTION
Hive stores DATE types as `int32` with logical type of `DATE` whereas
PXF is storing DATE types as `BINARY` with `STRING` logical type:

**Hive**
```
 $ java -jar parquet-tools-1.12.0-SNAPSHOT.jar schema /tmp/000000_0
message hive_schema {
  optional int32 dt (DATE);
}
```

**PXF**
```
 $ java -jar parquet-tools-1.12.0-SNAPSHOT.jar schema /tmp/1597879570-0000000014_2.0.snappy.parquet
message hive_schema {
  optional binary dt (STRING);
}
```

This commit fixes how PXF stores DATE types to make it consistent with
the way Hive stores DATE types.