### PR TITLE
pxf-hive: properly escape strings in complex data types

### DIFF
--- a/automation/jsystem.properties
+++ b/automation/jsystem.properties
@@ -13,5 +13,5 @@ reporter.classes=jsystem.extensions.report.html.LevelHtmlTestReporter;jsystem.fr
 resources.src=/home/gpadmin/workspace/pxf/automation/src/main/resources
 sutClassName=jsystem.framework.sut.SutImpl
 sutFile=default.xml
-tests.dir=/home/gpadmin/workspace/pxf/automation/target/test-classes
+tests.dir=/Users/axue/workspace/pxf/automation/target/test-classes
 tests.src=/home/gpadmin/workspace/pxf/automation/src/main/java

--- a/automation/jsystem.properties
+++ b/automation/jsystem.properties
@@ -13,5 +13,5 @@ reporter.classes=jsystem.extensions.report.html.LevelHtmlTestReporter;jsystem.fr
 resources.src=/home/gpadmin/workspace/pxf/automation/src/main/resources
 sutClassName=jsystem.framework.sut.SutImpl
 sutFile=default.xml
-tests.dir=/Users/axue/workspace/pxf/automation/target/test-classes
+tests.dir=/home/gpadmin/workspace/pxf/automation/target/test-classes
 tests.src=/home/gpadmin/workspace/pxf/automation/src/main/java

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveBaseTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveBaseTest.java
@@ -229,6 +229,13 @@ public class HiveBaseTest extends BaseFeature {
             "dcm          DECIMAL(38,12)", // 1.0
             "ext_hive_par STRING"          // ext_hive_par_10
     };
+    // PXF Table columns for testing string escaping of complex types with nulls
+    static final String[] PXF_HIVE_NESTED_STRUCT_COLS = {
+            "t1    TEXT"
+    };
+    static final String[] HIVE_NESTED_STRUCT_COLS = {
+            "t1    STRUCT<field1:STRUCT<subfield1:STRING, subfield2:STRING>, field2:INT>"
+    };
 
     static final String HIVE_TYPES_DATA_FILE_NAME = "hive_types.txt";
     static final String HIVE_COLLECTIONS_FILE_NAME = "hive_collections.txt";
