### PR TITLE
Hive profile names now split "protocol" and "format"

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -159,7 +159,7 @@ public abstract class TableFactory {
                                                                  HBaseTable hbaseTable) {
         ReadableExternalTable exTable = new ReadableExternalTable(tableName,
                 fields, hbaseTable.getName(), "CUSTOM");
-        exTable.setProfile("hbaase");
+        exTable.setProfile("hbase");
         exTable.setFormatter("pxfwritable_import");
         return exTable;
     }
@@ -398,7 +398,7 @@ public abstract class TableFactory {
             userParameters.add(customParameters);
         }
         exTable.setUserParameters(userParameters.toArray(new String[userParameters.size()]));
-        exTable.setProfile("Jdbc");
+        exTable.setProfile("jdbc");
         exTable.setFormatter("pxfwritable_import");
 
         return exTable;
@@ -434,7 +434,7 @@ public abstract class TableFactory {
             userParameters.add(customParameters);
         }
         exTable.setUserParameters(userParameters.toArray(new String[userParameters.size()]));
-        exTable.setProfile("Jdbc");
+        exTable.setProfile("jdbc");
         exTable.setFormatter("pxfwritable_export");
 
         return exTable;

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -38,7 +38,7 @@ public abstract class TableFactory {
                 fields, hiveTable.getName(), "CUSTOM");
 
         if (useProfile) {
-            exTable.setProfile("Hive");
+            exTable.setProfile("hive");
         } else {
             exTable.setFragmenter("org.greenplum.pxf.plugins.hive.HiveDataFragmenter");
             exTable.setAccessor("org.greenplum.pxf.plugins.hive.HiveAccessor");
@@ -159,7 +159,7 @@ public abstract class TableFactory {
                                                                  HBaseTable hbaseTable) {
         ReadableExternalTable exTable = new ReadableExternalTable(tableName,
                 fields, hbaseTable.getName(), "CUSTOM");
-        exTable.setProfile("HBase");
+        exTable.setProfile("hbaase");
         exTable.setFormatter("pxfwritable_import");
         return exTable;
     }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveVectorizedOrcTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveVectorizedOrcTest.java
@@ -39,6 +39,7 @@ public class HiveVectorizedOrcTest extends HiveBaseTest {
     private void preparePxfHiveOrcTypes() throws Exception {
         exTable = TableFactory.getPxfHiveOrcReadableTable(PXF_HIVE_ORC_TABLE,
                 gpdbTypesNoTMCols.toArray(new String[gpdbTypesNoTMCols.size()]), hiveOrcAllTypes, true);
+        // this profile is now deprecated
         exTable.setProfile("HiveVectorizedORC");
         createTable(exTable);
     }

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveProtocolHandler.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveProtocolHandler.java
@@ -1,0 +1,48 @@
+package org.greenplum.pxf.plugins.hive;
+
+import org.greenplum.pxf.api.model.ProtocolHandler;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of ProtocolHandler for "hive" protocol.
+ */
+public class HiveProtocolHandler implements ProtocolHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HiveProtocolHandler.class);
+    private static final String HIVE_VECTORIZED_ORC_ACCESSOR = HiveORCVectorizedAccessor.class.getName();
+    private static final String HIVE_VECTORIZED_ORC_RESOLVER = HiveORCVectorizedResolver.class.getName();
+    private static final String OPTION_VECTORIZE = "VECTORIZE";
+
+    @Override
+    public String getFragmenterClassName(RequestContext context) {
+        return context.getFragmenter(); // default to fragmenter defined by the profile
+    }
+
+    @Override
+    public String getAccessorClassName(RequestContext context) {
+        // default to accessor defined by the profile, switch to vectorized if requested by the user
+        String accessor = useHiveVectorizedORC(context) ? HIVE_VECTORIZED_ORC_ACCESSOR : context.getAccessor();
+        LOG.debug("Determined to use {} accessor", accessor);
+        return accessor;
+    }
+
+    @Override
+    public String getResolverClassName(RequestContext context) {
+        // default to resolver defined by the profile, switch to vectorized if requested by the user
+        String resolver = useHiveVectorizedORC(context) ? HIVE_VECTORIZED_ORC_RESOLVER : context.getResolver();
+        LOG.debug("Determined to use {} resolver", resolver);
+        return resolver;
+    }
+
+    /**
+     * Determines whether the user has requested to use vectorized ORC accessor / resolver
+     * @param context request context
+     * @return true if vectorized ORC accessor and resolver will need to be used
+     */
+    private boolean useHiveVectorizedORC(RequestContext context) {
+        return ("hive:orc".equals(context.getProfile()) && context.getOption(OPTION_VECTORIZE, false));
+    }
+
+}

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactory.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactory.java
@@ -30,11 +30,12 @@ import org.apache.hadoop.mapred.TextInputFormat;
  */
 public class ProfileFactory {
 
-    private static final String HIVE_TEXT_PROFILE = "HiveText";
-    private static final String HIVE_RC_PROFILE = "HiveRC";
-    private static final String HIVE_ORC_PROFILE = "HiveORC";
-    private static final String HIVE_PROFILE = "Hive";
-    private static final String HIVE_ORC_VECTORIZED_PROFILE = "HiveVectorizedORC";
+    private static final String HIVE_PROFILE = "hive";
+    private static final String HIVE_TEXT_PROFILE = "hive:text";
+    private static final String HIVE_RC_PROFILE = "hive:rc";
+    private static final String HIVE_ORC_PROFILE = "hive:orc";
+    private static final String HIVE_ORC_VECTORIZED_PROFILE = "hive:orc:vectorized";
+    private static final String HIVE_ORC_VECTORIZED_PROFILE_OLD = "HiveVectorizedORC";
 
     /**
      * The method which returns optimal profile
@@ -46,8 +47,8 @@ public class ProfileFactory {
      */
     public static String get(InputFormat inputFormat, boolean hasComplexTypes, String userProfileName) {
         String profileName = null;
-        if (HIVE_ORC_VECTORIZED_PROFILE.equals(userProfileName))
-            return userProfileName;
+        if (HIVE_ORC_VECTORIZED_PROFILE.equals(userProfileName) || HIVE_ORC_VECTORIZED_PROFILE_OLD.equals(userProfileName))
+            return HIVE_ORC_VECTORIZED_PROFILE;
         if (inputFormat instanceof TextInputFormat && !hasComplexTypes) {
             profileName = HIVE_TEXT_PROFILE;
         } else if (inputFormat instanceof RCFileInputFormat) {

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactory.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactory.java
@@ -34,7 +34,6 @@ public class ProfileFactory {
     private static final String HIVE_TEXT_PROFILE = "hive:text";
     private static final String HIVE_RC_PROFILE = "hive:rc";
     private static final String HIVE_ORC_PROFILE = "hive:orc";
-    private static final String HIVE_ORC_VECTORIZED_PROFILE = "hive:orc:vectorized";
     private static final String HIVE_ORC_VECTORIZED_PROFILE_OLD = "HiveVectorizedORC";
 
     /**
@@ -46,9 +45,11 @@ public class ProfileFactory {
      * @return name of optimal profile
      */
     public static String get(InputFormat inputFormat, boolean hasComplexTypes, String userProfileName) {
-        String profileName = null;
-        if (HIVE_ORC_VECTORIZED_PROFILE.equals(userProfileName) || HIVE_ORC_VECTORIZED_PROFILE_OLD.equals(userProfileName))
-            return HIVE_ORC_VECTORIZED_PROFILE;
+        String profileName;
+        if (HIVE_ORC_VECTORIZED_PROFILE_OLD.equals(userProfileName))
+            // specialized Vectorized ORC profile is deprecated, fallback onto hive:orc profile
+            // that will apply vectorized execution logic if appropriate
+            return HIVE_ORC_PROFILE;
         if (inputFormat instanceof TextInputFormat && !hasComplexTypes) {
             profileName = HIVE_TEXT_PROFILE;
         } else if (inputFormat instanceof RCFileInputFormat) {

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetadataFetcherTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetadataFetcherTest.java
@@ -66,7 +66,7 @@ public class HiveMetadataFetcherTest {
 
         context = new RequestContext();
         context.setPluginConf(mockPluginConf);
-        when(mockPluginConf.getPlugins("HiveText")).thenReturn(mockProfileMap);
+        when(mockPluginConf.getPlugins("hive:text")).thenReturn(mockProfileMap);
         when(mockProfileMap.get("OUTPUTFORMAT")).thenReturn("org.greenplum.pxf.api.io.Text");
 
         mockHiveClient = mock(HiveMetaStoreClient.class);

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveProtocolHandlerTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveProtocolHandlerTest.java
@@ -1,0 +1,64 @@
+package org.greenplum.pxf.plugins.hive;
+
+import org.greenplum.pxf.api.model.RequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class HiveProtocolHandlerTest {
+
+    @Mock
+    RequestContext context;
+
+    private HiveProtocolHandler handler;
+
+    @BeforeEach
+    public void setup() {
+        handler = new HiveProtocolHandler();
+        when(context.getFragmenter()).thenReturn("fragmenter-from-context");
+        Mockito.lenient().when(context.getAccessor()).thenReturn("accessor-from-context");
+        Mockito.lenient().when(context.getResolver()).thenReturn("resolver-from-context");
+    }
+
+    @Test
+    public void testVectorizedChosenForOrc() {
+        when(context.getProfile()).thenReturn("hive:orc");
+        when(context.getOption("VECTORIZE", false)).thenReturn(true);
+        assertEquals("fragmenter-from-context", handler.getFragmenterClassName(context));
+        assertEquals("org.greenplum.pxf.plugins.hive.HiveORCVectorizedAccessor", handler.getAccessorClassName(context));
+        assertEquals("org.greenplum.pxf.plugins.hive.HiveORCVectorizedResolver", handler.getResolverClassName(context));
+    }
+
+    @Test
+    public void testVectorizedNotChosenForOrc_VectorizedOptionMissing() {
+        when(context.getProfile()).thenReturn("hive:orc");
+        assertEquals("fragmenter-from-context", handler.getFragmenterClassName(context));
+        assertEquals("accessor-from-context", handler.getAccessorClassName(context));
+        assertEquals("resolver-from-context", handler.getResolverClassName(context));
+    }
+
+    @Test
+    public void testVectorizedNotChosenForOrc_VectorizedOptionSetFalse() {
+        when(context.getProfile()).thenReturn("hive:orc");
+        when(context.getOption("VECTORIZE", false)).thenReturn(false);
+        assertEquals("fragmenter-from-context", handler.getFragmenterClassName(context));
+        assertEquals("accessor-from-context", handler.getAccessorClassName(context));
+        assertEquals("resolver-from-context", handler.getResolverClassName(context));
+    }
+
+    @Test
+    public void testVectorizedNotChosenForOther() {
+        when(context.getProfile()).thenReturn("hive:other");
+        Mockito.lenient().when(context.getOption("VECTORIZE", false)).thenReturn(true);
+        assertEquals("fragmenter-from-context", handler.getFragmenterClassName(context));
+        assertEquals("accessor-from-context", handler.getAccessorClassName(context));
+        assertEquals("resolver-from-context", handler.getResolverClassName(context));
+    }
+}

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactoryTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactoryTest.java
@@ -34,10 +34,7 @@ public class ProfileFactoryTest {
 
         // if user specified vectorized ORC, no matter what the input format is, the profile should be used
         String profileName = ProfileFactory.get(new TextInputFormat(), false, "HiveVectorizedORC");
-        assertEquals("hive:orc:vectorized", profileName);
-
-        profileName = ProfileFactory.get(new TextInputFormat(), false, "hive:orc:vectorized");
-        assertEquals("hive:orc:vectorized", profileName);
+        assertEquals("hive:orc", profileName);
 
         // For TextInputFormat when table has no complex types, HiveText profile should be used
         profileName = ProfileFactory.get(new TextInputFormat(), false);

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactoryTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactoryTest.java
@@ -32,33 +32,40 @@ public class ProfileFactoryTest {
     @Test
     public void get() throws Exception {
 
+        // if user specified vectorized ORC, no matter what the input format is, the profile should be used
+        String profileName = ProfileFactory.get(new TextInputFormat(), false, "HiveVectorizedORC");
+        assertEquals("hive:orc:vectorized", profileName);
+
+        profileName = ProfileFactory.get(new TextInputFormat(), false, "hive:orc:vectorized");
+        assertEquals("hive:orc:vectorized", profileName);
+
         // For TextInputFormat when table has no complex types, HiveText profile should be used
-        String profileName = ProfileFactory.get(new TextInputFormat(), false);
-        assertEquals("HiveText", profileName);
+        profileName = ProfileFactory.get(new TextInputFormat(), false);
+        assertEquals("hive:text", profileName);
 
         // For TextInputFormat when table has complex types, Hive profile should be used, HiveText doesn't support complex types yet
         profileName = ProfileFactory.get(new TextInputFormat(), true);
-        assertEquals("Hive", profileName);
+        assertEquals("hive", profileName);
 
         // For RCFileInputFormat when table has complex types, HiveRC profile should be used
         profileName = ProfileFactory.get(new RCFileInputFormat(), true);
-        assertEquals("HiveRC", profileName);
+        assertEquals("hive:rc", profileName);
 
         // For RCFileInputFormat when table has no complex types, HiveRC profile should be used
         profileName = ProfileFactory.get(new RCFileInputFormat(), false);
-        assertEquals("HiveRC", profileName);
+        assertEquals("hive:rc", profileName);
 
         // For OrcInputFormat when table has complex types, HiveORC profile should be used
         profileName = ProfileFactory.get(new OrcInputFormat(), true);
-        assertEquals("HiveORC", profileName);
+        assertEquals("hive:orc", profileName);
 
         // For OrcInputFormat when table has no complex types, HiveORC profile should be used
         profileName = ProfileFactory.get(new OrcInputFormat(), false);
-        assertEquals("HiveORC", profileName);
+        assertEquals("hive:orc", profileName);
 
         // For other formats Hive profile should be used
         profileName = ProfileFactory.get(new SequenceFileInputFilter(), false);
-        assertEquals("Hive", profileName);
+        assertEquals("hive", profileName);
     }
 
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
@@ -75,7 +75,8 @@ public class HttpRequestParser implements RequestParser<MultiValueMap<String, St
         context.setRequestType(requestType);
 
         // first of all, set profile and enrich parameters with information from specified profile
-        String profile = params.removeUserProperty("PROFILE");
+        String profileUserValue = params.removeUserProperty("PROFILE");
+        String profile = profileUserValue == null ? null : profileUserValue.toLowerCase();
         context.setProfile(profile);
         addProfilePlugins(profile, params);
 

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -25,8 +25,30 @@ under the License.
     For adding new custom profiles please edit pxf-profiles.xml
 -->
 <profiles>
+
+    <!-- ==================== JDBC PROFILE ==================== -->
     <profile>
-        <name>HBase</name>
+        <name>jdbc</name>
+        <description>A profile for reading and writing data via JDBC</description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.jdbc.JdbcPartitionFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.jdbc.JdbcAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.jdbc.JdbcResolver</resolver>
+        </plugins>
+        <optionMappings>
+            <mapping option="jdbc_driver" property="jdbc.driver"/>
+            <mapping option="db_url" property="jdbc.url"/>
+            <mapping option="user" property="jdbc.user"/>
+            <mapping option="pass" property="jdbc.password"/>
+            <mapping option="batch_size" property="jdbc.statement.batchSize"/>
+            <mapping option="fetch_size" property="jdbc.statement.fetchSize"/>
+            <mapping option="query_timeout" property="jdbc.statement.queryTimeout"/>
+        </optionMappings>
+    </profile>
+
+    <!-- ==================== HBASE PROFILE ==================== -->
+    <profile>
+        <name>hbase</name>
         <description>This profile is suitable for using when connecting to an HBase data store
             engine
         </description>
@@ -36,6 +58,8 @@ under the License.
             <resolver>org.greenplum.pxf.plugins.hbase.HBaseResolver</resolver>
         </plugins>
     </profile>
+
+    <!-- ==================== HIVE PROFILES ==================== -->
     <profile>
         <name>hive</name>
         <description>
@@ -54,6 +78,7 @@ under the License.
             <mapping option="ppd" property="pxf.ppd.hive"/>
         </optionMappings>
     </profile>
+    <!-- this profile is obsolete in favor of hive:rc -->
     <profile>
         <name>HiveRC</name>
         <description>This profile is suitable only for Hive tables stored in RC files and serialized
@@ -92,6 +117,7 @@ under the License.
             <mapping option="ppd" property="pxf.ppd.hive"/>
         </optionMappings>
     </profile>
+    <!-- this profile is obsolete in favor of hive:text -->
     <profile>
         <name>HiveText</name>
         <description>This profile is suitable only for Hive tables stored as Text files. It is much
@@ -122,6 +148,7 @@ under the License.
             <outputFormat>org.greenplum.pxf.api.io.Text</outputFormat>
         </plugins>
     </profile>
+    <!-- this profile is obsolete in favor of hive:orc -->
     <profile>
         <name>HiveORC</name>
         <description>This profile is suitable only for Hive tables stored in ORC files and
@@ -158,6 +185,7 @@ under the License.
             <mapping option="ppd" property="pxf.ppd.hive"/>
         </optionMappings>
     </profile>
+    <!-- this profile is obsolete in favor of hive:orc with VECTORIZE=true user option -->
     <profile>
         <name>HiveVectorizedORC</name>
         <description>This profile is same as HiveORC profile, but operates on batches of rows
@@ -172,7 +200,7 @@ under the License.
         </plugins>
     </profile>
     <profile>
-        <name>hive:vectorizedorc</name>
+        <name>hive:orc:vectorized</name>
         <description>This profile is same as HiveORC profile, but operates on batches of rows
             instead of one row at a time, leading to faster reading and resolution phases.
         </description>
@@ -184,6 +212,9 @@ under the License.
             <outputFormat>org.greenplum.pxf.api.io.GPDBWritable</outputFormat>
         </plugins>
     </profile>
+
+    <!-- ==================== TEXT PROFILES ==================== -->
+    <!-- this profile is obsolete in favor of hdfs:text -->
     <profile>
         <name>HdfsTextSimple</name>
         <description>This profile is suitable for using when reading delimited single line records
@@ -195,6 +226,7 @@ under the License.
             <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
         </plugins>
     </profile>
+    <!-- this profile is obsolete in favor of hdfs:text:multi -->
     <profile>
         <name>HdfsTextMulti</name>
         <description>This profile is suitable for using when reading delimited single or multi line
@@ -207,70 +239,6 @@ under the License.
             <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
         </plugins>
     </profile>
-    <profile>
-        <name>SequenceWritable</name>
-        <description>
-            Profile for accessing Sequence files serialized with a custom Writable class
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
-        </plugins>
-    </profile>
-    <profile>
-        <name>SequenceText</name>
-        <description>
-            Profile for accessing Sequence files serialized with a custom Writable class
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
-        </plugins>
-    </profile>
-    <profile>
-        <name>Json</name>
-        <description>
-            Access JSON data either as:
-            * one JSON record per line (default)
-            * or multiline JSON records with an IDENTIFIER parameter indicating a member name used
-            to determine the encapsulating json object to return
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
-        </plugins>
-    </profile>
-    <profile>
-        <name>Jdbc</name>
-        <description>A profile for reading and writing data via JDBC</description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.jdbc.JdbcPartitionFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.jdbc.JdbcAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.jdbc.JdbcResolver</resolver>
-        </plugins>
-        <optionMappings>
-            <mapping option="jdbc_driver" property="jdbc.driver"/>
-            <mapping option="db_url" property="jdbc.url"/>
-            <mapping option="user" property="jdbc.user"/>
-            <mapping option="pass" property="jdbc.password"/>
-            <mapping option="batch_size" property="jdbc.statement.batchSize"/>
-            <mapping option="fetch_size" property="jdbc.statement.fetchSize"/>
-            <mapping option="query_timeout" property="jdbc.statement.queryTimeout"/>
-        </optionMappings>
-    </profile>
-    <profile>
-        <name>Parquet</name>
-        <description>A profile for reading and writing Parquet data from HDFS</description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.ParquetFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.ParquetResolver</resolver>
-        </plugins>
-    </profile>
-    <!-- TEXT PROFILES -->
     <profile>
         <name>hdfs:text</name>
         <description>This profile is suitable for using when reading delimited single line records
@@ -356,7 +324,6 @@ under the License.
             <mapping option="secretkey" property="fs.s3a.secret.key"/>
         </optionMappings>
     </profile>
-
     <profile>
         <name>adl:text</name>
         <description>This profile is suitable for using when reading delimited single line records
@@ -395,6 +362,43 @@ under the License.
         <protocol>adl</protocol>
     </profile>
     <profile>
+        <name>wasbs:text</name>
+        <description>This profile is suitable for using when reading delimited single line records
+            from plain text, tab-delimited, files on Azure Blob Storage
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+        <protocol>wasbs</protocol>
+    </profile>
+    <profile>
+        <name>wasbs:csv</name>
+        <description>This profile is suitable for using when reading delimited single line records
+            from plain text CSV files on Azure Blob Storage
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+        <protocol>wasbs</protocol>
+    </profile>
+    <profile>
+        <name>wasbs:text:multi</name>
+        <description>This profile is suitable for using when reading delimited single or multi line
+            records (with quoted linefeeds) from plain text files on Azure Blob Storage. It is not
+            splittable (non parallel) and slower than HdfsTextSimple.
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+        <protocol>wasbs</protocol>
+    </profile>
+    <profile>
         <name>gs:text</name>
         <description>This profile is suitable for using when reading delimited single line records
             from plain text, tab-delimited, files on Azure Data Lake
@@ -431,7 +435,52 @@ under the License.
         </plugins>
         <protocol>gs</protocol>
     </profile>
-    <!-- PARQUET PROFILES -->
+    <profile>
+        <name>file:text</name>
+        <description>This profile is suitable for using when reading delimited single line records
+            from plain text, tab-delimited, files
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+    </profile>
+    <profile>
+        <name>file:csv</name>
+        <description>This profile is suitable for using when reading delimited single line records
+            from plain text CSV files
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+    </profile>
+    <profile>
+        <name>file:text:multi</name>
+        <description>This profile is suitable for using when reading delimited single or multi line
+            records (with quoted linefeeds) from plain text files. It is not splittable (non
+            parallel) and slower than HdfsTextSimple.
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+    </profile>
+
+    <!-- ==================== PARQUET PROFILES ==================== -->
+    <!-- this profile is obsolete in favor of hdfs:parquet -->
+    <profile>
+        <name>parquet</name>
+        <description>A profile for reading and writing Parquet data from HDFS</description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.ParquetFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.ParquetResolver</resolver>
+        </plugins>
+    </profile>
     <profile>
         <name>hdfs:parquet</name>
         <description>A profile for reading and writing Parquet data from HDFS</description>
@@ -468,6 +517,17 @@ under the License.
         <protocol>adl</protocol>
     </profile>
     <profile>
+        <name>wasbs:parquet</name>
+        <description>A profile for reading and writing Parquet data from Azure Blob Storage
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.ParquetFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.ParquetResolver</resolver>
+        </plugins>
+        <protocol>wasbs</protocol>
+    </profile>
+    <profile>
         <name>gs:parquet</name>
         <description>A profile for reading and writing Parquet data from Google Cloud Storage
         </description>
@@ -478,7 +538,18 @@ under the License.
         </plugins>
         <protocol>gs</protocol>
     </profile>
-    <!-- ORC PROFILES -->
+    <profile>
+        <name>file:parquet</name>
+        <description>A profile for reading and writing Parquet files
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.ParquetFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.ParquetResolver</resolver>
+        </plugins>
+    </profile>
+
+    <!-- ==================== ORC PROFILES ==================== -->
     <profile>
         <name>hdfs:orc</name>
         <description>A profile for reading ORC data from HDFS</description>
@@ -546,9 +617,11 @@ under the License.
             <resolver>org.greenplum.pxf.plugins.hdfs.orc.ORCVectorizedResolver</resolver>
         </plugins>
     </profile>
-    <!-- AVRO PROFILES -->
+
+    <!-- ==================== AVRO PROFILES ==================== -->
+    <!-- this profile is obsolete in favor of hdfs:avro -->
     <profile>
-        <name>Avro</name>
+        <name>avro</name>
         <description>This profile is suitable for using when reading Avro files (i.e
             fileName.avro)
         </description>
@@ -598,6 +671,18 @@ under the License.
         <protocol>adl</protocol>
     </profile>
     <profile>
+        <name>wasbs:avro</name>
+        <description>This profile is suitable for using when reading Avro files (i.e
+            fileName.avro)
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.AvroFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.AvroResolver</resolver>
+        </plugins>
+        <protocol>wasbs</protocol>
+    </profile>
+    <profile>
         <name>gs:avro</name>
         <description>This profile is suitable for using when reading Avro files (i.e
             fileName.avro)
@@ -609,7 +694,34 @@ under the License.
         </plugins>
         <protocol>gs</protocol>
     </profile>
-    <!-- JSON PROFILES -->
+    <profile>
+        <name>file:avro</name>
+        <description>This profile is suitable for using when reading Avro files (i.e
+            fileName.avro)
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.AvroFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.AvroResolver</resolver>
+        </plugins>
+    </profile>
+
+    <!-- ==================== JSON PROFILES ==================== -->
+    <!-- this profile is obsolete in favor of hdfs:json -->
+    <profile>
+        <name>json</name>
+        <description>
+            Access JSON data either as:
+            * one JSON record per line (default)
+            * or multiline JSON records with an IDENTIFIER parameter indicating a member name used
+            to determine the encapsulating json object to return
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
+        </plugins>
+    </profile>
     <profile>
         <name>hdfs:json</name>
         <description>
@@ -660,6 +772,21 @@ under the License.
         <protocol>adl</protocol>
     </profile>
     <profile>
+        <name>wasbs:json</name>
+        <description>
+            Access JSON data either as:
+            * one JSON record per line (default)
+            * or multiline JSON records with an IDENTIFIER parameter indicating a member name used
+            to determine the encapsulating json object to return
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
+        </plugins>
+        <protocol>wasbs</protocol>
+    </profile>
+    <profile>
         <name>gs:json</name>
         <description>
             Access JSON data either as:
@@ -674,7 +801,110 @@ under the License.
         </plugins>
         <protocol>gs</protocol>
     </profile>
-    <!-- AVRO SEQUENCEFILE PROFILES -->
+    <profile>
+        <name>file:json</name>
+        <description>
+            Access JSON data either as:
+            * one JSON record per line (default)
+            * or multiline JSON records with an IDENTIFIER parameter indicating a member name used
+            to determine the encapsulating json object to return
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
+        </plugins>
+    </profile>
+
+    <!-- ==================== SEQUENCE FILE PROFILES ==================== -->
+    <!-- this profile is obsolete in favor of hdfs:SequenceFile -->
+    <profile>
+        <name>SequenceWritable</name>
+        <description>
+            Profile for accessing Sequence files serialized with a custom Writable class
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
+        </plugins>
+    </profile>
+    <profile>
+        <name>SequenceText</name>
+        <description>
+            Profile for accessing Sequence files serialized with a custom Writable class
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
+        </plugins>
+    </profile>
+    <profile>
+        <name>hdfs:SequenceFile</name>
+        <description>
+            Profile for accessing Sequence files serialized with a custom Writable class
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
+        </plugins>
+    </profile>
+    <profile>
+        <name>s3:SequenceFile</name>
+        <description>
+            Profile for accessing Sequence files serialized with a custom Writable class
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
+        </plugins>
+        <protocol>s3a</protocol>
+        <optionMappings>
+            <mapping option="accesskey" property="fs.s3a.access.key"/>
+            <mapping option="secretkey" property="fs.s3a.secret.key"/>
+        </optionMappings>
+    </profile>
+    <profile>
+        <name>adl:SequenceFile</name>
+        <description>
+            Profile for accessing Sequence files serialized with a custom Writable class
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
+        </plugins>
+        <protocol>adl</protocol>
+    </profile>
+    <profile>
+        <name>wasbs:SequenceFile</name>
+        <description>
+            Profile for accessing Sequence files serialized with a custom Writable class
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
+        </plugins>
+        <protocol>wasbs</protocol>
+    </profile>
+    <profile>
+        <name>gs:SequenceFile</name>
+        <description>
+            Profile for accessing Sequence files serialized with a custom Writable class
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
+        </plugins>
+        <protocol>gs</protocol>
+    </profile>
+
+    <!-- ==================== AVRO SEQUENCE FILES PROFILES ==================== -->
     <profile>
         <name>hdfs:AvroSequenceFile</name>
         <description>
@@ -716,148 +946,6 @@ under the License.
         <protocol>adl</protocol>
     </profile>
     <profile>
-        <name>gs:AvroSequenceFile</name>
-        <description>
-            Read an Avro format stored in sequence file, with separated schema file from Google
-            Cloud Storage
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.AvroResolver</resolver>
-        </plugins>
-        <protocol>gs</protocol>
-    </profile>
-    <!-- SEQUENCEFILE PROFILES -->
-    <profile>
-        <name>hdfs:SequenceFile</name>
-        <description>
-            Profile for accessing Sequence files serialized with a custom Writable class
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
-        </plugins>
-    </profile>
-    <profile>
-        <name>s3:SequenceFile</name>
-        <description>
-            Profile for accessing Sequence files serialized with a custom Writable class
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
-        </plugins>
-        <protocol>s3a</protocol>
-        <optionMappings>
-            <mapping option="accesskey" property="fs.s3a.access.key"/>
-            <mapping option="secretkey" property="fs.s3a.secret.key"/>
-        </optionMappings>
-    </profile>
-    <profile>
-        <name>adl:SequenceFile</name>
-        <description>
-            Profile for accessing Sequence files serialized with a custom Writable class
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
-        </plugins>
-        <protocol>adl</protocol>
-    </profile>
-    <profile>
-        <name>gs:SequenceFile</name>
-        <description>
-            Profile for accessing Sequence files serialized with a custom Writable class
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
-        </plugins>
-        <protocol>gs</protocol>
-    </profile>
-
-    <!-- WASBS - Azure Blob Storage -->
-    <profile>
-        <name>wasbs:text</name>
-        <description>This profile is suitable for using when reading delimited single line records
-            from plain text, tab-delimited, files on Azure Blob Storage
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
-        </plugins>
-        <protocol>wasbs</protocol>
-    </profile>
-    <profile>
-        <name>wasbs:csv</name>
-        <description>This profile is suitable for using when reading delimited single line records
-            from plain text CSV files on Azure Blob Storage
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
-        </plugins>
-        <protocol>wasbs</protocol>
-    </profile>
-    <profile>
-        <name>wasbs:text:multi</name>
-        <description>This profile is suitable for using when reading delimited single or multi line
-            records (with quoted linefeeds) from plain text files on Azure Blob Storage. It is not
-            splittable (non parallel) and slower than HdfsTextSimple.
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
-        </plugins>
-        <protocol>wasbs</protocol>
-    </profile>
-    <profile>
-        <name>wasbs:parquet</name>
-        <description>A profile for reading and writing Parquet data from Azure Blob Storage
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.ParquetFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.ParquetResolver</resolver>
-        </plugins>
-        <protocol>wasbs</protocol>
-    </profile>
-    <profile>
-        <name>wasbs:avro</name>
-        <description>This profile is suitable for using when reading Avro files (i.e
-            fileName.avro)
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.AvroFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.AvroResolver</resolver>
-        </plugins>
-        <protocol>wasbs</protocol>
-    </profile>
-    <profile>
-        <name>wasbs:json</name>
-        <description>
-            Access JSON data either as:
-            * one JSON record per line (default)
-            * or multiline JSON records with an IDENTIFIER parameter indicating a member name used
-            to determine the encapsulating json object to return
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
-        </plugins>
-        <protocol>wasbs</protocol>
-    </profile>
-    <profile>
         <name>wasbs:AvroSequenceFile</name>
         <description>
             Read an Avro format stored in sequence file, with separated schema file from Azure Blob
@@ -871,87 +959,17 @@ under the License.
         <protocol>wasbs</protocol>
     </profile>
     <profile>
-        <name>wasbs:SequenceFile</name>
+        <name>gs:AvroSequenceFile</name>
         <description>
-            Profile for accessing Sequence files serialized with a custom Writable class
+            Read an Avro format stored in sequence file, with separated schema file from Google
+            Cloud Storage
         </description>
         <plugins>
             <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
             <accessor>org.greenplum.pxf.plugins.hdfs.SequenceFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.WritableResolver</resolver>
-        </plugins>
-        <protocol>wasbs</protocol>
-    </profile>
-
-    <!-- File profiles for file systems mounted on the Greenplum cluster -->
-    <profile>
-        <name>file:text</name>
-        <description>This profile is suitable for using when reading delimited single line records
-            from plain text, tab-delimited, files
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
-        </plugins>
-    </profile>
-    <profile>
-        <name>file:csv</name>
-        <description>This profile is suitable for using when reading delimited single line records
-            from plain text CSV files
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.LineBreakAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
-        </plugins>
-    </profile>
-    <profile>
-        <name>file:text:multi</name>
-        <description>This profile is suitable for using when reading delimited single or multi line
-            records (with quoted linefeeds) from plain text files. It is not splittable (non
-            parallel) and slower than HdfsTextSimple.
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.QuotedLineBreakAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
-        </plugins>
-    </profile>
-    <profile>
-        <name>file:parquet</name>
-        <description>A profile for reading and writing Parquet files
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.ParquetFileAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hdfs.ParquetResolver</resolver>
-        </plugins>
-    </profile>
-    <profile>
-        <name>file:avro</name>
-        <description>This profile is suitable for using when reading Avro files (i.e
-            fileName.avro)
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hdfs.AvroFileAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.hdfs.AvroResolver</resolver>
         </plugins>
-    </profile>
-    <profile>
-        <name>file:json</name>
-        <description>
-            Access JSON data either as:
-            * one JSON record per line (default)
-            * or multiline JSON records with an IDENTIFIER parameter indicating a member name used
-            to determine the encapsulating json object to return
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
-        </plugins>
+        <protocol>gs</protocol>
     </profile>
 
     <!-- SYSTEM PROFILES -->
@@ -967,4 +985,5 @@ under the License.
             <resolver>org.greenplum.pxf.plugins.hdfs.StringPassResolver</resolver>
         </plugins>
     </profile>
+
 </profiles>

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -37,7 +37,7 @@ under the License.
         </plugins>
     </profile>
     <profile>
-        <name>Hive</name>
+        <name>hive</name>
         <description>
             This profile is suitable for using when connecting to Hive. Supports GPDBWritable output
             format, as specified in FORMAT header parameter. It auto-detects actual file storage
@@ -74,7 +74,41 @@ under the License.
         </optionMappings>
     </profile>
     <profile>
+        <name>hive:rc</name>
+        <description>This profile is suitable only for Hive tables stored in RC files and serialized
+            with either the ColumnarSerDe or the LazyBinaryColumnarSerDe. It is much faster than the
+            general purpose Hive profile. DELIMITER parameter is mandatory. Supports both
+            GPDBWritable and TEXT output formats, as specified in FORMAT header parameter. Primary
+            optimized for TEXT output format.
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hive.HiveInputFormatFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hive.HiveRCFileAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hive.HiveColumnarSerdeResolver</resolver>
+            <metadata>org.greenplum.pxf.plugins.hive.HiveMetadataFetcher</metadata>
+            <outputFormat>org.greenplum.pxf.api.io.Text</outputFormat>
+        </plugins>
+        <optionMappings>
+            <mapping option="ppd" property="pxf.ppd.hive"/>
+        </optionMappings>
+    </profile>
+    <profile>
         <name>HiveText</name>
+        <description>This profile is suitable only for Hive tables stored as Text files. It is much
+            faster than the general purpose Hive profile. DELIMITER parameter is mandatory. Supports
+            both GPDBWritable and TEXT output formats, as specified in FORMAT header parameter.
+            Primary optimized for TEXT output format.
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hive.HiveInputFormatFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hive.HiveLineBreakAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hive.HiveStringPassResolver</resolver>
+            <metadata>org.greenplum.pxf.plugins.hive.HiveMetadataFetcher</metadata>
+            <outputFormat>org.greenplum.pxf.api.io.Text</outputFormat>
+        </plugins>
+    </profile>
+    <profile>
+        <name>hive:text</name>
         <description>This profile is suitable only for Hive tables stored as Text files. It is much
             faster than the general purpose Hive profile. DELIMITER parameter is mandatory. Supports
             both GPDBWritable and TEXT output formats, as specified in FORMAT header parameter.
@@ -107,7 +141,38 @@ under the License.
         </optionMappings>
     </profile>
     <profile>
+        <name>hive:orc</name>
+        <description>This profile is suitable only for Hive tables stored in ORC files and
+            serialized with either the ColumnarSerDe or the LazyBinaryColumnarSerDe. It is much
+            faster than the general purpose Hive profile. Supports GPDBWritable output format, as
+            specified in FORMAT header parameter.
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hive.HiveInputFormatFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hive.HiveORCAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hive.HiveORCSerdeResolver</resolver>
+            <metadata>org.greenplum.pxf.plugins.hive.HiveMetadataFetcher</metadata>
+            <outputFormat>org.greenplum.pxf.api.io.GPDBWritable</outputFormat>
+        </plugins>
+        <optionMappings>
+            <mapping option="ppd" property="pxf.ppd.hive"/>
+        </optionMappings>
+    </profile>
+    <profile>
         <name>HiveVectorizedORC</name>
+        <description>This profile is same as HiveORC profile, but operates on batches of rows
+            instead of one row at a time, leading to faster reading and resolution phases.
+        </description>
+        <plugins>
+            <fragmenter>org.greenplum.pxf.plugins.hive.HiveInputFormatFragmenter</fragmenter>
+            <accessor>org.greenplum.pxf.plugins.hive.HiveORCVectorizedAccessor</accessor>
+            <resolver>org.greenplum.pxf.plugins.hive.HiveORCVectorizedResolver</resolver>
+            <metadata>org.greenplum.pxf.plugins.hive.HiveMetadataFetcher</metadata>
+            <outputFormat>org.greenplum.pxf.api.io.GPDBWritable</outputFormat>
+        </plugins>
+    </profile>
+    <profile>
+        <name>hive:vectorizedorc</name>
         <description>This profile is same as HiveORC profile, but operates on batches of rows
             instead of one row at a time, leading to faster reading and resolution phases.
         </description>

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -960,7 +960,7 @@ under the License.
         <protocol>gs</protocol>
     </profile>
 
-    <!-- SYSTEM PROFILES -->
+    <!-- ==================== SYSTEM PROFILES ==================== -->
     <profile>
         <name>system:filter</name>
         <description>

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -181,26 +181,14 @@ under the License.
             <metadata>org.greenplum.pxf.plugins.hive.HiveMetadataFetcher</metadata>
             <outputFormat>org.greenplum.pxf.api.io.GPDBWritable</outputFormat>
         </plugins>
+        <handler>org.greenplum.pxf.plugins.hive.HiveProtocolHandler</handler>
         <optionMappings>
             <mapping option="ppd" property="pxf.ppd.hive"/>
         </optionMappings>
     </profile>
-    <!-- this profile is obsolete in favor of hive:orc with VECTORIZE=true user option -->
+    <!-- this profile is deprecated in favor of hive:orc with VECTORIZE=true user option -->
     <profile>
         <name>HiveVectorizedORC</name>
-        <description>This profile is same as HiveORC profile, but operates on batches of rows
-            instead of one row at a time, leading to faster reading and resolution phases.
-        </description>
-        <plugins>
-            <fragmenter>org.greenplum.pxf.plugins.hive.HiveInputFormatFragmenter</fragmenter>
-            <accessor>org.greenplum.pxf.plugins.hive.HiveORCVectorizedAccessor</accessor>
-            <resolver>org.greenplum.pxf.plugins.hive.HiveORCVectorizedResolver</resolver>
-            <metadata>org.greenplum.pxf.plugins.hive.HiveMetadataFetcher</metadata>
-            <outputFormat>org.greenplum.pxf.api.io.GPDBWritable</outputFormat>
-        </plugins>
-    </profile>
-    <profile>
-        <name>hive:orc:vectorized</name>
         <description>This profile is same as HiveORC profile, but operates on batches of rows
             instead of one row at a time, leading to faster reading and resolution phases.
         </description>

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
@@ -21,7 +21,6 @@ package org.greenplum.pxf.service;
 
 
 import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.commons.codec.binary.Base64;
 import org.greenplum.pxf.api.examples.DemoFragmentMetadata;
@@ -432,7 +431,25 @@ public class HttpRequestParserTest {
         RequestContext context = parser.parseRequest(parameters, RequestType.FRAGMENTER);
 
         assertEquals("test-protocol", context.getProfileScheme());
+    }
 
+    @Test
+    public void protocolIsSetWhenProfileIsSpecifiedInMixedCase() {
+        parameters.add("X-GP-OPTIONS-PROFILE", "teST-pROFile");
+        when(mockPluginConf.getProtocol("test-profile")).thenReturn("test-protocol");
+
+        RequestContext context = parser.parseRequest(parameters, RequestType.FRAGMENTER);
+
+        assertEquals("test-protocol", context.getProfileScheme());
+    }
+
+    @Test
+    public void profileIsSetInLowerCase() {
+        parameters.add("X-GP-OPTIONS-PROFILE", "teST-pROFile");
+
+        RequestContext context = parser.parseRequest(parameters, RequestType.FRAGMENTER);
+
+        assertEquals("test-profile", context.getProfile());
     }
 
     @Test


### PR DESCRIPTION
The hive profile names do not follow the "protocol":"format" naming
convention introduced for HCFS profiles. This commit adds Hive profile
names with the new format. For example, `HiveORC` becomes `hive:orc`.