### PR TITLE
Hard-code git branch to 'master' when setting prod build pipeline

### DIFF
--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -50,7 +50,6 @@ set-build-pipeline:
 		build_deb=$(BUILD_DEB) \
 		email_notification=$(EMAIL) \
 		slack_notification=$(SLACK) \
-		git_branch=$(BRANCH) \
 		num_gpdb5_versions=$(NUM_GPDB5_VERSIONS) \
 		num_gpdb6_versions=$(NUM_GPDB6_VERSIONS) >"$${PIPELINE_FILE}" && \
 	$(FLY_CMD) --target=$(CONCOURSE) \
@@ -63,7 +62,7 @@ set-build-pipeline:
 		--load-vars-from=$(SECRETS_HOME)/pxf-secrets.yml \
 		--load-vars-from=$(SECRETS_HOME)/pxf-common.yml \
 		--load-vars-from=$(SECRETS_HOME)/pxf-prod.yml \
-		--var=pxf-git-branch=${BRANCH} \
+		--var=pxf-git-branch=master \
 		${FLY_OPTION_NON-INTERACTIVE} || echo "Generated yaml has errors: check $${PIPELINE_FILE}"
 
 	@echo using the following command to unpause the pipeline:

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -1543,7 +1543,7 @@ jobs:
     params:
       GCS_RELEASES_BUCKET: data-gpdb-ud-pxf-releases
       GCS_RELEASES_PATH: ((pxf-releases-bucket-prefix))/releases
-      GIT_BRANCH: [[git_branch]]
+      GIT_BRANCH: ((pxf-git-branch))
       GIT_EMAIL: ((pxf-git-deploy-email))
       GIT_REMOTE_URL: ((pxf-git-remote-ssh-url))
       GIT_SSH_KEY: ((pxf-git-deploy-key))


### PR DESCRIPTION
When setting the production build pipeline for PXF, the git branch
should always be set to master. Hard-coding it to 'master' safegaurds
against setting the pipeline when not on master. It also allows
state-checker to correctly check the build pipeline.

When the Conourse git resource clones, it will checkout a particular
commit causing the local working copy to be detached and the queried
branch name will be reported as `HEAD`.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>