### PR TITLE
Add lib/native directory in PXF_CONF

### DIFF
--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -256,6 +256,7 @@ function generateUserConfigs()
     setup_conf_directory "${PXF_CONF}/conf" "${PXF_HOME}/templates/user/conf"
     setup_conf_directory "${PXF_CONF}/keytabs"
     setup_conf_directory "${PXF_CONF}/lib"
+    setup_conf_directory "${PXF_CONF}/lib/native"
     setup_conf_directory "${PXF_CONF}/servers/default"
     setup_conf_directory "${PXF_CONF}/templates" "${PXF_HOME}/templates/user/templates" 'override'
 }

--- a/server/pxf-service/src/scripts/pxf-env-default.sh
+++ b/server/pxf-service/src/scripts/pxf-env-default.sh
@@ -30,7 +30,7 @@ export PXF_CONF=${PXF_CONF:-NOT_INITIALIZED}
 export PXF_HOME=${PXF_HOME:=${PARENT_SCRIPT_DIR}}
 
 # Path to HDFS native libraries
-export LD_LIBRARY_PATH=/usr/lib/hadoop/lib/native${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/lib/hadoop/lib/native
 
 # Path to JAVA
 export JAVA_HOME=${JAVA_HOME:=/usr/java/default}

--- a/server/pxf-service/src/scripts/pxf-env-default.sh
+++ b/server/pxf-service/src/scripts/pxf-env-default.sh
@@ -30,7 +30,7 @@ export PXF_CONF=${PXF_CONF:-NOT_INITIALIZED}
 export PXF_HOME=${PXF_HOME:=${PARENT_SCRIPT_DIR}}
 
 # Path to HDFS native libraries
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/lib/hadoop/lib/native
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${PXF_CONF}/lib/native:/usr/lib/hadoop/lib/native
 
 # Path to JAVA
 export JAVA_HOME=${JAVA_HOME:=/usr/java/default}

--- a/server/pxf-service/src/scripts/pxf-env-default.sh
+++ b/server/pxf-service/src/scripts/pxf-env-default.sh
@@ -30,7 +30,7 @@ export PXF_CONF=${PXF_CONF:-NOT_INITIALIZED}
 export PXF_HOME=${PXF_HOME:=${PARENT_SCRIPT_DIR}}
 
 # Path to HDFS native libraries
-export LD_LIBRARY_PATH=/usr/lib/hadoop/lib/native:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=/usr/lib/hadoop/lib/native${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 
 # Path to JAVA
 export JAVA_HOME=${JAVA_HOME:=/usr/java/default}

--- a/server/pxf-service/src/templates/user/conf/pxf-env.sh
+++ b/server/pxf-service/src/templates/user/conf/pxf-env.sh
@@ -59,5 +59,5 @@ PXF_CONF="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 # Dump heap on OutOfMemoryError, set to dump path to enable
 # export PXF_OOM_DUMP_PATH=/tmp/pxf_heap_dump
 
-# Uncomment below if you installed native libraries to be loaded by PXF
-# export LD_LIBRARY_PATH=${PXF_CONF}/lib/native${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+# Additional native libraries to be loaded by PXF
+# export LD_LIBRARY_PATH=

--- a/server/pxf-service/src/templates/user/conf/pxf-env.sh
+++ b/server/pxf-service/src/templates/user/conf/pxf-env.sh
@@ -60,4 +60,4 @@ PXF_CONF="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 # export PXF_OOM_DUMP_PATH=/tmp/pxf_heap_dump
 
 # Uncomment below if you installed native libraries to be loaded by PXF
-# export LD_LIBRARY_PATH=${PXF_CONF}/lib/native:${LD_LIBRARY_PATH}
+# export LD_LIBRARY_PATH=${PXF_CONF}/lib/native${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}

--- a/server/pxf-service/src/templates/user/conf/pxf-env.sh
+++ b/server/pxf-service/src/templates/user/conf/pxf-env.sh
@@ -58,3 +58,6 @@ PXF_CONF="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 # Dump heap on OutOfMemoryError, set to dump path to enable
 # export PXF_OOM_DUMP_PATH=/tmp/pxf_heap_dump
+
+# Uncomment below if you installed native libraries to be loaded by PXF
+# export LD_LIBRARY_PATH=${PXF_CONF}/lib/native:${LD_LIBRARY_PATH}


### PR DESCRIPTION
Add a new configuration directory, `$PXF_CONF/lib/native`, where users
can install native libraries for PXF (i.e. Hadoop native libraries).
Also, add an option to export the LD_LIBRARY_PATH to that location if
users configure their native dependencies in that location.