### PR TITLE
add application property for configuring logging level

### DIFF
--- a/server/pxf-service/src/templates/conf/pxf-application.properties
+++ b/server/pxf-service/src/templates/conf/pxf-application.properties
@@ -16,3 +16,7 @@
 # pxf.task.pool.core-size=8
 # pxf.task.pool.queue-capacity=0
 # pxf.task.pool.max-size=200
+
+# Logging
+# To enable debug logging, uncomment and change `info` to `debug` here
+# pxf.log.level=info

--- a/server/pxf-service/src/templates/conf/pxf-log4j2.xml
+++ b/server/pxf-service/src/templates/conf/pxf-log4j2.xml
@@ -6,6 +6,7 @@
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
     <Property name="CONSOLE_LOG_PATTERN">%clr{%d{${LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
     <Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+    <Property name="PXF_LOG_LEVEL">${bundle:pxf-application:pxf.log.level}</Property>
 </Properties>
 <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">
@@ -24,8 +25,7 @@
         <AppenderRef ref="RollingFile"/>
     </Root>
 
-    <!-- Uncomment to see DEBUG messages from PXF service -->
-    <!-- <Logger name="org.greenplum.pxf" level="debug"/> -->
+    <Logger name="org.greenplum.pxf" level="${env:PXF_LOG_LEVEL:-${sys:PXF_LOG_LEVEL:-info}}"/>
 
     <!-- The levels below are tuned to provide minimal output, change to INFO or DEBUG to troubleshoot -->
     <Logger name="com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase" level="warn"/>


### PR DESCRIPTION
The application property `pxf.log.level` is added for setting the value
of Spring Boot's `logging.level.root` property. This allows a user to
change the logging level of the PXF service by editing the property in
pxf-application.properties or setting an environment variable
(`PXF_LOG_LEVEL`) when (re-)starting PXF.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>