### PR TITLE
Add metrics for reporting records sent from PXF to gpdb

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
@@ -74,6 +74,8 @@ public class ReadServiceImpl extends BaseServiceImpl implements ReadService {
         String originalResolver = context.getResolver();
         String originalProfileScheme = context.getProfileScheme();
 
+        int recordReportFrequency = metricsReporter.getReportFrequency(MetricsReporter.PxfMetric.RECORDS_SENT);
+
         try {
             List<Fragment> fragments = fragmenterService.getFragmentsForSegment(context);
             DataOutputStream dos = new DataOutputStream(outputStream);
@@ -92,7 +94,7 @@ public class ReadServiceImpl extends BaseServiceImpl implements ReadService {
                 context.setFragmentIndex(fragment.getIndex());
                 context.setFragmentMetadata(fragment.getMetadata());
 
-                recordCount += processFragment(dos, context, fragment);
+                recordCount += processFragment(dos, context, fragment, recordReportFrequency);
 
                 // In cases where we have hundreds of thousands of fragments,
                 // we want to release the fragment reference as soon as we are
@@ -129,7 +131,7 @@ public class ReadServiceImpl extends BaseServiceImpl implements ReadService {
         return OperationStats.builder().operation("read").recordCount(recordCount).build();
     }
 
-    private int processFragment(DataOutputStream dos, RequestContext context, Fragment fragment) throws Exception {
+    private int processFragment(DataOutputStream dos, RequestContext context, Fragment fragment, int recordReportFrequency) throws Exception {
         Writable record;
         int recordCount = 0;
         boolean success = false;
@@ -146,16 +148,26 @@ public class ReadServiceImpl extends BaseServiceImpl implements ReadService {
                 while ((record = bridge.getNext()) != null) {
                     record.write(dos);
                     ++recordCount;
+                    // report records based off the recordReportFrequency
+                    if (recordCount % recordReportFrequency == 0) {
+                        metricsReporter.reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, recordReportFrequency, context);
+                    }
+                }
+                // report the remaining records that have yet to be reported
+                int remainder = recordCount % recordReportFrequency;
+                if (remainder != 0) {
+                    metricsReporter.reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, remainder, context);
                 }
             }
             success = true;
         } finally {
-            try {
-                if (bridge != null) {
+            if (bridge != null) {
+                try {
                     bridge.endIteration();
+                } catch (Exception e) {
+                    log.warn("{} Ignoring error encountered during bridge.endIteration()", context.getId(), e);
                 }
-            } catch (Exception e) {
-                log.warn("{} Ignoring error encountered during bridge.endIteration()", context.getId(), e);
+
             }
             Duration duration = Duration.between(startTime, Instant.now());
             log.debug("{} Finished processing fragment {} of resource {}, {} records in {} ms.",

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -13,6 +13,8 @@ management.metrics.tags.application=pxf-service
 
 # PXF-specific metrics
 pxf.metrics.fragments.enabled=true
+pxf.metrics.records.enabled=true
+pxf.metrics.records.report-frequency=1000
 
 spring.profiles.active=default
 

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/MetricsReporterTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/MetricsReporterTest.java
@@ -1,5 +1,6 @@
 package org.greenplum.pxf.service;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
@@ -22,6 +23,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class MetricsReporterTest {
+
+    Tags expectedTags = Tags.of("user", "Alex").and("segment", "5").and("profile", "test:text").and("server", "test_server");
 
     private MeterRegistry registry;
     private MetricsReporter reporter;
@@ -50,11 +53,7 @@ public class MetricsReporterTest {
     @Test
     public void testFragmentsSentMetricEnabled() {
         enableFragmentMetrics();
-        when(mockContext.getUser()).thenReturn("Alex");
-        when(mockContext.getSegmentId()).thenReturn(5);
-        when(mockContext.getProfile()).thenReturn("test:text");
-        when(mockContext.getServerName()).thenReturn("test_server");
-        Tags expectedTags = Tags.of("user", "Alex").and("segment", "5").and("profile", "test:text").and("server", "test_server");
+        setContext();
 
         reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(100), mockContext);
         Timer timer = registry.get("fragments.sent").tags(expectedTags).timer();
@@ -72,12 +71,7 @@ public class MetricsReporterTest {
     @Test
     public void testFragmentsSentMetricEnabledWithOutcome() {
         enableFragmentMetrics();
-        when(mockContext.getUser()).thenReturn("Alex");
-        when(mockContext.getSegmentId()).thenReturn(5);
-        when(mockContext.getProfile()).thenReturn("test:text");
-        when(mockContext.getServerName()).thenReturn("test_server");
-        Tags expectedTags = Tags.of("user", "Alex").and("segment", "5").and("profile", "test:text")
-                .and("server", "test_server").and("outcome", "success");
+        setContext();
 
         // success outcome
         reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(100), mockContext, true);
@@ -87,10 +81,10 @@ public class MetricsReporterTest {
         assertEquals(100, timer.totalTime(TimeUnit.MILLISECONDS));
 
         // error outcome
-        expectedTags = Tags.of("user", "Alex").and("segment", "5").and("profile", "test:text")
+        Tags expectedErrorTags = Tags.of("user", "Alex").and("segment", "5").and("profile", "test:text")
                 .and("server", "test_server").and("outcome", "error");
         reporter.reportTimer(MetricsReporter.PxfMetric.FRAGMENTS_SENT, Duration.ofMillis(51), mockContext, false);
-        timer = registry.get("fragments.sent").tags(expectedTags).timer();
+        timer = registry.get("fragments.sent").tags(expectedErrorTags).timer();
         assertNotNull(timer);
         assertEquals(1, timer.count());
         assertEquals(51, timer.totalTime(TimeUnit.MILLISECONDS));
@@ -109,6 +103,37 @@ public class MetricsReporterTest {
         assertEquals(100, timer.totalTime(TimeUnit.MILLISECONDS));
     }
 
+    @Test
+    public void testRecordsSentMetricDisabled() {
+        disableRecordsMetrics();
+
+        reporter.reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 100, mockContext);
+        assertTrue(registry.getMeters().isEmpty());
+    }
+
+    @Test
+    public void testRecordsSentMetricEnabled() {
+        enableRecordsMetrics();
+        setContext();
+
+        reporter.reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 1000, mockContext);
+        Counter counter = registry.get("records.sent").tags(expectedTags).counter();
+        assertNotNull(counter);
+        assertEquals(1000, counter.count());
+
+        reporter.reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 51, mockContext);
+        counter = registry.get("records.sent").tags(expectedTags).counter();
+        assertNotNull(counter);
+        assertEquals(1051, counter.count());
+    }
+
+    private void setContext() {
+        when(mockContext.getUser()).thenReturn("Alex");
+        when(mockContext.getSegmentId()).thenReturn(5);
+        when(mockContext.getProfile()).thenReturn("test:text");
+        when(mockContext.getServerName()).thenReturn("test_server");
+    }
+
     private void enableFragmentMetrics() {
         when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(true);
     }
@@ -117,4 +142,11 @@ public class MetricsReporterTest {
         when(mockEnvironment.getProperty("pxf.metrics.fragments.enabled", Boolean.class, Boolean.FALSE)).thenReturn(false);
     }
 
+    private void enableRecordsMetrics() {
+        when(mockEnvironment.getProperty("pxf.metrics.records.enabled", Boolean.class, Boolean.FALSE)).thenReturn(true);
+    }
+
+    private void disableRecordsMetrics() {
+        when(mockEnvironment.getProperty("pxf.metrics.records.enabled", Boolean.class, Boolean.FALSE)).thenReturn(false);
+    }
 }


### PR DESCRIPTION
This commit adds a counter for tracking the number of records PXF sends
out. We report on frequency determined by
pxf.metrics.records.report-frequency.

Co-authored-by: Ashuka Xue <axue@vmware.com>
Co-authored-by: Alex Denissov <adenissov@vmware.com>