### PR TITLE
Enhance MDC with PXF context

### DIFF
--- a/server/pxf-hdfs/build.gradle
+++ b/server/pxf-hdfs/build.gradle
@@ -57,8 +57,12 @@ dependencies {
     implementation("org.apache.commons:commons-compress:1.20")    { transitive = false }
     implementation("org.tukaani:xz:1.8")                          { transitive = false }
 
-    // Dependency in hadoop 2.9.2
+    // Hadoop 2.10.1 uses log4j:1.2.17, but since we are using slf4j
+    // we bring log4j-over-slf4j which provides compatibility for log4j
+    // using underlying slf4j functionality (i.e MDC).
     implementation("org.slf4j:log4j-over-slf4j:1.7.30")          { transitive = false }
+
+    // Dependency in hadoop 2.10.1
     implementation("com.fasterxml.woodstox:woodstox-core:5.0.3") { transitive = false }
     implementation("org.codehaus.woodstox:stax2-api:3.1.4")      { transitive = false }
 

--- a/server/pxf-hdfs/build.gradle
+++ b/server/pxf-hdfs/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation("org.apache.parquet:parquet-jackson:${parquetVersion}") { transitive = false }
     implementation("org.apache.hive:hive-storage-api:${hiveStorageApiVersion}") { transitive = false }// for parquet writing
 
-    implementation("org.codehaus.jackson:jackson-core-asl:1.9.13") { transitive = false }
+    implementation("org.codehaus.jackson:jackson-core-asl:1.9.13")   { transitive = false }
     implementation("org.codehaus.jackson:jackson-mapper-asl:1.9.13") { transitive = false }
 
     implementation("org.apache.avro:avro:1.7.7")                  { transitive = false }
@@ -58,7 +58,7 @@ dependencies {
     implementation("org.tukaani:xz:1.8")                          { transitive = false }
 
     // Dependency in hadoop 2.9.2
-    implementation("log4j:log4j:1.2.17")                         { transitive = false }
+    implementation("org.slf4j:log4j-over-slf4j:1.7.30")          { transitive = false }
     implementation("com.fasterxml.woodstox:woodstox-core:5.0.3") { transitive = false }
     implementation("org.codehaus.woodstox:stax2-api:3.1.4")      { transitive = false }
 

--- a/server/pxf-service/build.gradle
+++ b/server/pxf-service/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testCompileOnly("org.apache.hadoop:hadoop-annotations:${hadoopVersion}")
     testImplementation("com.esotericsoftware:kryo:3.0.3")
     testImplementation("commons-io:commons-io")
+    testImplementation("org.simplify4u:slf4j-mock:2.1.0") // for MDC mocking
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation('org.springframework.boot:spring-boot-starter-test')

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/FragmenterService.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/FragmenterService.java
@@ -185,21 +185,22 @@ public class FragmenterService {
     }
 
     /**
-     * Returns a key for the fragmenter cache. TransactionID is not sufficient to key
-     * the cache. For the case where we have multiple slices (i.e select a, b from c
-     * where a = 'part1' union all select a, b from c where a = 'part2'), the list of
-     * fragments for each slice in the query will be different, but the transactionID
-     * will be the same. For that reason we must include the server name, data source
-     * and the filter string as part of the fragmenter cache.
+     * Returns a key for the fragmenter cache. TransactionID is not sufficient
+     * to key the cache. For the case where we have multiple scans (i.e
+     * select a, b from c where a = 'part1' union all select a, b from c
+     * where a = 'part2'), the list of fragments for each scan in the query
+     * will be different, but the transactionID will be the same. For that
+     * reason we must include the schema name, table name, and the filter
+     * string as part of the fragmenter cache key.
      *
      * @param context the request context
      * @return the key for the fragmenter cache
      */
     private String getFragmenterCacheKey(RequestContext context) {
         return String.format("%s:%s:%s:%s",
-                context.getServerName(),
                 context.getTransactionId(),
-                context.getDataSource(),
+                context.getSchemaName(),
+                context.getTableName(),
                 context.getFilterString());
     }
 

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfContextMdcLogEnhancerDecorator.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfContextMdcLogEnhancerDecorator.java
@@ -1,0 +1,33 @@
+package org.greenplum.pxf.service.spring;
+
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * A task decorator that gets a copy of the MDC context map in the web thread
+ * context, and then sets the context map to the async thread context.
+ */
+@Component
+public class PxfContextMdcLogEnhancerDecorator implements TaskDecorator {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        // Web thread context: (Grab the current thread MDC data)
+        Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        return () -> {
+            try {
+                // @Async thread context: (Restore the Web thread context's MDC data)
+                MDC.setContextMap(contextMap);
+                runnable.run();
+            } finally {
+                MDC.clear();
+            }
+        };
+    }
+}

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfContextMdcLogEnhancerFilter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfContextMdcLogEnhancerFilter.java
@@ -1,5 +1,6 @@
 package org.greenplum.pxf.service.spring;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.service.HttpHeaderDecoder;
 import org.slf4j.MDC;
@@ -16,6 +17,7 @@ import java.io.IOException;
  * A servlet filter that enhances MDC with request headers that provide
  * PXF session/segment IDs (if available).
  */
+@Slf4j
 @Component
 public class PxfContextMdcLogEnhancerFilter extends OncePerRequestFilter {
 
@@ -55,10 +57,13 @@ public class PxfContextMdcLogEnhancerFilter extends OncePerRequestFilter {
         }
 
         // xid : server
-        String serverName = StringUtils.defaultString(decoder.getHeaderValue("X-GP-OPTIONS-SERVER", request, encoded), "default");
+        String serverName = StringUtils.defaultIfBlank(decoder.getHeaderValue("X-GP-OPTIONS-SERVER", request, encoded), "default");
         String sessionId = String.format("%s:%s", xid, serverName);
+        String segmentId = decoder.getHeaderValue("X-GP-SEGMENT-ID", request, encoded);
         MDC.put(MDC_SESSION_ID, sessionId);
-        MDC.put(MDC_SEGMENT_ID, decoder.getHeaderValue("X-GP-SEGMENT-ID", request, encoded));
+        MDC.put(MDC_SEGMENT_ID, segmentId);
+        log.debug("MDC: Added {}={}", MDC_SESSION_ID, sessionId);
+        log.debug("MDC: Added {}={}", MDC_SEGMENT_ID, segmentId);
     }
 
     /**

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfContextMdcLogEnhancerFilter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfContextMdcLogEnhancerFilter.java
@@ -1,0 +1,72 @@
+package org.greenplum.pxf.service.spring;
+
+import org.apache.commons.lang.StringUtils;
+import org.greenplum.pxf.service.HttpHeaderDecoder;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * A servlet filter that enhances MDC with request headers that provide
+ * PXF session/segment IDs (if available).
+ */
+@Component
+public class PxfContextMdcLogEnhancerFilter extends OncePerRequestFilter {
+
+    private static final String MDC_SESSION_ID = "sessionId";
+    private static final String MDC_SEGMENT_ID = "segmentId";
+
+    private final HttpHeaderDecoder decoder;
+
+    public PxfContextMdcLogEnhancerFilter(HttpHeaderDecoder decoder) {
+        this.decoder = decoder;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        insertIntoMDC(request);
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            clearMDC();
+        }
+    }
+
+    /**
+     * Adds entries to MDC from the request headers
+     *
+     * @param request the servlet request
+     */
+    private void insertIntoMDC(HttpServletRequest request) {
+        boolean encoded = decoder.areHeadersEncoded(request);
+        String xid = decoder.getHeaderValue("X-GP-XID", request, encoded);
+        if (StringUtils.isBlank(xid)) {
+            return; // Not a PXF extension request
+        }
+
+        // xid : server
+        String serverName = StringUtils.defaultString(decoder.getHeaderValue("X-GP-OPTIONS-SERVER", request, encoded), "default");
+        String sessionId = String.format("%s:%s", xid, serverName);
+        MDC.put(MDC_SESSION_ID, sessionId);
+        MDC.put(MDC_SEGMENT_ID, decoder.getHeaderValue("X-GP-SEGMENT-ID", request, encoded));
+    }
+
+    /**
+     * Removes entries added to MDC
+     */
+    private void clearMDC() {
+        // removing possibly non-existent item is OK
+        MDC.remove(MDC_SEGMENT_ID);
+        MDC.remove(MDC_SESSION_ID);
+    }
+}

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -43,3 +43,4 @@ pxf.task.pool.queue-capacity=0
 # logging
 logging.file.name=${pxf.logdir:/tmp}/pxf-service.log
 logging.file.path=${pxf.logdir:/tmp}
