### PR TITLE
Stop using jcenter and replace with maven central (Backport PXF 5)

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -26,8 +26,8 @@
 
     <repositories>
         <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
+            <id>test-dependencies</id>
+            <url>https://repo.pivotal.io/artifactory/gpdb-ud/</url>
         </repository>
     </repositories>
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     apply plugin: 'idea'
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     group = 'org.greenplum.pxf'


### PR DESCRIPTION
Bintray is being shutdown, which includes jcenter hosting for java
artifacts. Using maven central