### PR TITLE
report "fragments.sent" PXF metric

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/MetricsReporter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/MetricsReporter.java
@@ -1,0 +1,129 @@
+package org.greenplum.pxf.service;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Service responsible for submitting metrics to MeterRegistry.
+ */
+@Component
+@Slf4j
+public class MetricsReporter {
+
+    private static final String UNKNOWN_VALUE = "unknown";
+    private static final Tags SUCCESS_TAG = Tags.of("outcome", "success");
+    private static final Tags ERROR_TAG = Tags.of("outcome", "error");
+
+    private final MeterRegistry registry;
+    private final Environment env;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param registry meter registry to submit metrics to
+     * @param env      environment which serves as the source of property values
+     */
+    public MetricsReporter(MeterRegistry registry, Environment env) {
+        this.registry = registry;
+        this.env = env;
+    }
+
+    /**
+     * Reports timer metric with a given name and duration to the registry. Applies custom tags before reporting.
+     *
+     * @param metric   metric to apply
+     * @param duration duration measured by the metric
+     * @param context  request context
+     */
+    public void reportTimer(PxfMetric metric, Duration duration, RequestContext context) {
+        reportTimer(metric, duration, context, null);
+    }
+
+    /**
+     * Reports timer metric, duration and outcome of the timed operation to the registry.
+     * Applies custom tags before reporting and adds an outcome tag.
+     *
+     * @param metric   metric to apply
+     * @param duration duration measured by the metric
+     * @param context  request context
+     * @param success  true if timed operation was successful, false otherwise
+     */
+    public void reportTimer(PxfMetric metric, Duration duration, RequestContext context, boolean success) {
+        reportTimer(metric, duration, context, success ? SUCCESS_TAG : ERROR_TAG);
+    }
+
+    /**
+     * Reports timer metric with a given name, duration and additional tags to the registry.
+     * Applies custom tags before reporting and adds a success outcome tag.
+     *
+     * @param metric
+     * @param duration
+     * @param context
+     * @param extraTags
+     */
+    private void reportTimer(PxfMetric metric, Duration duration, RequestContext context, Tags extraTags) {
+        String metricName = metric.getMetricName();
+        long durationMs = duration.toMillis();
+        if (env.getProperty(metric.getEnabledPropertyName(), Boolean.class, Boolean.FALSE)) {
+            Tags tags = (extraTags == null) ? getTags(context) : getTags(context).and(extraTags);
+            Timer timer = Timer.builder(metric.getMetricName()).tags(tags).register(registry);
+            timer.record(duration);
+            if (log.isTraceEnabled()) {
+                log.trace("Reported timer {}{} with duration={}ms", metricName, tags, durationMs);
+            }
+        } else {
+            log.trace("Skipping reporting metric {} with duration {}ms", metricName, durationMs);
+        }
+    }
+
+    /**
+     * Produces a set of custom tags with values from the provided request context.
+     *
+     * @param context request context
+     * @return collection of custom tags
+     */
+    private Tags getTags(RequestContext context) {
+        return Tags.empty()
+                .and("user", StringUtils.defaultIfBlank(context.getUser(), UNKNOWN_VALUE))
+                .and("segment", String.valueOf(context.getSegmentId()))
+                .and("profile", StringUtils.defaultIfBlank(context.getProfile(), UNKNOWN_VALUE))
+                .and("server", StringUtils.defaultIfBlank(context.getServerName(), "default"));
+    }
+
+    /**
+     * Enum that has information about all custom metrics for PXF.
+     */
+    public enum PxfMetric {
+        FRAGMENTS_SENT("fragments.sent", "pxf.metrics.fragments.enabled");
+
+        private final String metricName;
+        private final String enabledPropertyName;
+
+        /**
+         * Creates a new instance.
+         *
+         * @param metricName          name of the metric as will be seen by the registry
+         * @param enabledPropertyName property name that manages whether reporting of this metric is turned on / off
+         */
+        PxfMetric(String metricName, String enabledPropertyName) {
+            this.metricName = metricName;
+            this.enabledPropertyName = enabledPropertyName;
+        }
+
+        public String getMetricName() {
+            return metricName;
+        }
+
+        public String getEnabledPropertyName() {
+            return enabledPropertyName;
+        }
+    }
+}

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.greenplum.pxf.api.model.ConfigurationFactory;
 import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.service.MetricsReporter;
 import org.greenplum.pxf.service.bridge.Bridge;
 import org.greenplum.pxf.service.bridge.BridgeFactory;
 import org.greenplum.pxf.service.security.SecurityService;
