### PR TITLE
Log OOM messages to a log file

### DIFF
--- a/server/pxf-service/src/scripts/kill-pxf.sh
+++ b/server/pxf-service/src/scripts/kill-pxf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log() {
-  echo "=====> $(date) $* <======"
+  echo "=====> $(date) $* <======" >> "${PXF_LOGDIR}/pxf-oom.log"
 }
 
 _main() {


### PR DESCRIPTION
The OOM messages used to be logged in PXF log files for PXF 5, but this
functionality broke in PXF 6.0. This PR restores logging to a log file
`pxf-oom.log` located under the configured `${PXF_LOGDIR}`.