### PR TITLE
Bump PXF external-table extension to 2.0 and test upgrade

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -36,6 +36,8 @@ ifeq "$(PROTOCOL)" "minio"
 endif
 
 PXF_BASE ?= $(PXF_HOME)
+TEMPLATES_DIR=$(PXF_HOME)/templates
+
 PXF_BASE_SERVERS=$(PXF_BASE)/servers
 
 ifneq "$(PROTOCOL)" ""
@@ -121,7 +123,7 @@ dev: symlink_pxf_jars
 sync_jdbc_config:
 	@mkdir -p $(PXF_BASE_SERVERS)/database
 	@if [ ! -f $(PXF_BASE_SERVERS)/database/jdbc-site.xml ]; then \
-		cp $(PXF_HOME)/templates/jdbc-site.xml $(PXF_BASE_SERVERS)/database/; \
+		cp $(TEMPLATES_DIR)/jdbc-site.xml $(PXF_BASE_SERVERS)/database/; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.postgresql.Driver|" $(PXF_BASE_SERVERS)/database/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_URL|jdbc:postgresql://$(JDBC_HOST):$(JDBC_PORT)/pxfautomation|" $(PXF_BASE_SERVERS)/database/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_USER||" $(PXF_BASE_SERVERS)/database/jdbc-site.xml; \
@@ -132,7 +134,7 @@ sync_jdbc_config:
 	@cp src/test/resources/report.sql $(PXF_BASE_SERVERS)/database
 	@mkdir -p $(PXF_BASE_SERVERS)/db-session-params
 	@if [ ! -f $(PXF_BASE_SERVERS)/db-session-params/jdbc-site.xml ]; then \
-		cp $(PXF_HOME)/templates/jdbc-site.xml $(PXF_BASE_SERVERS)/db-session-params/; \
+		cp $(TEMPLATES_DIR)/jdbc-site.xml $(PXF_BASE_SERVERS)/db-session-params/; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.postgresql.Driver|" $(PXF_BASE_SERVERS)/db-session-params/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_URL|jdbc:postgresql://$(JDBC_HOST):$(JDBC_PORT)/pxfautomation|" $(PXF_BASE_SERVERS)/db-session-params/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_USER||" $(PXF_BASE_SERVERS)/db-session-params/jdbc-site.xml; \
@@ -142,7 +144,7 @@ sync_jdbc_config:
 	fi
 	@mkdir -p $(PXF_BASE_SERVERS)/db-hive
 	@if [ ! -f $(PXF_BASE_SERVERS)/db-hive/jdbc-site.xml ]; then \
-		cp $(PXF_HOME)/templates/jdbc-site.xml $(PXF_BASE_SERVERS)/db-hive/; \
+		cp $(TEMPLATES_DIR)/jdbc-site.xml $(PXF_BASE_SERVERS)/db-hive/; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.apache.hive.jdbc.HiveDriver|" $(PXF_BASE_SERVERS)/db-hive/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_URL|jdbc:hive2://$(HIVE_SERVER_HOST):$(HIVE_SERVER_PORT)/default|" $(PXF_BASE_SERVERS)/db-hive/jdbc-site.xml; \
 		sed $(SED_OPTS) "s|YOUR_DATABASE_JDBC_USER||" $(PXF_BASE_SERVERS)/db-hive/jdbc-site.xml; \
@@ -156,8 +158,8 @@ sync_cloud_configs:
 ifneq "$(PROTOCOL)" ""
 	@mkdir -p $(PROTOCOL_HOME)
 	@if [ ! -f "$(PROTOCOL_HOME)/$(PROTOCOL)-site.xml" ]; then \
-		cp $(PXF_HOME)/templates/$(PROTOCOL)-site.xml $(PROTOCOL_HOME)/; \
-		cp $(PXF_HOME)/templates/mapred-site.xml $(PROTOCOL_HOME)/; \
+		cp $(TEMPLATES_DIR)/$(PROTOCOL)-site.xml $(PROTOCOL_HOME)/; \
+		cp $(TEMPLATES_DIR)/mapred-site.xml $(PROTOCOL_HOME)/; \
 		if [ $(PROTOCOL) = file ]; then \
 			if [ ! -d "$(BASE_PATH)" ]; then \
 				echo "The NFS directory '$(BASE_PATH)' does not exist. Please configure it and try again"; \
