### PR TITLE
Increase default maximumPoolSize property in jdbc-site.xml

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -334,7 +334,7 @@ public class JdbcBasePlugin extends BasePlugin {
         if (isConnectionPoolUsed) {
             poolConfiguration = new Properties();
             // for PXF upgrades where jdbc-site template has not been updated, make sure there're sensible defaults
-            poolConfiguration.setProperty("maximumPoolSize", "5");
+            poolConfiguration.setProperty("maximumPoolSize", "15");
             poolConfiguration.setProperty("connectionTimeout", "30000");
             poolConfiguration.setProperty("idleTimeout", "30000");
             poolConfiguration.setProperty("minimumIdle", "0");

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
@@ -74,7 +74,7 @@ public class JdbcBasePluginTest {
         context.setUser("test-user");
 
         poolProps = new Properties();
-        poolProps.setProperty("maximumPoolSize", "5");
+        poolProps.setProperty("maximumPoolSize", "15");
         poolProps.setProperty("connectionTimeout", "30000");
         poolProps.setProperty("idleTimeout", "30000");
         poolProps.setProperty("minimumIdle", "0");
@@ -426,7 +426,7 @@ public class JdbcBasePluginTest {
         connProps.setProperty("foo", "foo-val");
         connProps.setProperty("bar", "bar-val");
 
-        verify(mockConnectionManager).getConnection("test-server", "test-url", connProps, true, poolProps, null);
+       verify(mockConnectionManager).getConnection("test-server", "test-url", connProps, true, poolProps, null);
     }
 
     @Test

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTestInitialize.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTestInitialize.java
@@ -643,7 +643,7 @@ public class JdbcBasePluginTestInitialize {
         Properties poolConfiguration = (Properties) getInternalState(plugin, "poolConfiguration");
         assertNotNull(poolConfiguration);
         assertEquals(4, poolConfiguration.size());
-        assertEquals("5", poolConfiguration.getProperty("maximumPoolSize"));
+        assertEquals("15", poolConfiguration.getProperty("maximumPoolSize"));
         assertEquals("30000", poolConfiguration.getProperty("connectionTimeout"));
         assertEquals("30000", poolConfiguration.getProperty("idleTimeout"));
         assertEquals("0", poolConfiguration.getProperty("minimumIdle"));
@@ -678,7 +678,7 @@ public class JdbcBasePluginTestInitialize {
         assertEquals(6, poolProps.size());
 
         Properties expectedProps = new Properties();
-        expectedProps.setProperty("maximumPoolSize", "5");
+        expectedProps.setProperty("maximumPoolSize", "15");
         expectedProps.setProperty("connectionTimeout", "30000");
         expectedProps.setProperty("idleTimeout", "30000");
         expectedProps.setProperty("minimumIdle", "0");

--- a/server/pxf-service/src/templates/user/templates/jdbc-site.xml
+++ b/server/pxf-service/src/templates/user/templates/jdbc-site.xml
@@ -34,7 +34,7 @@
 
     <property>
         <name>jdbc.pool.property.maximumPoolSize</name>
-        <value>5</value>
+        <value>15</value>
         <description>The maximum number of actual connections to the database backend</description>
     </property>
     <property>


### PR DESCRIPTION
The default value for jdbc.pool.property.maximumPoolSize is causing
problems in multiple users. The out-of-the-box experience for PXF with
JDBC is not great because an error is encountered during writes for
example when we have a large amount of data. The same is true for reads
that transfer large amounts of data.

This error is encountered on segment hosts that have more than 5
segments per host. A typical use case for PXF is residing on a host with
8 segments per hosts. This issue will surface right away on those
segment hosts. In some cases users have 12 segments per host. Increasing
the maximumPoolSize to 15 seems like a new sensible default that will
allow the out-of-the-box experience be smoother for PXF.