### PR TITLE
pxf.service.user.name is commented out by default in pxf-site.xml

### DIFF
--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -450,7 +450,7 @@ function init_and_configure_pxf_server() {
 		# Only copy this file when testing against non-cloud
 		if [[ ! -f ${PXF_CONF_DIR}/servers/default/pxf-site.xml ]]; then
 			cp ${PXF_CONF_DIR}/templates/pxf-site.xml ${PXF_CONF_DIR}/servers/default/pxf-site.xml
-			sed -i -e "s|\${user.name}|${PROXY_USER}|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
+			sed -i -e "s|</configuration>|<property><name>pxf.service.user.name</name><value>${PROXY_USER}</value></property></configuration>|g" ${PXF_CONF_DIR}/servers/default/pxf-site.xml
 		fi
 	fi
 
@@ -667,7 +667,7 @@ function configure_pxf_default_server() {
 
 		sed -i \
 			-e "/<name>pxf.service.user.impersonation<\/name>/ {n;s|<value>.*</value>|<value>false</value>|g;}" \
-			-e "/<name>pxf.service.user.name<\/name>/ {n;s|<value>.*</value>|<value>foobar</value>|g;}" \
+			-e "s|</configuration>|<property><name>pxf.service.user.name</name><value>foobar</value></property></configuration>|g" \
 			${PXF_CONF_DIR}/servers/default-no-impersonation/pxf-site.xml
 	fi
 }

--- a/concourse/scripts/test_pxf_multinode.bash
+++ b/concourse/scripts/test_pxf_multinode.bash
@@ -130,7 +130,7 @@ function setup_pxf_on_cluster() {
 			fi
 			sed -i \
 			-e '/<name>pxf.service.user.impersonation<\/name>/ {n;s|<value>.*</value>|<value>false</value>|g;}' \
-			-e '/<name>pxf.service.user.name<\/name>/ {n;s|<value>.*</value>|<value>foobar</value>|g;}' \
+			-e 's|</configuration>|<property><name>pxf.service.user.name</name><value>foobar</value></property></configuration>|g' \
 			${PXF_CONF_DIR}/servers/default-no-impersonation/pxf-site.xml
 		fi &&
 		${PXF_HOME}/bin/pxf cluster sync

--- a/server/pxf-service/src/templates/user/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/user/templates/pxf-site.xml
@@ -15,17 +15,24 @@
         <value>${pxf.service.user.impersonation.enabled}</value>
         <description>End-user identity impersonation, set to true to enable, false to disable</description>
     </property>
+    <!--
     <property>
         <name>pxf.service.user.name</name>
         <value>${user.name}</value>
         <description>
-            The pxf.service.user.name property is used to specify the login
-            identity when connecting to a remote system, typically an unsecured
-            Hadoop cluster. By default, it is set to the user that started the
-            PXF process. If PXF impersonation feature is used, this is the
-            identity that needs to be granted Hadoop proxy user privileges.
-            Change it ONLY if you would like to use another identity to login to
-            an unsecured Hadoop cluster
+
+            Uncomment and set the proper value only if:
+
+            - user impersonation is enabled and you want to use the specified
+              user as a proxy on the unsecured Hadoop clusters. This is useful
+              when a proxy user has already been configured on the Hadoop side,
+              and you don't want to add gpadmin (the default) as a proxy user.
+
+            - user impersonation is disabled and you want queries from all
+              Greenplum users to appear on the Hadoop side as coming from the
+              specified user.
+
         </description>
     </property>
+    -->
 </configuration>


### PR DESCRIPTION
Comment out pxf.service.user.name to prevent the value of this property
to be used on users are trying to access a secure hadoop cluster as
Kerberos Principal for queries from all users (impersonation is
disabled). Modify the description (once again) to make it more clear
when this property should be used.

Co-authored-by: Alexander Denissov <adenissov@vmware.com>