### PR TITLE
Add reporting for BYTES_SENT by PXF

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/BufferWritable.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/BufferWritable.java
@@ -68,10 +68,11 @@ public class BufferWritable implements Writable {
      * @throws IOException if the buffer was not set
      */
     @Override
-    public void write(DataOutput out) throws IOException {
+    public long write(DataOutput out) throws IOException {
         if (buf == null)
             throw new IOException("BufferWritable was not set");
         out.write(buf, 0, length);
+        return length;
     }
 
     /**

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/GPDBWritable.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/GPDBWritable.java
@@ -332,7 +332,7 @@ public class GPDBWritable implements Writable {
     }
 
     @Override
-    public void write(DataOutput out) throws IOException {
+    public long write(DataOutput out) throws IOException {
         int numCol = colType.length;
         boolean[] nullBits = new boolean[numCol];
         int[] colLength = new int[numCol];
@@ -465,7 +465,8 @@ public class GPDBWritable implements Writable {
                     /* For BYTEA format, add 4byte length header at the beginning  */
                     case BYTEA:
                         out.writeInt(colLength[i]);
-                        out.write((byte[]) colValue[i]);
+                        byte[] value = (byte[]) colValue[i];
+                        out.write(value);
                         break;
 
                     /* For text format, add 4byte length header. string is already '\0' terminated */
@@ -481,6 +482,7 @@ public class GPDBWritable implements Writable {
 
         /* End padding */
         out.write(padbytes, 0, endpadding);
+        return datlen;
     }
 
     /**

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/Text.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/Text.java
@@ -339,9 +339,11 @@ public class Text implements Writable {
     }
 
     @Override
-    public void write(DataOutput out) throws IOException {
+    public long write(DataOutput out) throws IOException {
         byte[] bytes = getBytes();
-        out.write(bytes, 0, getLength());
+        int length = getLength();
+        out.write(bytes, 0, length);
+        return length;
     }
 
     /**

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/Writable.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/io/Writable.java
@@ -8,9 +8,9 @@ package org.greenplum.pxf.api.io;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -34,9 +34,10 @@ public interface Writable {
      * Serialize the fields of this object to <code>out</code>.
      *
      * @param out <code>DataOutput</code> to serialize this object into.
+     * @return number of bytes written
      * @throws IOException if I/O error occurs
      */
-    void write(DataOutput out) throws IOException;
+    long write(DataOutput out) throws IOException;
 
     /**
      * Deserialize the fields of this object from <code>in</code>.

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/io/BufferWritableTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/io/BufferWritableTest.java
@@ -21,10 +21,22 @@ package org.greenplum.pxf.api.io;
 
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.DataOutput;
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 public class BufferWritableTest {
+
+    @Mock
+    private DataOutput mockOutput;
 
     @Test
     public void append() throws Exception {
@@ -38,5 +50,15 @@ public class BufferWritableTest {
         bw1.append(data2.getBytes());
 
         assertArrayEquals((data1+data2).getBytes(), bw1.buf);
+    }
+
+    @Test
+    public void testWriteBytes() throws IOException {
+        String data1 = "hello world";
+
+        BufferWritable bw = new BufferWritable(data1.getBytes());
+        long bytes = bw.write(mockOutput);
+        assertEquals(11,bytes);
+        verify(mockOutput).write(data1.getBytes(), 0, 11);
     }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/io/TextTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/io/TextTest.java
@@ -1,0 +1,27 @@
+package org.greenplum.pxf.api.io;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class TextTest {
+
+    @Mock
+    private DataOutput mockOutput;
+
+    @Test
+    public void testWriteBytes() throws IOException {
+        Text text = new Text("hello");
+        long bytes = text.write(mockOutput);
+        assertEquals(5, bytes);
+        verify(mockOutput).write(text.getBytes(), 0, 5);
+    }
+}

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/MetricsReporter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/MetricsReporter.java
@@ -140,8 +140,9 @@ public class MetricsReporter {
      */
     public enum PxfMetric {
         FRAGMENTS_SENT("fragments.sent", "pxf.metrics.fragments.enabled", null),
-        RECORDS_SENT("records.sent", "pxf.metrics.records.enabled", "pxf.metrics.records.report-frequency"),
-        RECORDS_RECEIVED("records.received", "pxf.metrics.records.enabled", "pxf.metrics.records.report-frequency");
+        RECORDS_SENT("records.sent", "pxf.metrics.records.enabled", "pxf.metrics.report-frequency"),
+        RECORDS_RECEIVED("records.received", "pxf.metrics.records.enabled", "pxf.metrics.report-frequency"),
+        BYTES_SENT("bytes.sent", "pxf.metrics.bytes.enabled", "pxf.metrics.bytes.report-frequency");
 
         private final String metricName;
         private final String enabledPropertyName;

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
@@ -71,17 +71,21 @@ public abstract class BaseServiceImpl {
 
         Instant startTime = Instant.now();
         OperationStats stats = securityService.doAs(context, action);
-        Long recordCount = stats.getRecordCount();
+        long recordCount = stats.getRecordCount();
+        long bytesCount = stats.getByteCount();
         if (recordCount > 0) {
             long durationMs = Duration.between(startTime, Instant.now()).toMillis();
             double rate = durationMs == 0 ? 0 : (1000.0 * recordCount / durationMs);
-            log.info("{} completed {} operation for {} record{} in {} ms. rate = {} records/sec",
+            double byteRate = durationMs == 0 ? 0 : (1000.0 * bytesCount / durationMs);
+            log.info("{} completed {} operation in {} ms for {} record{} ({} records/sec) and {} bytes ({} bytes/sec)",
                     context.getId(),
                     stats.getOperation(),
+                    durationMs,
                     recordCount,
                     recordCount == 1 ? "" : "s",
-                    durationMs,
-                    String.format("%.2f", rate));
+                    String.format("%.2f", rate),
+                    bytesCount,
+                    String.format("%.2f", byteRate));
         } else {
             log.info("{} completed", context.getId());
         }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/OperationStats.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/OperationStats.java
@@ -10,7 +10,21 @@ import lombok.Getter;
 @Builder
 public class OperationStats {
     private String operation;
-    private Long recordCount;
-    private Long batchCount;
-    private Long byteCount;
+    private long recordCount;
+    private long batchCount;
+    private long byteCount;
+
+    /**
+     * Increments the values of the object using the values from the passed in stats
+     *
+     * Note: we do not check to see if the operation matches because the operation stats
+     * only live within the context of processing data, which is confined to a single
+     * operation type.
+     * @param operationStats statistics to add to the existing object
+     */
+    public void update(OperationStats operationStats) {
+        this.recordCount += operationStats.getRecordCount();
+        this.batchCount += operationStats.getBatchCount();
+        this.byteCount += operationStats.getByteCount();
+    }
 }

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -14,7 +14,8 @@ management.metrics.tags.application=pxf-service
 # PXF-specific metrics
 pxf.metrics.fragments.enabled=true
 pxf.metrics.records.enabled=true
-pxf.metrics.records.report-frequency=1000
+pxf.metrics.bytes.enabled=true
+pxf.metrics.report-frequency=1000
 
 spring.profiles.active=default
 

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadSamplingBridgeTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadSamplingBridgeTest.java
@@ -59,7 +59,7 @@ public class ReadSamplingBridgeTest {
         }
 
         @Override
-        public void write(DataOutput out) throws IOException {
+        public long write(DataOutput out) throws IOException {
             throw new IOException("not implemented");
         }
 

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/OperationStatsTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/OperationStatsTest.java
@@ -1,0 +1,30 @@
+package org.greenplum.pxf.service.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OperationStatsTest {
+    @Test
+    public void testDefaultValues() {
+        OperationStats defaultStats = OperationStats.builder().build();
+
+        assertEquals(null, defaultStats.getOperation());
+        assertEquals(0L, defaultStats.getRecordCount());
+        assertEquals(0L, defaultStats.getBatchCount());
+        assertEquals(0L, defaultStats.getByteCount());
+    }
+
+    @Test
+    public void testUpdate() {
+        OperationStats startingStats = OperationStats.builder().operation("read").build();
+        OperationStats addMe = OperationStats.builder().operation("addMe").recordCount(10L).batchCount(15L).byteCount(20L).build();
+
+        startingStats.update(addMe);
+
+        assertEquals("read", startingStats.getOperation());
+        assertEquals(10L, startingStats.getRecordCount());
+        assertEquals(15L, startingStats.getBatchCount());
+        assertEquals(20L, startingStats.getByteCount());
+    }
+}


### PR DESCRIPTION
This commit adds byte reporting at query and fragment level for Text,
BufferWritable, and GPDBWritable.

Co-authored-by: Ashuka Xue <axue@vmware.com>
Co-authored-by: Bradford Boyle <bradfordb@vmware.com>
Co-authored-by: Alex Denissov <adenissov@vmware.com>