### PR TITLE
Stop using jcenter and replace with maven central

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -26,8 +26,7 @@
 
     <repositories>
         <repository>
-            <id>pivotal-releases</id>
-            <name>pivotal-releases</name>
+            <id>test-dependencies</id>
             <url>https://repo.pivotal.io/artifactory/gpdb-ud/</url>
         </repository>
     </repositories>

--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -26,8 +26,9 @@
 
     <repositories>
         <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
+            <id>pivotal-releases</id>
+            <name>pivotal-releases</name>
+            <url>https://repo.pivotal.io/artifactory/gpdb-ud/</url>
         </repository>
     </repositories>
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,7 +19,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -39,7 +39,7 @@ allprojects {
     apply plugin: "eclipse"
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Bintray is being shutdown, which includes jcenter hosting for java
artifacts. Using maven central