### PR TITLE
docs: Add error message and solution to troubleshooting table

### DIFF
--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -33,6 +33,7 @@ The following table describes some errors you may encounter while using PXF:
 | PXF server error : NoSuchObjectException(message:\<schema\>.\<hivetable\> table not found) | **Cause**: The Hive table that you specified with \<schema\>.\<hivetable\> does not exist. <br>**Solution**: Provide the name of an existing Hive table. |
 | PXF server error : Failed connect to localhost:5888; Connection refused (\<segment-id\> slice\<N\> \<segment-host\>:\<port\> pid=\<process-id\>)<br> ... |**Cause**: The PXF Service is not running on \<segment-host\>.<br>**Solution**: Restart PXF on \<segment-host\>. |
 | PXF server error: Permission denied: user=\<user\>, access=READ, inode=&quot;\<filepath\>&quot;:-rw------- | **Cause**: The Greenplum Database user that executed the PXF operation does not have permission to access the underlying Hadoop service (HDFS or Hive). See [Configuring the Hadoop User, User Impersonation, and Proxying](pxfuserimpers.html). |
+| PXF server error: PXF service could not be reached. PXF is not running in the tomcat container | **Cause**: The `pxf` extension was updated to a new version but the PXF server has not been updated to a compatible version. <br>**Solution**: Ensure that the PXF server has been updated and restarted on all hosts.
 
 Most PXF error messages include a `HINT` that you can use to resolve the error, or to collect more information to identify the error.
 


### PR DESCRIPTION
If the PXF service returns an HTTP 404 error code to the `pxf`
extension, it is not immediately obvious what the correct resolution
should be. This commit adds a troubleshooting hint for this scenario.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>