@@ -165,16 +167,16 @@ ifneq "$(PROTOCOL)" ""
 				exit 1; \
 			fi; \
 			echo "Make sure your $PXF_BASE/conf/pxf-profiles.xml file configures the file:AvroSequenceFile and file:SequenceFile profiles"; \
-			cp $(PXF_HOME)/templates/pxf-site.xml $(PROTOCOL_HOME)/; \
+			cp $(TEMPLATES_DIR)/pxf-site.xml $(PROTOCOL_HOME)/; \
 			sed $(SED_OPTS) 's|</configuration>|<property><name>pxf.fs.basePath</name><value>$(BASE_PATH)</value></property></configuration>|g' $(PROTOCOL_HOME)/pxf-site.xml; \
 		fi; \
 		if [ $(PROTOCOL) = s3 ]; then \
 			if [ "$(MINIO)" = "true" ]; then \
-				cp $(PXF_HOME)/templates/minio-site.xml $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
+				cp $(TEMPLATES_DIR)/minio-site.xml $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
 				sed $(SED_OPTS) "s|YOUR_MINIO_URL|http://localhost:9000|" $(PROTOCOL_HOME)/$(PROTOCOL)-site.xml; \
 			fi; \
 			mkdir -p $(PROTOCOL_HOME)-invalid; \
-			cp $(PXF_HOME)/templates/$(PROTOCOL)-site.xml $(PROTOCOL_HOME)-invalid/; \
+			cp $(TEMPLATES_DIR)/$(PROTOCOL)-site.xml $(PROTOCOL_HOME)-invalid/; \
 			if [ -z "$(ACCESS_KEY_ID)" ] || [ -z "$(SECRET_ACCESS_KEY)" ]; then \
 				echo "AWS Keys (ACCESS_KEY_ID, SECRET_ACCESS_KEY) not set"; \
 				rm -rf $(PROTOCOL_HOME); \

--- a/concourse/scripts/cli/test_reset_init.sh
+++ b/concourse/scripts/cli/test_reset_init.sh
@@ -89,7 +89,7 @@ PXF initialized successfully on 4 out of 4 hosts"
 
 control_file_content=\
 "directory = '/usr/local/pxf-gp6/gpextable/'
-default_version = '1.0'
+default_version = '2.0'
 comment = 'Extension which allows to access unmanaged data'
 module_pathname = '/usr/local/pxf-gp6/gpextable/pxf'
 superuser = true

--- a/concourse/scripts/install_pxf.bash
+++ b/concourse/scripts/install_pxf.bash
@@ -251,6 +251,15 @@ function run_pxf_installer_scripts() {
 			'
 		fi
 	"
+
+	# Create a database for PXF extension upgrade testing
+	if [[ ${PXF_VERSION} == 5 ]]; then
+		ssh "${MASTER_HOSTNAME}" "
+			source ${GPHOME}/greenplum_path.sh &&
+			createdb testupgrade &&
+			psql -d testupgrade -c 'CREATE EXTENSION IF NOT EXISTS pxf'
+		"
+	fi
 }
 
 function _main() {

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -8,6 +8,7 @@ PXF_VERSION=${PXF_VERSION:=6}
 PROXY_USER=${PROXY_USER:-pxfuser}
 PROTOCOL=${PROTOCOL:-}
 GOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID:-data-gpdb-ud}
+PXF_SRC=$(find /tmp/build -name pxf_src -type d)
 
 # on purpose do not call this PXF_CONF|PXF_BASE so that it is not set during pxf operations
 if [[ ${PXF_VERSION} == 5 ]]; then
