### PR TITLE
added column on tables that shows supported operations for different …

### DIFF
--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -103,23 +103,23 @@ The PXF Hadoop connectors provide built-in profiles to support the following dat
 
 The PXF Hadoop connectors expose the following profiles to read, and in many cases write, these supported data formats:
 
-| Data Source | Data Format | Profile Name(s) | Deprecated Profile Name |
-|-------------|------|---------|-----|
-| HDFS | delimited single line [text](hdfs_text.html#profile_text) | hdfs:text | n/a |
-| HDFS | delimited [text with quoted linefeeds](hdfs_text.html#profile_textmulti) | hdfs:text:multi | n/a |
-| HDFS | [Avro](hdfs_avro.html) | hdfs:avro | n/a |
-| HDFS | [JSON](hdfs_json.html) | hdfs:json | n/a |
-| HDFS | [ORC](hdfs_orc.html) | hdfs:orc | n/a |
-| HDFS | [Parquet](hdfs_parquet.html) | hdfs:parquet | n/a |
-| HDFS | AvroSequenceFile | hdfs:AvroSequenceFile | n/a |
-| HDFS | [SequenceFile](hdfs_seqfile.html) | hdfs:SequenceFile | n/a |
-| [Hive](hive_pxf.html) | stored as TextFile | hive, [hive:text](hive_pxf.html#hive_text) | Hive, HiveText |
-| [Hive](hive_pxf.html) | stored as SequenceFile | hive | Hive |
-| [Hive](hive_pxf.html) | stored as RCFile | hive, [hive:rc](hive_pxf.html#hive_hiverc) | Hive, HiveRC |
-| [Hive](hive_pxf.html) | stored as ORC | hive, [hive:orc](hive_pxf.html#hive_orc) | Hive, HiveORC, HiveVectorizedORC |
-| [Hive](hive_pxf.html) | stored as Parquet | hive | Hive |
-| [Hive](hive_pxf.html) | stored as Avro | hive | Hive |
-| [HBase](hbase_pxf.html) | Any | hbase | HBase |
+| Data Source | Data Format | Profile Name(s) | Deprecated Profile Name | Supported operations |
+|-------------|------|---------|-----|-----|
+| HDFS | delimited single line [text](hdfs_text.html#profile_text) | hdfs:text | n/a | Read, Write |
+| HDFS | delimited [text with quoted linefeeds](hdfs_text.html#profile_textmulti) | hdfs:text:multi | n/a | Read |
+| HDFS | [Avro](hdfs_avro.html) | hdfs:avro | n/a | Read, Write |
+| HDFS | [JSON](hdfs_json.html) | hdfs:json | n/a | Read |
+| HDFS | [ORC](hdfs_orc.html) | hdfs:orc | n/a | Read |
+| HDFS | [Parquet](hdfs_parquet.html) | hdfs:parquet | n/a | Read, Write |
+| HDFS | AvroSequenceFile | hdfs:AvroSequenceFile | n/a | Read, Write |
+| HDFS | [SequenceFile](hdfs_seqfile.html) | hdfs:SequenceFile | n/a | Read, Write |
+| [Hive](hive_pxf.html) | stored as TextFile | hive, [hive:text] (hive_pxf.html#hive_text) | Hive, HiveText | Read |
+| [Hive](hive_pxf.html) | stored as SequenceFile | hive | Hive | Read |
+| [Hive](hive_pxf.html) | stored as RCFile | hive, [hive:rc](hive_pxf.html#hive_hiverc) | Hive, HiveRC | Read |
+| [Hive](hive_pxf.html) | stored as ORC | hive, [hive:orc](hive_pxf.html#hive_orc) | Hive, HiveORC, HiveVectorizedORC | Read |
+| [Hive](hive_pxf.html) | stored as Parquet | hive | Hive | Read |
+| [Hive](hive_pxf.html) | stored as Avro | hive | Hive | Read |
+| [HBase](hbase_pxf.html) | Any | hbase | HBase | Read |
 
 ### <a id="choose_profile"></a>Choosing the Profile
 

--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -103,7 +103,7 @@ The PXF Hadoop connectors provide built-in profiles to support the following dat
 
 The PXF Hadoop connectors expose the following profiles to read, and in many cases write, these supported data formats:
 
-| Data Source | Data Format | Profile Name(s) | Deprecated Profile Name | Supported operations |
+| Data Source | Data Format | Profile Name(s) | Deprecated Profile Name | Supported Operations |
 |-------------|------|---------|-----|-----|
 | HDFS | delimited single line [text](hdfs_text.html#profile_text) | hdfs:text | n/a | Read, Write |
 | HDFS | delimited [text with quoted linefeeds](hdfs_text.html#profile_textmulti) | hdfs:text:multi | n/a | Read |

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -70,7 +70,6 @@ Similarly, the PXF connectors to Google Cloud Storage, Minio, and S3 expose thes
 | AvroSequenceFile | gs:AvroSequenceFile | s3:AvroSequenceFile | Read, Write |
 | [SequenceFile](objstore_seqfile.html) | gs:SequenceFile | s3:SequenceFile | Read, Write |
 
-
 You provide the profile name when you specify the `pxf` protocol on a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table that references a file or directory in the specific object store.
 
 ## <a id="sample_ddl"></a>Sample CREATE EXTERNAL TABLE Commands

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -46,7 +46,7 @@ The PXF object store connectors provide built-in profiles to support the followi
 
 The PXF connectors to Azure expose the following profiles to read, and in many cases write, these supported data formats:
 
-| Data Format | Azure Blob Storage | Azure Data Lake | Supported operations |
+| Data Format | Azure Blob Storage | Azure Data Lake | Supported Operations |
 |-----|------|---------| ---------|
 | delimited single line [plain text](objstore_text.html) | wasbs:text | adl:text | Read, Write |
 | delimited [text with quoted linefeeds](objstore_text.html) | wasbs:text:multi | adl:text:multi | Read |
@@ -59,7 +59,7 @@ The PXF connectors to Azure expose the following profiles to read, and in many c
 
 Similarly, the PXF connectors to Google Cloud Storage, Minio, and S3 expose these profiles:
 
-| Data Format | Google Cloud Storage | S3 or Minio | Supported operations |
+| Data Format | Google Cloud Storage | S3 or Minio | Supported Operations |
 |-----|------|---------| ---------|
 | delimited single line [plain text](objstore_text.html) | gs:text | s3:text | Read, Write |
 | delimited [text with quoted linefeeds](objstore_text.html) | gs:text:multi | s3:text:multi | Read |

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -46,29 +46,30 @@ The PXF object store connectors provide built-in profiles to support the followi
 
 The PXF connectors to Azure expose the following profiles to read, and in many cases write, these supported data formats:
 
-| Data Format | Azure Blob Storage | Azure Data Lake |
-|-----|------|---------|
-| delimited single line [plain text](objstore_text.html) | wasbs:text | adl:text |
-| delimited [text with quoted linefeeds](objstore_text.html) | wasbs:text:multi | adl:text:multi |
-| [Avro](objstore_avro.html) | wasbs:avro | adl:avro |
-| [JSON](objstore_json.html) | wasbs:json | adl:json |
-| [ORC](objstore_orc.html) | wasbs:orc | adl:orc |
-| [Parquet](objstore_parquet.html) | wasbs:parquet | adl:parquet |
-| AvroSequenceFile | wasbs:AvroSequenceFile | adl:AvroSequenceFile |
-| [SequenceFile](objstore_seqfile.html) | wasbs:SequenceFile | adl:SequenceFile |
+| Data Format | Azure Blob Storage | Azure Data Lake | Supported operations |
+|-----|------|---------| ---------|
+| delimited single line [plain text](objstore_text.html) | wasbs:text | adl:text | Read, Write |
+| delimited [text with quoted linefeeds](objstore_text.html) | wasbs:text:multi | adl:text:multi | Read |
+| [Avro](objstore_avro.html) | wasbs:avro | adl:avro | Read, Write |
+| [JSON](objstore_json.html) | wasbs:json | adl:json | Read |
+| [ORC](objstore_orc.html) | wasbs:orc | adl:orc | Read |
+| [Parquet](objstore_parquet.html) | wasbs:parquet | adl:parquet | Read, Write |
+| AvroSequenceFile | wasbs:AvroSequenceFile | adl:AvroSequenceFile | Read, Write |
+| [SequenceFile](objstore_seqfile.html) | wasbs:SequenceFile | adl:SequenceFile | Read, Write |
 
 Similarly, the PXF connectors to Google Cloud Storage, Minio, and S3 expose these profiles:
 
-| Data Format | Google Cloud Storage | S3 or Minio |
-|-----|------|---------|
-| delimited single line [plain text](objstore_text.html) | gs:text | s3:text |
-| delimited [text with quoted linefeeds](objstore_text.html) | gs:text:multi | s3:text:multi |
-| [Avro](objstore_avro.html) | gs:avro | s3:avro |
-| [JSON](objstore_json.html) | gs:json | s3:json |
-| [ORC](objstore_orc.html) | gs:orc | s3:orc |
-| [Parquet](objstore_parquet.html) | gs:parquet | s3:parquet |
-| AvroSequenceFile | gs:AvroSequenceFile | s3:AvroSequenceFile |
-| [SequenceFile](objstore_seqfile.html) | gs:SequenceFile | s3:SequenceFile |
+| Data Format | Google Cloud Storage | S3 or Minio | Supported operations |
+|-----|------|---------| ---------|
+| delimited single line [plain text](objstore_text.html) | gs:text | s3:text | Read, Write |
+| delimited [text with quoted linefeeds](objstore_text.html) | gs:text:multi | s3:text:multi | Read |
+| [Avro](objstore_avro.html) | gs:avro | s3:avro | Read, Write |
+| [JSON](objstore_json.html) | gs:json | s3:json | Read|
+| [ORC](objstore_orc.html) | gs:orc | s3:orc | Read |
+| [Parquet](objstore_parquet.html) | gs:parquet | s3:parquet | Read, Write |
+| AvroSequenceFile | gs:AvroSequenceFile | s3:AvroSequenceFile | Read, Write |
+| [SequenceFile](objstore_seqfile.html) | gs:SequenceFile | s3:SequenceFile | Read, Write |
+
 
 You provide the profile name when you specify the `pxf` protocol on a `CREATE EXTERNAL TABLE` command to create a Greenplum Database external table that references a file or directory in the specific object store.
 


### PR DESCRIPTION
In order for user to be able to learn supported operations for the different profiles, I have added an extra column to the existing tables in the landing pages for both HDFS and Object Storage that indicate supported operations.

https://mireia-pxf-profiles.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/access_hdfs.html
https://mireia-pxf-profiles.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/access_objstore.html

Assumptions: `AvroSequenceFile`, supports read and write, since `SequenceFile` does.