### PR TITLE
Add bytes reporting to PXF

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
@@ -71,17 +71,21 @@ public abstract class BaseServiceImpl {
 
         Instant startTime = Instant.now();
         OperationStats stats = securityService.doAs(context, action);
-        Long recordCount = stats.getRecordCount();
+        long recordCount = stats.getRecordCount();
+        long byteCount = stats.getByteCount();
         if (recordCount > 0) {
             long durationMs = Duration.between(startTime, Instant.now()).toMillis();
             double rate = durationMs == 0 ? 0 : (1000.0 * recordCount / durationMs);
-            log.info("{} completed {} operation for {} record{} in {} ms. rate = {} records/sec",
+            double byteRate = durationMs == 0 ? 0 : (1000.0 * byteCount / durationMs);
+            log.info("{} completed {} operation in {} ms for {} record{} ({} records/sec) and {} bytes ({} bytes/sec)",
                     context.getId(),
-                    stats.getOperation(),
+                    stats.getOperation().name().toLowerCase(),
+                    durationMs,
                     recordCount,
                     recordCount == 1 ? "" : "s",
-                    durationMs,
-                    String.format("%.2f", rate));
+                    String.format("%.2f", rate),
+                    byteCount,
+                    String.format("%.2f", byteRate));
         } else {
             log.info("{} completed", context.getId());
         }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/OperationStats.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/OperationStats.java
@@ -1,16 +1,91 @@
 package org.greenplum.pxf.service.controller;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.service.MetricsReporter;
 
 /**
  * Holds statistics about performed operation.
  */
-@Getter
-@Builder
 public class OperationStats {
-    private String operation;
-    private Long recordCount;
-    private Long batchCount;
-    private Long byteCount;
+    @Getter
+    private final Operation operation;
+    private final RequestContext context;
+    private final MetricsReporter metricsReporter;
+    private final long reportFrequency;
+    @Getter
+    private long recordCount = 0;
+    @Getter
+    @Setter
+    private long byteCount = 0;
+    private long lastReportedRecordCount = 0;
+    private long lastReportedByteCount = 0;
+
+    enum Operation {
+        READ(MetricsReporter.PxfMetric.RECORDS_SENT, MetricsReporter.PxfMetric.BYTES_SENT),
+        WRITE(MetricsReporter.PxfMetric.RECORDS_RECEIVED, MetricsReporter.PxfMetric.BYTES_RECEIVED);
+
+        private final MetricsReporter.PxfMetric recordMetric;
+        private final MetricsReporter.PxfMetric byteMetric;
+
+        Operation(MetricsReporter.PxfMetric recordMetric, MetricsReporter.PxfMetric byteMetric) {
+            this.recordMetric = recordMetric;
+            this.byteMetric = byteMetric;
+        }
+    }
+
+    public OperationStats(Operation operation, MetricsReporter metricsReporter, RequestContext context) {
+        this.operation = operation;
+        this.context = context;
+        this.metricsReporter = metricsReporter;
+        this.reportFrequency = metricsReporter.getReportFrequency();
+    }
+    /**
+     * Increments the values of the object using the values from the passed in stats
+     *
+     * Note: we do not check to see if the operation matches because the operation stats
+     * only live within the context of processing data, which is confined to a single
+     * operation type.
+     * @param operationStats statistics to add to the existing object
+     */
+    public void update(OperationStats operationStats) {
+        this.recordCount += operationStats.getRecordCount();
+        this.byteCount += operationStats.getByteCount();
+    }
+
+    /**
+     * Add a completed record to the operation's stats. Report the stats when necessary.
+     *
+     * @param byteCount the total number of bytes written to date for the entire operation
+     */
+    public void reportCompletedRecord(long byteCount) {
+        recordCount++;
+        this.byteCount = byteCount;
+
+        if ((reportFrequency != 0) && (recordCount % reportFrequency == 0)) {
+            flushStats();
+        }
+    }
+
+    /**
+     * Send all the stats to the metric reporter. Set last reported values.
+     */
+    public void flushStats() {
+        if (reportFrequency == 0) {
+            return;
+        }
+
+        long recordsProcessed = recordCount - lastReportedRecordCount;
+        if (recordsProcessed != 0) {
+            metricsReporter.reportCounter(operation.recordMetric, recordsProcessed, context);
+            lastReportedRecordCount = recordCount;
+        }
+
+        long bytesProcessed = byteCount - lastReportedByteCount;
+        if (bytesProcessed != 0) {
+            metricsReporter.reportCounter(operation.byteMetric, bytesProcessed, context);
+            lastReportedByteCount = byteCount;
+        }
+    }
 }

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -14,7 +14,8 @@ management.metrics.tags.application=pxf-service
 # PXF-specific metrics
 pxf.metrics.fragments.enabled=true
 pxf.metrics.records.enabled=true
-pxf.metrics.records.report-frequency=1000
+pxf.metrics.bytes.enabled=true
+pxf.metrics.report-frequency=1000
 
 spring.profiles.active=default
 

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/MetricsReporterTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/MetricsReporterTest.java
@@ -151,6 +151,18 @@ public class MetricsReporterTest {
         assertEquals(1051, counter.count());
     }
 
+    @Test
+    public void testGetReportFrequency() {
+        when(mockEnvironment.getProperty("pxf.metrics.report-frequency", Long.class, 1000L)).thenReturn(5L);
+        assertEquals(5L, reporter.getReportFrequency());
+    }
+
+    @Test
+    public void testGetReportFrequencyNegativeValue() {
+        when(mockEnvironment.getProperty("pxf.metrics.report-frequency", Long.class, 1000L)).thenReturn(-5L);
+        assertEquals(0L, reporter.getReportFrequency());
+    }
+
     private void setContext() {
         when(mockContext.getUser()).thenReturn("Alex");
         when(mockContext.getSegmentId()).thenReturn(5);

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/OperationStatsTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/OperationStatsTest.java
@@ -1,0 +1,188 @@
+package org.greenplum.pxf.service.controller;
+
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.service.MetricsReporter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OperationStatsTest {
+    @Mock
+    private MetricsReporter mockMetricReporter;
+    @Mock
+    private RequestContext mockContext;
+
+    @Test
+    public void testDefaultValues() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(5L);
+        OperationStats defaultStats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+
+        assertEquals(OperationStats.Operation.READ, defaultStats.getOperation());
+        assertEquals(0L, defaultStats.getRecordCount());
+        assertEquals(0L, defaultStats.getByteCount());
+    }
+
+    @Test
+    public void testReportCurrentStatsZeroReportFrequency() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(0L);
+        OperationStats stats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        stats.reportCompletedRecord(15L);
+
+        assertEquals(1L, stats.getRecordCount());
+        assertEquals(15L, stats.getByteCount());
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testReportCurrentStatsNoReport() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(5L);
+        OperationStats stats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        stats.reportCompletedRecord(15L);
+
+        assertEquals(1L, stats.getRecordCount());
+        assertEquals(15L, stats.getByteCount());
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testReportCurrentStatsReport() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(1L);
+        OperationStats stats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        stats.reportCompletedRecord(15L);
+
+        assertEquals(1L, stats.getRecordCount());
+        assertEquals(15L, stats.getByteCount());
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 1, mockContext);
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 15, mockContext);
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testReportCurrentStatsMultiRecordReport() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(2L);
+        OperationStats stats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        stats.reportCompletedRecord(15L);
+        stats.reportCompletedRecord(25L);
+
+        assertEquals(2L, stats.getRecordCount());
+        assertEquals(25L, stats.getByteCount());
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 2, mockContext);
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 25, mockContext);
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testFlushStatsZeroReportFrequency() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(0L);
+        OperationStats stats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        stats.setByteCount(15L);
+        stats.flushStats();
+
+        assertEquals(0L, stats.getRecordCount());
+        assertEquals(15L, stats.getByteCount());
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testFlushStatsReport() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(1L);
+        OperationStats stats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        stats.setByteCount(15l);
+        stats.flushStats();
+
+        assertEquals(0L, stats.getRecordCount());
+        assertEquals(15L, stats.getByteCount());
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 15, mockContext);
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testFlushStatsReportAfterBatch() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(2L);
+        OperationStats stats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        stats.reportCompletedRecord(5L);
+        stats.reportCompletedRecord(15L);
+        stats.setByteCount(35L);
+        stats.flushStats();
+
+        assertEquals(2L, stats.getRecordCount());
+        assertEquals(35L, stats.getByteCount());
+        // report from reportCompletedRecord
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 2, mockContext);
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 15, mockContext);
+        // report from flushStats
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 20, mockContext);
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testFlushStatsReportAfterBatchWithRecord() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(2L);
+        OperationStats stats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        stats.reportCompletedRecord(5L);
+        stats.reportCompletedRecord(15L);
+        stats.reportCompletedRecord(35L);
+        stats.flushStats();
+
+        assertEquals(3L, stats.getRecordCount());
+        assertEquals(35L, stats.getByteCount());
+        // report from reportCompletedRecord
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 2, mockContext);
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 15, mockContext);
+        // report from flushStats
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 1, mockContext);
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 20, mockContext);
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testFlushStatsReportAfterBatchWithRecordNoBytes() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(2L);
+        OperationStats stats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        stats.reportCompletedRecord(5L);
+        stats.reportCompletedRecord(15L);
+        stats.reportCompletedRecord(15L);
+        stats.flushStats();
+
+        assertEquals(3L, stats.getRecordCount());
+        assertEquals(15L, stats.getByteCount());
+        // report from reportCompletedRecord
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 2, mockContext);
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 15, mockContext);
+        // report from flushStats
+        verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 1, mockContext);
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testUpdate() {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(0L);
+        OperationStats startingStats = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        OperationStats addMe = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        addMe.reportCompletedRecord(15L);
+
+        startingStats.update(addMe);
+
+        assertEquals(OperationStats.Operation.READ, startingStats.getOperation());
+        assertEquals(1L, startingStats.getRecordCount());
+        assertEquals(15L, startingStats.getByteCount());
+
+        OperationStats addMeToo = new OperationStats(OperationStats.Operation.READ, mockMetricReporter, mockContext);
+        addMeToo.reportCompletedRecord(25L);
+
+        startingStats.update(addMeToo);
+
+        assertEquals(OperationStats.Operation.READ, startingStats.getOperation());
+        assertEquals(2L, startingStats.getRecordCount());
+        assertEquals(40L, startingStats.getByteCount());
+
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+}

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/ReadServiceImplTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/ReadServiceImplTest.java
@@ -1,0 +1,269 @@
+package org.greenplum.pxf.service.controller;
+
+import org.apache.hadoop.conf.Configuration;
+import org.greenplum.pxf.api.io.Writable;
+import org.greenplum.pxf.api.model.ConfigurationFactory;
+import org.greenplum.pxf.api.model.Fragment;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.service.FragmenterService;
+import org.greenplum.pxf.service.MetricsReporter;
+import org.greenplum.pxf.service.bridge.Bridge;
+import org.greenplum.pxf.service.bridge.BridgeFactory;
+import org.greenplum.pxf.service.security.SecurityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivilegedExceptionAction;
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+public class ReadServiceImplTest {
+
+    @Mock
+    private ConfigurationFactory mockConfigurationFactory;
+    @Mock
+    private BridgeFactory mockBridgeFactory;
+    @Mock
+    private SecurityService mockSecurityService;
+    @Mock
+    private FragmenterService mockFragmenterService;
+    @Mock
+    private MetricsReporter mockMetricReporter;
+    @Mock
+    private OutputStream mockOutputStream;
+    @Mock
+    private Configuration mockConfiguration;
+    @Mock
+    private List<Fragment> mockFragmentList;
+    @Mock
+    private Fragment mockFragment1, mockFragment2;
+    @Mock
+    private Bridge mockBridge1, mockBridge2;
+    @Mock
+    private Writable mockRecord1, mockRecord2, mockRecord3;
+    @Mock
+    private RequestContext mockContext;
+
+    private ReadServiceImpl readService;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        when(mockConfigurationFactory.initConfiguration(any(), any(), any(), any())).thenReturn(mockConfiguration);
+        when(mockFragmenterService.getFragmentsForSegment(mockContext)).thenReturn(mockFragmentList);
+        when(mockSecurityService.doAs(same(mockContext), any())).thenAnswer(invocation -> {
+            PrivilegedExceptionAction<OperationStats> action = invocation.getArgument(1);
+            OperationStats result = action.run();
+            return result;
+        });
+
+        readService = new ReadServiceImpl(mockConfigurationFactory, mockBridgeFactory, mockSecurityService, mockFragmenterService, mockMetricReporter);
+    }
+
+    @Test
+    public void testReadDataOneFragOneRecord() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(1L);
+        when(mockFragmentList.size()).thenReturn(1);
+        when(mockFragmentList.get(0)).thenReturn(mockFragment1);
+        when(mockBridgeFactory.getBridge(mockContext)).thenReturn(mockBridge1);
+        when(mockBridge1.beginIteration()).thenReturn(true);
+        when(mockBridge1.getNext()).thenReturn(mockRecord1).thenReturn(null);
+        doAnswer(writeTestData("hello")).when(mockRecord1).write(any(DataOutputStream.class));
+
+        readService.readData(mockContext, mockOutputStream);
+
+        InOrder inOrder = inOrder(mockOutputStream, mockMetricReporter);
+        inOrder.verify(mockOutputStream).write("hello".getBytes(StandardCharsets.UTF_8), 0, 5);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 1, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 5, mockContext);
+        inOrder.verify(mockMetricReporter).reportTimer(same(MetricsReporter.PxfMetric.FRAGMENTS_SENT), any(Duration.class), same(mockContext), eq(true));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadDataOneFragMultiRecordsReportBatch() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(2L);
+        when(mockFragmentList.size()).thenReturn(1);
+        when(mockFragmentList.get(0)).thenReturn(mockFragment1);
+        when(mockBridgeFactory.getBridge(mockContext)).thenReturn(mockBridge1);
+        when(mockBridge1.beginIteration()).thenReturn(true);
+        when(mockBridge1.getNext()).thenReturn(mockRecord1, mockRecord2, null);
+        doAnswer(writeTestData("hello")).when(mockRecord1).write(any(DataOutputStream.class));
+        doAnswer(writeTestData("world!")).when(mockRecord2).write(any(DataOutputStream.class));
+
+        readService.readData(mockContext, mockOutputStream);
+
+        InOrder inOrder = inOrder(mockOutputStream, mockMetricReporter);
+        inOrder.verify(mockOutputStream).write("hello".getBytes(StandardCharsets.UTF_8), 0, 5);
+        inOrder.verify(mockOutputStream).write("world!".getBytes(StandardCharsets.UTF_8), 0, 6);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 2, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 11, mockContext);
+        inOrder.verify(mockMetricReporter).reportTimer(same(MetricsReporter.PxfMetric.FRAGMENTS_SENT), any(Duration.class), same(mockContext), eq(true));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadDataOneFragMultiRecordsRemainder() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(5L);
+        when(mockFragmentList.size()).thenReturn(1);
+        when(mockFragmentList.get(0)).thenReturn(mockFragment1);
+        when(mockBridgeFactory.getBridge(mockContext)).thenReturn(mockBridge1);
+        when(mockBridge1.beginIteration()).thenReturn(true);
+        when(mockBridge1.getNext()).thenReturn(mockRecord1, mockRecord2, null);
+        doAnswer(writeTestData("hello")).when(mockRecord1).write(any(DataOutputStream.class));
+        doAnswer(writeTestData("world!")).when(mockRecord2).write(any(DataOutputStream.class));
+
+        readService.readData(mockContext, mockOutputStream);
+
+        InOrder inOrder = inOrder(mockOutputStream, mockMetricReporter);
+        inOrder.verify(mockOutputStream).write("hello".getBytes(StandardCharsets.UTF_8), 0, 5);
+        inOrder.verify(mockOutputStream).write("world!".getBytes(StandardCharsets.UTF_8), 0, 6);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 2, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 11, mockContext);
+        inOrder.verify(mockMetricReporter).reportTimer(same(MetricsReporter.PxfMetric.FRAGMENTS_SENT), any(Duration.class), same(mockContext), eq(true));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadDataOneFragMultiRecordsRemainderAfterBatch() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(2L);
+        when(mockFragmentList.size()).thenReturn(1);
+        when(mockFragmentList.get(0)).thenReturn(mockFragment1);
+        when(mockBridgeFactory.getBridge(mockContext)).thenReturn(mockBridge1);
+        when(mockBridge1.beginIteration()).thenReturn(true);
+        when(mockBridge1.getNext()).thenReturn(mockRecord1, mockRecord2, mockRecord3, null);
+        doAnswer(writeTestData("hello")).when(mockRecord1).write(any(DataOutputStream.class));
+        doAnswer(writeTestData("world!")).when(mockRecord2).write(any(DataOutputStream.class));
+        doAnswer(writeTestData("Boo!")).when(mockRecord3).write(any(DataOutputStream.class));
+
+        readService.readData(mockContext, mockOutputStream);
+
+        InOrder inOrder = inOrder(mockOutputStream, mockMetricReporter);
+        inOrder.verify(mockOutputStream).write("hello".getBytes(StandardCharsets.UTF_8), 0, 5);
+        inOrder.verify(mockOutputStream).write("world!".getBytes(StandardCharsets.UTF_8), 0, 6);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 2, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 11, mockContext);
+        inOrder.verify(mockOutputStream).write("Boo!".getBytes(StandardCharsets.UTF_8), 0, 4);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 1, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 4, mockContext);
+        inOrder.verify(mockMetricReporter).reportTimer(same(MetricsReporter.PxfMetric.FRAGMENTS_SENT), any(Duration.class), same(mockContext), eq(true));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadDataOneFragRecordsException() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(5L);
+        when(mockFragmentList.size()).thenReturn(1);
+        when(mockFragmentList.get(0)).thenReturn(mockFragment1);
+        when(mockBridgeFactory.getBridge(mockContext)).thenReturn(mockBridge1);
+        when(mockBridge1.beginIteration()).thenReturn(true);
+        when(mockBridge1.getNext()).thenReturn(mockRecord1).thenThrow(new Exception());
+        doAnswer(writeTestData("hello")).when(mockRecord1).write(any(DataOutputStream.class));
+
+        assertThrows(Exception.class, () -> readService.readData(mockContext, mockOutputStream));
+        InOrder inOrder = inOrder(mockOutputStream, mockMetricReporter);
+        inOrder.verify(mockOutputStream).write("hello".getBytes(StandardCharsets.UTF_8), 0, 5);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 1, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 5, mockContext);
+        inOrder.verify(mockMetricReporter).reportTimer(same(MetricsReporter.PxfMetric.FRAGMENTS_SENT), any(Duration.class), same(mockContext), eq(false));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadDataMultiFragmentMultiRecord() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(2L);
+        when(mockFragmentList.size()).thenReturn(2);
+        when(mockBridgeFactory.getBridge(mockContext)).thenReturn(mockBridge1, mockBridge2);
+
+        // 1st frag
+        when(mockFragmentList.get(0)).thenReturn(mockFragment1);
+        when(mockBridge1.beginIteration()).thenReturn(true);
+        when(mockBridge1.getNext()).thenReturn(mockRecord1).thenReturn(null);
+        doAnswer(writeTestData("hello")).when(mockRecord1).write(any(DataOutputStream.class));
+
+        // 2nd frag
+        when(mockFragmentList.get(1)).thenReturn(mockFragment2);
+        when(mockBridge2.beginIteration()).thenReturn(true);
+        when(mockBridge2.getNext()).thenReturn(mockRecord2, mockRecord3, null);
+        doAnswer(writeTestData("world!")).when(mockRecord2).write(any(DataOutputStream.class));
+        doAnswer(writeTestData("Boo!")).when(mockRecord3).write(any(DataOutputStream.class));
+
+        readService.readData(mockContext, mockOutputStream);
+
+        InOrder inOrder = inOrder(mockOutputStream, mockMetricReporter);
+        inOrder.verify(mockOutputStream).write("hello".getBytes(StandardCharsets.UTF_8), 0, 5);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 1, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 5, mockContext);
+        inOrder.verify(mockMetricReporter).reportTimer(same(MetricsReporter.PxfMetric.FRAGMENTS_SENT), any(Duration.class), same(mockContext), eq(true));
+        inOrder.verify(mockOutputStream).write("world!".getBytes(StandardCharsets.UTF_8), 0, 6);
+        inOrder.verify(mockOutputStream).write("Boo!".getBytes(StandardCharsets.UTF_8), 0, 4);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_SENT, 2, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_SENT, 10, mockContext);
+        inOrder.verify(mockMetricReporter).reportTimer(same(MetricsReporter.PxfMetric.FRAGMENTS_SENT), any(Duration.class), same(mockContext), eq(true));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadDataZeroReportFrequency() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(0L);
+        when(mockFragmentList.size()).thenReturn(1);
+        when(mockFragmentList.get(0)).thenReturn(mockFragment1);
+        when(mockBridgeFactory.getBridge(mockContext)).thenReturn(mockBridge1);
+        when(mockBridge1.beginIteration()).thenReturn(true);
+        when(mockBridge1.getNext()).thenReturn(mockRecord1).thenReturn(null);
+        doAnswer(writeTestData("hello")).when(mockRecord1).write(any(DataOutputStream.class));
+
+        readService.readData(mockContext, mockOutputStream);
+
+        InOrder inOrder = inOrder(mockOutputStream, mockMetricReporter);
+        inOrder.verify(mockOutputStream).write("hello".getBytes(StandardCharsets.UTF_8), 0, 5);
+        inOrder.verify(mockMetricReporter).reportTimer(same(MetricsReporter.PxfMetric.FRAGMENTS_SENT), any(Duration.class), same(mockContext), eq(true));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadDataBeginIterationFalse() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(1L);
+        when(mockFragmentList.size()).thenReturn(1);
+        when(mockFragmentList.get(0)).thenReturn(mockFragment1);
+        when(mockBridgeFactory.getBridge(mockContext)).thenReturn(mockBridge1);
+        when(mockBridge1.beginIteration()).thenReturn(false);
+
+        readService.readData(mockContext, mockOutputStream);
+
+        InOrder inOrder = inOrder(mockBridge1, mockMetricReporter);
+        inOrder.verify(mockBridge1).endIteration();
+        inOrder.verify(mockMetricReporter).reportTimer(same(MetricsReporter.PxfMetric.FRAGMENTS_SENT), any(Duration.class), same(mockContext), eq(true));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    // helper for writing mock record to a mock output stream
+    // mockOutputStream -> CountingOutputStream -> DataOutputStream
+    // in order for the us to see the side-effect of CountingOutputStream,
+    // we need to actually call the `write` method of DataOutputStream.
+    private Answer writeTestData(String testData) {
+        return invocation -> {
+            DataOutputStream dos = invocation.getArgument(0);
+            dos.write(testData.getBytes(StandardCharsets.UTF_8));
+            return null;
+        };
+    }
+}

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/WriteServiceImplTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/WriteServiceImplTest.java
@@ -1,0 +1,207 @@
+package org.greenplum.pxf.service.controller;
+
+import org.apache.hadoop.conf.Configuration;
+import org.greenplum.pxf.api.model.ConfigurationFactory;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.service.MetricsReporter;
+import org.greenplum.pxf.service.bridge.Bridge;
+import org.greenplum.pxf.service.bridge.BridgeFactory;
+import org.greenplum.pxf.service.security.SecurityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.PrivilegedExceptionAction;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+public class WriteServiceImplTest {
+
+    @Mock
+    private ConfigurationFactory mockConfigurationFactory;
+    @Mock
+    private BridgeFactory mockBridgeFactory;
+    @Mock
+    private SecurityService mockSecurityService;
+    @Mock
+    private MetricsReporter mockMetricReporter;
+    @Mock
+    private InputStream mockInputStream;
+    @Mock
+    private Configuration mockConfiguration;
+    @Mock
+    private Bridge mockBridge;
+    @Mock
+    private RequestContext mockContext;
+
+    private WriteServiceImpl writeService;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        when(mockConfigurationFactory.initConfiguration(any(), any(), any(), any())).thenReturn(mockConfiguration);
+        when(mockSecurityService.doAs(same(mockContext), any())).thenAnswer(invocation -> {
+            PrivilegedExceptionAction<OperationStats> action = invocation.getArgument(1);
+            OperationStats result = action.run();
+            return result;
+        });
+        when(mockBridgeFactory.getBridge(mockContext)).thenReturn(mockBridge);
+
+        writeService = new WriteServiceImpl(mockConfigurationFactory, mockBridgeFactory, mockSecurityService, mockMetricReporter);
+    }
+
+    @Test
+    public void testWriteDataOneRecord() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(1L);
+        when(mockBridge.beginIteration()).thenReturn(true);
+        when(mockInputStream.read(any(), eq(0), eq(10))).thenReturn(4);
+        doAnswer(readTestData(10))
+                .doAnswer(invocation -> false)
+                .when(mockBridge).setNext(any(DataInputStream.class));
+
+        writeService.writeData(mockContext, mockInputStream);
+
+        InOrder inOrder = inOrder(mockMetricReporter);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_RECEIVED, 1, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_RECEIVED, 4, mockContext);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testWriteDataMultiRecordsReportBatch() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(2L);
+        when(mockBridge.beginIteration()).thenReturn(true);
+        when(mockInputStream.read(any(), eq(0), eq(10))).thenReturn(4, 6);
+        doAnswer(readTestData(10))
+                .doAnswer(readTestData(10))
+                .doAnswer(invocation -> false)
+                .when(mockBridge).setNext(any(DataInputStream.class));
+
+        writeService.writeData(mockContext, mockInputStream);
+
+        InOrder inOrder = inOrder(mockMetricReporter);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_RECEIVED, 2, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_RECEIVED, 10, mockContext);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testWriteDataMultiRecordsRemainder() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(5L);
+        when(mockBridge.beginIteration()).thenReturn(true);
+        when(mockInputStream.read(any(), eq(0), eq(10))).thenReturn(4, 6);
+        doAnswer(readTestData(10))
+                .doAnswer(readTestData(10))
+                .doAnswer(invocation -> false)
+                .when(mockBridge).setNext(any(DataInputStream.class));
+
+        writeService.writeData(mockContext, mockInputStream);
+
+        InOrder inOrder = inOrder(mockMetricReporter);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_RECEIVED, 2, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_RECEIVED, 10, mockContext);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testWriteDataMultiRecordsRemainderAfterBatch() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(2L);
+        when(mockBridge.beginIteration()).thenReturn(true);
+        when(mockInputStream.read(any(), eq(0), eq(10))).thenReturn(4, 6, 5);
+        doAnswer(readTestData(10))
+                .doAnswer(readTestData(10))
+                .doAnswer(readTestData(10))
+                .doAnswer(invocation -> false)
+                .when(mockBridge).setNext(any(DataInputStream.class));
+
+        writeService.writeData(mockContext, mockInputStream);
+
+        InOrder inOrder = inOrder(mockMetricReporter);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_RECEIVED, 2, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_RECEIVED, 10, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_RECEIVED, 1, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_RECEIVED, 5, mockContext);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testWriteDataRecordsException() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(5L);
+        when(mockBridge.beginIteration()).thenReturn(true);
+        when(mockInputStream.read(any(), eq(0), eq(10))).thenReturn(4);
+        doAnswer(readTestData(10))
+                .doThrow(new Exception())
+                .when(mockBridge).setNext(any(DataInputStream.class));
+
+        assertThrows(Exception.class, () -> writeService.writeData(mockContext, mockInputStream));
+        InOrder inOrder = inOrder(mockMetricReporter);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.RECORDS_RECEIVED, 1, mockContext);
+        inOrder.verify(mockMetricReporter).reportCounter(MetricsReporter.PxfMetric.BYTES_RECEIVED, 4, mockContext);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testReadDataZeroReportFrequency() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(0L);
+        when(mockBridge.beginIteration()).thenReturn(true);
+        when(mockInputStream.read(any(), eq(0), eq(10))).thenReturn(4);
+        doAnswer(readTestData(10))
+                .doAnswer(invocation -> false)
+                .when(mockBridge).setNext(any(DataInputStream.class));
+
+        writeService.writeData(mockContext, mockInputStream);
+
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testReadDataBeginIterationException() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(1L);
+        when(mockBridge.beginIteration()).thenThrow(Exception.class);
+
+        assertThrows(IOException.class, () -> writeService.writeData(mockContext, mockInputStream));
+        verifyNoMoreInteractions(mockMetricReporter);
+    }
+
+    @Test
+    public void testWriteDataSetNextFalse() throws Exception {
+        when(mockMetricReporter.getReportFrequency()).thenReturn(1L);
+        when(mockBridge.beginIteration()).thenReturn(true);
+        when(mockBridge.setNext(any(DataInputStream.class))).thenReturn(false);
+
+        writeService.writeData(mockContext, mockInputStream);
+
+        InOrder inOrder = inOrder(mockInputStream, mockBridge, mockMetricReporter);
+        inOrder.verify(mockInputStream).close();
+        inOrder.verify(mockBridge).endIteration();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    // helper for reading mock stream to a mock input stream
+    // mockInputStream -> CountingInputStream ->
+    // in order for the us to see the side-effect of CountingInputStream,
+    // we need to actually call the `read` method of DataInputStream.
+    private Answer readTestData(int len) {
+        return invocation -> {
+            DataInputStream dis = invocation.getArgument(0);
+            // needed to call the mockInputStream
+            dis.read(null, 0, len);
+            return true;
+        };
+    }
+}


### PR DESCRIPTION
Add reporting for BYTES_SENT and BYTES_RECEIVED
- Wrap OutputStream into CountingOutputStream for recording bytes sent
- Wrap InputStream into CountingInputStream for recording bytes received

- remove FrequencyName from MetricReporter
- add test cases for Read and Write Service Impls

Co-authored-by: Alex Denissov <adenissov@vmware.com>
Co-authored-by: Ashuka Xue <axue@vmware.com>
Co-authored-by: Bradford D. Boyle <bradfordb@vmware.com>