@@ -145,7 +146,7 @@ function install_gpdb_binary() {
 		export_pythonpath+=:/usr/local/lib/$python_dir
 	fi
 
-	echo "$export_pythonpath" >> "${PXF_COMMON_SRC_DIR}/../../automation/tinc/main/tinc_env.sh"
+	echo "$export_pythonpath" >> "${PXF_SRC}/automation/tinc/main/tinc_env.sh"
 }
 
 function install_gpdb_package() {
@@ -195,7 +196,7 @@ function install_gpdb_package() {
 		exit 1
 	fi
 
-	echo "$export_pythonpath" >> "${PXF_COMMON_SRC_DIR}/../../automation/tinc/main/tinc_env.sh"
+	echo "$export_pythonpath" >> "${PXF_SRC}/automation/tinc/main/tinc_env.sh"
 
 	# create symlink to allow pgregress to run (hardcoded to look for /usr/local/greenplum-db-devel/psql)
 	rm -rf /usr/local/greenplum-db-devel
@@ -313,10 +314,10 @@ function install_pxf_server() {
 }
 
 function install_pxf_tarball() {
-    local tarball_dir=${PXF_PKG_DIR:-pxf_tarball}
-    tar -xzf "${tarball_dir}/"pxf-*.tar.gz -C /tmp
-    /tmp/pxf*/install_component
-    chown -R gpadmin:gpadmin "${PXF_HOME}"
+	local tarball_dir=${PXF_PKG_DIR:-pxf_tarball}
+	tar -xzf "${tarball_dir}/"pxf-*.tar.gz -C /tmp
+	/tmp/pxf*/install_component
+	chown -R gpadmin:gpadmin "${PXF_HOME}"
 }
 
 function install_pxf_package() {
@@ -694,8 +695,7 @@ function configure_pxf_default_server() {
 				-e 's|</configuration>|<property><name>hadoop.security.authentication</name><value>kerberos</value></property></configuration>|g' \
 				${BASE_DIR}/servers/db-hive/jdbc-site.xml
 
-			PXF_SRC_DIR=$(find /tmp/build/ -name pxf_src)
-			cp "${PXF_SRC_DIR}"/automation/src/test/resources/hive-report.sql ${BASE_DIR}/servers/db-hive/
+			cp "${PXF_SRC}"/automation/src/test/resources/hive-report.sql ${BASE_DIR}/servers/db-hive/
 		fi
 	else
 		# copy hadoop config files to BASE_DIR/servers/default

--- a/concourse/scripts/upgrade_pxf.bash
+++ b/concourse/scripts/upgrade_pxf.bash
@@ -55,6 +55,9 @@ function upgrade_pxf() {
 
 	echoGreen "Starting PXF 6"
 	ssh "${MASTER_HOSTNAME}" "PXF_BASE=${PXF_BASE_DIR} ${PXF_HOME}/bin/pxf cluster start"
+
+	echoGreen "ALTER EXTENSION pxf UPDATE - for testupgrade database"
+	ssh "${MASTER_HOSTNAME}" "source ${GPHOME}/greenplum_path.sh && psql -d testupgrade -c 'ALTER EXTENSION pxf UPDATE'"
 }
 
 function _main() {

--- a/concourse/tasks/test_pxf_on_ccp.yml
+++ b/concourse/tasks/test_pxf_on_ccp.yml
@@ -3,9 +3,9 @@ image_resource:
   type: docker-image
 inputs:
 - name: pxf_src
+- name: pxf_tarball
 - name: cluster_env_files
 - name: gpdb_package
-- name: pxf_tarball
 - name: dataproc_env_files
   optional: true
 - name: dataproc_2_env_files

--- a/external-table/Makefile
+++ b/external-table/Makefile
@@ -1,5 +1,5 @@
 EXTENSION = pxf
-DATA = pxf--1.0.sql
+DATA = pxf--2.0.sql pxf--1.0--2.0.sql pxf--1.0.sql
 MODULE_big = pxf
 OBJS       = src/pxfprotocol.o src/pxfbridge.o src/pxfuriparser.o src/libchurl.o src/pxfutils.o src/pxfheaders.o src/gpdbwritableformatter.o src/pxffilters.o
 REGRESS    = setup pxf pxfinvalid
@@ -22,6 +22,8 @@ stage: pxf.so
 	install -c -m 755 pxf.so build/stage/pxf.so
 	install -c -m 644 pxf.control build/stage/
 	install -c -m 644 pxf--1.0.sql build/stage/
+	install -c -m 644 pxf--2.0.sql build/stage/
+	install -c -m 644 pxf--1.0--2.0.sql build/stage/
 	@echo $(GP_MAJORVERSION) > build/metadata/gp_major_version
 	@echo $(BLD_ARCH) | sed 's/_/-/' > build/metadata/build_arch
 

--- a/external-table/pxf--1.0--2.0.sql
+++ b/external-table/pxf--1.0--2.0.sql
@@ -1,0 +1,30 @@
+/* external_table/pxf--1.0--2.0.sql */
+
+-- No new functions were added in 2.0, but we need to recreate the existing
+-- functions.
+-- We expect pxf.control's MODULE_PATHNAME to point to a new location
+-- outside of $GPHOME and inside $PXF_HOME.
+-- We will require users to perform an `ALTER EXTENSION pxf UPDATE`
+-- to reflect the new module_pathname in pg_proc.
+-- To check the updated pg_proc run the following query:
+-- select prosrc, probin from pg_proc where proname like '%pxf%';
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxf_write() RETURNS integer
+AS 'MODULE_PATHNAME', 'pxfprotocol_export'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxf_read() RETURNS integer
+AS 'MODULE_PATHNAME', 'pxfprotocol_import'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxf_validate() RETURNS void
+AS 'MODULE_PATHNAME', 'pxfprotocol_validate_urls'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxfwritable_import() RETURNS record
+AS 'MODULE_PATHNAME', 'gpdbwritableformatter_import'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxfwritable_export(record) RETURNS bytea
+AS 'MODULE_PATHNAME', 'gpdbwritableformatter_export'
+LANGUAGE C STABLE;

--- a/external-table/pxf--2.0.sql
+++ b/external-table/pxf--2.0.sql
@@ -1,0 +1,28 @@
+------------------------------------------------------------------
+-- PXF Protocol/Formatters
+------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxf_write() RETURNS integer
+AS 'MODULE_PATHNAME', 'pxfprotocol_export'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxf_read() RETURNS integer
+AS 'MODULE_PATHNAME', 'pxfprotocol_import'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxf_validate() RETURNS void
+AS 'MODULE_PATHNAME', 'pxfprotocol_validate_urls'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxfwritable_import() RETURNS record
+AS 'MODULE_PATHNAME', 'gpdbwritableformatter_import'
+LANGUAGE C STABLE;
+
+CREATE OR REPLACE FUNCTION pg_catalog.pxfwritable_export(record) RETURNS bytea
+AS 'MODULE_PATHNAME', 'gpdbwritableformatter_export'
+LANGUAGE C STABLE;
+
+CREATE TRUSTED PROTOCOL pxf (
+  writefunc     = pxf_write,
+  readfunc      = pxf_read,
+  validatorfunc = pxf_validate);

--- a/external-table/pxf.control
+++ b/external-table/pxf.control
@@ -1,5 +1,5 @@
 directory = 'extension'
-default_version = '1.0'
+default_version = '2.0'
 comment = 'Extension which allows to access unmanaged data'
 module_pathname = '$libdir/pxf'
 superuser = true


### PR DESCRIPTION
Add a test that creates a database `testupgrade` before upgrading to PXF 6. This will surface an issue where the current extension will point to the old `.so` library location that was originally registered in the `pg_proc` catalog table. When installing the new extension, we need to run a `ALTER EXTENSION pxf UPDATE` to register the new extension (`pxf.so`) location. To be able to run an `ALTER EXTENSION` we need to bump up the version of the PXF external-table extension. The upgrade script will recreate the pxf functions with the updated `MODULE_PATHNAME`.