### PR TITLE
docs - Hive profile supports column projection and pushdown

### DIFF
--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -119,7 +119,25 @@ The PXF Hadoop connectors expose the following profiles to read, and in many cas
 | [Hive](hive_pxf.html) | stored as Parquet | Hive | n/a |
 | [HBase](hbase_pxf.html) | Any | HBase | n/a |
 
-You provide the profile name when you specify the `pxf` protocol on a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table that references a Hadoop file, directory, or table. For example, the following command creates an external table that uses the default server and specifies the profile named `hdfs:text`:
+
+### <a id="choose_profile"></a>Choosing the Profile
+
+PXF provides more than one profile to access text and Parquet data on Hadoop. Here are some things to consider as you determine which profile to choose.
+
+Choose the `Hive` profile when:
+
+- The data resides in a Hive table, and you do not know the type of data up front.
+- The data resides in a Hive table, and the Hive table is partitioned.
+
+Choose the `hdfs:text` or `hdfs:parquet` profile when:
+
+- You know the file type, and you know the location of the file in the HDFS file system.
+- The file is Parquet, you know the location of the file in the HDFS file system, and you want to take advantage of extended filter pushdown support for additional data types and operators.
+
+
+### <a id="specify_profile"></a>Specifying the Profile
+
+You must provide the profile name when you specify the `pxf` protocol on a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table that references a Hadoop file or directory, or HBase or Hive table. For example, the following command creates an external table that uses the default server and specifies the profile named `hdfs:text` to access the HDFS file `/data/pxf_examples/pxf_hdfs_simple.txt`:
 
 ``` sql
 CREATE EXTERNAL TABLE pxf_hdfs_text(location text, month text, num_orders int, total_sales float8)

--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -129,15 +129,14 @@ Choose the `Hive` profile when:
 - The data resides in a Hive table, and you do not know the underlying file type of the table up front.
 - The data resides in a Hive table, and the Hive table is partitioned.
 
-Choose the `hdfs:text` or `hdfs:parquet` profile when:
+Choose the `hdfs:text` profile when the file is text and you know the location of the file in the HDFS file system.
 
-- You know the file type, and you know the location of the file in the HDFS file system.
-- The file is Parquet, you know the location of the file in the HDFS file system, and you want to take advantage of extended filter pushdown support for additional data types and operators.
+Choose the `hdfs:parquet` profile when the file is Parquet, you know the location of the file in the HDFS file system, and you want to take advantage of extended filter pushdown support for additional data types and operators.
 
 
 ### <a id="specify_profile"></a>Specifying the Profile
 
-You must provide the profile name when you specify the `pxf` protocol on a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table that references a Hadoop file or directory, or HBase or Hive table. For example, the following command creates an external table that uses the default server and specifies the profile named `hdfs:text` to access the HDFS file `/data/pxf_examples/pxf_hdfs_simple.txt`:
+You must provide the profile name when you specify the `pxf` protocol in a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table that references a Hadoop file or directory, HBase table, or Hive table. For example, the following command creates an external table that uses the default server and specifies the profile named `hdfs:text` to access the HDFS file `/data/pxf_examples/pxf_hdfs_simple.txt`:
 
 ``` sql
 CREATE EXTERNAL TABLE pxf_hdfs_text(location text, month text, num_orders int, total_sales float8)

--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -126,7 +126,7 @@ PXF provides more than one profile to access text and Parquet data on Hadoop. He
 
 Choose the `Hive` profile when:
 
-- The data resides in a Hive table, and you do not know the type of data up front.
+- The data resides in a Hive table, and you do not know the underlying file type of the table up front.
 - The data resides in a Hive table, and the Hive table is partitioned.
 
 Choose the `hdfs:text` or `hdfs:parquet` profile when:

--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -108,6 +108,9 @@ You configure properties in the `pxf-site.xml` file for a PXF server when one or
 | pxf.service.user.name | The log in user for the remote system. | The operating system user that starts the pxf process, typically `gpadmin`. |
 | pxf.service.user.impersonation | Enables/disables user impersonation on the remote system. | The value of the (deprecated) `PXF_USER_IMPERSONATION` property when that property is set. If the `PXF_USER_IMPERSONATION` property does not exist and the `pxf.service.user.impersonation` property is missing from `pxf-site.xml`, the default is `false`, user impersonation is disabled on the remote system. |
 | pxf.fs.basePath | Identifies the base path or share point on the remote file system. This property is applicable when the server configuration is used with a profile that accesses a file. | None; this property is commented out by default. |
+| pxf.ppd.hive<sup>1</sup> | Specifies whether or not predicate pushdown is enabled for queries on external tables that specify the `Hive`, `HiveRC`, and `HiveORC` profiles. | True; predicate pushdown is enabled. |
+
+</br><sup>1</sup>&nbsp;Should you need to, you can override this setting on a per-table basis by specifying the `&PPD=<boolean>` option in the `LOCATION` clause when you create the external table.
 
 Refer to [Configuring PXF Hadoop Connectors ](client_instcfg.html) and [Configuring the JDBC Connector ](jdbc_cfg.html) for information about relevant `pxf-site.xml` property settings for Hadoop and JDBC server configurations, respectively. See [Configuring a PXF Network File System Server](nfs_pxf.html#ex_fscfg) for information about relevant `pxf-site.xml` property settings when you configure a PXF server to access a network file system.
 

--- a/docs/content/col_project.html.md.erb
+++ b/docs/content/col_project.html.md.erb
@@ -11,7 +11,7 @@ Column projection is automatically enabled for the `pxf` external table protocol
 | Data Source | Connector | Profile(s) |
 |-------------|---------------|---------|
 | External SQL database | JDBC Connector | Jdbc |
-| Hive | Hive Connector | Hive, HiveRC, HiveORC, HiveVectorizedORC |
+| Hive | Hive Connector | Hive (accessing tables stored as Parquet, RCFile, and ORC), HiveRC, HiveORC, HiveVectorizedORC |
 | Hadoop | HDFS Connector | hdfs:parquet |
 | Network File System | File Connector | file:parquet |
 | Amazon S3 | S3-Compatible Object Store Connectors | s3:parquet |

--- a/docs/content/col_project.html.md.erb
+++ b/docs/content/col_project.html.md.erb
@@ -11,7 +11,7 @@ Column projection is automatically enabled for the `pxf` external table protocol
 | Data Source | Connector | Profile(s) |
 |-------------|---------------|---------|
 | External SQL database | JDBC Connector | Jdbc |
-| Hive | Hive Connector | Hive (accessing tables stored as Parquet, RCFile, and ORC), HiveRC, HiveORC, HiveVectorizedORC |
+| Hive | Hive Connector | Hive (accessing tables stored as Text, Parquet, RCFile, and ORC), HiveRC, HiveORC, HiveVectorizedORC |
 | Hadoop | HDFS Connector | hdfs:parquet |
 | Network File System | File Connector | file:parquet |
 | Amazon S3 | S3-Compatible Object Store Connectors | s3:parquet |

--- a/docs/content/filter_push.html.md.erb
+++ b/docs/content/filter_push.html.md.erb
@@ -56,13 +56,12 @@ PXF accesses data sources using profiles exposed by different connectors, and fi
 | *:parquet | Y<sup>1</sup> | N | Y<sup>1</sup> | N | Y<sup>1</sup> | Y<sup>1</sup> | Y<sup>1</sup> |
 | s3:parquet and s3:text with S3-Select | Y |  N | Y | Y | Y | Y | Y |
 | HBase | Y | N | Y | N | Y | Y | N |
-| Hive | Y<sup>2</sup> | N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
 | Hive (accessing stored as Parquet) | Y, Y<sup>2</sup> | N | N | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | Hive (accessing stored as RCFile or ORC) | Y, Y<sup>2</sup> | N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | HiveText | Y<sup>2</sup> | N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
 | HiveRC | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | HiveORC | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
-| HiveVectorizedORC | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
+| HiveVectorizedORC | Y<sup>2</sup> |  N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
 
 </br><sup>1</sup>&nbsp;PXF applies the predicate, rather than the remote system, reducing CPU usage and the memory footprint.
 </br><sup>2</sup>&nbsp;PXF supports partition pruning based on partition keys.

--- a/docs/content/filter_push.html.md.erb
+++ b/docs/content/filter_push.html.md.erb
@@ -37,9 +37,9 @@ PXF filter pushdown can be used with these data types (connector- and profile-sp
 - `INT2`, `INT4`, `INT8`
 - `CHAR`, `TEXT`
 - `FLOAT`
-- `NUMERIC` (not available with the S3 connector when using S3 Select)
+- `NUMERIC` (not available with the S3 connector when using S3 Select, nor with the `Hive` profile when accessing `STORED AS Parquet`)
 - `BOOL`
-- `DATE`, `TIMESTAMP` (available only with the JDBC connector and the S3 connector when using S3 Select)
+- `DATE`, `TIMESTAMP` (available only with the JDBC connector, the S3 connector when using S3 Select, the `HiveRC` and `HiveORC` profiles, and the `Hive` profile when accessing `STORED AS` `RCFile` or `ORC`)
 
 You can use PXF filter pushdown with these arithmetic and logical operators (connector- and profile-specific):
 
@@ -57,8 +57,10 @@ PXF accesses data sources using profiles exposed by different connectors, and fi
 | s3:parquet and s3:text with S3-Select | Y |  N | Y | Y | Y | Y | Y |
 | HBase | Y | N | Y | N | Y | Y | N |
 | Hive | Y<sup>2</sup> | N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
+| Hive (accessing stored as Parquet) | Y, Y<sup>2</sup> | N | N | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
+| Hive (accessing stored as RCFile or ORC) | Y, Y<sup>2</sup> | N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | HiveText | Y<sup>2</sup> | N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
-| HiveRC | Y<sup>2</sup> |  N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
+| HiveRC | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | HiveORC | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | HiveVectorizedORC | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 
@@ -72,7 +74,7 @@ To summarize, all of the following criteria must be met for filter pushdown to o
 * You enable external table filter pushdown by setting the `gp_external_enable_filter_pushdown` server configuration parameter to `'on'`.
 * The Greenplum Database protocol that you use to access external data source must support filter pushdown. The `pxf` external table protocol supports pushdown.
 * The external data source that you are accessing must support pushdown. For example, HBase and Hive support pushdown.
-* For queries on external tables that you create with the `pxf` protocol, the underlying PXF connector must also support filter pushdown. For example, the PXF Hive, HBase, and JDBC connectors support pushdown.
+* For queries on external tables that you create with the `pxf` protocol, the underlying PXF connector must also support filter pushdown. For example, the PXF Hive, HBase, and JDBC connectors support pushdown, as do the PXF connectors that support reading Parquet data.
 
     - Refer to Hive [Partition Filter Pushdown](hive_pxf.html#partitionfiltering) for more information about Hive support for this feature.
 

--- a/docs/content/filter_push.html.md.erb
+++ b/docs/content/filter_push.html.md.erb
@@ -75,5 +75,5 @@ To summarize, all of the following criteria must be met for filter pushdown to o
 * The external data source that you are accessing must support pushdown. For example, HBase and Hive support pushdown.
 * For queries on external tables that you create with the `pxf` protocol, the underlying PXF connector must also support filter pushdown. For example, the PXF Hive, HBase, and JDBC connectors support pushdown, as do the PXF connectors that support reading Parquet data.
 
-    - Refer to Hive [Partition Filter Pushdown](hive_pxf.html#partitionfiltering) for more information about Hive support for this feature.
+    - Refer to Hive [Partition Pruning](hive_pxf.html#partitionfiltering) for more information about Hive support for this feature.
 

--- a/docs/content/hive_pxf.html.md.erb
+++ b/docs/content/hive_pxf.html.md.erb
@@ -185,7 +185,7 @@ Use the following syntax to create a Greenplum Database external table that refe
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<hive-db-name>.<hive-table-name>
-    ?PROFILE=Hive|HiveText|HiveRC|HiveORC|HiveVectorizedORC[&SERVER=<server_name>]'])
+    ?PROFILE=Hive|HiveText|HiveRC|HiveORC|HiveVectorizedORC[&SERVER=<server_name>][&PPD=<boolean>]')
 FORMAT 'CUSTOM|TEXT' (FORMATTER='pxfwritable_import' | delimiter='<delim>')
 ```
 
@@ -197,6 +197,7 @@ Hive connector-specific keywords and values used in the Greenplum Database [CREA
 | \<hive&#8209;table&#8209;name\>    | The name of the Hive table. |
 | PROFILE    | The `PROFILE` keyword must specify one of the values `Hive`, `HiveText`, `HiveRC`, `HiveORC`, or `HiveVectorizedORC`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
+| PPD=\<boolean\>    | Enable or disable predicate pushdown for all queries on this table; this option applies only to the `Hive`, `HiveORC`, and `HiveRC` profiles, and overrides a `pxf.ppd.hive` property setting in the \<server_name\> configuration. |
 | FORMAT (`Hive`, `HiveORC`, and `HiveVectorizedORC` profiles)   | The `FORMAT` clause must specify `'CUSTOM'`. The `CUSTOM` format requires the built-in `pxfwritable_import` `formatter`.   |
 | FORMAT (`HiveText` and `HiveRC` profiles) | The `FORMAT` clause must specify `TEXT`. Specify the single ascii character field delimiter in the `delimiter='<delim>'` formatting option. |
 
@@ -476,9 +477,6 @@ And query the table:
 ``` sql
 postgres=# SELECT month, number_of_orders FROM pxf_parquet_table;
 ```
-
-<div class="note">PXF does not support reading a Hive table stored as Parquet if the table is backed by more than one Parquet file and the columns are in a different order. This limitation applies even when the Parquet files have the same column names in their schema.</div>
-
 
 ## <a id="hive_complex"></a>Working with Complex Data Types
 

--- a/docs/content/hive_pxf.html.md.erb
+++ b/docs/content/hive_pxf.html.md.erb
@@ -662,9 +662,9 @@ In the following example, you will create and populate a Hive table stored in OR
 
     `intarray` and `propmap` are again serialized as text strings.
 
-## <a id="partitionfiltering"></a>Partition Filter Pushdown
+## <a id="partitionfiltering"></a>Partition Pruning
 
-The PXF Hive connector supports Hive partitioning pruning and the Hive partition directory structure. This enables partition exclusion on selected HDFS files comprising a Hive table. To use the partition filtering feature to reduce network traffic and I/O, run a query on a PXF external table using a `WHERE` clause that refers to a specific partition column in a partitioned Hive table.
+The PXF Hive connector supports Hive partition pruning and the Hive partition directory structure. This enables partition exclusion on selected HDFS files comprising a Hive table. To use the partition filtering feature to reduce network traffic and I/O, run a query on a PXF external table using a `WHERE` clause that refers to a specific partition column in a partitioned Hive table.
 
 The PXF Hive Connector partition filtering support for Hive string and integral types is described below:
 


### PR DESCRIPTION
misc doc updates for the recent Hive* work.  in this PR:
- add a "choosing the profile" topic to main hdfs page that mentions which data types have more than one profile, and some criteria for choosing
- add info about pxf.ppd.hive property in pxf-site.xml
- add column projection info
- add filter pushdown info - I AM NOT SURE IF I AM REPRESENTING THIS CORRECTLY IN THE TABLE
- hive topic - discuss new PPD option, remove limitation.  

note:  wanted to get this part out for review; i am still determining if other edits are required to the hive topic.

doc review site links:
- choosing the profile - http://docs-lisa-hive-colppd.cfapps.io/pxf/5-16/using/access_hdfs.html#choose_profile
- pxf.ppd.hive property description - http://docs-lisa-hive-colppd.cfapps.io/pxf/5-16/using/cfg_server.html#pxf-site
- filter pushdown - http://docs-lisa-hive-colppd.cfapps.io/pxf/5-16/using/filter_push.html
- hive topic PPD - http://docs-lisa-hive-colppd.cfapps.io/pxf/5-16/using/hive_pxf.html#hive_queryextdata