@@ -20,6 +21,7 @@ import java.time.Instant;
 @Slf4j
 public abstract class BaseServiceImpl {
 
+    protected final MetricsReporter metricsReporter;
     private final String serviceName;
     private final ConfigurationFactory configurationFactory;
     private final BridgeFactory bridgeFactory;
@@ -27,25 +29,30 @@ public abstract class BaseServiceImpl {
 
     /**
      * Creates a new instance of the service with auto-wired dependencies.
-     * @param serviceName name of the service
+     *
+     * @param serviceName          name of the service
      * @param configurationFactory configuration factory
-     * @param bridgeFactory bridge factory
-     * @param securityService security service
+     * @param bridgeFactory        bridge factory
+     * @param securityService      security service
+     * @param metricsReporter      metrics reporter service
      */
     protected BaseServiceImpl(String serviceName,
                               ConfigurationFactory configurationFactory,
                               BridgeFactory bridgeFactory,
-                              SecurityService securityService) {
+                              SecurityService securityService,
+                              MetricsReporter metricsReporter) {
         this.serviceName = serviceName;
         this.configurationFactory = configurationFactory;
         this.bridgeFactory = bridgeFactory;
         this.securityService = securityService;
+        this.metricsReporter = metricsReporter;
     }
 
     /**
      * Executes an action with the identity determined by the PXF security service.
+     *
      * @param context request context
-     * @param action action to execute
+     * @param action  action to execute
      * @return operation statistics
      * @throws IOException if an error occurs during the operation
      */

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
@@ -10,6 +10,7 @@ import org.greenplum.pxf.api.model.PluginConf;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.utilities.Utilities;
 import org.greenplum.pxf.service.FragmenterService;
+import org.greenplum.pxf.service.MetricsReporter;
 import org.greenplum.pxf.service.bridge.Bridge;
 import org.greenplum.pxf.service.bridge.BridgeFactory;
 import org.greenplum.pxf.service.security.SecurityService;
@@ -18,6 +19,8 @@ import org.springframework.stereotype.Service;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -37,12 +40,14 @@ public class ReadServiceImpl extends BaseServiceImpl implements ReadService {
      * @param bridgeFactory        bridge factory
      * @param securityService      security service
      * @param fragmenterService    fragmenter service
+     * @param metricsReporter      metrics reporter service
      */
     public ReadServiceImpl(ConfigurationFactory configurationFactory,
                            BridgeFactory bridgeFactory,
                            SecurityService securityService,
-                           FragmenterService fragmenterService) {
-        super("Read", configurationFactory, bridgeFactory, securityService);
+                           FragmenterService fragmenterService,
+                           MetricsReporter metricsReporter) {
+        super("Read", configurationFactory, bridgeFactory, securityService, metricsReporter);
         this.fragmenterService = fragmenterService;
     }
 
@@ -127,26 +132,33 @@ public class ReadServiceImpl extends BaseServiceImpl implements ReadService {
     private int processFragment(DataOutputStream dos, RequestContext context, Fragment fragment) throws Exception {
         Writable record;
         int recordCount = 0;
-        Bridge bridge = getBridge(context);
+        boolean success = false;
+        Instant startTime = Instant.now();
+        Bridge bridge = null;
         try {
-            if (!bridge.beginIteration()) return 0;
-
-            log.debug("{} Starting streaming fragment {} of resource {}",
-                    context.getId(), fragment.getIndex(), context.getDataSource());
-            while ((record = bridge.getNext()) != null) {
-                record.write(dos);
-                ++recordCount;
+            bridge = getBridge(context);
+            if (!bridge.beginIteration()) {
+                log.debug("{} Skipping streaming fragment {} of resource {}",
+                        context.getId(), fragment.getIndex(), context.getDataSource());
+            } else {
+                log.debug("{} Starting streaming fragment {} of resource {}",
+                        context.getId(), fragment.getIndex(), context.getDataSource());
+                while ((record = bridge.getNext()) != null) {
+                    record.write(dos);
+                    ++recordCount;
+                }
             }
-            log.debug("{} Finished streaming fragment {} of resource {}, {} records.",
-                    context.getId(), fragment.getIndex(), context.getDataSource(), recordCount);
+            success = true;
         } finally {
-            log.debug("{} Stopped streaming fragment {} of resource {}, {} records.",
-                    context.getId(), fragment.getIndex(), context.getDataSource(), recordCount);
             try {
                 bridge.endIteration();
             } catch (Exception e) {
                 log.warn("{} Ignoring error encountered during bridge.endIteration()", context.getId(), e);
             }
+            Duration duration = Duration.between(startTime, Instant.now());
+            log.debug("{} Finished streaming fragment {} of resource {}, {} records in {} ms.",
+                    context.getId(), fragment.getIndex(), context.getDataSource(), recordCount, duration.toMillis());
+            metricsReporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, duration, context, success);
         }
         return recordCount;
     }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
@@ -158,7 +158,7 @@ public class ReadServiceImpl extends BaseServiceImpl implements ReadService {
                 log.warn("{} Ignoring error encountered during bridge.endIteration()", context.getId(), e);
             }
             Duration duration = Duration.between(startTime, Instant.now());
-            log.debug("{} Finished streaming fragment {} of resource {}, {} records in {} ms.",
+            log.debug("{} Finished processing fragment {} of resource {}, {} records in {} ms.",
                     context.getId(), fragment.getIndex(), context.getDataSource(), recordCount, duration.toMillis());
             metricsReporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, duration, context, success);
         }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
@@ -151,7 +151,9 @@ public class ReadServiceImpl extends BaseServiceImpl implements ReadService {
             success = true;
         } finally {
             try {
-                bridge.endIteration();
+                if (bridge != null) {
+                    bridge.endIteration();
+                }
             } catch (Exception e) {
                 log.warn("{} Ignoring error encountered during bridge.endIteration()", context.getId(), e);
             }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/WriteServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/WriteServiceImpl.java
@@ -5,6 +5,7 @@ import org.apache.catalina.connector.ClientAbortException;
 import org.greenplum.pxf.api.model.ConfigurationFactory;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.utilities.Utilities;
+import org.greenplum.pxf.service.MetricsReporter;
 import org.greenplum.pxf.service.bridge.Bridge;
 import org.greenplum.pxf.service.bridge.BridgeFactory;
 import org.greenplum.pxf.service.security.SecurityService;
@@ -30,8 +31,9 @@ public class WriteServiceImpl extends BaseServiceImpl implements WriteService {
      */
     public WriteServiceImpl(ConfigurationFactory configurationFactory,
                             BridgeFactory bridgeFactory,
-                            SecurityService securityService) {
-        super("Write", configurationFactory, bridgeFactory, securityService);
+                            SecurityService securityService,
+                            MetricsReporter metricsReporter) {
+        super("Write", configurationFactory, bridgeFactory, securityService, metricsReporter);
     }
 
     @Override

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -11,6 +11,9 @@ management.endpoint.health.probes.enabled=true
 # common tags applied to all metrics
 management.metrics.tags.application=pxf-service
 
+# PXF-specific metrics
+pxf.metrics.fragments.enabled=true
+
 spring.profiles.active=default
 
 server.port=${pxf.port:5888}

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/MetricsReporterTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/MetricsReporterTest.java
@@ -41,7 +41,7 @@ public class MetricsReporterTest {
 
     @Test
     public void testFragmentsSentMetricDisabled() {
-        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(false);
+        disableFragmentMetrics();
 
         reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(100), mockContext);
         assertTrue(registry.getMeters().isEmpty());
@@ -49,7 +49,7 @@ public class MetricsReporterTest {
 
     @Test
     public void testFragmentsSentMetricEnabled() {
-        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(true);
+        enableFragmentMetrics();
         when(mockContext.getUser()).thenReturn("Alex");
         when(mockContext.getSegmentId()).thenReturn(5);
         when(mockContext.getProfile()).thenReturn("test:text");
@@ -71,7 +71,7 @@ public class MetricsReporterTest {
 
     @Test
     public void testFragmentsSentMetricEnabledWithOutcome() {
-        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(true);
+        enableFragmentMetrics();
         when(mockContext.getUser()).thenReturn("Alex");
         when(mockContext.getSegmentId()).thenReturn(5);
         when(mockContext.getProfile()).thenReturn("test:text");
@@ -98,7 +98,7 @@ public class MetricsReporterTest {
 
     @Test
     public void testFragmentsSentMetricEnabledDefaultTagValues() {
-        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(true);
+        enableFragmentMetrics();
         when(mockContext.getSegmentId()).thenReturn(5);
         Tags expectedTags = Tags.of("user", "unknown").and("segment", "5").and("profile", "unknown").and("server", "default");
 
@@ -107,6 +107,14 @@ public class MetricsReporterTest {
         assertNotNull(timer);
         assertEquals(1, timer.count());
         assertEquals(100, timer.totalTime(TimeUnit.MILLISECONDS));
+    }
+
+    private void enableFragmentMetrics() {
+        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(true);
+    }
+
+    private void disableFragmentMetrics() {
+        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(false);
     }
 
 }

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/MetricsReporterTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/MetricsReporterTest.java
@@ -1,0 +1,112 @@
+package org.greenplum.pxf.service;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MetricsReporterTest {
+
+    private MeterRegistry registry;
+    private MetricsReporter reporter;
+
+    @Mock
+    private RequestContext mockContext;
+    @Mock
+    private Environment mockEnvironment;
+
+    @BeforeEach
+    public void setup() {
+        // it is not possible to mock the registry as Timer.Builder calls a package-level function that cannot be mocked.
+        // so using an actual registry for verification
+        registry = new SimpleMeterRegistry();
+        reporter = new MetricsReporter(registry, mockEnvironment);
+    }
+
+    @Test
+    public void testFragmentsSentMetricDisabled() {
+        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(false);
+
+        reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(100), mockContext);
+        assertTrue(registry.getMeters().isEmpty());
+    }
+
+    @Test
+    public void testFragmentsSentMetricEnabled() {
+        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(true);
+        when(mockContext.getUser()).thenReturn("Alex");
+        when(mockContext.getSegmentId()).thenReturn(5);
+        when(mockContext.getProfile()).thenReturn("test:text");
+        when(mockContext.getServerName()).thenReturn("test_server");
+        Tags expectedTags = Tags.of("user", "Alex").and("segment", "5").and("profile", "test:text").and("server", "test_server");
+
+        reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(100), mockContext);
+        Timer timer = registry.get("fragments.sent").tags(expectedTags).timer();
+        assertNotNull(timer);
+        assertEquals(1, timer.count());
+        assertEquals(100, timer.totalTime(TimeUnit.MILLISECONDS));
+
+        reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(51), mockContext);
+        timer = registry.get("fragments.sent").tags(expectedTags).timer();
+        assertNotNull(timer);
+        assertEquals(2, timer.count());
+        assertEquals(151, timer.totalTime(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testFragmentsSentMetricEnabledWithOutcome() {
+        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(true);
+        when(mockContext.getUser()).thenReturn("Alex");
+        when(mockContext.getSegmentId()).thenReturn(5);
+        when(mockContext.getProfile()).thenReturn("test:text");
+        when(mockContext.getServerName()).thenReturn("test_server");
+        Tags expectedTags = Tags.of("user", "Alex").and("segment", "5").and("profile", "test:text")
+                .and("server", "test_server").and("outcome", "success");
+
+        // success outcome
+        reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(100), mockContext, true);
+        Timer timer = registry.get("fragments.sent").tags(expectedTags).timer();
+        assertNotNull(timer);
+        assertEquals(1, timer.count());
+        assertEquals(100, timer.totalTime(TimeUnit.MILLISECONDS));
+
+        // error outcome
+        expectedTags = Tags.of("user", "Alex").and("segment", "5").and("profile", "test:text")
+                .and("server", "test_server").and("outcome", "error");
+        reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(51), mockContext, false);
+        timer = registry.get("fragments.sent").tags(expectedTags).timer();
+        assertNotNull(timer);
+        assertEquals(1, timer.count());
+        assertEquals(51, timer.totalTime(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testFragmentsSentMetricEnabledDefaultTagValues() {
+        when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(true);
+        when(mockContext.getSegmentId()).thenReturn(5);
+        Tags expectedTags = Tags.of("user", "unknown").and("segment", "5").and("profile", "unknown").and("server", "default");
+
+        reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(100), mockContext);
+        Timer timer = registry.get("fragments.sent").tags(expectedTags).timer();
+        assertNotNull(timer);
+        assertEquals(1, timer.count());
+        assertEquals(100, timer.totalTime(TimeUnit.MILLISECONDS));
+    }
+
+}


### PR DESCRIPTION
PXF will report `fragment.sent` Timer metric to Spring Boot Metric Registry. It will measure the time it takes to send data for a single fragment. The metric will also calculate the total number of invocations, which means the system will know a total number of fragments served. The metric will have a standard set of tags: `user`, `segment`, `profile`, `server` and the additional tag `outcome` with values either `success` or `error`, depending on whether all data for the fragment has been sent without errors.

The metric will be available from the `/actuator/metrics/fragments.sent` endpoint, e.g.:
```
{"name":"fragments.sent","description":null,"baseUnit":"seconds","measurements":[{"statistic":"COUNT","value":6.0},{"statistic":"TOTAL_TIME","value":0.039},{"statistic":"MAX","value":0.012}],"availableTags":[{"tag":"server","values":["default"]},{"tag":"application","values":["pxf-service"]},{"tag":"segment","values":["0","1","2"]},{"tag":"profile","values":["unknown"]},{"tag":"user","values":["adenissov"]},{"tag":"outcome","values":["success"]}]}
```

The metric will be also available from the `/actuator/prometheus` endpoint, e.g.:
```
# HELP fragments_sent_seconds  
# TYPE fragments_sent_seconds summary
fragments_sent_seconds_count{application="pxf-service",outcome="success",profile="unknown",segment="1",server="default",user="adenissov",} 2.0
fragments_sent_seconds_sum{application="pxf-service",outcome="success",profile="unknown",segment="1",server="default",user="adenissov",} 0.013
fragments_sent_seconds_count{application="pxf-service",outcome="success",profile="unknown",segment="2",server="default",user="adenissov",} 2.0
fragments_sent_seconds_sum{application="pxf-service",outcome="success",profile="unknown",segment="2",server="default",user="adenissov",} 0.013
fragments_sent_seconds_count{application="pxf-service",outcome="success",profile="unknown",segment="0",server="default",user="adenissov",} 2.0
fragments_sent_seconds_sum{application="pxf-service",outcome="success",profile="unknown",segment="0",server="default",user="adenissov",} 0.013
# HELP fragments_sent_seconds_max  
# TYPE fragments_sent_seconds_max gauge
fragments_sent_seconds_max{application="pxf-service",outcome="success",profile="unknown",segment="1",server="default",user="adenissov",} 0.012
fragments_sent_seconds_max{application="pxf-service",outcome="success",profile="unknown",segment="2",server="default",user="adenissov",} 0.012
fragments_sent_seconds_max{application="pxf-service",outcome="success",profile="unknown",segment="0",server="default",user="adenissov",} 0.012
```