### PR TITLE
pxf-build-base: Cache gradle in the build dependencies

### DIFF
--- a/concourse/docker/pxf-build-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-build-base/cloudbuild.yaml
@@ -25,10 +25,10 @@ steps:
     waitFor: [ 'retrieve-pxf-automation-dependencies' ]
 
   # use gradle image with JDK8 to build the project
-  - name: gradle:6.6.1-jdk8
+  - name: openjdk:8-jdk
     id: gradle-build
-    entrypoint: gradle
-    args: [ '--gradle-user-home=/workspace/.gradle', '-Dorg.gradle.daemon=false', '-b', './server/build.gradle', 'test', 'stage' ]
+    entrypoint: bash
+    args: [ './server/gradlew', '--gradle-user-home=/workspace/.gradle', '-Dorg.gradle.daemon=false', '-b', './server/build.gradle', 'test', 'stage' ]
     waitFor: [ 'untar-pxf-build-dependencies' ]
 
   - name: golang:1.15.3


### PR DESCRIPTION
gradle is not being cached as part of the build dependencies because we
are using an image that already has gradle. By switching to the java 8
image, we ensure that gradle will be downloaded to the ~/.gradle
directory during dependency cache building.