### PR TITLE
Docs: removed Servlet.service error references

### DIFF
--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -48,7 +48,6 @@ You use the PXF JDBC connector to access data stored in an external SQL database
 For example, if you use the PXF JDBC connector to access an Oracle database with a conflicting time zone, PXF logs an error similar to the following:
 
 ``` pre
-SEVERE: Servlet.service() for servlet [PXF REST Service] in context with path [/pxf] threw exception
 java.io.IOException: ORA-00604: error occurred at recursive SQL level 1
 ORA-01882: timezone region not found
 ```


### PR DESCRIPTION
From PR https://github.com/greenplum-db/pxf/pull/604
Removing references to Servlet.service from the troubleshooting guide.

Let me know if anything else needs to be added/removed here.