@@ -269,6 +276,8 @@ public class HiveBaseTest extends BaseFeature {
     static final String PXF_HIVE_HETEROGEN_TABLE = "pxf_hive_heterogen";
     static final String GPDB_SMALL_DATA_TABLE = "gpdb_small_data";
     static final String GPDB_HIVE_TYPES_TABLE = "gpdb_hive_types";
+    static final String HIVE_NESTED_STRUCT_TABLE = "hive_nested_struct";
+    static final String PXF_HIVE_NESTED_STRUCT_TABLE = "pxf_hive_nested_struct";
 
     static final String HIVE_SCHEMA = "userdb";
     static final String AVRO = "AVRO";
@@ -305,6 +314,7 @@ public class HiveBaseTest extends BaseFeature {
     HiveTable hiveNonDefaultSchemaTable;
     HiveTable hiveOpenCsvTable;
     Table comparisonDataTable;
+    HiveTable hiveNestedStructTable;
 
     String configuredNameNodeAddress;
     String hdfsBaseDir;

--- a/automation/tincrepo/main/pxf/features/hive/nested_struct/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hive/nested_struct/expected/query01.ans
@@ -1,0 +1,7 @@
+-- @description query01 for PXF Hive nested struct
+SELECT * FROM pxf_hive_nested_struct ORDER BY t1;
+                                              t1
+----------------------------------------------------------------------------------------------
+ {"field1":{"subfield1":"a really \"fancy\" string","subfield2":"test string"},"field2":1002}
+ {"field1":{"subfield1":null,"subfield2":"test string"},"field2":1002}
+(2 rows)

--- a/automation/tincrepo/main/pxf/features/hive/nested_struct/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hive/nested_struct/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLTestCase
+from mpp.models import SQLConcurrencyTestCase
+
+class PxfHiveNestedStruct(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hive/nested_struct/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/nested_struct/sql/query01.sql
@@ -1,0 +1,3 @@
+-- @description query01 for PXF Hive nested struct
+
+SELECT * FROM pxf_hive_nested_struct ORDER BY t1;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
@@ -612,6 +612,7 @@ public class HiveResolver extends BasePlugin implements Resolver {
             case STRING: {
                 val = (o != null) ? ((StringObjectInspector) oi).getPrimitiveJavaObject(o)
                         : null;
+                // for more complex types, we need to properly handle special characters by escaping the val
                 val = toFlatten
                         ? val != null ? String.format("\"%s\"", StringEscapeUtils.escapeJava(val.toString())) : "null"
                         : val;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
@@ -612,7 +612,9 @@ public class HiveResolver extends BasePlugin implements Resolver {
             case STRING: {
                 val = (o != null) ? ((StringObjectInspector) oi).getPrimitiveJavaObject(o)
                         : null;
-                val = toFlatten ? String.format("\"%s\"", StringEscapeUtils.escapeJava(val.toString())) : val;
+                val = toFlatten
+                        ? val != null ? String.format("\"%s\"", StringEscapeUtils.escapeJava(val.toString())) : "null"
+                        : val;
                 addOneFieldToRecord(record, DataType.TEXT, val);
                 break;
             }

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
@@ -20,6 +20,7 @@ package org.greenplum.pxf.plugins.hive;
  */
 
 import org.apache.commons.lang.CharUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -611,8 +612,8 @@ public class HiveResolver extends BasePlugin implements Resolver {
             case STRING: {
                 val = (o != null) ? ((StringObjectInspector) oi).getPrimitiveJavaObject(o)
                         : null;
-                addOneFieldToRecord(record, DataType.TEXT,
-                        toFlatten ? String.format("\"%s\"", val) : val);
+                val = toFlatten ? String.format("\"%s\"", StringEscapeUtils.escapeJava(val.toString())) : val;
+                addOneFieldToRecord(record, DataType.TEXT, val);
                 break;
             }
             case VARCHAR:

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveResolverTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveResolverTest.java
@@ -63,8 +63,8 @@ public class HiveResolverTest {
         properties.put("serialization.lib", SERDE_CLASS_NAME);
         properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_SIMPLE);
         properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_SIMPLE);
-        columnDescriptors.add(new ColumnDescriptor("name", DataType.TEXT.getOID(), 1, "text", null));
-        columnDescriptors.add(new ColumnDescriptor("amt", DataType.FLOAT8.getOID(), 3, "float8", null));
+        columnDescriptors.add(new ColumnDescriptor("name", DataType.TEXT.getOID(), 0, "text", null));
+        columnDescriptors.add(new ColumnDescriptor("amt", DataType.FLOAT8.getOID(), 1, "float8", null));
 
         ArrayWritable aw = new ArrayWritable(Text.class, new Writable[]{new Text("plain string"), new DoubleWritable(1000)});
         OneRow row = new OneRow(aw);
@@ -89,8 +89,8 @@ public class HiveResolverTest {
         properties.put("serialization.lib", SERDE_CLASS_NAME);
         properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_SIMPLE);
         properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_SIMPLE);
-        columnDescriptors.add(new ColumnDescriptor("name", DataType.TEXT.getOID(), 1, "text", null));
-        columnDescriptors.add(new ColumnDescriptor("amt", DataType.FLOAT8.getOID(), 3, "float8", null));
+        columnDescriptors.add(new ColumnDescriptor("name", DataType.TEXT.getOID(), 0, "text", null));
+        columnDescriptors.add(new ColumnDescriptor("amt", DataType.FLOAT8.getOID(), 1, "float8", null));
 
         ArrayWritable aw = new ArrayWritable(Text.class, new Writable[]{new Text("a really \"fancy\" string? *wink*"), new DoubleWritable(1000)});
         OneRow row = new OneRow(aw);
@@ -114,7 +114,7 @@ public class HiveResolverTest {
         properties.put("serialization.lib", SERDE_CLASS_NAME_STRUCT);
         properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_STRUCT);
         properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_STRUCT);
-        columnDescriptors.add(new ColumnDescriptor("address", DataType.TEXT.getOID(), 3, "struct", null));
+        columnDescriptors.add(new ColumnDescriptor("address", DataType.TEXT.getOID(), 0, "struct", null));
 
         OneRow row = new OneRow(0, new Text("plain string\u00021001"));
 
@@ -134,7 +134,7 @@ public class HiveResolverTest {
         properties.put("serialization.lib", SERDE_CLASS_NAME_STRUCT);
         properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_STRUCT);
         properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_STRUCT);
-        columnDescriptors.add(new ColumnDescriptor("address", DataType.TEXT.getOID(), 3, "struct", null));
+        columnDescriptors.add(new ColumnDescriptor("address", DataType.TEXT.getOID(), 0, "struct", null));
 
         OneRow row = new OneRow(0, new Text("a really \"fancy\" string\u00021001"));
 
@@ -154,7 +154,7 @@ public class HiveResolverTest {
         properties.put("serialization.lib", SERDE_CLASS_NAME_STRUCT);
         properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_NESTED_STRUCT);
         properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_NESTED_STRUCT);
-        columnDescriptors.add(new ColumnDescriptor("address", DataType.TEXT.getOID(), 3, "struct", null));
+        columnDescriptors.add(new ColumnDescriptor("address", DataType.TEXT.getOID(), 0, "struct", null));
 
         OneRow row = new OneRow(0, new Text("1000\u0003a really \"fancy\" string\u0002plain string\u00031001"));
 

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveResolverTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveResolverTest.java
@@ -1,0 +1,165 @@
+package org.greenplum.pxf.plugins.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.greenplum.pxf.api.io.DataType;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.api.OneField;
+import org.greenplum.pxf.api.OneRow;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+import org.greenplum.pxf.plugins.hive.utilities.HiveUtilities;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+@ExtendWith(MockitoExtension.class)
+public class HiveResolverTest {
+
+    @Mock
+    HiveUtilities mockHiveUtilities;
+
+    private static final String SERDE_CLASS_NAME = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe";
+    private static final String COL_NAMES_SIMPLE = "name,amt";
+    private static final String COL_TYPES_SIMPLE = "string:double";
+
+    private static final String SERDE_CLASS_NAME_STRUCT = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe";
+    private static final String COL_NAMES_STRUCT = "address";
+    private static final String COL_TYPES_STRUCT = "struct<street:string,zipcode:bigint>";
+    private static final String COL_NAMES_NESTED_STRUCT = "address";
+    private static final String COL_TYPES_NESTED_STRUCT = "struct<line1:struct<number:bigint,street_name:string>,line2:struct<city:string,zipcode:bigint>>";
+    Configuration configuration;
+    Properties properties;
+    List<ColumnDescriptor> columnDescriptors;
+    private HiveResolver resolver;
+    RequestContext context;
+    List<Integer> hiveIndexes;
+
+    @BeforeEach
+    public void setup() {
+        properties = new Properties();
+        configuration = new Configuration();
+        columnDescriptors = new ArrayList<>();
+        context = new RequestContext();
+        // metadata usually set in accessor
+        hiveIndexes = Arrays.asList(0, 1);
+    }
+
+    @Test
+    public void testSimpleString() throws Exception {
+
+        properties.put("serialization.lib", SERDE_CLASS_NAME);
+        properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_SIMPLE);
+        properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_SIMPLE);
+        columnDescriptors.add(new ColumnDescriptor("name", DataType.TEXT.getOID(), 1, "text", null));
+        columnDescriptors.add(new ColumnDescriptor("amt", DataType.FLOAT8.getOID(), 3, "float8", null));
+
+        ArrayWritable aw = new ArrayWritable(Text.class, new Writable[]{new Text("plain string\u00011000")});
+        OneRow row = new OneRow(aw);
+
+        context.setConfiguration(configuration);
+        context.setMetadata(new HiveMetadata(properties, null /*List<HivePartition>*/, hiveIndexes));
+        context.setTupleDescription(columnDescriptors);
+        resolver = new HiveResolver(mockHiveUtilities);
+        resolver.setRequestContext(context);
+        resolver.afterPropertiesSet();
+        List<OneField> output = resolver.getFields(row);
+
+        assertThat(output.get(0).toString(), is("plain string\u00011000"));
+    }
+
+    @Test
+    public void testSpecialCharString() throws Exception {
+
+        properties.put("serialization.lib", SERDE_CLASS_NAME);
+        properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_SIMPLE);
+        properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_SIMPLE);
+        columnDescriptors.add(new ColumnDescriptor("name", DataType.TEXT.getOID(), 1, "text", null));
+        columnDescriptors.add(new ColumnDescriptor("amt", DataType.FLOAT8.getOID(), 3, "float8", null));
+
+        ArrayWritable aw = new ArrayWritable(Text.class, new Writable[]{new Text("a really \"fancy\" string? *wink*\u00011000")});
+        OneRow row = new OneRow(aw);
+
+        context.setConfiguration(configuration);
+        context.setMetadata(new HiveMetadata(properties, null /*List<HivePartition>*/, hiveIndexes));
+        context.setTupleDescription(columnDescriptors);
+        resolver = new HiveResolver(mockHiveUtilities);
+        resolver.setRequestContext(context);
+        resolver.afterPropertiesSet();
+        List<OneField> output = resolver.getFields(row);
+
+        assertThat(output.get(0).toString(), is("a really \"fancy\" string? *wink*\u00011000"));
+    }
+
+    @Test
+    public void testStructSimpleString() throws Exception {
+        properties.put("serialization.lib", SERDE_CLASS_NAME_STRUCT);
+        properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_STRUCT);
+        properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_STRUCT);
+        columnDescriptors.add(new ColumnDescriptor("address", DataType.TEXT.getOID(), 3, "struct", null));
+
+        OneRow row = new OneRow(0, new Text("plain string\u00021001"));
+
+        context.setConfiguration(configuration);
+        context.setMetadata(new HiveMetadata(properties, null /*List<HivePartition>*/, hiveIndexes));
+        context.setTupleDescription(columnDescriptors);
+        resolver = new HiveResolver(mockHiveUtilities);
+        resolver.setRequestContext(context);
+        resolver.afterPropertiesSet();
+        List<OneField> output = resolver.getFields(row);
+
+        assertThat(output.get(0).toString(), is("{\"street\":\"plain string\",\"zipcode\":1001}"));
+    }
+
+    @Test
+    public void testStructSpecialCharString() throws Exception {
+        properties.put("serialization.lib", SERDE_CLASS_NAME_STRUCT);
+        properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_STRUCT);
+        properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_STRUCT);
+        columnDescriptors.add(new ColumnDescriptor("address", DataType.TEXT.getOID(), 3, "struct", null));
+
+        OneRow row = new OneRow(0, new Text("a really \"fancy\" string\u00021001"));
+
+        context.setConfiguration(configuration);
+        context.setMetadata(new HiveMetadata(properties, null /*List<HivePartition>*/, hiveIndexes));
+        context.setTupleDescription(columnDescriptors);
+        resolver = new HiveResolver(mockHiveUtilities);
+        resolver.setRequestContext(context);
+        resolver.afterPropertiesSet();
+        List<OneField> output = resolver.getFields(row);
+
+        assertThat(output.get(0).toString(), is("{\"street\":\"a really \\\"fancy\\\" string\",\"zipcode\":1001}"));
+    }
+
+    @Test
+    public void testNestedStruct() throws Exception {
+        properties.put("serialization.lib", SERDE_CLASS_NAME_STRUCT);
+        properties.put(serdeConstants.LIST_COLUMNS, COL_NAMES_NESTED_STRUCT);
+        properties.put(serdeConstants.LIST_COLUMN_TYPES, COL_TYPES_NESTED_STRUCT);
+        columnDescriptors.add(new ColumnDescriptor("address", DataType.TEXT.getOID(), 3, "struct", null));
+
+        OneRow row = new OneRow(0, new Text("1000\u0003a really \"fancy\" string\u0002plain string\u00031001"));
+
+        context.setConfiguration(configuration);
+        context.setMetadata(new HiveMetadata(properties, null /*List<HivePartition>*/, hiveIndexes));
+        context.setTupleDescription(columnDescriptors);
+        resolver = new HiveResolver(mockHiveUtilities);
+        resolver.setRequestContext(context);
+        resolver.afterPropertiesSet();
+        List<OneField> output = resolver.getFields(row);
+
+        assertThat(output.get(0).toString(), is("{\"line1\":{\"number\":1000,\"street_name\":\"a really \\\"fancy\\\" string\"},\"line2\":{\"city\":\"plain string\",\"zipcode\":1001}}"));
+    }
+}


### PR DESCRIPTION
Previously, strings inside complex data types such as structs were not being properly escaped by the HiveResolver. This led to improperly formatted data being returned by PXF. 

Now, when resolving STRING primitives, we escape the string of a complex data type.