### PR TITLE
Add base_branch for the pxf PR pipeline

### DIFF
--- a/concourse/pipelines/templates/pr_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/pr_pipeline-tpl.yml
@@ -40,7 +40,7 @@ resources:
   type: pull-request
   source:
     repository: greenplum-db/pxf
-    base_branch: "master"
+    base_branch: {{pxf-git-branch}}
     access_token: {{pxf-bot-access-token}}
 
 ## ---------- Docker Images ----------

--- a/concourse/pipelines/templates/pr_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/pr_pipeline-tpl.yml
@@ -40,6 +40,7 @@ resources:
   type: pull-request
   source:
     repository: greenplum-db/pxf
+    base_branch: "master"
     access_token: {{pxf-bot-access-token}}
 
 ## ---------- Docker Images ----------


### PR DESCRIPTION
PR's against the 5.16 branch should not be run through this PR pipeline.