### PR TITLE
Docs: added CSV profile references

### DIFF
--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -93,6 +93,7 @@ $ hdfs dfs -cat /data/exampledir/example.txt
 The PXF Hadoop connectors provide built-in profiles to support the following data formats:
 
 - Text
+- CSV
 - Avro
 - JSON
 - ORC
@@ -106,6 +107,7 @@ The PXF Hadoop connectors expose the following profiles to read, and in many cas
 | Data Source | Data Format | Profile Name(s) | Deprecated Profile Name | Supported Operations |
 |-------------|------|---------|-----|-----|
 | HDFS | delimited single line [text](hdfs_text.html#profile_text) | hdfs:text | n/a | Read, Write |
+| HDFS | delimited single line comma-separated values of [text](hdfs_text.html#profile_text) | hdfs:csv | n/a | Read, Write |
 | HDFS | delimited [text with quoted linefeeds](hdfs_text.html#profile_textmulti) | hdfs:text:multi | n/a | Read |
 | HDFS | [Avro](hdfs_avro.html) | hdfs:avro | n/a | Read, Write |
 | HDFS | [JSON](hdfs_json.html) | hdfs:json | n/a | Read |
@@ -130,7 +132,7 @@ Choose the `hive` profile when:
 - The data resides in a Hive table, and you do not know the underlying file type of the table up front.
 - The data resides in a Hive table, and the Hive table is partitioned.
 
-Choose the `hdfs:text` profile when the file is text and you know the location of the file in the HDFS file system.
+Choose the `hdfs:text`, `hdfs:csv` profiles when the file is text and you know the location of the file in the HDFS file system.
 
 When accessing ORC-format data:
 

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -37,6 +37,7 @@ Before working with object store data using PXF, ensure that:
 The PXF object store connectors provide built-in profiles to support the following data formats:
 
 - Text
+- CSV
 - Avro
 - JSON
 - ORC
@@ -49,6 +50,7 @@ The PXF connectors to Azure expose the following profiles to read, and in many c
 | Data Format | Azure Blob Storage | Azure Data Lake | Supported Operations |
 |-----|------|---------| ---------|
 | delimited single line [plain text](objstore_text.html) | wasbs:text | adl:text | Read, Write |
+| delimited single line comma-separated values of [plain text](objstore_text.html) | wasbs:csv | adl:csv | Read, Write |
 | delimited [text with quoted linefeeds](objstore_text.html) | wasbs:text:multi | adl:text:multi | Read |
 | [Avro](objstore_avro.html) | wasbs:avro | adl:avro | Read, Write |
 | [JSON](objstore_json.html) | wasbs:json | adl:json | Read |
@@ -62,6 +64,7 @@ Similarly, the PXF connectors to Google Cloud Storage, Minio, and S3 expose thes
 | Data Format | Google Cloud Storage | S3 or Minio | Supported Operations |
 |-----|------|---------| ---------|
 | delimited single line [plain text](objstore_text.html) | gs:text | s3:text | Read, Write |
+| delimited single line comma-separated values of [plain text](objstore_text.html) | gs:csv | s3:csv | Read, Write |
 | delimited [text with quoted linefeeds](objstore_text.html) | gs:text:multi | s3:text:multi | Read |
 | [Avro](objstore_avro.html) | gs:avro | s3:avro | Read, Write |
 | [JSON](objstore_json.html) | gs:json | s3:json | Read|

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -29,12 +29,12 @@ Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_
 
 ## <a id="profile_text"></a>Reading Text Data
 
-Use the `hdfs:text` profile when you read plain text delimited or .csv data where each row is a single record. The following syntax creates a Greenplum Database readable external table that references such a text file on HDFS: 
+Use the `hdfs:text` profile when you read plain text delimited, and either `hdfs:text` or `hdfs:csv` when reading .csv data where each row is a single record. The following syntax creates a Greenplum Database readable external table that references such a text file on HDFS: 
 
 ``` sql
 CREATE EXTERNAL TABLE <table_name> 
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:text[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>][&SKIP_HEADER_COUNT=<numlines>]')
+LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:text|csv[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>][&SKIP_HEADER_COUNT=<numlines>]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 ```
 
@@ -43,7 +43,7 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | Keyword  | Value |
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;hdfs&#8209;file\>    | The path to the directory or file in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
-| PROFILE    | The `PROFILE` keyword must specify `hdfs:text`. |
+| PROFILE    | Use `PROFILE` `hdfs:text` when \<path-to-hdfs-file\> references plain text delimited data.<br> Use `PROFILE` `hdfs:text` or `hdfs:csv` when \<path-to-hdfs-file\> references comma-separated value data. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
 | IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | SKIP_HEADER_COUNT=\<numlines\> | Specify the number of header lines that PXF should skip in the first split of each \<hdfs-file\> before reading the data. The default value is 0, do not skip any lines. |
@@ -54,7 +54,7 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 
 ### <a id="profile_text_query"></a>Example: Reading Text Data on HDFS
 
-Perform the following procedure to create a sample text file, copy the file to HDFS, and use the `hdfs:text` profile and the default PXF server to create two PXF external tables to query the data:
+Perform the following procedure to create a sample text file, copy the file to HDFS, and use the `hdfs:text` and `hdfs:csv` profiles and the default PXF server to create two PXF external tables to query the data:
 
 1. Create an HDFS directory for PXF example data files. For example:
 
@@ -115,11 +115,11 @@ Beijing,Jul,411,11600.67' > /tmp/pxf_hdfs_simple.txt
     (4 rows)
     ```
 
-2. Create a second external table that references `pxf_hdfs_simple.txt`, this time specifying the `CSV` `FORMAT`:
+2. Create a second external table that references `pxf_hdfs_simple.txt`, this time specifying the `hdfs:csv` `PROFILE`:
 
     ``` sql
     postgres=# CREATE EXTERNAL TABLE pxf_hdfs_textsimple_csv(location text, month text, num_orders int, total_sales float8)
-                LOCATION ('pxf://data/pxf_examples/pxf_hdfs_simple.txt?PROFILE=hdfs:text')
+                LOCATION ('pxf://data/pxf_examples/pxf_hdfs_simple.txt?PROFILE=hdfs:csv')
               FORMAT 'CSV';
     postgres=# SELECT * FROM pxf_hdfs_textsimple_csv;          
     ```
@@ -218,7 +218,7 @@ Perform the following steps to create a sample text file, copy the file to HDFS,
 
 ## <a id="hdfswrite_text"></a>Writing Text Data to HDFS
 
-The PXF HDFS connector "hdfs:text" profile supports writing single line plain text data to HDFS. When you create a writable external table with the PXF HDFS connector, you specify the name of a directory on HDFS. When you insert records into a writable external table, the block(s) of data that you insert are written to one or more files in the directory that you specified.
+The PXF HDFS connector profiles `hdfs:text` and `hdfs:csv` support writing single line plain text data to HDFS. When you create a writable external table with the PXF HDFS connector, you specify the name of a directory on HDFS. When you insert records into a writable external table, the block(s) of data that you insert are written to one or more files in the directory that you specified.
 
 **Note**: External tables that you create with a writable profile can only be used for `INSERT` operations. If you want to query the data that you inserted, you must create a separate readable external table that references the HDFS directory.
 
@@ -228,7 +228,7 @@ Use the following syntax to create a Greenplum Database writable external table 
 CREATE WRITABLE EXTERNAL TABLE <table_name> 
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<path-to-hdfs-dir>
-    ?PROFILE=hdfs:text[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+    ?PROFILE=hdfs:text|csv[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 [DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
 ```
@@ -238,20 +238,20 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://gpd
 | Keyword  | Value |
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;hdfs&#8209;dir\>    | The path to the directory in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;dir\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;dir\> must not specify a relative path nor include the dollar sign (`$`) character. |
-| PROFILE    | The `PROFILE` keyword must specify `hdfs:text` |
+| PROFILE    | Use `PROFILE` `hdfs:text` to write plain, delimited text to \<path-to-hdfs-file\>.<br> Use `PROFILE` `hdfs:text` or `hdfs:csv` to write comma-separated value text to \<path-to-hdfs-dir\>. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
 | \<custom&#8209;option\>  | \<custom-option\>s are described below.|
 | FORMAT | Use `FORMAT` `'TEXT'` to write plain, delimited text to \<path-to-hdfs-dir\>.<br> Use `FORMAT` `'CSV'` to write comma-separated value text to \<path-to-hdfs-dir\>. |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
-Writable external tables that you create using the `hdfs:text` profile can optionally use record or block compression. The PXF `hdfs:text` profile supports the following compression codecs:
+Writable external tables that you create using the `hdfs:text` or the `hdfs:csv` profiles can optionally use record or block compression. The PXF `hdfs:text` and `hdfs:csv` profiles support the following compression codecs:
 
 - org.apache.hadoop.io.compress.DefaultCodec
 - org.apache.hadoop.io.compress.GzipCodec
 - org.apache.hadoop.io.compress.BZip2Codec
 
-You specify the compression codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:text` profile support the following custom write options:
+You specify the compression codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:text` and `hdfs:csv` profiles support the following custom write options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -115,7 +115,7 @@ Beijing,Jul,411,11600.67' > /tmp/pxf_hdfs_simple.txt
     (4 rows)
     ```
 
-2. Create a second external table that references `pxf_hdfs_simple.txt`, this time specifying the `hdfs:csv` `PROFILE`:
+2. Create a second external table that references `pxf_hdfs_simple.txt`, this time specifying the `hdfs:csv` `PROFILE` and the `CSV` `FORMAT`:
 
     ``` sql
     postgres=# CREATE EXTERNAL TABLE pxf_hdfs_textsimple_csv(location text, month text, num_orders int, total_sales float8)

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -29,7 +29,7 @@ Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_
 
 ## <a id="profile_text"></a>Reading Text Data
 
-Use the `hdfs:text` profile when you read plain text delimited, and either `hdfs:text` or `hdfs:csv` when reading .csv data where each row is a single record. The following syntax creates a Greenplum Database readable external table that references such a text file on HDFS: 
+Use the `hdfs:text` profile when you read plain text delimited, and `hdfs:csv` when reading .csv data where each row is a single record. The following syntax creates a Greenplum Database readable external table that references such a text file on HDFS: 
 
 ``` sql
 CREATE EXTERNAL TABLE <table_name> 
@@ -43,7 +43,7 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | Keyword  | Value |
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;hdfs&#8209;file\>    | The path to the directory or file in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
-| PROFILE    | Use `PROFILE` `hdfs:text` when \<path-to-hdfs-file\> references plain text delimited data.<br> Use `PROFILE` `hdfs:text` or `hdfs:csv` when \<path-to-hdfs-file\> references comma-separated value data. |
+| PROFILE    | Use `PROFILE` `hdfs:text` when \<path-to-hdfs-file\> references plain text delimited data.<br> Use `PROFILE` `hdfs:csv` when \<path-to-hdfs-file\> references comma-separated value data. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
 | IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | SKIP_HEADER_COUNT=\<numlines\> | Specify the number of header lines that PXF should skip in the first split of each \<hdfs-file\> before reading the data. The default value is 0, do not skip any lines. |
@@ -238,7 +238,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://gpd
 | Keyword  | Value |
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;hdfs&#8209;dir\>    | The path to the directory in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;dir\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;dir\> must not specify a relative path nor include the dollar sign (`$`) character. |
-| PROFILE    | Use `PROFILE` `hdfs:text` to write plain, delimited text to \<path-to-hdfs-file\>.<br> Use `PROFILE` `hdfs:text` or `hdfs:csv` to write comma-separated value text to \<path-to-hdfs-dir\>. |
+| PROFILE    | Use `PROFILE` `hdfs:text` to write plain, delimited text to \<path-to-hdfs-file\>.<br> Use `PROFILE` `hdfs:csv` to write comma-separated value text to \<path-to-hdfs-dir\>. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
 | \<custom&#8209;option\>  | \<custom-option\>s are described below.|
 | FORMAT | Use `FORMAT` `'TEXT'` to write plain, delimited text to \<path-to-hdfs-dir\>.<br> Use `FORMAT` `'CSV'` to write comma-separated value text to \<path-to-hdfs-dir\>. |

--- a/docs/content/objstore_text.html.md.erb
+++ b/docs/content/objstore_text.html.md.erb
@@ -31,7 +31,7 @@ Ensure that you have met the PXF Object Store [Prerequisites](access_objstore.ht
 
 ## <a id="profile_text"></a>Reading Text Data
 
-Use the `<objstore>:text` profile when you read plain text delimited or .csv data from an object store where each row is a single record.  PXF supports the following `<objstore>` profile prefixes:
+Use the `<objstore>:text` profile when you read plain text delimited and either `<objstore>:text` or `<objstore>:csv` when reading .csv data from an object store where each row is a single record.  PXF supports the following `<objstore>` profile prefixes:
 
 | Object Store  | Profile Prefix |
 |-------|-------------------------------------|
@@ -46,7 +46,7 @@ The following syntax creates a Greenplum Database readable external table that r
 ``` sql
 CREATE EXTERNAL TABLE <table_name> 
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text&SERVER=<server_name>[&IGNORE_MISSING_PATH=<boolean>][&SKIP_HEADER_COUNT=<numlines>][&<custom-option>=<value>[...]]')
+LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:text|csv&SERVER=<server_name>[&IGNORE_MISSING_PATH=<boolean>][&SKIP_HEADER_COUNT=<numlines>][&<custom-option>=<value>[...]]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 ```
 
@@ -55,7 +55,7 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | Keyword  | Value |
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;file\>    | The path to the directory or file in the object store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
-| PROFILE=\<objstore\>:text    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text`. |
+| PROFILE=\<objstore\>:text<br> PROFILE=\<objstore\>:csv    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | SKIP_HEADER_COUNT=\<numlines\> | Specify the number of header lines that PXF should skip in the first split of each \<file\> before reading the data. The default value is 0, do not skip any lines. |
@@ -72,7 +72,7 @@ If you are accessing an S3 object store:
 
 ### <a id="profile_text_query"></a>Example: Reading Text Data from S3
 
-Perform the following procedure to create a sample text file, copy the file to S3, and use the `s3:text` profile to create two PXF external tables to query the data.
+Perform the following procedure to create a sample text file, copy the file to S3, and use the `s3:text` and `s3:csv` profiles to create two PXF external tables to query the data.
 
 To run this example, you must:
 
@@ -139,11 +139,11 @@ Beijing,Jul,411,11600.67' > /tmp/pxf_s3_simple.txt
     (4 rows)
     ```
 
-2. Create a second external table that references `pxf_s3_simple.txt`, this time specifying the `CSV` `FORMAT`:
+2. Create a second external table that references `pxf_s3_simple.txt`, this time specifying the `s3:csv` `PROFILE`:
 
     ``` sql
     postgres=# CREATE EXTERNAL TABLE pxf_s3_textsimple_csv(location text, month text, num_orders int, total_sales float8)
-                LOCATION ('pxf://BUCKET/pxf_examples/pxf_s3_simple.txt?PROFILE=s3:text&SERVER=s3srvcfg')
+                LOCATION ('pxf://BUCKET/pxf_examples/pxf_s3_simple.txt?PROFILE=s3:csv&SERVER=s3srvcfg')
               FORMAT 'CSV';
     postgres=# SELECT * FROM pxf_s3_textsimple_csv;          
     ```
@@ -250,7 +250,7 @@ To run this example, you must:
 
 ## <a id="write_text"></a>Writing Text Data
 
-The "\<objstore\>:text" profiles support writing single line plain text data to an object store. When you create a writable external table with PXF, you specify the name of a directory. When you insert records into a writable external table, the block(s) of data that you insert are written to one or more files in the directory that you specified.
+The `<objstore>:text|csv` profiles support writing single line plain text data to an object store. When you create a writable external table with PXF, you specify the name of a directory. When you insert records into a writable external table, the block(s) of data that you insert are written to one or more files in the directory that you specified.
 
 **Note**: External tables that you create with a writable profile can only be used for `INSERT` operations. If you want to query the data that you inserted, you must create a separate readable external table that references the directory.
 
@@ -260,7 +260,7 @@ Use the following syntax to create a Greenplum Database writable external table 
 CREATE WRITABLE EXTERNAL TABLE <table_name> 
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<path-to-dir>
-    ?PROFILE=<objstore>:text&SERVER=<server_name>[&<custom-option>=<value>[...]]')
+    ?PROFILE=<objstore>:text|csv&SERVER=<server_name>[&<custom-option>=<value>[...]]')
 FORMAT '[TEXT|CSV]' (delimiter[=|<space>][E]'<delim_value>');
 [DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
 ```
@@ -270,20 +270,20 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://gpd
 | Keyword  | Value |
 |-------|-------------------------------------|
 | \<path&#8209;to&#8209;dir\>    | The path to the directory in the data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;dir\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;dir\> must not specify a relative path nor include the dollar sign (`$`) character. |
-| PROFILE=\<objstore\>:text    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text`. |
+| PROFILE=\<objstore\>:text<br> PROFILE=\<objstore\>:csv    | The `PROFILE` keyword must identify the specific object store. For example, `s3:text`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\>  | \<custom-option\>s are described below.|
 | FORMAT | Use `FORMAT` `'TEXT'` to write plain, delimited text to \<path-to-dir\>.<br> Use `FORMAT` `'CSV'` to write comma-separated value text to \<path-to-dir\>. |
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma `,`. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or \<column_name\> on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
-Writable external tables that you create using an `<objstore>:text` profile can optionally use record or block compression. The PXF `<objstore>:text` profiles support the following compression codecs:
+Writable external tables that you create using an `<objstore>:text|csv` profile can optionally use record or block compression. The PXF `<objstore>:text|csv` profiles support the following compression codecs:
 
 - org.apache.hadoop.io.compress.DefaultCodec
 - org.apache.hadoop.io.compress.GzipCodec
 - org.apache.hadoop.io.compress.BZip2Codec
 
-You specify the compression codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `<objstore>:text` profile support the following custom write options:
+You specify the compression codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `<objstore>:text|csv` profile support the following custom write options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|
@@ -313,7 +313,7 @@ Perform the following procedure to create Greenplum Database writable external t
 
     ``` sql
     postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_s3_writetbl_1(location text, month text, num_orders int, total_sales float8)
-                LOCATION ('pxf://BUCKET/pxf_examples/pxfwrite_s3_textsimple1?PROFILE=s3:text&SERVER=s3srvcfg')
+                LOCATION ('pxf://BUCKET/pxf_examples/pxfwrite_s3_textsimple1?PROFILE=s3:text|csv&SERVER=s3srvcfg')
               FORMAT 'TEXT' (delimiter=',');
     ```
     

--- a/docs/content/objstore_text.html.md.erb
+++ b/docs/content/objstore_text.html.md.erb
@@ -139,7 +139,7 @@ Beijing,Jul,411,11600.67' > /tmp/pxf_s3_simple.txt
     (4 rows)
     ```
 
-2. Create a second external table that references `pxf_s3_simple.txt`, this time specifying the `s3:csv` `PROFILE`:
+2. Create a second external table that references `pxf_s3_simple.txt`, this time specifying the `s3:csv` `PROFILE` and the `CSV` `FORMAT`:
 
     ``` sql
     postgres=# CREATE EXTERNAL TABLE pxf_s3_textsimple_csv(location text, month text, num_orders int, total_sales float8)

--- a/docs/content/objstore_text.html.md.erb
+++ b/docs/content/objstore_text.html.md.erb
@@ -31,7 +31,7 @@ Ensure that you have met the PXF Object Store [Prerequisites](access_objstore.ht
 
 ## <a id="profile_text"></a>Reading Text Data
 
-Use the `<objstore>:text` profile when you read plain text delimited and either `<objstore>:text` or `<objstore>:csv` when reading .csv data from an object store where each row is a single record.  PXF supports the following `<objstore>` profile prefixes:
+Use the `<objstore>:text` profile when you read plain text delimited and `<objstore>:csv` when reading .csv data from an object store where each row is a single record.  PXF supports the following `<objstore>` profile prefixes:
 
 | Object Store  | Profile Prefix |
 |-------|-------------------------------------|


### PR DESCRIPTION
Added references to CSV profile since this had not been documented:

https://mireia-pxf-csv-profile.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/access_hdfs.html
https://mireia-pxf-csv-profile.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/hdfs_text.html
https://mireia-pxf-csv-profile.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/access_objstore.html
https://mireia-pxf-csv-profile.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/access_s3.html