### PR TITLE
docs - add content for native orc read support, new xxx:orc profiles

### DIFF
--- a/docs/book/master_middleman/source/subnavs/pxf-subnav.erb
+++ b/docs/book/master_middleman/source/subnavs/pxf-subnav.erb
@@ -56,6 +56,7 @@
           <li><a href="/pxf/WIP/hdfs_text.html" format="markdown">Reading and Writing Text Data</a></li>
           <li><a href="/pxf/WIP/hdfs_avro.html" format="markdown">Reading and Writing Avro Data</a></li>
           <li><a href="/pxf/WIP/hdfs_json.html" format="markdown">Reading JSON Data</a></li>
+          <li><a href="/pxf/WIP/hdfs_orc.html" format="markdown">Reading ORC Data</a></li>
           <li><a href="/pxf/WIP/hdfs_parquet.html" format="markdown">Reading and Writing Parquet Data</a></li>
           <li><a href="/pxf/WIP/hdfs_seqfile.html" format="markdown">Reading and Writing SequenceFile Data</a></li>
           <li><a href="/pxf/WIP/hdfs_fileasrow.html" format="markdown">Reading a Multi-Line Text File into a Single Table Row</a></li>
@@ -70,12 +71,14 @@
           <li><a href="/pxf/WIP/objstore_text.html" format="markdown">Reading and Writing Text Data</a></li>
           <li><a href="/pxf/WIP/objstore_avro.html" format="markdown">Reading and Writing Avro Data</a></li>
           <li><a href="/pxf/WIP/objstore_json.html" format="markdown">Reading JSON Data</a></li>
+          <li><a href="/pxf/WIP/objstore_orc.html" format="markdown">Reading ORC Data</a></li>
           <li><a href="/pxf/WIP/objstore_parquet.html" format="markdown">Reading and Writing Parquet Data</a></li>
           <li><a href="/pxf/WIP/objstore_seqfile.html" format="markdown">Reading and Writing SequenceFile Data</a></li>
           <li><a href="/pxf/WIP/objstore_fileasrow.html" format="markdown">Reading a Multi-Line Text File into a Single Table Row</a></li>
           <li><a href="/pxf/WIP/read_s3_s3select.html" format="markdown">Reading CSV and Parquet Data From S3 Using S3 Select</a></li>
         </ul>
       </li>
+      <li><a href="/pxf/WIP/nfs_pxf.html" format="markdown">Accessing Files on a Network File System with PXF</a></li>
       <li><a href="/pxf/WIP/jdbc_pxf.html" format="markdown">Accessing an SQL Database with PXF (JDBC)</a></li>
       <li><a href="/pxf/WIP/troubleshooting_pxf.html" format="markdown">Troubleshooting PXF</a></li>
       <li class="has_submenu">

