### PR TITLE
Publish PXF binary tarballs

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -260,21 +260,17 @@ resources:
 
 ## ---------- RelEng Drop Artifacts ----------
 - name: pxf_gp5_rhel6_release_to_releng
-  type: s3
+  type: gcs
   source:
-    access_key_id: ((bucket-access-key-id))
     bucket: ((pxf-releng-gp5-drop-bucket))
-    region_name: ((aws-region))
-    secret_access_key: ((bucket-secret-access-key))
+    json_key: ((concourse-gcs-resources-service-account-key))
     regexp: ((pxf-releng-gp5-drop-path))/pxf-gp5-(.*)-2.el6.x86_64.rpm
 
 - name: pxf_gp5_rhel7_release_to_releng
-  type: s3
+  type: gcs
   source:
-    access_key_id: ((bucket-access-key-id))
     bucket: ((pxf-releng-gp5-drop-bucket))
-    region_name: ((aws-region))
-    secret_access_key: ((bucket-secret-access-key))
+    json_key: ((concourse-gcs-resources-service-account-key))
     regexp: ((pxf-releng-gp5-drop-path))/pxf-gp5-(.*)-2.el7.x86_64.rpm
 
 - name: pxf_gp6_rhel7_release_to_releng

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -305,6 +305,21 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: ((pxf-releng-odp-drop-path))/((pxf-odp-file-prefix))-(.*)-ODP.tar.gz
 
