### PR TITLE
Build the pxf-tools tarball

### DIFF
--- a/concourse/docker/pxf-build-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-build-base/cloudbuild.yaml
@@ -98,7 +98,20 @@ steps:
         mkdir -p /root/pxf/servers/db-session-params/ && cp ./server/pxf-service/src/templates/templates/jdbc-site.xml /root/pxf/servers/db-session-params/
         mkdir -p /root/pxf/servers/db-hive/ && cp ./server/pxf-service/src/templates/templates/jdbc-site.xml /root/pxf/servers/db-hive/
         GPHD_ROOT=/tmp PXF_HOME=/tmp/pxf mvn -B -e -Dpxf.lib=/workspace/automation_tmp_lib -Dtest=HdfsSmokeTest -Djava.awt.headless=true -Dmaven.repo.local=/workspace/.m2/repository -f ./automation/pom.xml -U test || true 
+        # create pxf-tools directory and copy jars needed by pxf
+        mkdir -p pxf-tools
+        cp $(find . -name avro-tools*.jar) pxf-tools
     waitFor: [ 'mvn-dev-build' ]
+
+  # create a tarball with tools used by PXF, for example avro-tools
+  - name: 'gcr.io/$PROJECT_ID/tar'
+    id: tar-pxf-tools
+    args: [ '-czf', 'pxf-tools.tar.gz', 'pxf-tools' ]
+    waitFor: [ 'mvn-test-build' ]
+  # Push the pxf-tools.tar.gz tarball to Google Cloud Storage
+  - name: 'gcr.io/cloud-builders/gsutil'
+    args: [ 'cp', '/workspace/pxf-tools.tar.gz', 'gs://${_PXF_BUILD_BUCKET}/regression-dependencies/pxf-tools.tar.gz' ]
+    waitFor: [ 'tar-pxf-tools' ]
 
   # create an updated tarball with automation dependencies and upload it
   - name: 'gcr.io/$PROJECT_ID/tar'

--- a/concourse/docker/pxf-build-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-build-base/cloudbuild.yaml
@@ -98,20 +98,20 @@ steps:
         mkdir -p /root/pxf/servers/db-session-params/ && cp ./server/pxf-service/src/templates/templates/jdbc-site.xml /root/pxf/servers/db-session-params/
         mkdir -p /root/pxf/servers/db-hive/ && cp ./server/pxf-service/src/templates/templates/jdbc-site.xml /root/pxf/servers/db-hive/
         GPHD_ROOT=/tmp PXF_HOME=/tmp/pxf mvn -B -e -Dpxf.lib=/workspace/automation_tmp_lib -Dtest=HdfsSmokeTest -Djava.awt.headless=true -Dmaven.repo.local=/workspace/.m2/repository -f ./automation/pom.xml -U test || true 
-        # create pxf-tools directory and copy jars needed by pxf
-        mkdir -p pxf-tools
-        cp $(find . -name avro-tools*.jar) pxf-tools
+        # create regression-tools directory and copy jars needed by pxf
+        mkdir -p regression-tools
+        cp $(find . -name avro-tools*.jar) regression-tools
     waitFor: [ 'mvn-dev-build' ]
 
   # create a tarball with tools used by PXF, for example avro-tools
   - name: 'gcr.io/$PROJECT_ID/tar'
-    id: tar-pxf-tools
-    args: [ '-czf', 'pxf-tools.tar.gz', 'pxf-tools' ]
+    id: tar-regression-tools
+    args: [ '-czf', 'regression-tools.tar.gz', 'regression-tools' ]
     waitFor: [ 'mvn-test-build' ]
-  # Push the pxf-tools.tar.gz tarball to Google Cloud Storage
+  # Push the regression-tools.tar.gz tarball to Google Cloud Storage
   - name: 'gcr.io/cloud-builders/gsutil'
-    args: [ 'cp', '/workspace/pxf-tools.tar.gz', 'gs://${_PXF_BUILD_BUCKET}/regression-dependencies/pxf-tools.tar.gz' ]
-    waitFor: [ 'tar-pxf-tools' ]
+    args: [ 'cp', '/workspace/regression-tools.tar.gz', 'gs://${_PXF_BUILD_BUCKET}/regression-dependencies/regression-tools.tar.gz' ]
+    waitFor: [ 'tar-regression-tools' ]
 
   # create an updated tarball with automation dependencies and upload it
   - name: 'gcr.io/$PROJECT_ID/tar'

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -46,8 +46,8 @@ function inflate_dependencies() {
 		tarballs+=(pxf-automation-dependencies/pxf-automation-dependencies.tar.gz)
 		files_to_link+=(~gpadmin/.m2)
 	fi
-	if [[ -f pxf-tools/pxf-tools.tar.gz ]]; then
-		tarballs+=(pxf-tools/pxf-tools.tar.gz)
+	if [[ -f regression-tools/regression-tools.tar.gz ]]; then
+		tarballs+=(regression-tools/regression-tools.tar.gz)
 	fi
 	(( ${#tarballs[@]} == 0 )) && return
 	for t in "${tarballs[@]}"; do

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -43,8 +43,11 @@ function inflate_dependencies() {
 		files_to_link+=(~gpadmin/.{go-mod-cached-sources,gradle})
 	fi
 	if [[ -f pxf-automation-dependencies/pxf-automation-dependencies.tar.gz ]]; then
-		tarballs+=pxf-automation-dependencies/pxf-automation-dependencies.tar.gz
+		tarballs+=(pxf-automation-dependencies/pxf-automation-dependencies.tar.gz)
 		files_to_link+=(~gpadmin/.m2)
+	fi
+	if [[ -f pxf-tools/pxf-tools.tar.gz ]]; then
+		tarballs+=(pxf-tools/pxf-tools.tar.gz)
 	fi
 	(( ${#tarballs[@]} == 0 )) && return
 	for t in "${tarballs[@]}"; do


### PR DESCRIPTION
PXF regression tests require some tools, for example the avro tools jar,
to perform data preparation. We build the pxf-tools tarball and add all
the jars needed for data preparation, we then push it to the
dependencies bucket. This tarball can then be later consumed by the
regression test suite.