### PR TITLE
Docs- Sum up of the directory changes with PXF 6

### DIFF
--- a/docs/content/about_pxf_dir.html.md.erb
+++ b/docs/content/about_pxf_dir.html.md.erb
@@ -2,16 +2,16 @@
 title: About the PXF Installation and Configuration Directories
 ---
 
-This documentation uses `$PXF_HOME` to refer to the PXF installation directory. Its value depends on how PXF has been installed:
+This documentation uses `$PXF_HOME` to refer to the PXF installation directory. Its value depends on how you have installed PXF:
 
- - If you install PXF as part of Greenplum Database, its value will be `$GPHOME/pxf`.
- - If you install the PXF rpm or deb package, its value will be `/usr/local/pxf-gp<greenplum-major-version>`, or the directory of your choosing (CentOS/RHEL only). 
+ - If you install PXF as part of Greenplum Database, its value is `$GPHOME/pxf`.
+ - If you install the PXF `rpm` or `deb` package, its value is `/usr/local/pxf-gp<greenplum-major-version>`, or the directory of your choosing (CentOS/RHEL only). 
 
 `$PXF_HOME` includes both the PXF executables and the PXF runtime configuration files and directories. In PXF 5.x, you needed to specify a `$PXF_CONF` directory for the runtime configuration when you initialized PXF. In PXF 6.x, however, no initialization is required: `$PXF_BASE` now identifies the runtime configuration directory, and the default `$PXF_BASE` is `$PXF_HOME`.
 
-<div class="note">This documentation uses the <code>$PXF_HOME</code> and <code>$PXF_BASE</code> environment variables to <i>reference</i> the PXF installation and runtime configuration directories. PXF uses these variables internally at runtime; they are not set in your shell environment, and will display as empty if you attempt to <code>echo</code> their value.</div>
-
 If you want to store your configuration and runtime files in a different location, see [Relocating $PXF_BASE](#movebase).
+
+<div class="note">This documentation uses the <code>$PXF_HOME</code> environment variable to reference the PXF installation directory. PXF uses this variable internally at runtime; it is not set in your shell environment, and will display as empty if you attempt to <code>echo</code> its value. Similarly, this documentation uses the <code>$PXF_BASE</code> environment variable to reference the PXF runtime configuration directory. PXF uses the variable internally. it will only, and must, be set in your shell environment if you explicitly relocate the directory.</div>
 
 ## <a id="installed"></a>PXF Installation Directories
 

--- a/docs/content/about_pxf_dir.html.md.erb
+++ b/docs/content/about_pxf_dir.html.md.erb
@@ -11,7 +11,7 @@ This documentation uses `$PXF_HOME` to refer to the PXF installation directory. 
 
 If you want to store your configuration and runtime files in a different location, see [Relocating $PXF_BASE](#movebase).
 
-<div class="note">This documentation uses the <code>$PXF_HOME</code> environment variable to reference the PXF installation directory. PXF uses this variable internally at runtime; it is not set in your shell environment, and will display as empty if you attempt to <code>echo</code> its value. Similarly, this documentation uses the <code>$PXF_BASE</code> environment variable to reference the PXF runtime configuration directory. PXF uses the variable internally. it will only, and must, be set in your shell environment if you explicitly relocate the directory.</div>
+<div class="note">This documentation uses the <code>$PXF_HOME</code> environment variable to reference the PXF installation directory. PXF uses this variable internally at runtime; it is not set in your shell environment, and will display as empty if you attempt to <code>echo</code> its value. Similarly, this documentation uses the <code>$PXF_BASE</code> environment variable to reference the PXF runtime configuration directory. PXF uses the variable internally. it only needs to be set in your shell environment if you explicitly relocate the directory.</div>
 
 ## <a id="installed"></a>PXF Installation Directories
 

--- a/docs/content/about_pxf_dir.html.md.erb
+++ b/docs/content/about_pxf_dir.html.md.erb
@@ -2,9 +2,14 @@
 title: About the PXF Installation and Configuration Directories
 ---
 
-PXF may be installed to `$GPHOME/pxf` on your master, standby master, and segment nodes when you install Greenplum Database. If you install the PXF `rpm` or `deb` package, PXF is installed to `/usr/local/pxf-gp<greenplum-major-version>`, or to a directory of your choosing (CentOS/RHEL only). This documentation uses `$PXF_HOME` to refer to the PXF installation directory.
+This documentation uses `$PXF_HOME` to refer to the PXF installation directory. Its value depends on how PXF has been installed:
 
-After you install PXF 6.x, `$PXF_HOME` includes the both the PXF executables and the PXF runtime configuration files and directories. In PXF 5.x, you specified a `$PXF_CONF` directory for the runtime configuration when you initialized PXF.  In PXF 6.x, no initialization is required, `$PXF_BASE` now identifies the runtime configuration directory, and the default `$PXF_BASE` is `$PXF_HOME`.
+ - If you install PXF as part of Greenplum Database, its value will be `$GPHOME/pxf`.
+ - If you install the PXF rpm or deb package, its value will be `/usr/local/pxf-gp<greenplum-major-version>`, or the directory of your choosing (CentOS/RHEL only). 
+
+`$PXF_HOME` includes both the PXF executables and the PXF runtime configuration files and directories. In PXF 5.x, you needed to specify a `$PXF_CONF` directory for the runtime configuration when you initialized PXF. In PXF 6.x, however, no initialization is required: `$PXF_BASE` now identifies the runtime configuration directory, and the default `$PXF_BASE` is `$PXF_HOME`.
+
+<div class="note">This documentation uses the <code>$PXF_HOME</code> and <code>$PXF_BASE</code> environment variables to <i>reference</i> the PXF installation and runtime configuration directories. PXF uses these variables internally at runtime; they are not set in your shell environment, and will display as empty if you attempt to <code>echo</code> their value.</div>
 
 If you want to store your configuration and runtime files in a different location, see [Relocating $PXF_BASE](#movebase).
 


### PR DESCRIPTION
We want to make clear to users the main differences between the old $PXF_CONF in PXF and the new paths in PXF 6:
Can be previewed here:
https://mireia-pxf-base.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/about_pxf_dir.html