### PR TITLE
Add the InOperatorTransformer TreeVisitor

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/filter/InOperatorTransformer.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/filter/InOperatorTransformer.java
@@ -1,0 +1,86 @@
+package org.greenplum.pxf.api.filter;
+
+import org.greenplum.pxf.api.io.DataType;
+
+import java.util.List;
+
+/**
+ * Transforms IN operator into a chain of OR operators. This transformer is
+ * useful for predicate builders that do not support the IN operator.
+ */
+public class InOperatorTransformer implements TreeVisitor {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Node before(Node node, int level) {
+        return node;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Node visit(Node node, int level) {
+
+        if (node instanceof OperatorNode) {
+
+            OperatorNode operatorNode = (OperatorNode) node;
+
+            if (operatorNode.getOperator() == Operator.IN
+                    && operatorNode.getLeft() instanceof ColumnIndexOperandNode
+                    && operatorNode.getRight() instanceof CollectionOperandNode) {
+
+                ColumnIndexOperandNode columnNode = (ColumnIndexOperandNode) operatorNode.getLeft();
+                CollectionOperandNode collectionOperandNode = (CollectionOperandNode) operatorNode.getRight();
+                List<String> data = collectionOperandNode.getData();
+                DataType type = collectionOperandNode.getDataType().getTypeElem() != null
+                        ? collectionOperandNode.getDataType().getTypeElem()
+                        : collectionOperandNode.getDataType();
+
+                // Transform the IN operator into a chain of ORs
+                //       IN
+                //        |
+                //    --------
+                //    |      |
+                //   _1_   11,12
+                //
+                //  The transformed branch will look like this:
+
+                //                   OR
+                //                    |
+                //         ------------------------
+                //         |                      |
+                //         eq                     eq
+                //         |                      |
+                //     ---------              ---------
+                //     |       |              |       |
+                //    _1_      11            _1_      12
+
+                // build the first node as the equal operator of the column and the scalar operand
+                Node currentNode = new OperatorNode(Operator.EQUALS, columnNode, new ScalarOperandNode(type, data.get(0)));
+
+                for (int i = 1; i < data.size(); i++) {
+                    // current node becomes left node
+                    // scalar becomes right node
+                    // the or operator becomes the current node
+                    Node rightNode = new OperatorNode(Operator.EQUALS, columnNode, new ScalarOperandNode(type, data.get(i)));
+                    currentNode = new OperatorNode(Operator.OR, currentNode, rightNode);
+                }
+
+                return currentNode;
+            }
+        }
+
+        return node;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Node after(Node node, int level) {
+        return node;
+    }
+}

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/filter/InOperatorTransformerTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/filter/InOperatorTransformerTest.java
@@ -1,0 +1,40 @@
+package org.greenplum.pxf.api.filter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InOperatorTransformerTest {
+
+    private static final TreeTraverser TRAVERSER = new TreeTraverser();
+    private static final TreeVisitor IN_OPERATOR_TRANSFORMER = new InOperatorTransformer();
+
+    @Test
+    void transformOneValue() throws Exception {
+        helper("_1_ = 100", "a1m1007s3d100o10");
+    }
+
+    @Test
+    void transformTwoValues() throws Exception {
+        helper("(_1_ = 11 OR _1_ = 12)", "a1m1007s2d11s2d12o10");
+    }
+
+    @Test
+    void transformThreeValues() throws Exception {
+        helper("((_1_ = 11 OR _1_ = 12) OR _1_ = 15)", "a1m1007s2d11s2d12s2d15o10");
+    }
+
+    @Test
+    void transformFiveValues() throws Exception {
+        helper("((((_1_ = 11 OR _1_ = 12) OR _1_ = 15) OR _1_ = 100) OR _1_ = 5)", "a1m1007s2d11s2d12s2d15s3d100s1d5o10");
+    }
+
+    private void helper(String expected, String filterString)
+            throws Exception {
+        Node root = new FilterParser().parse(filterString);
+        ToStringTreeVisitor toStringTreeVisitor = new ToStringTreeVisitor();
+        TRAVERSER.traverse(root, IN_OPERATOR_TRANSFORMER, toStringTreeVisitor);
+        assertEquals(expected, toStringTreeVisitor.toString());
+    }
+
+}

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/ParquetFileAccessor.java
@@ -50,6 +50,7 @@ import org.apache.parquet.schema.Types;
 import org.greenplum.pxf.api.OneRow;
 import org.greenplum.pxf.api.error.UnsupportedTypeException;
 import org.greenplum.pxf.api.filter.FilterParser;
+import org.greenplum.pxf.api.filter.InOperatorTransformer;
 import org.greenplum.pxf.api.filter.Node;
 import org.greenplum.pxf.api.filter.Operator;
 import org.greenplum.pxf.api.filter.TreeTraverser;
@@ -129,6 +130,7 @@ public class ParquetFileAccessor extends BasePlugin implements Accessor {
 
     private static final TreeTraverser TRAVERSER = new TreeTraverser();
     private static final TreeVisitor BPCHAR_TRANSFORMER = new BPCharOperatorTransformer();
+    private static final TreeVisitor IN_OPERATOR_TRANSFORMER = new InOperatorTransformer();
 
     private ParquetReader<Group> fileReader;
     private CompressionCodecName codecName;
@@ -319,10 +321,11 @@ public class ParquetFileAccessor extends BasePlugin implements Accessor {
         try {
             // Parse the filter string into a expression tree Node
             Node root = new FilterParser().parse(filterString);
-            // Prune the parsed tree with valid supported operators and then
+            // Transform IN operators into a chain of ORs, then
+            // prune the parsed tree with valid supported operators and then
             // traverse the pruned tree with the ParquetRecordFilterBuilder to
             // produce a record filter for parquet
-            TRAVERSER.traverse(root, pruner, BPCHAR_TRANSFORMER, filterBuilder);
+            TRAVERSER.traverse(root, IN_OPERATOR_TRANSFORMER, pruner, BPCHAR_TRANSFORMER, filterBuilder);
             return filterBuilder.getRecordFilter();
         } catch (Exception e) {
             LOG.error(String.format("%s-%d: %s--%s Unable to generate Parquet Record Filter for filter",

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/parquet/ParquetFilterPushDownTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/parquet/ParquetFilterPushDownTest.java
@@ -672,11 +672,12 @@ public class ParquetFilterPushDownTest extends ParquetBaseTest {
     }
 
     @Test
-    public void testUnsupportedInOperationFilter() throws Exception {
+    public void testInOperationFilter() throws Exception {
         // a16 in (11, 12)
+        int[] expectedRows = {11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25};
         context.setFilterString("a16m1007s2d11s2d12o10");
         // all rows are expected
-        assertRowsReturned(ALL);
+        assertRowsReturned(expectedRows);
     }
 
     private void assertRowsReturned(int[] expectedRows) throws Exception {


### PR DESCRIPTION
Add the InOperatorTransformer that will take the IN operator and
transform it into a chain of OR operators. This transformer can be used
by filter builders that do not support the IN operator.