--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -109,6 +109,7 @@ The PXF Hadoop connectors expose the following profiles to read, and in many cas
 | HDFS | delimited [text with quoted linefeeds](hdfs_text.html#profile_textmulti) | hdfs:text:multi | n/a |
 | HDFS | [Avro](hdfs_avro.html) | hdfs:avro | n/a |
 | HDFS | [JSON](hdfs_json.html) | hdfs:json | n/a |
+| HDFS | [ORC](hdfs_orc.html) | hdfs:orc | n/a |
 | HDFS | [Parquet](hdfs_parquet.html) | hdfs:parquet | n/a |
 | HDFS | AvroSequenceFile | hdfs:AvroSequenceFile | n/a |
 | HDFS | [SequenceFile](hdfs_seqfile.html) | hdfs:SequenceFile | n/a |
@@ -120,7 +121,6 @@ The PXF Hadoop connectors expose the following profiles to read, and in many cas
 | [Hive](hive_pxf.html) | stored as Avro | hive | Hive |
 | [HBase](hbase_pxf.html) | Any | hbase | HBase |
 
-
 ### <a id="choose_profile"></a>Choosing the Profile
 
 PXF provides more than one profile to access text and Parquet data on Hadoop. Here are some things to consider as you determine which profile to choose.
@@ -131,6 +131,11 @@ Choose the `hive` profile when:
 - The data resides in a Hive table, and the Hive table is partitioned.
 
 Choose the `hdfs:text` profile when the file is text and you know the location of the file in the HDFS file system.
+
+When accessing ORC-format data:
+
+- Choose the `hdfs:orc` profile when the file is ORC, you know the location of the file in the HDFS file system, and the file is not managed by Hive or you do not want to use the Hive Metastore.
+- Choose the `hive:orc` profile when the table is ORC and the table is managed by Hive, and the data is partitioned or the data includes complex types.
 
 Choose the `hdfs:parquet` profile when the file is Parquet, you know the location of the file in the HDFS file system, and you want to take advantage of extended filter pushdown support for additional data types and operators.
 

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -39,6 +39,7 @@ The PXF object store connectors provide built-in profiles to support the followi
 - Text
 - Avro
 - JSON
+- ORC
 - Parquet
 - AvroSequenceFile
 - SequenceFile
@@ -51,6 +52,7 @@ The PXF connectors to Azure expose the following profiles to read, and in many c
 | delimited [text with quoted linefeeds](objstore_text.html) | wasbs:text:multi | adl:text:multi |
 | [Avro](objstore_avro.html) | wasbs:avro | adl:avro |
 | [JSON](objstore_json.html) | wasbs:json | adl:json |
+| [ORC](objstore_orc.html) | wasbs:orc | adl:orc |
 | [Parquet](objstore_parquet.html) | wasbs:parquet | adl:parquet |
 | AvroSequenceFile | wasbs:AvroSequenceFile | adl:AvroSequenceFile |
 | [SequenceFile](objstore_seqfile.html) | wasbs:SequenceFile | adl:SequenceFile |
@@ -63,6 +65,7 @@ Similarly, the PXF connectors to Google Cloud Storage, Minio, and S3 expose thes
 | delimited [text with quoted linefeeds](objstore_text.html) | gs:text:multi | s3:text:multi |
 | [Avro](objstore_avro.html) | gs:avro | s3:avro |
 | [JSON](objstore_json.html) | gs:json | s3:json |
+| [ORC](objstore_orc.html) | gs:orc | s3:orc |
 | [Parquet](objstore_parquet.html) | gs:parquet | s3:parquet |
 | AvroSequenceFile | gs:AvroSequenceFile | s3:AvroSequenceFile |
 | [SequenceFile](objstore_seqfile.html) | gs:SequenceFile | s3:SequenceFile |

--- a/docs/content/col_project.html.md.erb
+++ b/docs/content/col_project.html.md.erb
@@ -12,13 +12,13 @@ Column projection is automatically enabled for the `pxf` external table protocol
 |-------------|---------------|---------|
 | External SQL database | JDBC Connector | jdbc |
 | Hive | Hive Connector | hive (accessing tables stored as Text, Parquet, RCFile, and ORC), hive:rc, hive:orc |
-| Hadoop | HDFS Connector | hdfs:parquet |
-| Network File System | File Connector | file:parquet |
-| Amazon S3 | S3-Compatible Object Store Connectors | s3:parquet |
+| Hadoop | HDFS Connector | hdfs:orc, hdfs:parquet |
+| Network File System | File Connector | file:orc, file:parquet |
+| Amazon S3 | S3-Compatible Object Store Connectors | s3:orc, s3:parquet |
 | Amazon S3 using S3 Select | S3-Compatible Object Store Connectors | s3:parquet, s3:text |
-| Google Cloud Storage | GCS Object Store Connector | gs:parquet |
-| Azure Blob Storage | Azure Object Store Connector | wasbs:parquet |
-| Azure Data Lake | Azure Object Store Connector | adl:parquet |
+| Google Cloud Storage | GCS Object Store Connector | gs:orc, gs:parquet |
+| Azure Blob Storage | Azure Object Store Connector | wasbs:orc, wasbs:parquet |
+| Azure Data Lake | Azure Object Store Connector | adl:orc, adl:parquet |
 
 **Note:** PXF may disable column projection in cases where it cannot successfully serialize a query filter; for example, when the `WHERE` clause resolves to a `boolean` type.
 

--- a/docs/content/filter_push.html.md.erb
+++ b/docs/content/filter_push.html.md.erb
@@ -62,9 +62,11 @@ PXF accesses data sources using profiles exposed by different connectors, and fi
 | hive:rc | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | hive:orc | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | hive:orc and VECTORIZE=true | Y<sup>2</sup> |  N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
+| *:orc (all except hive:orc) | Y<sup>1,3</sup> | N | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> |
 
 </br><sup>1</sup>&nbsp;PXF applies the predicate, rather than the remote system, reducing CPU usage and the memory footprint.
 </br><sup>2</sup>&nbsp;PXF supports partition pruning based on partition keys.
+</br><sup>3</sup>&nbsp;PXF filtering is based on file-level, stripe-level, and row-level ORC statistics.
 
 PXF does not support filter pushdown for any profile not mentioned in the table above, including: *:avro, *:AvroSequenceFile, *:SequenceFile, *:json, *:text, and *:text:multi.
 
@@ -73,7 +75,7 @@ To summarize, all of the following criteria must be met for filter pushdown to o
 * You enable external table filter pushdown by setting the `gp_external_enable_filter_pushdown` server configuration parameter to `'on'`.
 * The Greenplum Database protocol that you use to access external data source must support filter pushdown. The `pxf` external table protocol supports pushdown.
 * The external data source that you are accessing must support pushdown. For example, HBase and Hive support pushdown.
-* For queries on external tables that you create with the `pxf` protocol, the underlying PXF connector must also support filter pushdown. For example, the PXF Hive, HBase, and JDBC connectors support pushdown, as do the PXF connectors that support reading Parquet data.
+* For queries on external tables that you create with the `pxf` protocol, the underlying PXF connector must also support filter pushdown. For example, the PXF Hive, HBase, and JDBC connectors support pushdown, as do the PXF connectors that support reading ORC and Parquet data.
 
     - Refer to Hive [Partition Pruning](hive_pxf.html#partitionfiltering) for more information about Hive support for this feature.
 

--- a/docs/content/hdfs_orc.html.md.erb
+++ b/docs/content/hdfs_orc.html.md.erb
@@ -1,0 +1,161 @@
+---
+title: Reading ORC Data
+---
+
+Use the PXF HDFS connector `hdfs:orc` profile to read ORC-format data when the data resides in a Hadoop file system. This section describes how to read HDFS files that are stored in ORC format, including how to create and query an external table that references these files in the HDFS data store.
+
+The `hdfs:orc` profile:
+
+- Reads 1024 rows of data at a time.
+- Supports column projection.
+- Supports filter pushdown based on file-level, stripe-level, and row-level ORC statistics.
+- Does not support complex types.
+
+The `hdfs:orc` profile currently supports reading scalar data types from ORC files. If the data resides in a Hive table, and you want to read complex types or the Hive table is partitioned, use the [`hive:orc`](hive_pxf.html#hive_orc) profile.
+
+
+## <a id="prereq"></a>Prerequisites
+
+Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq) before you attempt to read data from HDFS.
+
+
+## <a id="about_orc"></a>About the ORC Data Format
+
+The Optimized Row Columnar (ORC) file format is a columnar file format that provides a highly efficient way to both store and access HDFS data. ORC format offers improvements over text and RCFile formats in terms of both compression and performance. PXF supports ORC version 1.5.12.
+
+ORC is type-aware and specifically designed for Hadoop workloads. ORC files store both the type of, and encoding information for, the data in the file. All columns within a single group of row data (also known as stripe) are stored together on disk in ORC format files. The columnar nature of the ORC format type enables read projection, helping avoid accessing unnecessary columns during a query.
+
+ORC also supports predicate pushdown with built-in indexes at the file, stripe, and row levels, moving the filter operation to the data loading phase.
+
+Refer to the [Apache orc](https://orc.apache.org/docs/) documentation for detailed information about the ORC file format.
+
+
+## <a id="datatype_map"></a>Data Type Mapping
+
+To read ORC scalar data types in Greenplum Database, map ORC data values to Greenplum Database columns of the same type. PXF uses the following data type mapping when it reads ORC data:
+
+| ORC Physical Type | ORC Logical Type | PXF/Greenplum Data Type |
+|-------------------|---------------|--------------------------|
+| binary | decimal | Numeric |
+| binary | timestamp | Timestamp |
+| byte[] | string | Text |
+| byte[] | char | Bpchar |
+| byte[] | varchar | Varchar |
+| byte[] | binary | Bytea |
+| Double | float | Real |
+| Double | double | Float8 |
+| Integer | boolean (1 bit) | Boolean |
+| Integer | tinyint (8 bit) | Smallint |
+| Integer | smallint (16 bit) | Smallint |
+| Integer | int (32 bit) | Integer |
+| Integer | bigint (64 bit) | Bigint |
+| Integer | date | Date |
+
+
+## <a id="createexttbl"></a>Creating the External Table
+
+The PXF HDFS connector `hdfs:orc` profile supports reading ORC-format HDFS files. Use the following syntax to create a Greenplum Database external table that references a file or directory:
+
+``` sql
+CREATE EXTERNAL TABLE <table_name>
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<path-to-hdfs-file>
+    ?PROFILE=hdfs:orc[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import')
+```
+
+The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://gpdb.docs.pivotal.io/latest/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html) command are described below.
+
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<path&#8209;to&#8209;hdfs&#8209;file\>    | The path to the file or directory in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
+| PROFILE    | The `PROFILE` keyword must specify `hdfs:orc`. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
+| \<custom-option\>    | \<custom-option\>s are described below. |
+| FORMAT | Use `FORMAT 'CUSTOM'`; the `CUSTOM` format requires the built-in `pxfwritable_import` `formatter`.   |
+
+<a id="customopts"></a>
+The PXF `hdfs:orc` profile supports the following read options. You specify this option in the `LOCATION` clause:
+
+| Read Option  | Value Description |
+|-------|-------------------------------------|
+| IGNORE_MISSING_PATH | A Boolean value that specifies the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| MAP_BY_POSITION | A Boolean value that, when set to `true`, specifies that PXF should map an ORC column to a Greenplum Database column by position. The default value is `false`, PXF maps an ORC column to a Greenplum column by name. |
+
+
+## <a id="read_example"></a>Example: Reading an ORC File on HDFS
+
+This example operates on a simple data set that models a retail sales operation. The data includes fields with the following names and types:
+
+| Column Name  | Data Type |
+|--------------|---------------|
+| location | text |
+| month | text |
+| num\_orders | integer |
+| total\_sales | numeric(10,2) |
+
+In this example, you:
+
+- Create a sample data set in CSV format, use the `orc-tools` JAR utilities to convert the CSV file into an ORC-format file, and then copy the ORC file to HDFS.
+- Create a Greenplum Database readable external table that references the ORC file and that specifies the `hdfs:orc` profile.
+- Query the external table.
+
+You must have administrative privileges to both a Hadoop cluster and a Greenplum Database cluster to run the example. You must also have configured a PXF server to access Hadoop.
+
+
+Procedure:
+
+1. Create a CSV file named `sampledata.csv` in the `/tmp` directory:
+
+    ``` shell
+    hdfsclient$ echo 'Prague,Jan,101,4875.33
+Rome,Mar,87,1557.39
+Bangalore,May,317,8936.99
+Beijing,Jul,411,11600.67' > /tmp/sampledata.csv
+
+1. [Download](https://repo1.maven.org/maven2/org/apache/orc/orc-tools/1.6.2/orc-tools-1.6.2-uber.jar) the `orc-tools` JAR.
+
+1. Run the `orc-tools` `convert` command to convert `sampledata.csv` to the ORC file `/tmp/sampledata.orc`; provide the schema to the command:
+
+    ``` shell
+    hdfsclient$ java -jar orc-tools-1.6.2-uber.jar convert /tmp/sampledata.csv \
+      --schema 'struct<location:string,month:string,num_orders:int,total_sales:decimal(10,2)>' \
+      -o /tmp/sampledata.orc
+    ```
+
+1. Copy the ORC file to HDFS. The following command copies the file to the `/data/pxf_examples` directory:
+
+    ``` shell
+    hdfsclient$ hdfs dfs -put /tmp/sampledata.orc /data/pxf_examples/
+    ```
+
+1. Log in to the Greenplum Database master host and connect to a database. This command connects to the database named `testdb` as the `gpadmin` user:
+
+    ``` shell
+    gpadmin@gpmaster$ psql -d testdb
+    ```
+
+1. Create an external table named `sample_orc` that references the `/data/pxf_examples/sampledata.orc` file on HDFS. This command creates the table with the column names specified in the ORC schema, and uses the `default` PXF server:
+
+    ``` sql
+    testdb=# CREATE EXTERNAL TABLE sample_orc(location text, month text, num_orders int, total_sales numeric(10,2))
+               LOCATION ('pxf://data/pxf_examples/sampledata.orc?PROFILE=hdfs:orc')
+             FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+    ```
+
+1. Read the data in the file by querying the `sample_orc` table:
+
+    ``` sql
+    testdb=# SELECT * FROM sample_orc;
+    ```
+
+    ``` shell
+       location    | month | num_orders | total_sales 
+    ---------------+-------+------------+-------------
+     Prague        | Jan   |        101 |     4875.33
+     Rome          | Mar   |         87 |     1557.39
+     Bangalore     | May   |        317 |     8936.99
+     Beijing       | Jul   |        411 |    11600.67
+    (4 rows)
+    ```
+

--- a/docs/content/hdfs_orc.html.md.erb
+++ b/docs/content/hdfs_orc.html.md.erb
@@ -112,6 +112,7 @@ Procedure:
 Rome,Mar,87,1557.39
 Bangalore,May,317,8936.99
 Beijing,Jul,411,11600.67' > /tmp/sampledata.csv
+    ```
 
 1. [Download](https://repo1.maven.org/maven2/org/apache/orc/orc-tools/1.6.2/orc-tools-1.6.2-uber.jar) the `orc-tools` JAR.
 

--- a/docs/content/hdfs_orc.html.md.erb
+++ b/docs/content/hdfs_orc.html.md.erb
@@ -21,7 +21,7 @@ Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_
 
 ## <a id="about_orc"></a>About the ORC Data Format
 
-The Optimized Row Columnar (ORC) file format is a columnar file format that provides a highly efficient way to both store and access HDFS data. ORC format offers improvements over text and RCFile formats in terms of both compression and performance. PXF supports ORC version 1.5.12.
+The Optimized Row Columnar (ORC) file format is a columnar file format that provides a highly efficient way to both store and access HDFS data. ORC format offers improvements over text and RCFile formats in terms of both compression and performance. PXF supports ORC file versions v0 and v1.
 
 ORC is type-aware and specifically designed for Hadoop workloads. ORC files store both the type of, and encoding information for, the data in the file. All columns within a single group of row data (also known as stripe) are stored together on disk in ORC format files. The columnar nature of the ORC format type enables read projection, helping avoid accessing unnecessary columns during a query.
 

--- a/docs/content/nfs_pxf.html.md.erb
+++ b/docs/content/nfs_pxf.html.md.erb
@@ -10,6 +10,7 @@ You can use PXF to read data that resides on a network file system mounted on yo
 | delimited text with quoted linefeeds | file:text:multi | read |
 | Avro | file:avro | read, write |
 | JSON | file:json | read |
+| ORC | file:orc | read |
 | Parquet | file:parquet | read, write |
 
 PXF does not support user impersonation when you access a network file system. PXF accesses a file as the operating system user that started the PXF process, usually `gpadmin`.

--- a/docs/content/objstore_orc.html.md.erb
+++ b/docs/content/objstore_orc.html.md.erb
@@ -1,0 +1,89 @@
+---
+title: Reading ORC Data from an Object Store
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+The PXF object store connectors support reading ORC-format data. This section describes how to use PXF to access ORC data in an object store, including how to create and query an external table that references a file in the store.
+
+**Note**: Accessing ORC-format data from an object store is very similar to accessing ORC-format data in HDFS. This topic identifies object store-specific information required to read ORC data, and links to the [PXF Hadoop ORC documentation](hdfs_orc.html) where appropriate for common information.
+
+
+## <a id="prereq"></a>Prerequisites
+
+Ensure that you have met the PXF Object Store [Prerequisites](access_objstore.html#objstore_prereq) before you attempt to read data from an object store.
+
+
+## <a id="datatype_map"></a>Data Type Mapping
+
+Refer to [Data Type Mapping](hdfs_orc.html#datatype_map) in the PXF Hadoop ORC documentation for a description of the mapping between Greenplum Database and ORC data types.
+
+
+## <a id="orc_cet"></a>Creating the External Table
+
+Use the `<objstore>:orc` profile to read ORC-format files from an object store. PXF supports the following `<objstore>` profile prefixes:
+
+| Object Store  | Profile Prefix |
+|-------|------------------------|
+| Azure Blob Storage   | wasbs |
+| Azure Data Lake    | adl |
+| Google Cloud Storage    | gs |
+| Minio    | s3 |
+| S3    | s3 |
+
+The following syntax creates a Greenplum Database readable external table that references an ORC-format file:
+
+``` sql
+CREATE EXTERNAL TABLE <table_name>
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:orc&SERVER=<server_name>[&<custom-option>=<value>[...]]')
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+```
+
+The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://gpdb.docs.pivotal.io/latest/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<path&#8209;to&#8209;file\>    | The path to the directory or file in the object store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
+| PROFILE=\<objstore\>:orc    | The `PROFILE` keyword must identify the specific object store. For example, `s3:orc`. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
+| \<custom&#8209;option\>=\<value\> | ORC supports customs options as described in the [PXF Hadoop ORC documentation](hdfs_orc.html#customopts). |
+| FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `<objstore>:orc` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
+
+If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
+
+## <a id="example"></a>Example
+
+Refer to [Example: Reading an ORC File on HDFS](hdfs_orc.html#read_example) in the PXF Hadoop ORC documentation for an example. Modifications that you must make to run the example with an object store include:
+
+- Copying the file to the object store instead of HDFS. For example, to copy the file to S3:
+
+    ``` shell
+    $ aws s3 cp /tmp/sampledata.orc s3://BUCKET/pxf_examples/
+    ```
+
+- Using the `CREATE EXTERNAL TABLE` syntax and `LOCATION` keywords and settings described above. For example, if your server name is `s3srvcfg`:
+
+    ``` sql
+    CREATE EXTERNAL TABLE sample_orc( location TEXT, month TEXT, num_orders INTEGER, total_sales NUMERIC(10,2)
+      LOCATION('pxf://BUCKET/pxf_examples/sampledata.orc?PROFILE=s3:orc&SERVER=s3srvcfg')
+    FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+    ```
+

--- a/docs/content/objstore_orc.html.md.erb
+++ b/docs/content/objstore_orc.html.md.erb
@@ -2,25 +2,6 @@
 title: Reading ORC Data from an Object Store
 ---
 
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-
 The PXF object store connectors support reading ORC-format data. This section describes how to use PXF to access ORC data in an object store, including how to create and query an external table that references a file in the store.
 
 **Note**: Accessing ORC-format data from an object store is very similar to accessing ORC-format data in HDFS. This topic identifies object store-specific information required to read ORC data, and links to the [PXF Hadoop ORC documentation](hdfs_orc.html) where appropriate for common information.


### PR DESCRIPTION
doc changes for https://github.com/greenplum-db/pxf/pull/470

update the pxf docs for the new xxx:orc profiles.  in this PR:
- include new data format and profiles in some lists
- on hdfs landing page, add some verbage about when user would choose hdfs:orc vs hive:orc
- update column projection and filter pushdown topics (NOTE:  i plan to compare the tables/info with the recently-updated spreadsheet in a separate PR)
- add new topics "Reading ORC Data" and "Reading ORC Data from an Object Store".  follows pattern of previous profiles (objstore page xrefs to hdfs page).  add an example that creates a csv file, uses orc-tools to conver to orc, copy to hdfs, and create/query pxf external table

doc review site links:
- hdfs landing page:  http://docs-lisa-pxf6-nativeorc.cfapps.io/pxf/6-0/using/access_hdfs.html#hadoop_connectors
- hdfs orc topic:  http://docs-lisa-pxf6-nativeorc.cfapps.io/pxf/6-0/using/hdfs_orc.html
- objstore orc topic:  http://docs-lisa-pxf6-nativeorc.cfapps.io/pxf/6-0/using/objstore_orc.html