### PR TITLE
docs - text and sequencefile profiles support compression codec aliases

### DIFF
--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -23,6 +23,8 @@ under the License.
 
 Use the PXF HDFS connector to read and write Parquet-format data. This section describes how to read and write HDFS files that are stored in Parquet format, including how to create, query, and insert into external tables that reference files in the HDFS data store.
 
+PXF supports reading or writing Parquet files compressed with these codecs: `snappy`, `gzip`, and `lzo`.
+
 PXF currently supports reading and writing primitive Parquet data types only.
 
 

--- a/docs/content/hdfs_seqfile.html.md.erb
+++ b/docs/content/hdfs_seqfile.html.md.erb
@@ -66,7 +66,7 @@ The `hdfs:SequenceFile` profile supports the following custom options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|
-| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs include: `default`, `bzip2`, and `gzip`. If this option is not provided, Greenplum Database performs no data compression. |
+| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | DATA-SCHEMA    | The name of the writer serialization/deserialization class. The jar file in which this class resides must be in the PXF classpath. This option is required for the `hdfs:SequenceFile` profile and has no default value. |
 | IGNORE_MISSING_PATH | A Boolean value that specifies the action to take when \<path-to-hdfs-dir\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |

--- a/docs/content/hdfs_seqfile.html.md.erb
+++ b/docs/content/hdfs_seqfile.html.md.erb
@@ -23,7 +23,7 @@ under the License.
 
 The PXF HDFS connector supports SequenceFile format binary data. This section describes how to use PXF to read and write HDFS SequenceFile data, including how to create, insert, and query data in external tables that reference files in the HDFS data store.
 
-PXF supports reading or writing SequenceFile files compressed with the `bzip2` and `gzip` codecs.
+PXF supports reading or writing SequenceFile files compressed with the `default`, `bzip2`, and `gzip` codecs.
 
 ## <a id="prereq"></a>Prerequisites
 
@@ -58,11 +58,11 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 <a id="customopts"></a>
-SequenceFile format data can optionally employ record or block compression. You specify the compression type and codec via custom options to the `CREATE EXTERNAL TABLE` `LOCATION` clause.
+SequenceFile format data can optionally employ record or block compression and a specific compression codec.
 
-When you use the `hdfs:SequenceFile` profile to write SequenceFile format data, you must provide the name of the Java class to use for serializing/deserializing the binary data. This class must provide read and write methods for each data type referenced in the data schema. You also specify the Java serialization class via a custom option to the `CREATE EXTERNAL TABLE` `LOCATION` clause.
+When you use the `hdfs:SequenceFile` profile to write SequenceFile format data, you must provide the name of the Java class to use for serializing/deserializing the binary data. This class must provide read and write methods for each data type referenced in the data schema.
 
