### PR TITLE
pxfbridge: Return early when context->current_fragment is NULL

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hdfs/HdfsReadableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hdfs/HdfsReadableTextTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.greenplum.pxf.automation.features.tpch.LineItem.LINEITEM_SCHEMA;
 
@@ -32,6 +33,15 @@ import static org.greenplum.pxf.automation.features.tpch.LineItem.LINEITEM_SCHEM
  * "HDFS Readable - Text/CSV" section.
  */
 public class HdfsReadableTextTest extends BaseFeature {
+
+    public static final String[] SMALL_DATA_FIELDS = {
+            "name text",
+            "num integer",
+            "dub double precision",
+            "longNum bigint",
+            "bool boolean"
+    };
+
     // holds data for file generation
     Table dataTable = null;
     // path for storing data on HDFS
@@ -230,13 +240,8 @@ public class HdfsReadableTextTest extends BaseFeature {
         }
 
         exTable =
-                TableFactory.getPxfReadableTextTable("pxf_hdfs_small_data_bzip2", new String[]{
-                        "name text",
-                        "num integer",
-                        "dub double precision",
-                        "longNum bigint",
-                        "bool boolean"
-                }, protocol.getExternalTablePath(hdfs.getBasePath(), hdfs.getWorkingDirectory()) + "/bzip2/", ",");
+                TableFactory.getPxfReadableTextTable("pxf_hdfs_small_data_bzip2", SMALL_DATA_FIELDS,
+                        protocol.getExternalTablePath(hdfs.getBasePath(), hdfs.getWorkingDirectory()) + "/bzip2/", ",");
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
         exTable.setFormat("CSV");
@@ -593,6 +598,32 @@ public class HdfsReadableTextTest extends BaseFeature {
         gpdb.createTableAndVerify(exTable);
 
         runTincTest("pxf.features.hdfs.readable.text.errors.wrong_type.runTest");
+    }
+
+    /**
+     * When an unterminated quoted field at the end of the file is being read
+     * from a PXF external table with SEGMENT REJECT LIMIT for the table
+     * definition, a segmentation fault was being thrown by PXF. This test
+     * makes sure that the segfault does not occur.
+     */
+    @Test(groups = {"features", "gpdb", "hcfs", "security"})
+    public void unterminatedQuotedFieldAtEndOfFile() throws Exception {
+
+        Table smallDataTable = getSmallData("foo", 3);
+        List<String> secondRow = smallDataTable.getData().get(1);
+        // add a quote to the first field of the second row without closing the quote
+        secondRow.set(0, secondRow.get(0) + "\"");
+
+        String path = hdfs.getWorkingDirectory() + "/unterminated_quoted_field";
+        hdfs.writeTableToFile(path, smallDataTable, ",");
+
+        prepareReadableTable("unterminated_quoted_field", SMALL_DATA_FIELDS, path, exTable.getFormat());
+        exTable.setSegmentRejectLimit(10);
+        exTable.setDelimiter(",");
+        exTable.setFormat("csv");
+
+        gpdb.createTableAndVerify(exTable);
+        runTincTest("pxf.features.hdfs.readable.text.errors.unterminated_quoted_field.runTest");
     }
 
     /**

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/unterminated_quoted_field/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/unterminated_quoted_field/expected/query01.ans
@@ -1,0 +1,19 @@
+-- start_ignore
+-- end_ignore
+-- @description query01 for PXF HDFS Readable error when an unterminated quoted
+-- field at the end of the file is being read from a PXF external table with
+-- SEGMENT REJECT LIMIT for the table definition. A segmentation fault was
+-- being thrown by PXF. This test makes sure that the segfault does not occur.
+-- start_matchsubs
+-- m/ +:/
+-- s/( +):/\1|/
+-- m/\+$/
+-- s/\+$//
+-- end_matchsubs
+SELECT * FROM unterminated_quoted_field ORDER BY name ASC;
+NOTICE:  Found 1 data formatting errors (1 or more input rows). Rejected related input data.
+   name    | num | dub |   longnum    | bool 
+-----------+-----+-----+--------------+------
+ foo_row_1 |   1 |   1 | 100000000000 | f
+(1 row)
+

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/unterminated_quoted_field/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/unterminated_quoted_field/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLTestCase
+from mpp.models import SQLConcurrencyTestCase
+
+class PxfHdfsUnterminatedQuotedField(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/unterminated_quoted_field/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/unterminated_quoted_field/sql/query01.sql
@@ -1,0 +1,12 @@
+-- @description query01 for PXF HDFS Readable error when an unterminated quoted
+-- field at the end of the file is being read from a PXF external table with
+-- SEGMENT REJECT LIMIT for the table definition. A segmentation fault was
+-- being thrown by PXF. This test makes sure that the segfault does not occur.
+-- start_matchsubs
+-- m/ +:/
+-- s/( +):/\1|/
+-- m/\+$/
+-- s/\+$//
+-- end_matchsubs
+
+SELECT * FROM unterminated_quoted_field ORDER BY name ASC;

--- a/external-table/src/pxfbridge.c
+++ b/external-table/src/pxfbridge.c
@@ -101,7 +101,7 @@ gpbridge_read(gphadoop_context *context, char *databuf, int datalen)
 {
 	size_t		n = 0;
 
-	if (context->gphd_uri->fragments == NULL)
+	if (context->current_fragment == NULL)
 		return (int) n;
 
 	while ((n = fill_buffer(context, databuf, datalen)) == 0)


### PR DESCRIPTION
In some cases, the copy framework in Greenplum might call the PXF
protocol requesting for more data even when all the data from the
external system has been read. This occurs when there's an error while
reading the last tuple in Greenplum and SEGMENT REJECT LIMIT has been
specified in the table definition. In this commit, we make PXF more
resilient to cases where all the external data has been consumed and the
Greenplum copy framework requests additional data. Here, we return early
if there are no additional fragments to process in the context.

Backport: Automation: add error that reproduces the segmentation fault

When an unterminated quoted field at the end of the file is being read
from a PXF external table with SEGMENT REJECT LIMIT for the table
definition, a segmentation fault was being thrown by PXF. This test
reproduces the segmentation fault error.