+logging.pattern.level=%5p [%X{sessionId}:%X{segmentId}]

--- a/server/pxf-service/src/templates/conf/pxf-log4j2.xml
+++ b/server/pxf-service/src/templates/conf/pxf-log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
 <Properties>
     <Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
-    <Property name="LOG_LEVEL_PATTERN">%5p</Property>
+    <Property name="LOG_LEVEL_PATTERN">%5p [%X{sessionId}:%X{segmentId}]</Property>
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
     <Property name="CONSOLE_LOG_PATTERN">%clr{%d{${LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
     <Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/FragmenterServiceTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/FragmenterServiceTest.java
@@ -89,13 +89,30 @@ class FragmenterServiceTest {
     }
 
     @Test
-    public void testFragmenterCallIsNotCachedForDifferentDataSources() throws Throwable {
+    public void testFragmenterCallIsNotCachedForDifferentSchemas() throws Throwable {
         context1.setTransactionId("XID-XYZ-123456");
-        context1.setDataSource("foo.bar");
+        context1.setSchemaName("foo1");
+        context1.setTableName("bar");
         context1.setFilterString("a3c25s10d2016-01-03o6");
 
         context2.setTransactionId("XID-XYZ-123456");
-        context2.setDataSource("bar.foo");
+        context2.setSchemaName("foo2");
+        context2.setTableName("bar");
+        context2.setFilterString("a3c25s10d2016-01-03o6");
+
+        testContextsAreNotCached(context1, context2);
+    }
+
+    @Test
+    public void testFragmenterCallIsNotCachedForDifferentTables() throws Throwable {
+        context1.setTransactionId("XID-XYZ-123456");
+        context1.setSchemaName("foo");
+        context1.setTableName("bar1");
+        context1.setFilterString("a3c25s10d2016-01-03o6");
+
+        context2.setTransactionId("XID-XYZ-123456");
+        context2.setSchemaName("foo");
+        context2.setTableName("bar2");
         context2.setFilterString("a3c25s10d2016-01-03o6");
 
         testContextsAreNotCached(context1, context2);

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/PxfContextMdcLogEnhancerFilterTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/PxfContextMdcLogEnhancerFilterTest.java
@@ -1,0 +1,94 @@
+package org.greenplum.pxf.service;
+
+import org.greenplum.pxf.service.spring.PxfContextMdcLogEnhancerFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.spi.MDCAdapter;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class PxfContextMdcLogEnhancerFilterTest {
+
+    PxfContextMdcLogEnhancerFilter filter;
+    MockHttpServletRequest mockRequest;
+    MockHttpServletResponse mockResponse;
+    MockFilterChain mockFilterChain;
+
+    @Mock
+    MDCAdapter mdcMock;
+
+    @BeforeEach
+    void setup() {
+        mockRequest = new MockHttpServletRequest();
+        mockResponse = new MockHttpServletResponse();
+        mockFilterChain = new MockFilterChain();
+        filter = new PxfContextMdcLogEnhancerFilter(new HttpHeaderDecoder());
+    }
+
+    @Test
+    void testNonPxfContextRequest() throws ServletException, IOException {
+        filter.doFilter(mockRequest, mockResponse, mockFilterChain);
+        // always removes
+        verify(mdcMock).remove("segmentId");
+        verify(mdcMock).remove("sessionId");
+        verifyNoMoreInteractions(mdcMock);
+    }
+
+    @Test
+    void testPxfContextRequest() throws ServletException, IOException {
+
+        mockRequest.addHeader("X-GP-XID", "transaction:id");
+        mockRequest.addHeader("X-GP-SEGMENT-ID", "5");
+        filter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mdcMock).put("sessionId", "transaction:id:default");
+        verify(mdcMock).put("segmentId", "5");
+
+        verify(mdcMock).remove("segmentId");
+        verify(mdcMock).remove("sessionId");
+        verifyNoMoreInteractions(mdcMock);
+    }
+
+    @Test
+    void testPxfContextRequestWithServerName() throws ServletException, IOException {
+
+        mockRequest.addHeader("X-GP-XID", "transaction:id");
+        mockRequest.addHeader("X-GP-OPTIONS-SERVER", "s3");
+        mockRequest.addHeader("X-GP-SEGMENT-ID", "5");
+        filter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mdcMock).put("sessionId", "transaction:id:s3");
+        verify(mdcMock).put("segmentId", "5");
+
+        verify(mdcMock).remove("segmentId");
+        verify(mdcMock).remove("sessionId");
+        verifyNoMoreInteractions(mdcMock);
+    }
+
+    @Test
+    void testPxfContextEncodedRequest() throws ServletException, IOException {
+
+        mockRequest.addHeader("X-GP-ENCODED-HEADER-VALUES", "true");
+        mockRequest.addHeader("X-GP-XID", "transaction%3Aid");
+        mockRequest.addHeader("X-GP-SEGMENT-ID", "5");
+        filter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mdcMock).put("sessionId", "transaction:id:default");
+        verify(mdcMock).put("segmentId", "5");
+
+        verify(mdcMock).remove("segmentId");
+        verify(mdcMock).remove("sessionId");
+        verifyNoMoreInteractions(mdcMock);
+    }
+}

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/rest/PxfResourceIT.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/rest/PxfResourceIT.java
@@ -3,6 +3,7 @@ package org.greenplum.pxf.service.rest;
 import com.google.common.base.Charsets;
 import org.greenplum.pxf.api.error.PxfRuntimeException;
 import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.service.HttpHeaderDecoder;
 import org.greenplum.pxf.service.RequestParser;
 import org.greenplum.pxf.service.controller.ReadService;
 import org.greenplum.pxf.service.controller.WriteService;
@@ -46,6 +47,9 @@ public class PxfResourceIT {
 
     @MockBean
     private WriteService mockWriteService;
+
+    @MockBean
+    private HttpHeaderDecoder mockHttpHeaderDecoder;
 
     @Mock
     private RequestContext mockContext;

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/spring/PxfContextMdcLogEnhancerDecoratorTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/spring/PxfContextMdcLogEnhancerDecoratorTest.java
@@ -1,0 +1,61 @@
+package org.greenplum.pxf.service.spring;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.spi.MDCAdapter;
+import org.springframework.core.task.TaskDecorator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PxfContextMdcLogEnhancerDecoratorTest {
+
+    TaskDecorator decorator;
+
+    @Mock
+    MDCAdapter mdcMock;
+
+    @BeforeEach
+    void setup() {
+        decorator = new PxfContextMdcLogEnhancerDecorator();
+    }
+
+    @Test
+    void testDecorateWithoutContext() throws InterruptedException {
+
+        Map<String, String> contextMap = new HashMap<>();
+        when(mdcMock.getCopyOfContextMap()).thenReturn(contextMap);
+
+        Thread thread = new Thread(() -> System.out.println("Run"));
+        decorator.decorate(thread).run();
+        thread.join();
+        verify(mdcMock).getCopyOfContextMap();
+        verify(mdcMock).setContextMap(contextMap);
+        verify(mdcMock).clear();
+        verifyNoMoreInteractions(mdcMock);
+    }
+
+    @Test
+    void testDecorateWithContext() throws InterruptedException {
+
+        Map<String, String> contextMap = new HashMap<>();
+        contextMap.put("foo", "bar");
+        when(mdcMock.getCopyOfContextMap()).thenReturn(contextMap);
+
+        Thread thread = new Thread(() -> System.out.println("Run"));
+        decorator.decorate(thread).run();
+        thread.join();
+        verify(mdcMock).getCopyOfContextMap();
+        verify(mdcMock).setContextMap(contextMap);
+        verify(mdcMock).clear();
+        verifyNoMoreInteractions(mdcMock);
+    }
+}


### PR DESCRIPTION
Log the PXF sessionId (xid : server) and the segmentId in LOG entries
where the information is available for logging. Add the
`PxfContextMdcLogEnhancerDecorator` and `PxfContextMdcLogEnhancerFilter`
classes to support logging the PXF context when available.