### PR TITLE
Log all the libraries loaded by the PxfServiceApplication classloader

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/PxfServiceApplication.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/PxfServiceApplication.java
@@ -1,14 +1,45 @@
 package org.greenplum.pxf.service;
 
 import org.apache.hadoop.security.PxfUserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.net.URL;
+import java.net.URLClassLoader;
 
 /**
  * Main PXF Spring Configuration class.
  */
 @SpringBootApplication(scanBasePackages = "org.greenplum.pxf", scanBasePackageClasses = PxfUserGroupInformation.class)
 public class PxfServiceApplication {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PxfServiceApplication.class);
+
+    /**
+     * Constructs a new PxfServiceApplication
+     */
+    public PxfServiceApplication() {
+        logClassLoaderInfo();
+    }
+
+    /**
+     * Logs, at info level, all the libraries loaded by the ClassLoader used by
+     * the PxfServiceApplication.
+     */
+    private void logClassLoaderInfo() {
+        ClassLoader loader = this.getClass().getClassLoader();
+        if (loader instanceof URLClassLoader) {
+            URLClassLoader urlClassLoader = (URLClassLoader) loader;
+            URL[] urls = urlClassLoader.getURLs();
+            if (urls != null) {
+                for (URL url : urls) {
+                    LOG.info("Repository {} added", url);
+                }
+            }
+        }
+    }
 
     /**
      * Spring Boot Main.

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/PxfServiceApplication.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/PxfServiceApplication.java
@@ -35,7 +35,7 @@ public class PxfServiceApplication {
             URL[] urls = urlClassLoader.getURLs();
             if (urls != null) {
                 for (URL url : urls) {
-                    LOG.info("Repository {} added", url);
+                    LOG.info("Added repository {}", url);
                 }
             }
         }

--- a/server/pxf-service/src/templates/conf/pxf-log4j2.xml
+++ b/server/pxf-service/src/templates/conf/pxf-log4j2.xml
@@ -23,7 +23,6 @@
 </Appenders>
 <Loggers>
     <Root level="info">
-        <AppenderRef ref="Console"/>
         <AppenderRef ref="RollingFile"/>
     </Root>
 


### PR DESCRIPTION
This is to provide similar functionality as what we had before Spring
Boot.

Remove Console appender