### PR TITLE
docs - new jdbc.pool.property.maximumPoolSize default

### DIFF
--- a/docs/content/jdbc_cfg.html.md.erb
+++ b/docs/content/jdbc_cfg.html.md.erb
@@ -157,7 +157,7 @@ PXF exposes connection pooling properties that you can configure in a JDBC serve
 
 | Property       | Description                                | Default Value |
 |----------------|--------------------------------------------|-------|
-| jdbc.pool.property.maximumPoolSize | The maximum number of connections to the database backend. | 5 |
+| jdbc.pool.property.maximumPoolSize | The maximum number of connections to the database backend. | 15 |
 | jdbc.pool.property.connectionTimeout | The maximum amount of time, in milliseconds, to wait for a connection from the pool. | 30000 |
 | jdbc.pool.property.idleTimeout | The maximum amount of time, in milliseconds, after which an inactive connection is considered idle. | 30000 |
 | jdbc.pool.property.minimumIdle | The minimum number of idle connections maintained in the connection pool. | 0 |


### PR DESCRIPTION
minor doc change for https://github.com/greenplum-db/pxf/pull/461