### PR TITLE
docs: Add Dockerfile for building docs [ci skip]

### DIFF
--- a/concourse/docker/docs/Dockerfile
+++ b/concourse/docker/docs/Dockerfile
@@ -1,0 +1,32 @@
+FROM ruby:2.3
+
+RUN /bin/bash -l -c "gem install bundler --no-document -v '=1.16.1'"
+
+RUN /bin/bash -l -c "mkdir /temprackup"
+
+RUN /bin/bash -l -c "echo $'source \'http://rubygems.org\' \n\
+    ruby \'~> 2.3.0\'\n\
+    gem \'rack\', \'~> 2.0.1\'\n\
+    gem \'rack-rewrite\'\n\
+    gem \'puma\' \n\
+    gem \'therubyracer\' \n\
+    gem \'sendgrid-ruby\', \'< 3.0\' \n\
+    gem \'elasticsearch\' ' > /temprackup/Gemfile"
+
+RUN /bin/bash -l -c "cd /temprackup && bundle install"
+
+RUN /bin/bash -l -c "mkdir /temp"
+RUN echo 'source "https://rubygems.org"' > /temp/Gemfile
+RUN echo "gem 'bookbindery'" >> /temp/Gemfile
+RUN echo "gem 'libv8', '3.16.14.7'" >> /temp/Gemfile
+RUN /bin/bash -l -c "cd /temp && bundle install"
+
+RUN /bin/bash -l -c "cp /etc/hosts ~/hosts.new"
+RUN /bin/bash -l -c 'sed -i -E "s/(::1\s)localhost/\1/g" ~/hosts.new'
+
+RUN echo "export PATH=$PATH:/usr/local/bundle/bin" >> /etc/profile
+RUN echo "alias rackup='rackup -o 0.0.0'" >> /etc/profile
+
+EXPOSE 9292
+
+ENTRYPOINT ["/bin/sh", "-c" , "cat ~/hosts.new > /etc/hosts && . /etc/profile && alias rackup='rackup -o 0.0.0.0' && /bin/bash -l" ]

--- a/concourse/docker/docs/README.md
+++ b/concourse/docker/docs/README.md
@@ -1,0 +1,42 @@
+# Docker container for PXF Documentation
+
+PXF Documentation can be built using the `Dockerfile` provided in this
+directory.
+
+## How to build pxf-docs docker image locally?
+
+```shell script
+pushd ~/workspace/pxf/concourse/docker/docs/
+docker build \
+  --tag=pxf-docs \
+  -f ~/workspace/pxf/concourse/docker/docs/Dockerfile \
+  .
+popd
+```
+
+## Run the pxf-docs image
+
+```shell script
+docker run -it \
+  -p 9292:9292 \
+  -p 1234:1234 \
+  -v ~/workspace/pxf/docs:/pxfdocs \
+  --workdir /pxfdocs/book \
+  pxf-docs
+```
+
+Once inside the container run the following commands:
+
+```shell script
+bundle install
+bundle update nokogiri
+bundle update kramdown
+bundle update bookbindery
+bundle exec bookbinder bind local
+cd final_app
+rackup
+```
+
+At this point, you can go to a browser window and type
+http://localhost:9292 and you will see the formatted PXF open source
+documentation.


### PR DESCRIPTION
This Dockefile and README will help users build PXF documentation. This
is useful if someone wants to render the documentation and visualize the
result.

Co-authored-by: Lisa Owen <lowen@vmware.com>