### PR TITLE
Docs- Modified filter pushdown table

### DIFF
--- a/docs/content/filter_push.html.md.erb
+++ b/docs/content/filter_push.html.md.erb
@@ -41,25 +41,20 @@ PXF filter pushdown can be used with these data types (connector- and profile-sp
 - `BOOL`
 - `DATE`, `TIMESTAMP` (available only with the JDBC connector, the S3 connector when using S3 Select, the `hive:rc` and `hive:orc` profiles, and the `hive` profile when accessing `STORED AS` `RCFile` or `ORC`)
 
-You can use PXF filter pushdown with these arithmetic and logical operators (connector- and profile-specific):
-
-- `<`, `<=`, `>=`, `>`
-- `<>`, `=`
-- `AND`, `OR`, `NOT`
-- `LIKE` (`TEXT` fields, JDBC connector only)
-
-PXF accesses data sources using profiles exposed by different connectors, and filter pushdown support is determined by the specific connector implementation. The following PXF profiles support some aspect of filter pushdown:
+PXF accesses data sources using profiles exposed by different connectors, and filter pushdown support is determined by the specific connector implementation. 
+The following PXF profiles support some aspects of filter pushdown as well as different arithmetic and logical operations:
 
 |Profile | <,&nbsp;&nbsp; >,</br><=,&nbsp;&nbsp; >=,</br>=,&nbsp;&nbsp;<> | LIKE | IS [NOT] NULL | IN | AND | OR | NOT |
 |-------|:------------------------:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
-| jdbc | Y | Y | Y | Y | Y | Y | Y | Y | N | Y | Y | Y |
+| jdbc | Y | Y<sup>4</sup> | Y | N | Y | Y | Y | 
 | *:parquet | Y<sup>1</sup> | N | Y<sup>1</sup> | Y<sup>1</sup> | Y<sup>1</sup> | Y<sup>1</sup> | Y<sup>1</sup> |
 | s3:parquet and s3:text with S3-Select | Y |  N | Y | Y | Y | Y | Y |
 | hbase | Y | N | Y | N | Y | Y | N |
 | hive (accessing stored as Parquet) | Y, Y<sup>2</sup> | N | N | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
-| hive (accessing stored as RCFile or ORC) | Y, Y<sup>2</sup> | N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
+| hive (accessing stored as RCFile) | Y<sup>2</sup> | N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | N |
+| hive (accessing stored as ORC) | Y, Y<sup>2</sup> | N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | hive:text | Y<sup>2</sup> | N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
-| hive:rc | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
+| hive:rc | Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | N |
 | hive:orc | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | hive:orc and VECTORIZE=true | Y<sup>2</sup> |  N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
 | *:orc (all except hive:orc) | Y<sup>1,3</sup> | N | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> |
@@ -67,6 +62,7 @@ PXF accesses data sources using profiles exposed by different connectors, and fi
 </br><sup>1</sup>&nbsp;PXF applies the predicate, rather than the remote system, reducing CPU usage and the memory footprint.
 </br><sup>2</sup>&nbsp;PXF supports partition pruning based on partition keys.
 </br><sup>3</sup>&nbsp;PXF filtering is based on file-level, stripe-level, and row-level ORC statistics.
+</br><sup>4</sup>&nbsp;The PXF `jdbc` profile supports the `LIKE` operator only for `TEXT` fields.
 
 PXF does not support filter pushdown for any profile not mentioned in the table above, including: *:avro, *:AvroSequenceFile, *:SequenceFile, *:json, *:text, and *:text:multi.
 

--- a/docs/content/filter_push.html.md.erb
+++ b/docs/content/filter_push.html.md.erb
@@ -48,6 +48,7 @@ The following PXF profiles support some aspects of filter pushdown as well as di
 |-------|:------------------------:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
 | jdbc | Y | Y<sup>4</sup> | Y | N | Y | Y | Y | 
 | *:parquet | Y<sup>1</sup> | N | Y<sup>1</sup> | Y<sup>1</sup> | Y<sup>1</sup> | Y<sup>1</sup> | Y<sup>1</sup> |
+| *:orc (all except hive:orc) | Y<sup>1,3</sup> | N | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> |
 | s3:parquet and s3:text with S3-Select | Y |  N | Y | Y | Y | Y | Y |
 | hbase | Y | N | Y | N | Y | Y | N |
 | hive (accessing stored as Parquet) | Y, Y<sup>2</sup> | N | N | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
@@ -57,7 +58,6 @@ The following PXF profiles support some aspects of filter pushdown as well as di
 | hive:rc | Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | N |
 | hive:orc | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | hive:orc and VECTORIZE=true | Y<sup>2</sup> |  N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
-| *:orc (all except hive:orc) | Y<sup>1,3</sup> | N | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> |
 
 </br><sup>1</sup>&nbsp;PXF applies the predicate, rather than the remote system, reducing CPU usage and the memory footprint.
 </br><sup>2</sup>&nbsp;PXF supports partition pruning based on partition keys.

--- a/docs/content/filter_push.html.md.erb
+++ b/docs/content/filter_push.html.md.erb
@@ -51,12 +51,10 @@ The following PXF profiles support some aspects of filter pushdown as well as di
 | *:orc (all except hive:orc) | Y<sup>1,3</sup> | N | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> | Y<sup>1,3</sup> |
 | s3:parquet and s3:text with S3-Select | Y |  N | Y | Y | Y | Y | Y |
 | hbase | Y | N | Y | N | Y | Y | N |
-| hive (accessing stored as Parquet) | Y, Y<sup>2</sup> | N | N | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
-| hive (accessing stored as RCFile) | Y<sup>2</sup> | N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | N |
-| hive (accessing stored as ORC) | Y, Y<sup>2</sup> | N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | hive:text | Y<sup>2</sup> | N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
-| hive:rc | Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | N |
-| hive:orc | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
+| hive:rc, hive (accessing stored as RCFile) | Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
+| hive:orc, hive (accessing stored as ORC) | Y, Y<sup>2</sup> |  N | Y | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
+| hive (accessing stored as Parquet) | Y, Y<sup>2</sup> | N | N | Y | Y, Y<sup>2</sup> | Y, Y<sup>2</sup> | Y |
 | hive:orc and VECTORIZE=true | Y<sup>2</sup> |  N | N | N | Y<sup>2</sup> | Y<sup>2</sup> | N |
 
 </br><sup>1</sup>&nbsp;PXF applies the predicate, rather than the remote system, reducing CPU usage and the memory footprint.


### PR DESCRIPTION
I have modified the tabled based on the spreadsheet provided.
I have assumed that **Hive (accessing stored as Parquet)** stays the same it was before, can anyone confirm this?

https://mireia-pxf-filter.sc2-04-pcf1-apps.oc.vmware.com/pxf/WIP/filter_push.html