### PR TITLE
Log empty profile message at INFO level

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/profile/ProfilesConf.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/profile/ProfilesConf.java
@@ -132,7 +132,7 @@ public class ProfilesConf implements PluginConf {
             Profiles profiles = (Profiles) unmarshaller.unmarshal(url);
 
             if (profiles == null || profiles.getProfiles() == null || profiles.getProfiles().isEmpty()) {
-                LOG.warn("Profile file '{}' is empty", fileName);
+                LOG.info("Profile file '{}' is empty", fileName);
                 return;
             }
 


### PR DESCRIPTION
Previously, we used to log at WARN when a user did not have any custom
profiles. This message should not have been a warning, so we now log at
it at INFO level.