### PR TITLE
updated deps versions to correspond to what gets packaged

### DIFF
--- a/server/pxf-hbase/build.gradle
+++ b/server/pxf-hbase/build.gradle
@@ -28,8 +28,8 @@ dependencies {
     implementation("org.apache.hbase:hbase-protocol:${hbaseVersion}") { transitive = false }
     implementation("org.apache.htrace:htrace-core:3.1.0-incubating")  { transitive = false }
     implementation("org.apache.zookeeper:zookeeper:3.4.6")            { transitive = false }
-    implementation("io.netty:netty-common:4.0.56.Final")              { transitive = false }
-    implementation("io.netty:netty-transport:4.0.56.Final")           { transitive = false }
+    implementation("io.netty:netty-common:4.1.59.Final")              { transitive = false }
+    implementation("io.netty:netty-transport:4.1.59.Final")           { transitive = false }
     implementation("com.yammer.metrics:metrics-core:2.2.0")           { transitive = false }
 
     implementation("org.springframework.boot:spring-boot-starter-log4j2")

--- a/server/pxf-hive/build.gradle
+++ b/server/pxf-hive/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation("org.apache.hive:hive-common:${hiveVersion}") { transitive = false }
     implementation("org.apache.hive.shims:hive-shims-common:${hiveVersion}") { transitive = false }
     implementation("org.apache.hive.shims:hive-shims-0.23:${hiveVersion}") { transitive = false }
-    implementation("org.apache.commons:commons-lang3:3.1") { transitive = false }
+    implementation("org.apache.commons:commons-lang3:3.10") { transitive = false }
     implementation("org.apache.hive:hive-storage-api:${hiveStorageApiVersion}") { transitive = false }
     implementation("org.apache.orc:orc-core:${orcVersion}") { transitive = false }
     implementation("io.airlift:aircompressor:0.8") { transitive = false }

--- a/server/pxf-s3/build.gradle
+++ b/server/pxf-s3/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation("commons-codec:commons-codec")
     implementation("commons-lang:commons-lang")
     implementation("org.apache.commons:commons-lang3")
-    implementation("org.apache.httpcomponents:httpclient:4.5.9") { transitive = false }
-    implementation("org.apache.httpcomponents:httpcore:4.4.13") { transitive = false }
+    implementation("org.apache.httpcomponents:httpclient:4.5.13") { transitive = false }
+    implementation("org.apache.httpcomponents:httpcore:4.4.14") { transitive = false }
     implementation("org.apache.hadoop:hadoop-aws:${hadoopVersion}") { transitive = false }
     implementation("com.amazonaws:aws-java-sdk-core:${awsJavaSdk}") { transitive = false }
     implementation("com.amazonaws:aws-java-sdk-kms:${awsJavaSdk}") { transitive = false }

--- a/server/pxf-service/build.gradle
+++ b/server/pxf-service/build.gradle
@@ -62,12 +62,15 @@ dependencies {
     testImplementation("commons-io:commons-io")
     testImplementation("org.simplify4u:slf4j-mock:2.1.0") // for MDC mocking
 
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    developmentOnly('org.springframework.boot:spring-boot-devtools')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation('org.springframework.boot:spring-boot-starter-webflux')
 }
 
 bootJar {
+    layered {
+        enabled = false
+    }
     manifest {
         attributes("Implementation-Title": project.name)
         attributes("Implementation-Version": project.version)


### PR DESCRIPTION
The updated dependencies were already being bumped up to the higher versions by gradle resolution, so removing mentioning the old versions helps with not having them reported by the license finder.

Also removed layered JARs feature of Spring Boot as we are not yet building any docker images and having it present resulted in `spring-boot-jarmode-layertools-2.4.3.jar` being packaged but not reported by the license finder.