### PR TITLE
docs - add info about registering native libraries

### DIFF
--- a/docs/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/docs/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -47,7 +47,7 @@
           <li><a href="/pxf/WIP/upgrade_pxf_rpm.html" format="markdown">Upgrading PXF</a></li>
           <li><a href="/pxf/WIP/cfginitstart_pxf.html" format="markdown">Starting, Stopping, and Restarting PXF</a></li>
           <li><a href="/pxf/WIP/using_pxf.html" format="markdown">Granting Users Access to PXF</a></li>
-          <li><a href="/pxf/WIP/reg_jar_depend.html" format="markdown">Registering PXF JAR Dependencies</a></li>
+          <li><a href="/pxf/WIP/reg_jar_depend.html" format="markdown">Registering PXF Library Dependencies</a></li>
           <li><a href="/pxf/WIP/monitor_pxf.html" format="markdown">Monitoring PXF</a></li>
         </ul>
       </li>

--- a/docs/content/reg_jar_depend.html.md.erb
+++ b/docs/content/reg_jar_depend.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Registering PXF JAR Dependencies
+title: Registering PXF Library Dependencies
 ---
 
 <!--
@@ -25,7 +25,11 @@ You use PXF to access data stored on external systems. Depending upon the extern
 
 PXF depends on JAR files and other configuration information provided by these additional components. The `$PXF_HOME/conf/pxf-private.classpath` file identifies PXF internal JAR dependencies. In most cases, PXF manages the `pxf-private.classpath` file, adding entries as necessary based on the connectors that you use.
 
-Should you need to add an additional JAR dependency for PXF, for example a JDBC driver JAR file, you must log in to the Greenplum Database master host, copy the JAR file to the PXF user configuration runtime library directory (`$PXF_CONF/lib`), sync the PXF configuration to the Greenplum Database cluster, and then restart PXF on each segment host. For example:
+Should you need to add additional JAR or native library dependencies, you must register these dependencies with PXF.
+
+## <a id="reg_jar"></a> Registering a JAR Dependency
+
+To add a JAR dependency for PXF, for example a MySQL driver JAR file, you must log in to the Greenplum Database master host, copy the JAR file to the PXF user configuration runtime library directory (`$PXF_CONF/lib`), sync the PXF configuration to the Greenplum Database cluster, and then restart PXF on each segment host. For example:
 
 ``` shell
 $ ssh gpadmin@<gpmaster>
@@ -33,4 +37,45 @@ gpadmin@gpmaster$ cp new_dependent_jar.jar $PXF_CONF/lib/
 gpadmin@gpmaster$ pxf cluster sync
 gpadmin@gpmaster$ pxf cluster restart
 ```
+
+## <a id="reg_native"></a> Registering a Native Library Dependency
+
+To register a native library dependency for PXF, for example a Hadoop compression library, you must copy the native library to the Greenplum hosts, update PXF user configuration, synchronize the PXF configuration to the cluster, and then restart PXF on each segment host.
+
+You have two options for copying the native library to Greenplum hosts:
+
+- You copy the library to the same location on the Greenplum master, standby, and all segment hosts.
+- You copy the library to the `$PXF_CONF/lib` directory hierarchy on the Greenplum master host. When you next synchronize PXF, the PXF configuration, including the native library, is copied to all hosts in the Greenplum Database cluster.
+
+### <a id="reg_native_proc"></a> Procedure
+
+1. Copy the native library file to a user-defined location on all Greenplum Database hosts, or copy to the `$PXF_CONF/lib` directory hierarchy on the Greenplum Database master node. Note the file system location of the native library.
+
+2. Open the `$PXF_CONF/conf/pxf-env.sh` in the editor of your choice, and set `LD_LIBRARY_PATH`. For example, if you copied a native library named `dependent_native_lib.so` to `/usr/local/lib/dependent_native_lib.so` on all Greenplum hosts, add the following text to the `pxf-env.sh` file to set this environment variable:
+
+    ``` shell
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/dependent_native_lib.so
+    ```
+
+    If you copied a native library named `dependent_native_lib.so` to `$PXF_CONF/lib/native/dependent_native_lib.so` on the Greenplum master host, add the following text to the `pxf-env.sh` file to set this environment variable:
+
+    ``` shell
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PXF_CONF/lib/native/dependent_native_lib.so
+    ```
+
+3. Save the file and exit the editor.
+
+4. Synchronize the PXF configuration from the Greenplum Database master host to the standby and segment hosts. 
+
+    ``` shell
+    gpadmin@gpmaster$ pxf cluster sync
+    ```
+
+    If you copied the native library to the `$PXF_CONF/lib` directory hierarchy, this command copies the library to the same location on the standby and segment hosts. 
+
+5. Restart PXF on all segment hosts:
+
+    ``` shell
+    gpadmin@gpmaster$ pxf cluster restart
+    ```
 

