### PR TITLE
Add custom rule for HADOOP_SECURITY_AUTH_TO_LOCAL

### DIFF
--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
@@ -80,6 +80,9 @@ public class PxfUserGroupInformation {
             // create a new Subject to use for login, so that we can remember reference to Subject in LoginSession
             Subject subject = subjectProvider.get();
 
+            // set the configuration on the HadoopKerberosName
+            HadoopKerberosName.setConfiguration(configuration);
+
             // create login context with the given subject, using Kerberos principal and keytab filename; then login
             LoginContext login = loginContextProvider.newLoginContext(HadoopConfiguration.KEYTAB_KERBEROS_CONFIG_NAME,
                     subject, new HadoopConfiguration(principal, keytabFilename));

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseConfigurationFactory.java
@@ -18,6 +18,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTH_TO_LOCAL;
+
 @Component
 public class BaseConfigurationFactory implements ConfigurationFactory {
 
@@ -107,6 +109,14 @@ public class BaseConfigurationFactory implements ConfigurationFactory {
         } catch (NoSuchMethodError e) {
             // Expected exception for MapR
         }
+
+        // Starting with Hadoop 2.10.0, the "DEFAULT" rule will throw an
+        // exception when no rules are applied while getting the principal
+        // name translation into operating system user name. See
+        // org.apache.hadoop.security.authentication.util.KerberosName#getShortName
+        // We add a default rule that will return the service name as the
+        // short name, i.e. gpadmin/_HOST@REALM will map to gpadmin
+        configuration.set(HADOOP_SECURITY_AUTH_TO_LOCAL, "RULE:[1:$1] RULE:[2:$1] DEFAULT");
 
         return configuration;
     }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/SequenceFileAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/SequenceFileAccessor.java
@@ -23,6 +23,7 @@ package org.greenplum.pxf.plugins.hdfs;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FileContext;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.SequenceFile;
@@ -177,7 +178,8 @@ public class SequenceFileAccessor extends HdfsSplittableDataAccessor {
             // create writer - do not allow overwriting existing file
             writer = SequenceFile.createWriter(fc, configuration, file, keyClass,
                     valueClass, compressionType, codec,
-                    new SequenceFile.Metadata(), EnumSet.of(CreateFlag.CREATE));
+                    new SequenceFile.Metadata(), EnumSet.of(CreateFlag.CREATE),
+                    Options.CreateOpts.createParent());
         }
 
         try {


### PR DESCRIPTION
Starting with Hadoop 2.10.0, the "DEFAULT" rule will throw an exception
when no rules are applied while getting the principal name translation
into operating system user name. See
org.apache.hadoop.security.authentication.util.KerberosName#getShortName
We add a default rule that will return the service name as the short
name, i.e. gpadmin/_HOST@REALM will map to gpadmin.

The second commit fixes an issue with minio during write, when the parent
directory has not been created. We add the
`Options.CreateOpts.createParent()` option to make sure the parent directory
is created during write.