-The `hdfs:SequenceFile` profile supports the following custom options:
+You specify the compression type and codec, and the Java serialization/deserialization class, via custom options to the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:SequenceFile` profile supports the following custom options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|

--- a/docs/content/hdfs_seqfile.html.md.erb
+++ b/docs/content/hdfs_seqfile.html.md.erb
@@ -23,6 +23,8 @@ under the License.
 
 The PXF HDFS connector supports SequenceFile format binary data. This section describes how to use PXF to read and write HDFS SequenceFile data, including how to create, insert, and query data in external tables that reference files in the HDFS data store.
 
+PXF supports reading or writing SequenceFile files compressed with the `bzip2` and `gzip` codecs.
+
 ## <a id="prereq"></a>Prerequisites
 
 Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq) before you attempt to read data from or write data to HDFS.
@@ -56,20 +58,15 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 <a id="customopts"></a>
-SequenceFile format data can optionally employ record or block compression. The PXF `hdfs:SequenceFile` profile supports the following compression codecs:
+SequenceFile format data can optionally employ record or block compression. You specify the compression type and codec via custom options to the `CREATE EXTERNAL TABLE` `LOCATION` clause.
 
-- org.apache.hadoop.io.compress.DefaultCodec
-- org.apache.hadoop.io.compress.BZip2Codec
-
-When you use the `hdfs:SequenceFile` profile to write SequenceFile format data, you must provide the name of the Java class to use for serializing/deserializing the binary data. This class must provide read and write methods for each data type referenced in the data schema.
-
-You specify the compression codec and Java serialization class via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause.
+When you use the `hdfs:SequenceFile` profile to write SequenceFile format data, you must provide the name of the Java class to use for serializing/deserializing the binary data. This class must provide read and write methods for each data type referenced in the data schema. You also specify the Java serialization class via a custom option to the `CREATE EXTERNAL TABLE` `LOCATION` clause.
 
 The `hdfs:SequenceFile` profile supports the following custom options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|
-| COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
+| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs include: `default`, `bzip2`, and `gzip`. If this option is not provided, Greenplum Database performs no data compression. |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | DATA-SCHEMA    | The name of the writer serialization/deserialization class. The jar file in which this class resides must be in the PXF classpath. This option is required for the `hdfs:SequenceFile` profile and has no default value. |
 | IGNORE_MISSING_PATH | A Boolean value that specifies the action to take when \<path-to-hdfs-dir\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
@@ -231,11 +228,11 @@ public class PxfExample_CustomWritable implements Writable {
 
 3. Restart PXF on each Greenplum Database segment host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).
 
-5. Use the PXF `hdfs:SequenceFile` profile to create a Greenplum Database writable external table. Identify the serialization/deserialization Java class you created above in the `DATA-SCHEMA` \<custom-option\>. Use `BLOCK` mode compression with `BZip2` when you create the writable table.
+5. Use the PXF `hdfs:SequenceFile` profile to create a Greenplum Database writable external table. Identify the serialization/deserialization Java class you created above in the `DATA-SCHEMA` \<custom-option\>. Use `BLOCK` mode compression with `bzip2` when you create the writable table.
 
     ``` sql
     postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_tbl_seqfile (location text, month text, number_of_orders integer, total_sales real)
-                LOCATION ('pxf://data/pxf_examples/pxf_seqfile?PROFILE=hdfs:SequenceFile&DATA-SCHEMA=com.example.pxf.hdfs.writable.dataschema.PxfExample_CustomWritable&COMPRESSION_TYPE=BLOCK&COMPRESSION_CODEC=org.apache.hadoop.io.compress.BZip2Codec')
+                LOCATION ('pxf://data/pxf_examples/pxf_seqfile?PROFILE=hdfs:SequenceFile&DATA-SCHEMA=com.example.pxf.hdfs.writable.dataschema.PxfExample_CustomWritable&COMPRESSION_TYPE=BLOCK&COMPRESSION_CODEC=bzip2')
               FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
     ```
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -23,7 +23,7 @@ under the License.
 
 The PXF HDFS Connector supports plain delimited and comma-separated value form text data. This section describes how to use PXF to access HDFS text data, including how to create, query, and insert data into an external table that references files in the HDFS data store.
 
-PXF supports reading or writing text files compressed with the `bzip2` and `gzip` codecs.
+PXF supports reading or writing text files compressed with the `default`, `bzip2`, and `gzip` codecs.
 
 ## <a id="prereq"></a>Prerequisites
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -23,6 +23,8 @@ under the License.
 
 The PXF HDFS Connector supports plain delimited and comma-separated value form text data. This section describes how to use PXF to access HDFS text data, including how to create, query, and insert data into an external table that references files in the HDFS data store.
 
+PXF supports reading or writing text files compressed with the `bzip2` and `gzip` codecs.
+
 ## <a id="prereq"></a>Prerequisites
 
 Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq) before you attempt to read data from or write data to HDFS.
@@ -245,17 +247,11 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://gpd
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
-Writable external tables that you create using the `hdfs:text` profile can optionally use record or block compression. The PXF `hdfs:text` profile supports the following compression codecs:
-
-- org.apache.hadoop.io.compress.DefaultCodec
-- org.apache.hadoop.io.compress.GzipCodec
-- org.apache.hadoop.io.compress.BZip2Codec
-
-You specify the compression codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:text` profile support the following custom write options:
+Writable external tables that you create using the `hdfs:text` profile can optionally use record or block compression. You specify the compression type and codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:text` profile supports the following custom write options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|
-| COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
+| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing text data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 
 ### <a id="write_hdfstextsimple_example"></a>Example: Writing Text Data to HDFS
@@ -346,7 +342,7 @@ Perform the following procedure to create Greenplum Database writable external t
 
     ``` sql
     postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_hdfs_writabletbl_2 (location text, month text, num_orders int, total_sales float8)