+## ---------- RelEng Drop Artifacts for tarballs ----------
+- name: pxf_gp5_tarball_release_to_releng
+  type: gcs
+  source:
+    bucket: ((pxf-releng-gp6-drop-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: ((pxf-releng-gp5-drop-path))/pxf-(.*).tar.gz
+
+- name: pxf_gp6_tarball_release_to_releng
+  type: gcs
+  source:
+    bucket: ((pxf-releng-gp6-drop-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: ((pxf-releng-gp6-drop-path))/pxf-(.*).tar.gz
+
 ## ---------- PXF ShipIt resources ----------
 - name: pxf_shipit_file
   type: gcs
@@ -1563,6 +1578,18 @@ jobs:
     params:
       GP_VER: 6
       TARGET_OS_VERSION: ubuntu18.04
+  - task: Generate PXF binary tarball from PXF-GP5 on RHEL6 RPM
+    file: pxf_src/concourse/tasks/generate_tarball_from_rpm.yml
+    image: rpmrebuild-centos6-image
+    params:
+      GP_VER: 5
+      TARGET_OS_VERSION: 6
+  - task: Generate PXF binary tarball from PXF-GP6 on RHEL7 RPM
+    file: pxf_src/concourse/tasks/generate_tarball_from_rpm.yml
+    image: rpmrebuild-centos7-image
+    params:
+      GP_VER: 6
+      TARGET_OS_VERSION: 7
   - task: Generate Releng Email
     image: google-cloud-sdk-slim-image
     file: pxf_src/concourse/tasks/generate_releng_email.yml
@@ -1590,6 +1617,12 @@ jobs:
     - put: pxf_gp6_ubuntu18_release_to_releng
       params:
         file: pxf_artifacts/licensed/pxf-gp6-*-2-ubuntu18.04-amd64.deb
+    - put: pxf_gp5_tarball_release_to_releng
+      params:
+        file: pxf_artifacts/licensed/gp5/pxf-*.tar.gz
+    - put: pxf_gp6_tarball_release_to_releng
+      params:
+        file: pxf_artifacts/licensed/gp6/pxf-*.tar.gz
     - put: pxf_odp_to_releng
       params:
         file: pxf_artifacts/((pxf-odp-file-prefix))*.tar.gz

--- a/concourse/scripts/generate_releng_email.bash
+++ b/concourse/scripts/generate_releng_email.bash
@@ -25,6 +25,8 @@ pxf_gp6_el7_releng_url="${RELENG_GP6_DROP_URL}/pxf-gp6-${version}-2.el7.x86_64.r
 pxf_gp6_ubuntu18_releng_url="${RELENG_GP6_DROP_URL}/pxf-gp6-${version}-2-ubuntu18.04-amd64.deb"
 pxf_osl_releng_url="${RELENG_OSL_DROP_URL}/${PXF_OSL_FILE_PREFIX}_${version}_GA.txt"
 pxf_odp_releng_url="${RELENG_ODP_DROP_URL}/${PXF_ODP_FILE_PREFIX}-${version}-ODP.tar.gz"
+pxf_gp5_tarball_releng_url="${RELENG_GP5_DROP_URL}/pxf-${version}.tar.gz"
+pxf_gp6_tarball_releng_url="${RELENG_GP6_DROP_URL}/pxf-${version}.tar.gz"
 
 echo "Generating Releng Email"
 
@@ -41,8 +43,10 @@ The new PXF release ${version} is ready to be published to VMware Tanzu Network.
 
 We have uploaded PXF release artifacts to the following RelEng locations:
 
+${pxf_gp5_tarball_releng_url}
 ${pxf_gp5_el6_releng_url}
 ${pxf_gp5_el7_releng_url}
+${pxf_gp6_tarball_releng_url}
 ${pxf_gp6_el7_releng_url}
 ${pxf_gp6_ubuntu18_releng_url}
 ${pxf_osl_releng_url}

--- a/concourse/scripts/generate_tarball_from_rpm.bash
+++ b/concourse/scripts/generate_tarball_from_rpm.bash
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+: "${GP_VER:?GP_VER must be set}"
+: "${TARGET_OS_VERSION:?TARGET_OS_VERSION must be set}"
+
+function fail() {
+  echo "Error: $1"
+  exit 1
+}
+
+# check if directory with artifacts is available
+[[ -d pxf_artifacts ]] || fail "pxf_artifacts directory not found"
+
+# check if the RPM for GP version and TARGET_OS_VERSION is available
+rpm_file_name=$(find pxf_artifacts/licensed -type f -name "pxf-gp${GP_VER}-*-2.el${TARGET_OS_VERSION}.x86_64.rpm")
+[[ -f ${rpm_file_name} ]] || fail "pxf_artifacts/licensed/pxf-gp${GP_VER}-*-2.el${TARGET_OS_VERSION}.x86_64.rpm not found"
+
+# extract RPM
+build_dir=${PWD}
+pushd /
+rpm2cpio "${build_dir}/${rpm_file_name}" | cpio -idm
+popd
+echo "listing installed directory /usr/local/pxf-gp${GP_VER}:"
+ls -al "/usr/local/pxf-gp${GP_VER}"
+
+# determine the PXF version
+pxf_version=$(cat "/usr/local/pxf-gp${GP_VER}/version")
+
+# copy installed PXF into a staging directory
+mkdir -p /tmp/pxf_tarball_repackage
+cp -R "/usr/local/pxf-gp${GP_VER}/" /tmp/pxf_tarball_repackage/pxf
+
+# place gpextable into the appropriate locations when creating internal `pxf.tar.gz` tarball, so they are just extracted and no additional copying is required
+mv /tmp/pxf_tarball_repackage/pxf/gpextable/* /tmp/pxf_tarball_repackage/
+rm -rf /tmp/pxf_tarball_repackage/pxf/gpextable/
+
+# list staging directory
+echo "listing staging directory /tmp/pxf_tarball_repackage"
+ls -al /tmp/pxf_tarball_repackage
+
+# create the pxf.tar.gz that contains all files from the RPM installation
+echo "create the pxf tarball"
+mkdir -p /tmp/pxf_tarball
+tar -czf /tmp/pxf_tarball/pxf.tar.gz -C /tmp/pxf_tarball_repackage .
+
+# create the install_gpdb_component file
+cat > /tmp/pxf_tarball/install_gpdb_component <<EOF
+#!/bin/bash
+set -x
+CWDIR="\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
+: "\${GPHOME:?GPHOME must be set}"
+tar xvzf "\${CWDIR}/pxf.tar.gz" -C \$GPHOME
+EOF
+chmod +x /tmp/pxf_tarball/install_gpdb_component
+
+echo "create the pxf installer tarball in pxf_artifacts/licensed/gp${GP_VER}/pxf-${pxf_version}.tar.gz"
+mkdir -p "pxf_artifacts/licensed/gp${GP_VER}/"
+tar -czf "pxf_artifacts/licensed/gp${GP_VER}/pxf-${pxf_version}.tar.gz" -C /tmp/pxf_tarball .

--- a/concourse/tasks/generate_tarball_from_rpm.yml
+++ b/concourse/tasks/generate_tarball_from_rpm.yml
@@ -1,0 +1,18 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+
+inputs:
+  - name: pxf_src
+  - name: pxf_artifacts
+
+outputs:
+  - name: pxf_artifacts
+
+params:
+  GP_VER:
+  TARGET_OS_VERSION:
+
+run:
+  path: pxf_src/concourse/scripts/generate_tarball_from_rpm.bash


### PR DESCRIPTION
Support an internal component tarball for new PXF releases that fully
support installation with no manual action. The
`Publish_PXF-GP5_and_PXF-GP6_Artifacts_to_GP-RelEng` job in the
`pxf-build` pipeline will now has two new tasks:
- Generate PXF binary tarball from PXF-GP5 on RHEL6 RPM
- Generate PXF binary tarball from PXF-GP6 on RHEL7 RPM

These tasks will produce a tarball with an installer script from a
PXF RPM. The binary tarballs need to be created for both GP5 (RHEL6) and
GP6 (RHEL7) only.

The script that is run by the task does the following:
- Takes as input a `licensed` PXF RPM
- Tars the content of the PXF RPM so it is laid out in $GPHOME upon
  extraction
- Tars the resulting tar from the previous step and an installer script
- Provides an `install_gpdb_component` executable bash script that
  installs PXF under GPHOME (GPHOME is mandatory)

The produced artifacts are then uploaded to Google Cloud Storage buckets
to be consumed by release engineering.