### PR TITLE
Release UGI if there is an error during the filter execution

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/SessionId.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/SessionId.java
@@ -19,23 +19,23 @@ package org.greenplum.pxf.service;
  * under the License.
  */
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 
 /**
- * For the purposes of pxf-server, a session is the set of requests processed on a specific segment
- * on behalf of a particular user and transaction. Grouping requests together into a session allows
- * us to re-use the UserGroupInformation object (which is expensive to destroy) for each session.
+ * For the purposes of pxf-server, a session is the set of requests processed
+ * on a specific segment on behalf of a particular user and transaction ID.
+ * Grouping requests together into a session allows us to re-use the
+ * UserGroupInformation object (which is expensive to destroy) for each session.
  * <p>
- * SessionId is used as the cache key to look up the UserGroupInformation for a request. See {@link
- * UGICache}.
+ * SessionId is used as the cache key to look up the UserGroupInformation for
+ * a request. See {@link UGICache}.
  */
 public class SessionId {
 
     private final String user;
     private final Integer segmentId;
     private final String sessionId;
-    private final Configuration configuration;
+    private final boolean isSecurityEnabled;
     private final UserGroupInformation loginUser;
 
     /**
@@ -47,24 +47,24 @@ public class SessionId {
      * @param serverName    the name of the configuration server
      */
     public SessionId(Integer segmentId, String transactionId, String gpdbUser, String serverName) {
-        this(segmentId, transactionId, gpdbUser, serverName, null, null);
+        this(segmentId, transactionId, gpdbUser, serverName, false, null);
     }
 
     /**
      * Create a sessionId
      *
-     * @param segmentId     the calling segment
-     * @param transactionId the identifier for the transaction
-     * @param gpdbUser      the GPDB username
-     * @param serverName    the name of the configuration server
-     * @param configuration the configuration for the request
-     * @param loginUser     the UGI of the login user (user that runs the service or Kerberos principal)
+     * @param segmentId         the calling segment
+     * @param transactionId     the identifier for the transaction
+     * @param gpdbUser          the GPDB username
+     * @param serverName        the name of the configuration server
+     * @param isSecurityEnabled whether the Session is using Kerberos to establish user identities or is relying on simple authentication
+     * @param loginUser         the UGI of the login user (user that runs the service or Kerberos principal)
      */
-    public SessionId(Integer segmentId, String transactionId, String gpdbUser, String serverName, Configuration configuration, UserGroupInformation loginUser) {
+    public SessionId(Integer segmentId, String transactionId, String gpdbUser, String serverName, boolean isSecurityEnabled, UserGroupInformation loginUser) {
         this.segmentId = segmentId;
         this.user = gpdbUser;
         this.sessionId = gpdbUser + ":" + transactionId + ":" + segmentId + ":" + serverName;
-        this.configuration = configuration;
+        this.isSecurityEnabled = isSecurityEnabled;
         this.loginUser = loginUser;
     }
 
@@ -83,10 +83,10 @@ public class SessionId {
     }
 
     /**
-     * @return the configuration for the session
+     * @return whether the Session is using Kerberos to establish user identities or is relying on simple authentication
      */
-    public Configuration getConfiguration() {
-        return configuration;
+    public boolean isSecurityEnabled() {
+        return isSecurityEnabled;
     }
 
     /**

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/UGIProvider.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/UGIProvider.java
@@ -21,7 +21,6 @@ package org.greenplum.pxf.service;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.greenplum.pxf.api.utilities.Utilities;
 
 import java.io.IOException;
 
@@ -36,7 +35,7 @@ class UGIProvider {
      * Wrapper for {@link UserGroupInformation} creation
      *
      * @param effectiveUser the name of the user that we want to impersonate
-     * @param loginUser the UGI of the login user (or Kerberos principal)
+     * @param loginUser     the UGI of the login user (or Kerberos principal)
      * @return a {@link UserGroupInformation} for impersonation.
      * @throws IOException
      */
@@ -47,12 +46,12 @@ class UGIProvider {
     /**
      * Wrapper for {@link UserGroupInformation} creation of remote users
      *
-     * @param user the name of the remote user
+     * @param user    the name of the remote user
      * @param session session containing information on current configuration and login user
      * @return a remote {@link UserGroupInformation}.
      */
     UserGroupInformation createRemoteUser(String user, SessionId session) throws IOException {
-        if (Utilities.isSecurityEnabled(session.getConfiguration())) {
+        if (session.isSecurityEnabled()) {
             UserGroupInformation proxyUGI = createProxyUGI(user, session.getLoginUser());
             proxyUGI.setAuthenticationMethod(UserGroupInformation.AuthenticationMethod.KERBEROS);
             return proxyUGI;

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/servlet/SecurityServletFilter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/servlet/SecurityServletFilter.java
@@ -105,17 +105,16 @@ public class SecurityServletFilter implements Filter {
 
         final String serverName = StringUtils.defaultIfBlank(getHeaderValue(request, SERVER_HEADER, false), "default");
         final String configDirectory = StringUtils.defaultIfBlank(getHeaderValue(request, CONFIG_HEADER, false), serverName);
-
-        Configuration configuration = configurationFactory.initConfiguration(configDirectory, serverName, gpdbUser, null);
-
-        boolean isUserImpersonation = secureLogin.isUserImpersonationEnabled(configuration);
+        final Configuration configuration = configurationFactory.initConfiguration(configDirectory, serverName, gpdbUser, null);
+        final boolean isUserImpersonation = secureLogin.isUserImpersonationEnabled(configuration);
+        final boolean isSecurityEnabled = Utilities.isSecurityEnabled(configuration);
 
         // Establish the UGI for the login user or the Kerberos principal for the given server, if applicable
         UserGroupInformation loginUser = secureLogin.getLoginUser(serverName, configDirectory, configuration);
 
         String serviceUser = loginUser.getUserName();
 
-        if (!isUserImpersonation && Utilities.isSecurityEnabled(configuration)) {
+        if (!isUserImpersonation && isSecurityEnabled) {
             // When impersonation is disabled and security is enabled
             // we check whether the pxf.service.user.name property was provided
             // and if provided we use the value as the remote user instead of
@@ -134,7 +133,7 @@ public class SecurityServletFilter implements Filter {
                 transactionId,
                 remoteUser,
                 serverName,
-                configuration,
+                isSecurityEnabled,
                 loginUser);
 
         final String serviceUserName = serviceUser;

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/UGICacheMultiThreadTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/UGICacheMultiThreadTest.java
@@ -20,7 +20,6 @@ package org.greenplum.pxf.service;
  */
 
 import io.netty.util.internal.ConcurrentSet;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +31,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 public class UGICacheMultiThreadTest {
     private static final int numberOfSegments = 3;
@@ -47,13 +45,11 @@ public class UGICacheMultiThreadTest {
     public void setUp() throws IOException {
         provider = new FakeUgiProvider();
 
-        Configuration configuration = new Configuration();
-
         int l = 0;
         for (int i = 0; i < numberOfSegments; i++) {
             for (int j = 0; j < numberOfUsers; j++) {
                 for (int k = 0; k < numberOfTxns; k++) {
-                    sessions[l++] = new SessionId(i, "txn-id-" + k, "the-user-" + j, "default", configuration, UserGroupInformation.getLoginUser());
+                    sessions[l++] = new SessionId(i, "txn-id-" + k, "the-user-" + j, "default", false, UserGroupInformation.getLoginUser());
                 }
             }
         }

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/UGICacheTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/UGICacheTest.java
@@ -19,7 +19,6 @@ package org.greenplum.pxf.service;
  * under the License.
  */
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +50,7 @@ public class UGICacheTest {
     @Before
     public void setUp() throws Exception {
         provider = mock(UGIProvider.class);
-        session = new SessionId(0, "txn-id", "the-user", "default", new Configuration(), UserGroupInformation.getLoginUser());
+        session = new SessionId(0, "txn-id", "the-user", "default", false, UserGroupInformation.getLoginUser());
         fakeTicker = new FakeTicker();
         cache = new UGICache(provider, fakeTicker);
 
@@ -112,7 +111,7 @@ public class UGICacheTest {
 
     @Test
     public void getTwoUGIsWithDifferentTransactionsForSameUser() throws Exception {
-        SessionId otherSession = new SessionId(0, "txn-id-2", "the-user", "default", new Configuration(), UserGroupInformation.getLoginUser());
+        SessionId otherSession = new SessionId(0, "txn-id-2", "the-user", "default", false, UserGroupInformation.getLoginUser());
         UserGroupInformation ugi1 = cache.getUserGroupInformation(session, false);
         UserGroupInformation ugi2 = cache.getUserGroupInformation(otherSession, false);
         assertNotEquals(ugi1, ugi2);
@@ -123,7 +122,7 @@ public class UGICacheTest {
 
     @Test
     public void getTwoProxyUGIsWithDifferentTransactionsForSameUser() throws Exception {
-        SessionId otherSession = new SessionId(0, "txn-id-2", "the-user", "default", new Configuration(), UserGroupInformation.getLoginUser());
+        SessionId otherSession = new SessionId(0, "txn-id-2", "the-user", "default", false, UserGroupInformation.getLoginUser());
         UserGroupInformation proxyUGI1 = cache.getUserGroupInformation(session, true);
         UserGroupInformation proxyUGI2 = cache.getUserGroupInformation(otherSession, true);
         assertNotEquals(proxyUGI1, proxyUGI2);
@@ -137,7 +136,7 @@ public class UGICacheTest {
 
     @Test
     public void getTwoUGIsWithDifferentUsers() throws Exception {
-        SessionId otherSession = new SessionId(0, "txn-id", "different-user", "default", new Configuration(), UserGroupInformation.getLoginUser());
+        SessionId otherSession = new SessionId(0, "txn-id", "different-user", "default", false, UserGroupInformation.getLoginUser());
         UserGroupInformation ugi1 = cache.getUserGroupInformation(session, false);
         UserGroupInformation ugi2 = cache.getUserGroupInformation(otherSession, false);
         assertNotEquals(ugi1, ugi2);
@@ -150,7 +149,7 @@ public class UGICacheTest {
 
     @Test
     public void getTwoProxyUGIsWithDifferentUsers() throws Exception {
-        SessionId otherSession = new SessionId(0, "txn-id", "different-user", "default", new Configuration(), UserGroupInformation.getLoginUser());
+        SessionId otherSession = new SessionId(0, "txn-id", "different-user", "default", false, UserGroupInformation.getLoginUser());
         UserGroupInformation proxyUGI1 = cache.getUserGroupInformation(session, true);
         UserGroupInformation proxyUGI2 = cache.getUserGroupInformation(otherSession, true);
         assertNotEquals(proxyUGI1, proxyUGI2);

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/servlet/SecurityServletFilterTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/servlet/SecurityServletFilterTest.java
@@ -210,6 +210,7 @@ public class SecurityServletFilterTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void cleansUGICacheWhenTheFilterExecutionThrowsAnUndeclaredThrowableException() throws Exception {
         expectedException.expect(ServletException.class);
         expectScenario(false, false, false);
@@ -220,6 +221,7 @@ public class SecurityServletFilterTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void cleansUGICacheWhenTheFilterExecutionThrowsAnInterruptedException() throws Exception {
         expectedException.expect(ServletException.class);
         expectScenario(false, false, false);
@@ -256,7 +258,6 @@ public class SecurityServletFilterTest {
         verify(mockProxyUGI).doAs(Matchers.<PrivilegedExceptionAction<Object>>any());
         assertEquals(user, session.getValue().getUser());
         assertEquals(7, session.getValue().getSegmentId().intValue());
-        assertSame(mockConfiguration, session.getValue().getConfiguration());
         assertSame(mockLoginUGI, session.getValue().getLoginUser());
     }
 }


### PR DESCRIPTION
When the filter execution fails, for example when accessing a
non-existing HCFS path, the fragmenter call will throw an
InvalidInputException. This causes all segments to leave the UGI entry
available, and the FileSystem associated to the UGI does not get closed
until the UGI entry is expired 15 minutes earlier. This commit eagerly
closes UGI resources when an exception occurs.