### PR TITLE
Docker: Add java 8 to the gpdb7 centos 7 image to support hadoop

### DIFF
--- a/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
@@ -17,8 +17,9 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
     && chmod +x /opt/minio/bin/minio \
     && chown -R minio:minio /opt/minio
 
-# install java 11 and dependencies that are missing on the base images
-RUN yum install -y rpm-build sudo java-11-openjdk-devel
+# install java 8 and 11 and dependencies that are missing on the base images
+# java 8 is required to run hadoop. Do not use java 8 to build / run PXF
+RUN yum install -y rpm-build sudo java-1.8.0-openjdk java-11-openjdk-devel
 
 # create user gpadmin since GPDB cannot run under root
 RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -398,9 +398,7 @@ jobs:
   - put: pxf_gp[[gp_ver]]_tarball_rhel7
     params:
       file: dist/pxf-gp[[gp_ver]]-*.el7.tar.gz
-{% endfor %}
 
-{% for gp_ver in range(5, 7) %}
 - name: Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
   plan:
   - in_parallel:
@@ -424,7 +422,12 @@ jobs:
     params:
       ACCESS_KEY_ID: ((tf-machine-access-key-id))
       GP_VER: [[gp_ver]]
+{% if gp_ver == 7 %}
+      GROUP: fdw_gpdb_schedule,fdw_proxy_schedule
+      HADOOP_JAVA_HOME: /usr/lib/jvm/jre-1.8.0-openjdk
+{% else %}
       GROUP: gpdb,proxy,profile
+{% endif %}
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
       TARGET_OS: centos
       TARGET_OS_VERSION: 7

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -18,6 +18,9 @@ else
 	JAVA_HOME=$(find /usr/lib/jvm -name 'java-1.8.0-openjdk*' | head -1)
 fi
 
+# java home for hadoop services
+HADOOP_JAVA_HOME=${HADOOP_JAVA_HOME:-$JAVA_HOME}
+
 if [[ -d gpdb_src/gpAux/extensions/pxf ]]; then
 	PXF_EXTENSIONS_DIR=gpdb_src/gpAux/extensions/pxf
 else
@@ -424,17 +427,17 @@ function start_hadoop_services() {
 	local GPHD_ROOT=${1}
 
 	# Start all hadoop services
-	"${GPHD_ROOT}/bin/init-gphd.sh"
-	"${GPHD_ROOT}/bin/start-hdfs.sh"
-	"${GPHD_ROOT}/bin/start-zookeeper.sh"
-	"${GPHD_ROOT}/bin/start-yarn.sh" &
-	"${GPHD_ROOT}/bin/start-hbase.sh" &
-	"${GPHD_ROOT}/bin/start-hive.sh" &
+	JAVA_HOME=${HADOOP_JAVA_HOME} "${GPHD_ROOT}/bin/init-gphd.sh"
+	JAVA_HOME=${HADOOP_JAVA_HOME} "${GPHD_ROOT}/bin/start-hdfs.sh"
+	JAVA_HOME=${HADOOP_JAVA_HOME} "${GPHD_ROOT}/bin/start-zookeeper.sh"
+	JAVA_HOME=${HADOOP_JAVA_HOME} "${GPHD_ROOT}/bin/start-yarn.sh" &
+	JAVA_HOME=${HADOOP_JAVA_HOME} "${GPHD_ROOT}/bin/start-hbase.sh" &
+	JAVA_HOME=${HADOOP_JAVA_HOME} "${GPHD_ROOT}/bin/start-hive.sh" &
 	wait
 	export PATH=$PATH:${GPHD_ROOT}/bin
 
 	# list running Hadoop daemons
-	jps
+	JAVA_HOME=${HADOOP_JAVA_HOME} jps
 
 	# grant gpadmin user admin privilege for feature tests to be able to run on secured cluster
 	if [[ ${IMPERSONATION} == true ]]; then


### PR DESCRIPTION
Hadoop does not support java 11 yet, and many issues arise with data
prep when hadoop/hive/hbase run on java 11. We need java 8 to be able to
run hadoop services correctly.