### PR TITLE
Docs - replaced PXF_BASE=/usr/local/greenplum-pxf with PXF_BASE=/usr/…

### DIFF
--- a/docs/content/hdfs_seqfile.html.md.erb
+++ b/docs/content/hdfs_seqfile.html.md.erb
@@ -217,10 +217,10 @@ public class PxfExample_CustomWritable implements Writable {
     $ ssh gpadmin@<gpmaster>
     ````
 
-5. Copy the `pxfex-customwritable.jar` JAR file to the user runtime library directory, and note the location. For example, if `PXF_BASE=/usr/local/greenplum-pxf`:
+5. Copy the `pxfex-customwritable.jar` JAR file to the user runtime library directory, and note the location. For example, if `PXF_BASE=/usr/local/pxf-gp6`:
 
     ``` shell
-    gpadmin@gpmaster$ cp /home/gpadmin/pxfex-customwritable.jar /usr/local/greenplum-pxf/lib/pxfex-customwritable.jar
+    gpadmin@gpmaster$ cp /home/gpadmin/pxfex-customwritable.jar /usr/local/pxf-gp6/lib/pxfex-customwritable.jar
     ```
 
 5. Synchronize the PXF configuration to the Greenplum Database cluster:

--- a/docs/content/pxf_kerbhdfs.html.md.erb
+++ b/docs/content/pxf_kerbhdfs.html.md.erb
@@ -216,12 +216,12 @@ When you configure PXF for secure HDFS using an MIT Kerberos KDC server, you wil
     root@kdc-server$ kadmin.local -q "listprincs"
     ```
 
-6.  Copy the keytab file for each PXF Service principal to its respective host. For example, the following commands copy each principal generated in step 4 to the PXF default keytab directory on the host when `PXF_BASE=/usr/local/greenplum-pxf`:
+6.  Copy the keytab file for each PXF Service principal to its respective host. For example, the following commands copy each principal generated in step 4 to the PXF default keytab directory on the host when `PXF_BASE=/usr/local/pxf-gp6`:
 
     ``` shell
-    root@kdc-server$ scp /etc/security/keytabs/pxf-host1.service.keytab host1.example.com:/usr/local/greenplum-pxf/keytabs/pxf.service.keytab
-    root@kdc-server$ scp /etc/security/keytabs/pxf-host2.service.keytab host2.example.com:/usr/local/greenplum-pxf/keytabs/pxf.service.keytab
-    root@kdc-server$ scp /etc/security/keytabs/pxf-host3.service.keytab host3.example.com:/usr/local/greenplum-pxf/keytabs/pxf.service.keytab
+    root@kdc-server$ scp /etc/security/keytabs/pxf-host1.service.keytab host1.example.com:/usr/local/pxf-gp6/keytabs/pxf.service.keytab
+    root@kdc-server$ scp /etc/security/keytabs/pxf-host2.service.keytab host2.example.com:/usr/local/pxf-gp6/keytabs/pxf.service.keytab
+    root@kdc-server$ scp /etc/security/keytabs/pxf-host3.service.keytab host3.example.com:/usr/local/pxf-gp6/keytabs/pxf.service.keytab
     ```
 
     Note the file system location of the keytab file on each PXF host; you will need this information for a later configuration step.
@@ -229,12 +229,12 @@ When you configure PXF for secure HDFS using an MIT Kerberos KDC server, you wil
 7. Change the ownership and permissions on the `pxf.service.keytab` files. The files must be owned and readable by only the `gpadmin` user. For example:
 
     ``` shell 
-    root@kdc-server$ ssh host1.example.com chown gpadmin:gpadmin /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host1.example.com chmod 400 /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host2.example.com chown gpadmin:gpadmin /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host2.example.com chmod 400 /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host3.example.com chown gpadmin:gpadmin /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
-    root@kdc-server$ ssh host3.example.com chmod 400 /usr/local/greenplum-pxf/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host1.example.com chown gpadmin:gpadmin /usr/local/pxf-gp6/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host1.example.com chmod 400 /usr/local/pxf-gp6/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host2.example.com chown gpadmin:gpadmin /usr/local/pxf-gp6/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host2.example.com chmod 400 /usr/local/pxf-gp6/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host3.example.com chown gpadmin:gpadmin /usr/local/pxf-gp6/keytabs/pxf.service.keytab
+    root@kdc-server$ ssh host3.example.com chmod 400 /usr/local/pxf-gp6/keytabs/pxf.service.keytab
     ```
 
 **Perform the following steps on the Greenplum Database master host**:


### PR DESCRIPTION
Found two files still referencing to /usr/local/greenplum-pxf
hdfs_seqfile.html.md.erb
pxf_kerbhdfs.html.md.erb
I don't think this needs technical review but feel free to add other tech reviewers if you'd like.