### PR TITLE
added Prometheus metrics endpoint

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -79,6 +79,8 @@ configure(javaProjects) {
             dependency("com.fasterxml.jackson.core:jackson-core:2.11.0")
             dependency("com.fasterxml.jackson.core:jackson-annotations:2.11.0")
 
+            dependency("io.micrometer:micrometer-registry-prometheus:1.6.2")
+
             dependency("joda-time:joda-time:2.8.1")
 
             dependency("org.apache.commons:commons-lang3:3.10")

--- a/server/pxf-service/build.gradle
+++ b/server/pxf-service/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation("commons-lang:commons-lang")
     implementation("org.springframework.boot:spring-boot-starter-log4j2")
     implementation('org.springframework.boot:spring-boot-starter-actuator')
+    implementation('io.micrometer:micrometer-registry-prometheus')
 
     implementation("org.apache.hadoop:hadoop-hdfs-client:${hadoopVersion}") { transitive = false }
 

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/PxfConfiguration.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/PxfConfiguration.java
@@ -1,12 +1,10 @@
 package org.greenplum.pxf.service;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import org.greenplum.pxf.api.configuration.PxfServerProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.boot.autoconfigure.task.TaskExecutionProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.task.TaskExecutorBuilder;
@@ -101,10 +99,5 @@ public class PxfConfiguration implements WebMvcConfigurer {
                 shutdown.getAwaitTerminationPeriod());
 
         return builder.build(PxfThreadPoolTaskExecutor.class);
-    }
-
-    @Bean
-    MeterRegistryCustomizer<MeterRegistry> metricsCommonTags() {
-        return registry -> registry.config().commonTags("application", "pxf-service");
     }
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/PxfConfiguration.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/PxfConfiguration.java
@@ -1,10 +1,12 @@
 package org.greenplum.pxf.service;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.greenplum.pxf.api.configuration.PxfServerProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.boot.autoconfigure.task.TaskExecutionProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.task.TaskExecutorBuilder;
@@ -99,5 +101,10 @@ public class PxfConfiguration implements WebMvcConfigurer {
                 shutdown.getAwaitTerminationPeriod());
 
         return builder.build(PxfThreadPoolTaskExecutor.class);
+    }
+
+    @Bean
+    MeterRegistryCustomizer<MeterRegistry> metricsCommonTags() {
+        return registry -> registry.config().commonTags("application", "pxf-service");
     }
 }

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -1,8 +1,10 @@
-# Expose health, info, and shutdown endpoints by default
+# Expose health, info, shutdown, metrics, and prometheus endpoints by default
 # 1. health: returns the status of the application {"status":"UP"}
 # 2. info: returns information about the build {"build":{"version":"X.X.X","artifact":"pxf-service","name":"pxf-service","group":"org.greenplum.pxf","time":"timestamp"}}
 # 3. shutdown: allows shutting down the application
-management.endpoints.web.exposure.include=health,info,shutdown
+# 4. metrics: shows ‘metrics’ information for the application
+# 5. prometheus: exposes metrics in a format that can be scraped by a Prometheus server
+management.endpoints.web.exposure.include=health,info,shutdown,metrics,prometheus
 management.endpoint.shutdown.enabled=true
 management.endpoint.health.probes.enabled=true
 

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -8,6 +8,9 @@ management.endpoints.web.exposure.include=health,info,shutdown,metrics,prometheu
 management.endpoint.shutdown.enabled=true
 management.endpoint.health.probes.enabled=true
 
+# common tags applied to all metrics
+management.metrics.tags.application=pxf-service
+
 spring.profiles.active=default
 
 server.port=${pxf.port:5888}
@@ -24,6 +27,7 @@ server.max-http-header-size=${pxf.tomcat.max-header-size:1048576}
 server.tomcat.threads.max=${pxf.max.threads:200}
 server.tomcat.accept-count=100
 server.tomcat.connection-timeout=${pxf.connection.timeout:5m}
+server.tomcat.mbeanregistry.enabled=true
 pxf.tomcat.max-header-count=30000
 
 # timeout (ms) for the request - 1 day


### PR DESCRIPTION
This adds the endpoint of `http://localhost:5888/actuator/prometheus` to expose the PXF Micrometer metrics in Prometheus format.