-                LOCATION ('pxf://data/pxf_examples/pxfwritable_hdfs_textsimple2?PROFILE=hdfs:text&COMPRESSION_CODEC=org.apache.hadoop.io.compress.GzipCodec')
+                LOCATION ('pxf://data/pxf_examples/pxfwritable_hdfs_textsimple2?PROFILE=hdfs:text&COMPRESSION_CODEC=gzip')
               FORMAT 'TEXT' (delimiter=':');
     ```
 

--- a/docs/content/objstore_seqfile.html.md.erb
+++ b/docs/content/objstore_seqfile.html.md.erb
@@ -74,7 +74,7 @@ Refer to [Example: Writing Binary Data to HDFS](hdfs_seqfile.html#write_seqfile_
 
     ``` sql
     CREATE WRITABLE EXTERNAL TABLE pxf_tbl_seqfile_s3(location text, month text, number_of_orders integer, total_sales real)
-      LOCATION ('pxf://BUCKET/pxf_examples/pxf_seqfile?PROFILE=s3:SequenceFile&DATA-SCHEMA=com.example.pxf.hdfs.writable.dataschema.PxfExample_CustomWritable&COMPRESSION_TYPE=BLOCK&COMPRESSION_CODEC=org.apache.hadoop.io.compress.BZip2Codec&SERVER=s3srvcfg')
+      LOCATION ('pxf://BUCKET/pxf_examples/pxf_seqfile?PROFILE=s3:SequenceFile&DATA-SCHEMA=com.example.pxf.hdfs.writable.dataschema.PxfExample_CustomWritable&COMPRESSION_TYPE=BLOCK&COMPRESSION_CODEC=bzip2&SERVER=s3srvcfg')
     FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
     ```
 

--- a/docs/content/objstore_text.html.md.erb
+++ b/docs/content/objstore_text.html.md.erb
@@ -277,17 +277,11 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://gpd
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
-Writable external tables that you create using an `<objstore>:text` profile can optionally use record or block compression. The PXF `<objstore>:text` profiles support the following compression codecs:
-
-- org.apache.hadoop.io.compress.DefaultCodec
-- org.apache.hadoop.io.compress.GzipCodec
-- org.apache.hadoop.io.compress.BZip2Codec
-
-You specify the compression codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `<objstore>:text` profile support the following custom write options:
+Writable external tables that you create using an `<objstore>:text` profile can optionally use record or block compression. You specify the compression type and codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `<objstore>:text` profiles support the following custom write options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|
-| COMPRESSION_CODEC    | The compression codec Java class name. If this option is not provided, Greenplum Database performs no data compression. Supported compression codecs include:<br>`org.apache.hadoop.io.compress.DefaultCodec`<br>`org.apache.hadoop.io.compress.BZip2Codec`<br>`org.apache.hadoop.io.compress.GzipCodec` |
+| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing text data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 
 If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
@@ -366,7 +360,7 @@ Perform the following procedure to create Greenplum Database writable external t
 
     ``` sql
     postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_s3_writetbl_2 (location text, month text, num_orders int, total_sales float8)
-                LOCATION ('pxf://BUCKET/pxf_examples/pxfwrite_s3_textsimple2?PROFILE=s3:text&SERVER=s3srvcfg&COMPRESSION_CODEC=org.apache.hadoop.io.compress.GzipCodec')
+                LOCATION ('pxf://BUCKET/pxf_examples/pxfwrite_s3_textsimple2?PROFILE=s3:text&SERVER=s3srvcfg&COMPRESSION_CODEC=gzip')
               FORMAT 'TEXT' (delimiter=':');
     ```
 


### PR DESCRIPTION
doc changes for https://github.com/greenplum-db/pxf/pull/535.

in this PR:
- can use codec aliases for specifying COMPRESSION_CODEC in text and SequenceFile profiles.
- add statement upfront in parquet/text/sequencefile docs about the compression codecs supported.

question - can someone verify the compression codecs supported for sequencefile?  previous docs had bzip2 and gzip.

doc review site links:
- text - http://docs-lisa-pxf6-codecalias.cfapps.io/pxf/6-0/using/hdfs_text.html#hdfswrite_text
- sequencefile - http://docs-lisa-pxf6-codecalias.cfapps.io/pxf/6-0/using/hdfs_seqfile.html#hdfswrite_writeextdata