--- a/docs/content/reg_jar_depend.html.md.erb
+++ b/docs/content/reg_jar_depend.html.md.erb
@@ -56,9 +56,9 @@ When you register a native library dependency with PXF, for example [Hadoop nati
 
 You have three file location options when you register a native library with PXF:
 
-- You copy the library to the default PXF native library directory, `$PXF_CONF/lib/native`, on only the Greenplum Database master host. When you next synchronize PXF, PXF copies the native library to all hosts in the Greenplum cluster.
-- You copy the library to the default Hadoop native library directory, `/usr/lib/hadoop/lib/native`, on the Greenplum master, standby, and each segment host.
-- You copy the library to the same, custom location on the Greenplum master, standby, and each segment host, and uncomment and add the directory to the `pxf-env.sh` `LD_LIBRARY_PATH` setting.
+- Copy the library to the default PXF native library directory, `$PXF_CONF/lib/native`, on only the Greenplum Database master host. When you next synchronize PXF, PXF copies the native library to all hosts in the Greenplum cluster.
+- Copy the library to the default Hadoop native library directory, `/usr/lib/hadoop/lib/native`, on the Greenplum master, standby, and each segment host.
+- Copy the library to the same, custom location on the Greenplum master, standby, and each segment host, and uncomment and add the directory to the `pxf-env.sh` `LD_LIBRARY_PATH` setting.
 
 
 ### <a id="reg_native_proc"></a> Procedure

--- a/docs/content/reg_jar_depend.html.md.erb
+++ b/docs/content/reg_jar_depend.html.md.erb
@@ -64,7 +64,7 @@ You have three file location options when you register a native library with PXF
 ### <a id="reg_native_proc"></a> Procedure
 
 1. Copy the native library file to one of the following:
-    - The `$PXF_CONF/lib/native` directory on the Greenplum Database master host.
+    - The `$PXF_CONF/lib/native` directory on the Greenplum Database master host. (You may need to create this directory.)
     - The `/usr/lib/hadoop/lib/native` directory on all Greenplum Database hosts.
     - A user-defined location on all Greenplum Database hosts; note the file system location of the native library.
 

--- a/docs/content/reg_jar_depend.html.md.erb
+++ b/docs/content/reg_jar_depend.html.md.erb
@@ -40,7 +40,7 @@ gpadmin@gpmaster$ pxf cluster restart
 
 ## <a id="reg_native"></a> Registering a Native Library Dependency
 
-To register a native library dependency for PXF, for example a Hadoop compression library, you must copy the native library to the Greenplum hosts, update PXF user configuration, synchronize the PXF configuration to the cluster, and then restart PXF on each segment host.
+To register a native library dependency for PXF, for example [Hadoop native libraries](https://hadoop.apache.org/docs/r2.9.2/hadoop-project-dist/hadoop-common/NativeLibraries.html), you must copy the native library to the Greenplum hosts, update PXF user configuration, synchronize the PXF configuration to the cluster, and then restart PXF on each segment host.
 
 You have two options for copying the native library to Greenplum hosts:
 
@@ -54,13 +54,13 @@ You have two options for copying the native library to Greenplum hosts:
 2. Open the `$PXF_CONF/conf/pxf-env.sh` in the editor of your choice, and set `LD_LIBRARY_PATH`. For example, if you copied a native library named `dependent_native_lib.so` to `/usr/local/lib/dependent_native_lib.so` on all Greenplum hosts, add the following text to the `pxf-env.sh` file to set this environment variable:
 
     ``` shell
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/dependent_native_lib.so
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
     ```
 
     If you copied a native library named `dependent_native_lib.so` to `$PXF_CONF/lib/native/dependent_native_lib.so` on the Greenplum master host, add the following text to the `pxf-env.sh` file to set this environment variable:
 
     ``` shell
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PXF_CONF/lib/native/dependent_native_lib.so
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PXF_CONF/lib/native/
     ```
 
 3. Save the file and exit the editor.

--- a/docs/content/reg_jar_depend.html.md.erb
+++ b/docs/content/reg_jar_depend.html.md.erb
@@ -40,40 +40,62 @@ gpadmin@gpmaster$ pxf cluster restart
 
 ## <a id="reg_native"></a> Registering a Native Library Dependency
 
-To register a native library dependency for PXF, for example [Hadoop native libraries](https://hadoop.apache.org/docs/r2.9.2/hadoop-project-dist/hadoop-common/NativeLibraries.html), you must copy the native library to the Greenplum hosts, update PXF user configuration, synchronize the PXF configuration to the cluster, and then restart PXF on each segment host.
+PXF loads native libraries from the following directories in this order:
 
-You have two options for copying the native library to Greenplum hosts:
+1. The directories that you specify in the `$PXF_CONF/conf/pxf-env.sh` user configuration file `LD_LIBRARY_PATH` setting. Starting in PXF version 5.15.1, the `pxf-env.sh` file includes this commented-out block:
 
-- You copy the library to the same location on the Greenplum master, standby, and all segment hosts.
-- You copy the library to the `$PXF_CONF/lib` directory hierarchy on the Greenplum master host. When you next synchronize PXF, the PXF configuration, including the native library, is copied to all hosts in the Greenplum Database cluster.
+    ``` pre
+    # Additional native libraries to be loaded by PXF
+    # export LD_LIBRARY_PATH=
+    ```
+
+2. The default PXF native library directory `$PXF_CONF/lib/native`.
+3. The default Hadoop native library directory `/usr/lib/hadoop/lib/native`.
+
+When you register a native library dependency with PXF, for example [Hadoop native libraries](https://hadoop.apache.org/docs/r2.9.2/hadoop-project-dist/hadoop-common/NativeLibraries.html), you copy the native library to a location known to PXF *or* inform PXF of a custom location, and then you must synchronize and restart PXF.
+
+You have three file location options when you register a native library with PXF:
+
+- You copy the library to the default PXF native library directory, `$PXF_CONF/lib/native`, on only the Greenplum Database master host. When you next synchronize PXF, PXF copies the native library to all hosts in the Greenplum cluster.
+- You copy the library to the default Hadoop native library directory, `/usr/lib/hadoop/lib/native`, on the Greenplum master, standby, and each segment host.
+- You copy the library to the same, custom location on the Greenplum master, standby, and each segment host, and uncomment and add the directory to the `pxf-env.sh` `LD_LIBRARY_PATH` setting.
+
 
 ### <a id="reg_native_proc"></a> Procedure
 
-1. Copy the native library file to a user-defined location on all Greenplum Database hosts, or copy to the `$PXF_CONF/lib` directory hierarchy on the Greenplum Database master node. Note the file system location of the native library.
+1. Copy the native library file to one of the following:
+    - The `$PXF_CONF/lib/native` directory on the Greenplum Database master host.
+    - The `/usr/lib/hadoop/lib/native` directory on all Greenplum Database hosts.
+    - A user-defined location on all Greenplum Database hosts; note the file system location of the native library.
 
-2. Open the `$PXF_CONF/conf/pxf-env.sh` in the editor of your choice, and set `LD_LIBRARY_PATH`. For example, if you copied a native library named `dependent_native_lib.so` to `/usr/local/lib/dependent_native_lib.so` on all Greenplum hosts, add the following text to the `pxf-env.sh` file to set this environment variable:
+2. If you copied the native library to a custom location:
 
-    ``` shell
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
-    ```
+    1. Open the `$PXF_CONF/conf/pxf-env.sh` file in the editor of your choice, and uncomment the `LD_LIBRARY_PATH` setting:
 
-    If you copied a native library named `dependent_native_lib.so` to `$PXF_CONF/lib/native/dependent_native_lib.so` on the Greenplum master host, add the following text to the `pxf-env.sh` file to set this environment variable:
+        ``` pre
+        # Additional native libraries to be loaded by PXF
+        export LD_LIBRARY_PATH=
+        ```
 
-    ``` shell
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PXF_CONF/lib/native/
-    ```
+    2. Specify the custom location in the `LD_LIBRARY_PATH` setting. For example, if you copied a library named `dependent_native_lib.so` to `/usr/local/lib` on all Greenplum hosts, your `LD_LIBRARY_PATH` setting would look as follows:
 
-3. Save the file and exit the editor.
+        ``` shell
+        export LD_LIBRARY_PATH=/usr/local/lib
+        ```
 
-4. Synchronize the PXF configuration from the Greenplum Database master host to the standby and segment hosts. 
+    3. Save the file and exit the editor.
+
+3. Synchronize the PXF configuration from the Greenplum Database master host to the standby and segment hosts.
 
     ``` shell
     gpadmin@gpmaster$ pxf cluster sync
     ```
 
-    If you copied the native library to the `$PXF_CONF/lib` directory hierarchy, this command copies the library to the same location on the standby and segment hosts. 
+    If you copied the native library to the `$PXF_CONF/lib/native` directory, this command copies the library to the same location on the Greenplum Database standby and segment hosts.
 
-5. Restart PXF on all segment hosts:
+    If you updated the `pxf-env.sh` `LD_LIBRARY_PATH` setting, this command copies the configuration change to the Greenplum Database standby and segment hosts.
+
+4. Restart PXF on all segment hosts:
 
     ``` shell
     gpadmin@gpmaster$ pxf cluster restart


### PR DESCRIPTION
update the "registering jar dependencies" page to include registering native library dependencies.
- change the title
- move registering jars to a subsection
- add new subsection for registering native dependencies

doc review site link:  http://docs-lisa-pxf-regnative.cfapps.io/pxf/5-15/using/reg_jar_depend.html