### PR TITLE
Fix PXF startup when PID file is exists and another process acquire PID

### DIFF
--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -158,7 +158,7 @@ function checkWebapp()
 
 # determines whether the application is running
 function isRunning() {
-    ps -p "$1" &> /dev/null
+    ps -o pid,command -p "$1" | grep '[p]xf-app' &> /dev/null
 }
 
 # creates the runtime directory structure inside $PXF_BASE

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -158,7 +158,7 @@ function checkWebapp()
 
 # determines whether the application is running
 function isRunning() {
-    ps -o pid,command -p "$1" | grep '[p]xf-app' &> /dev/null
+    ps -o pid,command -p "$1" | grep 'pxf-app' &> /dev/null
 }
 
 # creates the runtime directory structure inside $PXF_BASE


### PR DESCRIPTION
An existing PID file can prevent a PXF startup, if the PID has been
recycled and has been acquired by a new process. This commit validates
that the process name contains `[p]xf-app`, adding more validation for
the check.