### PR TITLE
RPM: Install the $PXF_HOME/run directory during %posttran

### DIFF
--- a/package/pxf-gp5.spec
+++ b/package/pxf-gp5.spec
@@ -61,7 +61,7 @@ sed -i "s|module_pathname =.*|module_pathname = '%{prefix}/gpextable/pxf'|g" %{p
 %config(noreplace) %{prefix}/conf/pxf-log4j2.xml
 %config(noreplace) %{prefix}/conf/pxf-profiles.xml
 
-%preun
+%pre
 # cleanup files and directories created by 'pxf init' command
 # only applies for old installations (pre 6.0.0)
 %__rm -f %{prefix}/conf/pxf-private.classpath

--- a/package/pxf-gp5.spec
+++ b/package/pxf-gp5.spec
@@ -66,3 +66,10 @@ sed -i "s|module_pathname =.*|module_pathname = '%{prefix}/gpextable/pxf'|g" %{p
 # only applies for old installations (pre 6.0.0)
 %__rm -f %{prefix}/conf/pxf-private.classpath
 %__rm -rf %{prefix}/pxf-service
+
+%posttrans
+# PXF v5 RPM installation removes the run directory during the %preun step.
+# The lack of run directory prevents PXF v6+ from starting up.
+# %posttrans of the new package is the only step that runs after the %preun
+# of the old package
+%{__install} -d -m 700 %{prefix}/run

--- a/package/pxf-gp6.spec
+++ b/package/pxf-gp6.spec
@@ -61,7 +61,7 @@ sed -i "s|module_pathname =.*|module_pathname = '%{prefix}/gpextable/pxf'|g" %{p
 %config(noreplace) %{prefix}/conf/pxf-log4j2.xml
 %config(noreplace) %{prefix}/conf/pxf-profiles.xml
 
-%preun
+%pre
 # cleanup files and directories created by 'pxf init' command
 # only applies for old installations (pre 6.0.0)
 %__rm -f %{prefix}/conf/pxf-private.classpath

--- a/package/pxf-gp6.spec
+++ b/package/pxf-gp6.spec
@@ -66,3 +66,10 @@ sed -i "s|module_pathname =.*|module_pathname = '%{prefix}/gpextable/pxf'|g" %{p
 # only applies for old installations (pre 6.0.0)
 %__rm -f %{prefix}/conf/pxf-private.classpath
 %__rm -rf %{prefix}/pxf-service
+
+%posttrans
+# PXF v5 RPM installation removes the run directory during the %preun step.
+# The lack of run directory prevents PXF v6+ from starting up.
+# %posttrans of the new package is the only step that runs after the %preun
+# of the old package
+%{__install} -d -m 700 %{prefix}/run


### PR DESCRIPTION
PXF v5 RPM installation removes the run directory during the %preun
step. The lack of run directory prevents PXF v6+ from starting up. We
fix the issue by installing the `$PXF_HOME/run` directory during the
%posttran step. %posttrans of the new package is the only step that runs
after the %preun of the old package.