### PR TITLE
Certification: Use tagged pxf_src for the certification pipeline

### DIFF
--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -57,7 +57,7 @@ resources:
   type: git
   icon: git
   source:
-    branch: {{pxf-git-branch}}
+    tag_filter: release-*
     uri: {{pxf-git-remote}}
 
 ## ---------- Docker Images ----------


### PR DESCRIPTION
pxf_src might not have the right scripts to run the automation tests
because the src might be out of sync with the released PXF version. For
that reason we use the tagged version of pxf_src to test the released
PXF artifact.