### PR TITLE
Fix different encoding when using LineRecordReader 

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
@@ -431,9 +431,16 @@ public class Hdfs extends BaseSystemObject implements IFSFunctionality {
     public void writeTableToFile(String destPath, Table dataTable,
                                  String delimiter, Charset encoding,
                                  CompressionCodec codec) throws Exception {
+        writeTableToFile(destPath, dataTable, delimiter, encoding, codec, "\n");
+    }
+
+    @Override
+    public void writeTableToFile(String destPath, Table dataTable,
+                                 String delimiter, Charset encoding,
+                                 CompressionCodec codec, String newLine) throws Exception {
 
         ReportUtils.startLevel(report, getClass(),
-                "Write Text File (Delimiter = '" + delimiter + "') to "
+                "Write Text File (Delimiter = '" + delimiter + "', NewLine = '" + newLine + "') to "
                         + destPath
                         + ((encoding != null) ? " encoding: " + encoding : ""));
 
@@ -445,7 +452,7 @@ public class Hdfs extends BaseSystemObject implements IFSFunctionality {
             dos = new DataOutputStream(codec.createOutputStream(out));
         }
 
-        writeTableToStream(dos, dataTable, delimiter, encoding);
+        writeTableToStream(dos, dataTable, delimiter, encoding, newLine);
         ReportUtils.stopLevel(report);
     }
 
@@ -462,12 +469,12 @@ public class Hdfs extends BaseSystemObject implements IFSFunctionality {
 
         FSDataOutputStream out = fs.append(getDatapath(pathToFile));
         out.writeBytes("\n"); // Need to start on a new line
-        writeTableToStream(out, dataTable, delimiter, encoding);
+        writeTableToStream(out, dataTable, delimiter, encoding, "\n");
         ReportUtils.stopLevel(report);
     }
 
     private void writeTableToStream(DataOutputStream stream, Table dataTable,
-                                    String delimiter, Charset encoding) throws Exception {
+                                    String delimiter, Charset encoding, String newLine) throws Exception {
         BufferedWriter bufferedWriter = new BufferedWriter(
                 new OutputStreamWriter(stream, encoding));
         List<List<String>> data = dataTable.getData();
@@ -482,7 +489,7 @@ public class Hdfs extends BaseSystemObject implements IFSFunctionality {
                 }
             }
             if (i != data.size() - 1) {
-                sBuilder.append("\n");
+                sBuilder.append(newLine);
             }
             bufferedWriter.append(sBuilder.toString());
             if (flushThreshold > ROW_BUFFER) {

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/IFSFunctionality.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/IFSFunctionality.java
@@ -85,7 +85,7 @@ public interface IFSFunctionality extends SystemObject {
      * @throws Exception
      */
     void writeTableToFile(String destPath, Table dataTable,
-                                 String delimiter) throws Exception;
+                          String delimiter) throws Exception;
 
     /***
      * Write Data Table to file using different encodings
@@ -114,6 +114,21 @@ public interface IFSFunctionality extends SystemObject {
                           Charset encoding, CompressionCodec codec) throws Exception;
 
     /**
+     * Write Data Table to file using different encodings and using different
+     * codecs
+     *
+     * @param destPath  destination file
+     * @param dataTable {@link Table} with List of data
+     * @param delimiter between fields
+     * @param encoding  to use to write the file
+     * @param codec     to use for compression, or null to disable compression
+     * @param newLine   CR, LF or CRLF
+     */
+    void writeTableToFile(String destPath, Table dataTable,
+                          String delimiter, Charset encoding,
+                          CompressionCodec codec, String newLine) throws Exception;
+
+    /**
      * Write Dequence Object to file
      *
      * @param writableData
@@ -135,7 +150,7 @@ public interface IFSFunctionality extends SystemObject {
      * @throws Exception
      */
     void writeAvroFile(String pathToFile, String schemaName,
-                              String codecName, IAvroSchema[] data)
+                       String codecName, IAvroSchema[] data)
             throws Exception;
 
     /**
@@ -144,14 +159,14 @@ public interface IFSFunctionality extends SystemObject {
      * file will be compressed using the given codecName. Supported types are
      * specified in {@code CodecFactory}.
      *
-     * @param pathToFile path to file in hdfs
-     * @param schemaName path to local schema file
+     * @param pathToFile   path to file in hdfs
+     * @param schemaName   path to local schema file
      * @param jsonFileName path to local data file
-     * @param codecName codec name
+     * @param codecName    codec name
      * @throws Exception
      */
     void writeAvroFileFromJson(String pathToFile, String schemaName,
-                                      String jsonFileName, String codecName)
+                               String jsonFileName, String codecName)
             throws Exception;
 
     /**
@@ -164,7 +179,7 @@ public interface IFSFunctionality extends SystemObject {
      * @throws Exception
      */
     void writeAvroInSequenceFile(String pathToFile, String schemaName,
-                                        IAvroSchema[] data) throws Exception;
+                                 IAvroSchema[] data) throws Exception;
 
     /**
      * @return Replication Size
@@ -208,7 +223,7 @@ public interface IFSFunctionality extends SystemObject {
      * @throws Exception
      */
     void writeProtocolBufferFile(String filePath,
-                                        com.google.protobuf.GeneratedMessage generatedMessages)
+                                 com.google.protobuf.GeneratedMessage generatedMessages)
             throws Exception;
 
     boolean doesFileExist(String pathToFile) throws Exception;

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ExternalTable.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ExternalTable.java
@@ -33,6 +33,8 @@ public abstract class ExternalTable extends Table {
 
     private String escape;
 
+    private String newLine;
+
     private String[] userParameters;
 
     private String server;
@@ -184,9 +186,10 @@ public abstract class ExternalTable extends Table {
             createStatment += " (formatter='" + getFormatter() + "')";
         }
 
-        boolean hasDelimiterOrEscape = getDelimiter() != null || getEscape() != null;
+        boolean hasDelimiterOrEscapeOrNewLine =
+                getDelimiter() != null || getEscape() != null || getNewLine() != null;
 
-        if (hasDelimiterOrEscape) {
+        if (hasDelimiterOrEscapeOrNewLine) {
             createStatment += " (";
         }
 
@@ -210,7 +213,13 @@ public abstract class ExternalTable extends Table {
             createStatment += " ESCAPE " + parsedEscapeCharacter;
         }
 
-        if (hasDelimiterOrEscape) {
+        if (getNewLine() != null) {
+
+            String newLineCharacter = getNewLine();
+            createStatment += " NEWLINE '" + newLineCharacter + "'";
+        }
+
+        if (hasDelimiterOrEscapeOrNewLine) {
             createStatment += ")";
         }
 
@@ -261,6 +270,14 @@ public abstract class ExternalTable extends Table {
 
     public void setEscape(String escape) {
         this.escape = escape;
+    }
+
+    public void setNewLine(String newLine) {
+        this.newLine = newLine;
+    }
+
+    public String getNewLine() {
+        return newLine;
     }
 
     public String getProfile() {

--- a/automation/src/main/java/org/greenplum/pxf/automation/utils/csv/CsvUtils.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/utils/csv/CsvUtils.java
@@ -58,7 +58,7 @@ public abstract class CsvUtils {
 			throws IOException {
 
 		// create CsvWriter using FileWriter
-		CSVWriter csvWriter = new CSVWriter(new FileWriter(new File(targetCsvFile)));
+		CSVWriter csvWriter = new CSVWriter(new FileWriter(targetCsvFile));
 
 		try {
 			// go over list and write each inner list to csv file

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hdfs/HdfsReadableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hdfs/HdfsReadableTextTest.java
@@ -34,6 +34,8 @@ import static org.greenplum.pxf.automation.features.tpch.LineItem.LINEITEM_SCHEM
  */
 public class HdfsReadableTextTest extends BaseFeature {
 
+    private static final String SUFFIX_CLASS = ".class";
+
     public static final String[] SMALL_DATA_FIELDS = {
             "name text",
             "num integer",
@@ -49,10 +51,6 @@ public class HdfsReadableTextTest extends BaseFeature {
     // path for storing data on HDFS
     String hdfsFilePath = "";
 
-    private String resourcePath;
-
-    private final String SUFFIX_CLASS = ".class";
-
     String testPackageLocation = "/org/greenplum/pxf/automation/testplugin/";
     String testPackage = "org.greenplum.pxf.automation.testplugin.";
 
@@ -64,7 +62,7 @@ public class HdfsReadableTextTest extends BaseFeature {
     @Override
     public void beforeClass() throws Exception {
         // location of test plugin files
-        resourcePath = "target/classes" + testPackageLocation;
+        String resourcePath = "target/classes" + testPackageLocation;
 
         String newPath = "/tmp/publicstage/pxf";
         // copy additional plugins classes to cluster nodes, used for filter
@@ -84,8 +82,6 @@ public class HdfsReadableTextTest extends BaseFeature {
      * Before every method determine default hdfs data Path, default data, and
      * default external table structure. Each case change it according to it
      * needs.
-     *
-     * @throws Exception
      */
     @Override
     protected void beforeMethod() throws Exception {
@@ -130,8 +126,6 @@ public class HdfsReadableTextTest extends BaseFeature {
     /**
      * Read delimited text file from HDFS using explicit plugins and TEXT
      * format.
-     *
-     * @throws Exception
      */
     @Test(groups = {"features", "sanity", "gpdb", "security"})
     public void readDelimitedTextUsingTextFormat() throws Exception {
@@ -150,8 +144,6 @@ public class HdfsReadableTextTest extends BaseFeature {
 
     /**
      * Read quoted CSV file from HDFS using explicit plugins and CSV format.
-     *
-     * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "security"})
     public void readCsvUsingCsvFormat() throws Exception {
@@ -172,10 +164,7 @@ public class HdfsReadableTextTest extends BaseFeature {
     }
 
     /**
-     * Read quoted CSV file from HDFS using *:text profile and CSV
-     * format.
-     *
-     * @throws Exception
+     * Read quoted CSV file from HDFS using *:text profile and CSV format.
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
     public void readCsvUsingProfile() throws Exception {
@@ -253,10 +242,7 @@ public class HdfsReadableTextTest extends BaseFeature {
     }
 
     /**
-     * Create multi lined CSV data, use
-     * QuotedLineBreakAccessor to read.
-     *
-     * @throws Exception
+     * Create multi lined CSV data, use QuotedLineBreakAccessor to read.
      */
     @Test(groups = {"features", "gpdb", "security"})
     public void readMultiBlockedMultiLinedCsv() throws Exception {
@@ -267,8 +253,6 @@ public class HdfsReadableTextTest extends BaseFeature {
     /**
      * Create multi lined CSV data, use HdfsTextMulti pxf
      * profile to read.
-     *
-     * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
     public void readMultiBlockedMultiLinedCsvUsingProfile() throws Exception {
@@ -279,8 +263,6 @@ public class HdfsReadableTextTest extends BaseFeature {
     /**
      * Create multi lined CSV data, use HdfsTextMulti pxf
      * profile to read.
-     *
-     * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
     public void readMultiBlockedMultiLinedCsvWildcardLocation() throws Exception {
@@ -322,8 +304,6 @@ public class HdfsReadableTextTest extends BaseFeature {
     /**
      * Create 2 files located under the same HDFS directory and read it using
      * wildcard
-     *
-     * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
     public void wildcardLocation() throws Exception {
@@ -350,8 +330,6 @@ public class HdfsReadableTextTest extends BaseFeature {
      * Create "recursive" directory structure in HDFS, copy files to different
      * directories, read all data by specifying parent directory as the
      * location.
-     *
-     * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
     public void recursiveHdfsDirectories() throws Exception {
@@ -377,8 +355,6 @@ public class HdfsReadableTextTest extends BaseFeature {
 
     /**
      * Create empty file in HDFS and read it.
-     *
-     * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
     public void emptyTextFile() throws Exception {
@@ -396,16 +372,13 @@ public class HdfsReadableTextTest extends BaseFeature {
     /**
      * Create HDFS text file using "ISO_8859_1" encoding, define external table
      * with same encoding (called LATIN1 in gpdb) and read data.
-     *
-     * @throws Exception
      */
-    @Test(groups = {"features"})//, "gpdb", "hcfs" })
+    @Test(groups = {"features", "gpdb", "hcfs", "security"})
     public void differentEncoding() throws Exception {
+        ProtocolEnum protocol = ProtocolUtils.getProtocol();
         // define and create external table
         exTable.setFields(new String[]{"num1 int", "word text"});
-        exTable.setFragmenter("org.greenplum.pxf.plugins.hdfs.HdfsDataFragmenter");
-        exTable.setAccessor("org.greenplum.pxf.plugins.hdfs.LineBreakAccessor");
-        exTable.setResolver("org.greenplum.pxf.plugins.hdfs.StringPassResolver");
+        exTable.setProfile(protocol.value() + ":text");
         exTable.setDelimiter(",");
         exTable.setEncoding("LATIN1");
         gpdb.createTableAndVerify(exTable);
@@ -468,8 +441,6 @@ public class HdfsReadableTextTest extends BaseFeature {
      * pxf_enable_stat_collection=false to see default values, and than with
      * pxf_enable_stat_collection=true to see estimates results written to
      * pg_class table.
-     *
-     * @throws Exception
      */
     @Test(groups = "features")
     public void analyze() throws Exception {
@@ -522,8 +493,6 @@ public class HdfsReadableTextTest extends BaseFeature {
      * a case when the errors breach the limit. It also tests the cleanup of
      * segwork and metadata information in the filename parameter (the pxf URI)
      * in the error table (GPSQL-1708).
-     *
-     * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
     public void errorTable() throws Exception {

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/mixed_newline_char/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/mixed_newline_char/expected/query01.ans
@@ -1,0 +1,69 @@
+-- start_ignore
+-- end_ignore
+-- @description query01 for PXF HDFS Readable newline character
+-- Display on for output consistency between GPDB 5 and 6
+\x on
+Expanded display is on.
+\pset format unaligned
+Output format is unaligned.
+SELECT * from pxf_newline_char;
+name|newline_row_1
+a
+num|1
+dub|1
+longnum|100000000000
+bool|f
+
+name|newline_row_2
+num|2
+dub|2
+longnum|200000000000
+bool|t
+
+name|newline_row_3
+num|3
+dub|3
+longnum|300000000000
+bool|f
+
+name|newline_row_4
+num|4
+dub|4
+longnum|400000000000
+bool|t
+
+name|newline_row_5
+num|5
+dub|5
+longnum|500000000000
+bool|f
+
+name|newline_row_6
+num|6
+dub|6
+longnum|600000000000
+bool|t
+
+name|newline_row_7
+num|7
+dub|7
+longnum|700000000000
+bool|f
+
+name|newline_row_8
+num|8
+dub|8
+longnum|800000000000
+bool|t
+
+name|newline_row_9
+num|9
+dub|9
+longnum|900000000000
+bool|f
+
+name|newline_row_10
+num|10
+dub|10
+longnum|1000000000000
+bool|t

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/mixed_newline_char/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/mixed_newline_char/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLTestCase
+from mpp.models import SQLConcurrencyTestCase
+
+class PxfHdfsMixedNewLineChar(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/mixed_newline_char/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/mixed_newline_char/sql/query01.sql
@@ -1,0 +1,6 @@
+-- @description query01 for PXF HDFS Readable newline character
+
+-- Display on for output consistency between GPDB 5 and 6
+\x on
+\pset format unaligned
+SELECT * from pxf_newline_char;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/newline_char/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/newline_char/expected/query01.ans
@@ -1,0 +1,17 @@
+-- start_ignore
+-- end_ignore
+-- @description query01 for PXF HDFS Readable newline character
+SELECT * from pxf_newline_char;
+      name      | num | dub |    longnum    | bool 
+----------------+-----+-----+---------------+------
+ newline_row_1  |   1 |   1 |  100000000000 | f
+ newline_row_2  |   2 |   2 |  200000000000 | t
+ newline_row_3  |   3 |   3 |  300000000000 | f
+ newline_row_4  |   4 |   4 |  400000000000 | t
+ newline_row_5  |   5 |   5 |  500000000000 | f
+ newline_row_6  |   6 |   6 |  600000000000 | t
+ newline_row_7  |   7 |   7 |  700000000000 | f
+ newline_row_8  |   8 |   8 |  800000000000 | t
+ newline_row_9  |   9 |   9 |  900000000000 | f
+ newline_row_10 |  10 |  10 | 1000000000000 | t
+(10 rows)

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/newline_char/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/newline_char/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLTestCase
+from mpp.models import SQLConcurrencyTestCase
+
+class PxfHdfsNewLineChar(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/newline_char/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/newline_char/sql/query01.sql
@@ -1,0 +1,3 @@
+-- @description query01 for PXF HDFS Readable newline character
+
+SELECT * from pxf_newline_char;

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/BufferWritable.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/BufferWritable.java
@@ -8,9 +8,9 @@ package org.greenplum.pxf.api.io;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -31,7 +31,8 @@ import java.lang.UnsupportedOperationException;
  */
 public class BufferWritable implements Writable {
 
-    byte[] buf = null;
+    byte[] buf;
+    int length;
 
     /**
      * Constructs a BufferWritable. Copies the buffer reference and not the
@@ -39,10 +40,25 @@ public class BufferWritable implements Writable {
      * through the Bridge framework without copying the data each time the
      * buffer is passed between the Bridge objects.
      *
-     * @param inBuf buffer
+     * @param inBuf buffer reference
      */
     public BufferWritable(byte[] inBuf) {
-        buf = inBuf;
+        this(inBuf, inBuf.length);
+    }
+
+    /**
+     * Constructs a BufferWritable. Copies the buffer reference (not the
+     * actual bytes) and the length of bytes.
+     * This class is used when we intend to transport a buffer through the
+     * Bridge framework without copying the data each time the buffer is passed
+     * between the Bridge objects.
+     *
+     * @param inBuf  buffer reference
+     * @param length the length of data within the buffer
+     */
+    public BufferWritable(byte[] inBuf, int length) {
+        this.buf = inBuf;
+        this.length = length;
     }
 
     /**
@@ -55,7 +71,7 @@ public class BufferWritable implements Writable {
     public void write(DataOutput out) throws IOException {
         if (buf == null)
             throw new IOException("BufferWritable was not set");
-        out.write(buf);
+        out.write(buf, 0, length);
     }
 
     /**
@@ -84,6 +100,7 @@ public class BufferWritable implements Writable {
     public void append(byte[] app) {
         if (buf == null) {
             buf = app;
+            length = buf.length;
             return;
         }
         if (app == null) {
@@ -94,5 +111,6 @@ public class BufferWritable implements Writable {
         System.arraycopy(buf, 0, newbuf, 0, buf.length);
         System.arraycopy(app, 0, newbuf, buf.length, app.length);
         buf = newbuf;
+        length = newbuf.length;
     }
 }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/GreenplumCSV.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/GreenplumCSV.java
@@ -139,11 +139,29 @@ public class GreenplumCSV {
             // Greenplum only supports LF (Line feed, 0x0A), CR
             // (Carriage return, 0x0D), or CRLF (Carriage return plus line
             // feed, 0x0D 0x0A) as newline characters
-            if (newline.equals("\n") || newline.equals("\r") || newline.equals("\r\n")) {
-                this.newline = newline;
-            } else {
-                throw new IllegalArgumentException(String.format(
-                        "invalid newline character '%s'. Only LF, CR, or CRLF are supported for newline.", newline));
+
+            switch (newline.toLowerCase()) {
+                case "cr":
+                    this.newline = "\r";
+                    break;
+
+                case "lf":
+                    this.newline = "\n";
+                    break;
+
+                case "crlf":
+                    this.newline = "\r\n";
+                    break;
+
+                case "\n":
+                case "\r":
+                case "\r\n":
+                    this.newline = newline;
+                    break;
+
+                default:
+                    throw new IllegalArgumentException(String.format(
+                            "invalid newline character '%s'. Only LF, CR, or CRLF are supported for newline.", newline));
             }
         }
         this.newlineLength = newline != null ? newline.length() : 0;

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/GreenplumCSVTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/GreenplumCSVTest.java
@@ -258,6 +258,12 @@ public class GreenplumCSVTest {
         assertEquals("\r", gpCSV.getNewline());
         gpCSV.withNewline("\r\n");
         assertEquals("\r\n", gpCSV.getNewline());
+        gpCSV.withNewline("LF");
+        assertEquals("\n", gpCSV.getNewline());
+        gpCSV.withNewline("CR");
+        assertEquals("\r", gpCSV.getNewline());
+        gpCSV.withNewline("CRLF");
+        assertEquals("\r\n", gpCSV.getNewline());
     }
 
     @Test

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -37,6 +37,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A PXF Accessor for reading delimited plain text records.
@@ -83,7 +84,8 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
                 LOG.debug("Failed to use ChunkRecordReader, falling back to LineRecordReader : " + e.getMessage());
             }
         }
-        return new LineRecordReader(jobConf, (FileSplit) split);
+        return new LineRecordReader(jobConf, (FileSplit) split,
+                context.getGreenplumCSV().getNewline().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/StringPassResolver.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/StringPassResolver.java
@@ -62,7 +62,7 @@ public class StringPassResolver extends BasePlugin implements Resolver {
         if (data instanceof ChunkWritable) {
             record.add(new OneField(BYTEA.getOID(), ((ChunkWritable) data).box));
         } else {
-            record.add(new OneField(VARCHAR.getOID(), data.toString()));
+            record.add(new OneField(VARCHAR.getOID(), data));
         }
         return record;
     }

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsDataFragmenterTest.java
@@ -39,7 +39,7 @@ public class HdfsDataFragmenterTest {
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
         // empty.csv gets ignored
-        assertEquals(7, fragmentList.size());
+        assertEquals(8, fragmentList.size());
     }
 
     @Test
@@ -55,7 +55,7 @@ public class HdfsDataFragmenterTest {
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
         // empty.csv gets ignored
-        assertEquals(7, fragmentList.size());
+        assertEquals(8, fragmentList.size());
     }
 
     @Test

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenterTest.java
@@ -55,7 +55,7 @@ public class HdfsFileFragmenterTest {
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        assertEquals(8, fragmentList.size());
+        assertEquals(9, fragmentList.size());
     }
 
     @Test
@@ -70,7 +70,7 @@ public class HdfsFileFragmenterTest {
 
         List<Fragment> fragmentList = fragmenter.getFragments();
         assertNotNull(fragmentList);
-        assertEquals(8, fragmentList.size());
+        assertEquals(9, fragmentList.size());
     }
 
     @Test

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessorTest.java
@@ -126,6 +126,29 @@ public class LineBreakAccessorTest {
     }
 
     @Test
+    public void testMixedNewLineCharacters() throws Exception {
+        prepareTest("csv/csv_with_mixed_new_lines.csv");
+        context.getGreenplumCSV().withNewline("\r");
+
+        accessor.setRequestContext(context);
+        accessor.afterPropertiesSet();
+        accessor.openForRead();
+
+        OneRow oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("this,\nfile", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNotNull(oneRow);
+        assertEquals("has,line feeds\n", oneRow.getData().toString());
+
+        oneRow = accessor.readNextObject();
+        assertNull(oneRow);
+
+        accessor.closeForRead();
+    }
+
+    @Test
     public void testSkipHeaderCountIsNotANumber() {
         context.setDataSource("/foo");
         context.addOption("SKIP_HEADER_COUNT", "foo");

--- a/server/pxf-hdfs/src/test/resources/csv/csv_with_mixed_new_lines.csv
+++ b/server/pxf-hdfs/src/test/resources/csv/csv_with_mixed_new_lines.csv
@@ -1,0 +1,2 @@
+this,
+filehas,line feeds

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/BridgeOutputBuilder.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/BridgeOutputBuilder.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -61,16 +62,16 @@ public class BridgeOutputBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(BridgeOutputBuilder.class);
 
     private static final byte DELIM = 10; /* (byte)'\n'; */
-    private RequestContext context;
+    private final String newLine;
+    private final byte[] newLineBytes;
     private Writable output = null;
-    private LinkedList<Writable> outputList;
+    private final LinkedList<Writable> outputList;
     private Writable partialLine = null;
     private GPDBWritable errorRecord = null;
     private int[] schema;
     private String[] colNames;
-    private boolean samplingEnabled;
-    private boolean isPartialLine = false;
-    private GreenplumCSV greenplumCSV;
+    private final boolean samplingEnabled;
+    private final GreenplumCSV greenplumCSV;
     private final OutputFormat outputFormat;
     private final List<ColumnDescriptor> columnDescriptors;
 
@@ -81,13 +82,14 @@ public class BridgeOutputBuilder {
      *                information
      */
     public BridgeOutputBuilder(RequestContext context) {
-        this.context = context;
         columnDescriptors = context.getTupleDescription();
         greenplumCSV = context.getGreenplumCSV();
+        newLine = context.getGreenplumCSV().getNewline();
+        newLineBytes = newLine.getBytes(StandardCharsets.UTF_8);
         outputFormat = context.getOutputFormat();
         outputList = new LinkedList<>();
         makeErrorRecord();
-        samplingEnabled = (this.context.getStatsSampleRatio() > 0);
+        samplingEnabled = (context.getStatsSampleRatio() > 0);
     }
 
     /**
@@ -130,7 +132,7 @@ public class BridgeOutputBuilder {
             return new Text(
                     StringUtils.repeat(String.valueOf(greenplumCSV.getDelimiter()), columnDescriptors.size()) +
                             greenplumCSV.toCsvField(ex.getMessage(), true, true, true) +
-                            greenplumCSV.getNewline());
+                            newLine);
         }
     }
 
@@ -305,10 +307,20 @@ public class BridgeOutputBuilder {
                 output = new BufferWritable((byte[]) val);
             }
         } else {
-            String textRec = (recFields.size() == 1 && val instanceof String) ?
-                    val + greenplumCSV.getNewline() :
-                    fieldListToCSVString(recFields);
-            output = new Text(textRec);
+
+            if (recFields.size() == 1 && val instanceof org.apache.hadoop.io.Text) {
+                org.apache.hadoop.io.Text text = (org.apache.hadoop.io.Text) val;
+                text.append(newLineBytes, 0, newLineBytes.length);
+
+                // Note that text.getLength() might be different from the size
+                // of the underlying byte[] used by Text.
+                // text.getBytes().length not necessarily equals to text.getLength()
+                output = new BufferWritable(text.getBytes(), text.getLength());
+            } else if (recFields.size() == 1 && val instanceof String) {
+                output = new Text(val + newLine);
+            } else {
+                output = new Text(fieldListToCSVString(recFields));
+            }
         }
 
         outputList.add(output);
@@ -330,12 +342,13 @@ public class BridgeOutputBuilder {
     void convertTextDataToLines(byte[] val) {
         int len = val.length;
         int start = 0;
-        int end = 0;
+        int end;
         byte[] line;
         BufferWritable writable;
 
         while (start < len) {
             end = ArrayUtils.indexOf(val, DELIM, start);
+            boolean isPartialLine;
             if (end == ArrayUtils.INDEX_NOT_FOUND) {
                 // data finished in the middle of the line
                 end = len;
@@ -450,6 +463,6 @@ public class BridgeOutputBuilder {
                     else
                         return greenplumCSV.toCsvField((String) field.val, true, true, true);
                 })
-                .collect(Collectors.joining(String.valueOf(greenplumCSV.getDelimiter()), "", greenplumCSV.getNewline()));
+                .collect(Collectors.joining(String.valueOf(greenplumCSV.getDelimiter()), "", newLine));
     }
 }

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/BridgeOutputBuilderTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/BridgeOutputBuilderTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -232,6 +233,61 @@ public class BridgeOutputBuilderTest {
                 () -> builder.fillGPDBWritable(complete),
                 "testRecordBiggerThanSchema should have failed on - Record has 5 fields but the schema size is 4");
         assertEquals("Record has 5 fields but the schema size is 4", e.getMessage());
+    }
+
+    @Test
+    public void testLineBreakInDifferentEncodings() {
+        String lf = "\n";
+        String cr = "\r";
+        String crlf = "\r\n";
+
+        byte[] lfBytes = {10};
+        byte[] crBytes = {13};
+        byte[] crlfBytes = {13, 10};
+
+        assertArrayEquals(lfBytes, lf.getBytes());
+        assertArrayEquals(crBytes, cr.getBytes());
+        assertArrayEquals(crlfBytes, crlf.getBytes());
+
+        assertArrayEquals(lfBytes, lf.getBytes(StandardCharsets.UTF_8));
+        assertArrayEquals(crBytes, cr.getBytes(StandardCharsets.UTF_8));
+        assertArrayEquals(crlfBytes, crlf.getBytes(StandardCharsets.UTF_8));
+
+        assertArrayEquals(lfBytes, lf.getBytes(StandardCharsets.ISO_8859_1));
+        assertArrayEquals(crBytes, cr.getBytes(StandardCharsets.ISO_8859_1));
+        assertArrayEquals(crlfBytes, crlf.getBytes(StandardCharsets.ISO_8859_1));
+
+        assertArrayEquals(lfBytes, lf.getBytes(Charset.forName("windows-1251")));
+        assertArrayEquals(crBytes, cr.getBytes(Charset.forName("windows-1251")));
+        assertArrayEquals(crlfBytes, crlf.getBytes(Charset.forName("windows-1251")));
+
+        assertArrayEquals(lfBytes, lf.getBytes(Charset.forName("Big5")));
+        assertArrayEquals(crBytes, cr.getBytes(Charset.forName("Big5")));
+        assertArrayEquals(crlfBytes, crlf.getBytes(Charset.forName("Big5")));
+
+        assertArrayEquals(lfBytes, lf.getBytes(Charset.forName("GB18030")));
+        assertArrayEquals(crBytes, cr.getBytes(Charset.forName("GB18030")));
+        assertArrayEquals(crlfBytes, crlf.getBytes(Charset.forName("GB18030")));
+
+        assertArrayEquals(lfBytes, lf.getBytes(Charset.forName("MS936")));
+        assertArrayEquals(crBytes, cr.getBytes(Charset.forName("MS936")));
+        assertArrayEquals(crlfBytes, crlf.getBytes(Charset.forName("MS936")));
+
+        assertArrayEquals(lfBytes, lf.getBytes(Charset.forName("Windows-932")));
+        assertArrayEquals(crBytes, cr.getBytes(Charset.forName("Windows-932")));
+        assertArrayEquals(crlfBytes, crlf.getBytes(Charset.forName("Windows-932")));
+
+        assertArrayEquals(lfBytes, lf.getBytes(Charset.forName("KOI8")));
+        assertArrayEquals(crBytes, cr.getBytes(Charset.forName("KOI8")));
+        assertArrayEquals(crlfBytes, crlf.getBytes(Charset.forName("KOI8")));
+
+        assertArrayEquals(lfBytes, lf.getBytes(Charset.forName("Windows-949")));
+        assertArrayEquals(crBytes, cr.getBytes(Charset.forName("Windows-949")));
+        assertArrayEquals(crlfBytes, crlf.getBytes(Charset.forName("Windows-949")));
+
+        assertArrayEquals(lfBytes, lf.getBytes(Charset.forName("Cyrillic")));
+        assertArrayEquals(crBytes, cr.getBytes(Charset.forName("Cyrillic")));
+        assertArrayEquals(crlfBytes, crlf.getBytes(Charset.forName("Cyrillic")));
     }
 
     @Test


### PR DESCRIPTION
LineRecordReader produces a org.apache.hadoop.io.Text value, that is
being converted to String by PXF. However, during the String conversion
the encoding information is not taken into account. In this commit we
skip conversion to String and just pass org.apache.hadoop.io.Text and
then finally just byte[]. This allows us to more efficiently transport
the data from external source to Greenplum without worrying about
converting to the appropriate encoding. The encoding conversion is
handled by Greenplum later.

Restore automation test testing different encoding