### PR TITLE
docs - updates to troubleshooting error table

### DIFF
--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -36,6 +36,10 @@ The following table describes some errors you may encounter while using PXF:
 
 Most PXF error messages include a `HINT` that you can use to resolve the error, or to collect more information to identify the error.
 
+## <a id="pxf-loggin"></a>PXF Logging
+
+Refer to the [Logging](cfg_logging.html) topic for more information about logging levels, configuration, and the `pxf-service.log` log file.
+
 
 ## <a id="pxf-timezonecfg"></a>Addressing PXF JDBC Connector Time Zone Errors
 

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -28,12 +28,13 @@ The following table describes some errors you may encounter while using PXF:
 | Error Message                 | Discussion                     |
 |-------------------------------|---------------------------------|
 | Protocol "pxf" does not exist | **Cause**: The `pxf` extension was not registered.<br>**Solution**: Create (enable) the PXF extension for the database as described in the PXF [Enable Procedure](using_pxf.html#enable-pxf-ext).|
-| Invalid URI pxf://\<path-to-data\>: missing options section | **Cause**: The `LOCATION` URI does not include the profile or other required options.<br>**Solution**: Provide the profile and required options in the URI. |
-| org.apache.hadoop.mapred.InvalidInputException: Input path does not exist: hdfs://\<namenode\>:8020/\<path-to-file\> | **Cause**: The HDFS file that you specified in \<path-to-file\> does not exist. <br>**Solution**: Provide the path to an existing HDFS file. |
-| NoSuchObjectException(message:\<schema\>.\<hivetable\> table not found) | **Cause**: The Hive table that you specified with \<schema\>.\<hivetable\> does not exist. <br>**Solution**: Provide the name of an existing Hive table. |
-| Failed to connect to \<segment-host\> port 5888: Connection refused (libchurl.c:944)  (\<segment-id\> slice\<N\> \<segment-host\>:40000 pid=\<process-id\>)<br> ... |**Cause**: PXF is not running on \<segment-host\>.<br>**Solution**: Restart PXF on \<segment-host\>. |
-| *ERROR*: failed to acquire resources on one or more segments<br>*DETAIL*:  could not connect to server: Connection refused<br>&nbsp;&nbsp;&nbsp;&nbsp;Is the server running on host "\<segment-host\>" and accepting<br>&nbsp;&nbsp;&nbsp;&nbsp;TCP/IP connections on port 40000?(seg\<N\> \<segment-host\>:40000) | **Cause**: The Greenplum Database segment host \<segment-host\> is down. |
-| org.apache.hadoop.security.AccessControlException: Permission denied: user=<user>, access=READ, inode=&quot;<filepath>&quot;:<user>:<group>:-rw------- | **Cause**: The Greenplum Database user that executed the PXF operation does not have permission to access the underlying Hadoop service (HDFS or Hive). See [Configuring the Hadoop User, User Impersonation, and Proxying](pxfuserimpers.html). |
+| Invalid URI pxf://\<path-to-data\>: missing options section | **Cause**: The `LOCATION` URI does not include the profile or other required options.<br>**Solution**: Provide the profile and required options in the URI when you submit the `CREATE EXTERNAL TABLE` command. |
+| PXF server error : Input path does not exist: hdfs://\<namenode\>:8020/\<path-to-file\> | **Cause**: The HDFS file that you specified in \<path-to-file\> does not exist. <br>**Solution**: Provide the path to an existing HDFS file. |
+| PXF server error : NoSuchObjectException(message:\<schema\>.\<hivetable\> table not found) | **Cause**: The Hive table that you specified with \<schema\>.\<hivetable\> does not exist. <br>**Solution**: Provide the name of an existing Hive table. |
+| PXF server error : Failed connect to localhost:5888; Connection refused (\<segment-id\> slice\<N\> \<segment-host\>:\<port\> pid=\<process-id\>)<br> ... |**Cause**: The PXF Service is not running on \<segment-host\>.<br>**Solution**: Restart PXF on \<segment-host\>. |
+| PXF server error: Permission denied: user=\<user\>, access=READ, inode=&quot;\<filepath\>&quot;:-rw------- | **Cause**: The Greenplum Database user that executed the PXF operation does not have permission to access the underlying Hadoop service (HDFS or Hive). See [Configuring the Hadoop User, User Impersonation, and Proxying](pxfuserimpers.html). |
+
+Most PXF error messages include a `HINT` that you can use to resolve the error, or to collect more information to identify the error.
 
 
 ## <a id="pxf-timezonecfg"></a>Addressing PXF JDBC Connector Time Zone Errors


### PR DESCRIPTION
reviewed and updated some of the common errors on the troubleshooting page:
- i removed the error for one of the pxf hosts down, i couldn't reproduce it.  
- feel free to identify any other common errors we might want to add to this table.

doc review site link:  http://docs-lisa-pxf6-tserrors.cfapps.io/pxf/6-0/using/troubleshooting_pxf.html