### PR TITLE
Update template_tool to use python3 instead of python2

### DIFF
--- a/concourse/template_tool
+++ b/concourse/template_tool
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 """Simple tool for interpolating jinja vars in pipeline configs
 Example usage:
 template-tool --template external-table-tpl.yml --vars gpdb_type=5X_STABLE num_gpdb5_versions=4


### PR DESCRIPTION
python2 has reached EOL and can longer be installed via homebrew.
Homebrew can be used to install python3 and then jinja2 can be installed
with

```
python3 -m pip install jinja2
```

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>