### PR TITLE
Docs: Upgrade nokogiri to version 1.11.0.rc4 or later

### DIFF
--- a/docs/book/Gemfile.lock
+++ b/docs/book/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       middleman-livereload
       middleman-sprockets
       middleman-syntax (= 2.1.0)
-      nokogiri (= 1.10.8)
+      nokogiri (= 1.11.0.rc4)
       puma
       rack-rewrite
       redcarpet (~> 3.2.3)
@@ -157,7 +157,7 @@ GEM
     multi_json (1.14.1)
     multipart-post (2.0.0)
     nio4r (2.5.2)
-    nokogiri (1.10.8)
+    nokogiri (1.11.0.rc4)
       mini_portile2 (~> 2.3.0)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)


### PR DESCRIPTION
(CVE-2020-26247)[https://github.com/advisories/GHSA-vr8q-g5c7-m54m].