### PR TITLE
CLI: Add --skip-register flag for pxf [cluster] init

### DIFF
--- a/cli/go/src/pxf-cli/cmd/cluster.go
+++ b/cli/go/src/pxf-cli/cmd/cluster.go
@@ -39,7 +39,7 @@ func createCobraCommand(use string, short string, cmd *command) *cobra.Command {
 
 var (
 	clusterCmd  = createCobraCommand("cluster", "Perform <command> on each segment host in the cluster", nil)
-	initCmd     = createCobraCommand("init", "Initialize the PXF server instance and install PXF extension under $GPHOME on master, standby master, and all segment hosts", &InitCommand)
+	initCmd     = createCobraCommand("init", "Initialize the PXF server instance and install PXF extension under $GPHOME on master, standby master, and all segment hosts. Use --skip-register to skip PXF extension installation", &InitCommand)
 	startCmd    = createCobraCommand("start", "Start the PXF server instances on all segment hosts", &StartCommand)
 	stopCmd     = createCobraCommand("stop", "Stop the PXF server instances on all segment hosts", &StopCommand)
 	statusCmd   = createCobraCommand("status", "Get status of PXF servers on all segment hosts", &StatusCommand)
@@ -49,10 +49,13 @@ var (
 	restartCmd  = createCobraCommand("restart", "Restart the PXF server on all segment hosts", &RestartCommand)
 	// DeleteOnSync is a boolean for determining whether to use rsync with --delete, exported for tests
 	DeleteOnSync bool
+	// SkipRegisterOnInit determines whether the PXF extension installation is skipped or not
+	SkipRegisterOnInit bool
 )
 
 func init() {
 	rootCmd.AddCommand(clusterCmd)
+	initCmd.Flags().BoolVarP(&SkipRegisterOnInit, "skip-register", "s", false, "skips PXF extension installation during the PXF initialization process")
 	clusterCmd.AddCommand(initCmd)
 	clusterCmd.AddCommand(startCmd)
 	clusterCmd.AddCommand(stopCmd)

--- a/cli/go/src/pxf-cli/cmd/pxf.go
+++ b/cli/go/src/pxf-cli/cmd/pxf.go
@@ -83,6 +83,9 @@ func (cmd *command) GetFunctionToExecute() (func(string) string, error) {
 		if cmd.name == reset {
 			pxfCommand += " --force" // there is a prompt for local reset as well
 		}
+		if cmd.name == pxfInit && SkipRegisterOnInit {
+			pxfCommand += " --skip-register"
+		}
 		return func(_ string) string { return pxfCommand }, nil
 	}
 }

--- a/cli/go/src/pxf-cli/cmd/pxf_test.go
+++ b/cli/go/src/pxf-cli/cmd/pxf_test.go
@@ -134,6 +134,24 @@ var _ = Describe("CommandFunc", func() {
 			cmd.DeleteOnSync = false
 		})
 	})
+	Context("when user specifies --skip-register flag during initialization", func() {
+		BeforeEach(func() {
+			_ = os.Setenv("PXF_CONF", "/test/somewhere/pxf_conf")
+			_ = os.Setenv("PXF_HOME", "/test/pxfhome")
+			_ = os.Setenv("JAVA_HOME", "/etc/java/home")
+			cmd.SkipRegisterOnInit = true
+		})
+		It("initializes PXF with the --skip-register flag", func() {
+			commandFunc, err := cmd.InitCommand.GetFunctionToExecute()
+			expected := "GPHOME=/test/gphome PXF_CONF=/test/somewhere/pxf_conf JAVA_HOME=/etc/java/home /test/pxfhome/bin/pxf init --skip-register"
+			Expect(err).To(BeNil())
+			Expect(commandFunc("sdw1")).To(Equal(expected))
+			Expect(commandFunc("sdw2")).To(Equal(expected))
+		})
+		AfterEach(func() {
+			cmd.SkipRegisterOnInit = false
+		})
+	})
 	Context("when only PXF_CONF is set", func() {
 		BeforeEach(func() {
 			_ = os.Unsetenv("GPHOME")

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -312,7 +312,7 @@ doHelp() {
     cat <<-EOF
 
 	${bold}List of commands${normal}:
-	  init                initialize the local PXF server instance, install PXF extension under \$GPHOME
+	  init                initialize the local PXF server instance, install PXF extension under \$GPHOME. Use --skip-register to skip PXF extension installation
 	  start               start the local PXF server instance
 	  stop                stop the local PXF server instance
 	  restart             restart the local PXF server instance (not supported for cluster)
@@ -400,7 +400,11 @@ function doInit()
     deployWebapp || return 1
     createLogsDir || return 1
     createRunDir  || return 1
-    installExternalTableExtension || return 1
+    if [[ $skipRegister == false ]]; then
+      installExternalTableExtension || return 1
+    else
+      echo "Skipping PXF extension installation"
+    fi
 }
 
 function editPxfEnvSh()
@@ -499,20 +503,24 @@ function checkPxfConf()
 pxf_script_command=$1
 
 silent=false
+skipRegister=false
 
 validate_user
 validate_system
 
 case $pxf_script_command in
     'init')
-        if [[ $2 == -y || $2 == -Y ]]; then
+        if [[ $2 == -y || $2 == -Y || $3 == -y || $3 == -Y ]]; then
             silent=true
+        fi
+        if [[ $2 == -s || $2 == --skip-register || $3 == -s || $3 == --skip-register ]]; then
+            skipRegister=true
         fi
         doInit
         ;;
     'register')
         installExternalTableExtension
-	;;
+        ;;
     'start')
         doStart
         ;;


### PR DESCRIPTION
Add the --skip-register | -s flag to skip PXF extension installation
during PXF initialization.