### PR TITLE
docs - add note about non-support of hive 3 managed tables

### DIFF
--- a/docs/content/hive_pxf.html.md.erb
+++ b/docs/content/hive_pxf.html.md.erb
@@ -25,6 +25,8 @@ Apache Hive is a distributed data warehousing infrastructure. Hive facilitates m
 
 The PXF Hive connector reads data stored in a Hive table. This section describes how to use the PXF Hive connector. 
 
+<div class="note">When accessing Hive 3, the PXF Hive connector supports using the <code>Hive*</code> profiles described below to access Hive 3 external tables only. The Connector does not support using the <code>Hive*</code> profiles to access Hive 3 managed (CRUD and insert-only transactional, and temporary) tables. Use the PXF JDBC Connector to access Hive 3 managed tables instead.</div>
+
 ## <a id="prereq"></a>Prerequisites
 
 Before working with Hive table data using PXF, ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq).

--- a/docs/content/hive_pxf.html.md.erb
+++ b/docs/content/hive_pxf.html.md.erb
@@ -25,7 +25,7 @@ Apache Hive is a distributed data warehousing infrastructure. Hive facilitates m
 
 The PXF Hive connector reads data stored in a Hive table. This section describes how to use the PXF Hive connector. 
 
-<div class="note">When accessing Hive 3, the PXF Hive connector supports using the <code>Hive*</code> profiles described below to access Hive 3 external tables only. The Connector does not support using the <code>Hive*</code> profiles to access Hive 3 managed (CRUD and insert-only transactional, and temporary) tables. Use the PXF JDBC Connector to access Hive 3 managed tables instead.</div>
+<div class="note">When accessing Hive 3, the PXF Hive connector supports using the <code>Hive*</code> profiles described below to access Hive 3 external tables only. The Connector does not support using the <code>Hive*</code> profiles to access Hive 3 managed (CRUD and insert-only transactional, and temporary) tables. Use the <a href="jdbc_pxf.html">PXF JDBC Connector</a> to access Hive 3 managed tables instead.</div>
 
 ## <a id="prereq"></a>Prerequisites
 


### PR DESCRIPTION
add note to the top of the hive page about non-support for accessing hive 3 managed tables.

(may need to manually patch this into 5.x docs.)