### PR TITLE
clarify the pxf.fs.basePath description

### DIFF
--- a/server/pxf-service/src/templates/user/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/user/templates/pxf-site.xml
@@ -41,9 +41,9 @@
         <name>pxf.fs.basePath</name>
         <value></value>
         <description>
-            Sets the base path when constructing a URI for read and write
-            operations. This property must be configured on servers that
-            access file profiles.
+            Sets the base path when constructing a file URI for read and write
+            operations. This property *must* be configured for any server that
+            accesses a file using a file:* profile.
         </description>
     </property>
     !-->

--- a/server/pxf-service/src/templates/user/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/user/templates/pxf-site.xml
@@ -42,7 +42,7 @@
         <value></value>
         <description>
             Sets the base path when constructing a file URI for read and write
-            operations. This property *must* be configured for any server that
+            operations. This property MUST be configured for any server that
             accesses a file using a file:* profile.
         </description>
     </property>


### PR DESCRIPTION
update the property description; when i read it, i thought it was referring to profiles that access files.