### PR TITLE
docs - add some basic info about new monitoring support

### DIFF
--- a/docs/content/monitor_pxf.html.md.erb
+++ b/docs/content/monitor_pxf.html.md.erb
@@ -48,14 +48,14 @@ Perform the following procedure to request the PXF status of your Greenplum Data
 
 ## <a id="about_rtm"></a> About PXF Service Runtime Monitoring
 
-PXF exposes the following HTTP actuator endpoints that you can use to monitor a running PXF Service on the local host:
+PXF exposes the following HTTP endpoints that you can use to monitor a running PXF Service on the local host:
 
 - `health` - Returns the status of the PXF Service.
 - `info` - Returns build information for the PXF Service.
 - `metrics` - Returns JVM, extended Tomcat, system, process, Log4j2, and PXF-specific metrics for the PXF Service.
 - `prometheus` - Returns all metrics in a format that can be scraped by a Prometheus server.
 
-Any user can access the HTTP endpoints and view the information that PXF returns.
+Any user can access the HTTP endpoints and view the monitoring information that PXF returns.
 
 You can view the data associated with a specific endpoint by navigating to the desired URL in a browser window:
 
@@ -81,7 +81,7 @@ build:
     time:          "2021-03-24T22:26:22.780Z"
 ```
 
-Alternatively, you can use the `curl` command to examine the PXF information. For example, to view the status of the PXF Service running on `localhost`, query the `health` endpoint:
+Alternatively, you can use the `curl` command to examine the PXF information. For example, to view the status of the PXF Service running on the local Greenplum Database host, query the `health` endpoint:
 
 ``` shell
 gpadmin@gphost$ curl -S http://localhost:5888/actuator/health
@@ -104,7 +104,7 @@ PXF also exposes metrics that are specific to its processing, including:
 
 The information that PXF returns when you query a metric is the aggregate data collected since the last (re)start of the PXF Service.
 
-To view a list of all of the metrics (names) available from the PXF Service, query just the `metrics` actuator endpoint:
+To view a list of all of the metrics (names) available from the PXF Service, query just the `metrics` endpoint:
 
 ``` pre
 http://localhost:5888/actuator/metrics

--- a/docs/content/monitor_pxf.html.md.erb
+++ b/docs/content/monitor_pxf.html.md.erb
@@ -96,11 +96,13 @@ PXF also exposes metrics that are specific to its processing, including:
 
 | Metric Name  | Description |
 |---------|-------------|
-| pxf.fragments.sent  | The number of fragments and the time that it takes to send data for a single fragment to Greenplum Database. |
+| pxf.fragments.sent  | The number of fragments, and the total time it took to send all fragments to Greenplum Database. |
 | pxf.records.sent  | The number of records that PXF sends to Greenplum Database. |
 | pxf.records.received  | The number of records that PXF receives from Greenplum Database. |
 | pxf.bytes.sent  | The number of bytes that PXF sends to Greenplum Database. |
 | pxf.bytes.received  | The number of bytes that PXF receives from Greenplum Database. |
+| http.server.requests | Standard metric augmented with PXF tags. |
+
 
 The information that PXF returns when you query a metric is the aggregate data collected since the last (re)start of the PXF Service.
 

--- a/docs/content/monitor_pxf.html.md.erb
+++ b/docs/content/monitor_pxf.html.md.erb
@@ -50,41 +50,40 @@ Perform the following procedure to request the PXF status of your Greenplum Data
 
 PXF exposes the following HTTP endpoints that you can use to monitor a running PXF Service on the local host:
 
-- `health` - Returns the status of the PXF Service.
-- `info` - Returns build information for the PXF Service.
-- `metrics` - Returns JVM, extended Tomcat, system, process, Log4j2, and PXF-specific metrics for the PXF Service.
-- `prometheus` - Returns all metrics in a format that can be scraped by a Prometheus server.
+- `actuator/health` - Returns the status of the PXF Service.
+- `actuator/info` - Returns build information for the PXF Service.
+- `actuator/metrics` - Returns JVM, extended Tomcat, system, process, Log4j2, and PXF-specific metrics for the PXF Service.
+- `actuator/prometheus` - Returns all metrics in a format that can be scraped by a Prometheus server.
 
 Any user can access the HTTP endpoints and view the monitoring information that PXF returns.
 
-You can view the data associated with a specific endpoint by navigating to the desired URL in a browser window:
+You can view the data associated with a specific endpoint by viewing in a browser, or `curl`-ing, a URL of the following format:
 
 ``` pre
-http://localhost:5888/actuator/<endpoint>[/<name>]
+http://localhost:5888/<endpoint>[/<name>]
 ```
 
-For example, to view the build information for the PXF service running on `localhost`, query the `info` endpoint:
+For example, to view the build information for the PXF service running on `localhost`, query the `actuator/info` endpoint:
 
 ``` pre
 http://localhost:5888/actuator/info
 ```
 
-Sample JSON output:
+Sample output:
 
 ``` pre
-build:
-    version:       "6.0.0"
-    artifact:      "pxf-service"
-    name:          "pxf-service"
-    pxfApiVersion: "16"
-    group:         "org.greenplum.pxf"
-    time:          "2021-03-24T22:26:22.780Z"
+{"build":{"version":"6.0.0","artifact":"pxf-service","name":"pxf-service","pxfApiVersion":"16","group":"org.greenplum.pxf","time":"2021-03-29T22:26:22.780Z"}}
 ```
 
-Alternatively, you can use the `curl` command to examine the PXF information. For example, to view the status of the PXF Service running on the local Greenplum Database host, query the `health` endpoint:
+To view the status of the PXF Service running on the local Greenplum Database host, query the `actuator/health` endpoint:
 
-``` shell
-gpadmin@gphost$ curl -S http://localhost:5888/actuator/health
+``` pre
+http://localhost:5888/actuator/health
+```
+
+Sample output:
+
+``` pre
 {"status":"UP","groups":["liveness","readiness"]}
 ```
 

--- a/docs/content/monitor_pxf.html.md.erb
+++ b/docs/content/monitor_pxf.html.md.erb
@@ -95,11 +95,11 @@ PXF also exposes metrics that are specific to its processing, including:
 
 | Metric Name  | Description |
 |---------|-------------|
-| pxf.fragments.sent  | The number of fragments, and the total time it took to send all fragments to Greenplum Database. |
-| pxf.records.sent  | The number of records that PXF sends to Greenplum Database. |
-| pxf.records.received  | The number of records that PXF receives from Greenplum Database. |
-| pxf.bytes.sent  | The number of bytes that PXF sends to Greenplum Database. |
-| pxf.bytes.received  | The number of bytes that PXF receives from Greenplum Database. |
+| pxf.fragments.sent  | The number of fragments, and the total time that it took to send all fragments to Greenplum Database. |
+| pxf.records.sent  | The number of records that PXF sent to Greenplum Database. |
+| pxf.records.received  | The number of records that PXF received from Greenplum Database. |
+| pxf.bytes.sent  | The number of bytes that PXF sent to Greenplum Database. |
+| pxf.bytes.received  | The number of bytes that PXF received from Greenplum Database. |
 | http.server.requests | Standard metric augmented with PXF tags. |
 
 
@@ -117,7 +117,7 @@ PXF tags all metrics that it returns with an `application` label; the value of t
 
 PXF tags its specific metrics with the additional labels: `user`, `segment`, `profile`, and `server`. All of these tags are present for each PXF metric.  PXF returns the tag value `unknown` when the value cannot be determined.
 
-You can use the tags to filter the information returned for PXF-specific metrics. For example, to examine the `pxf.records.received` metric for the PXF server named `hadoop1` located on `segment` 1 on the  local host:
+You can use the tags to filter the information returned for PXF-specific metrics. For example, to examine the `pxf.records.received` metric for the PXF server named `hadoop1` located on `segment` 1 on the local host:
 
 ``` pre
 http://localhost:5888/actuator/metrics/pxf.records.received?tag=segment:1&tag=server:hadoop1

--- a/docs/content/monitor_pxf.html.md.erb
+++ b/docs/content/monitor_pxf.html.md.erb
@@ -21,6 +21,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+You can monitor the status of PXF from the command line.
+
+PXF also provides additional information about the runtime status of the PXF Service by exposing HTTP endpoints that you can use to query the health, build information, and various metrics of the running process.
+
+
+## <a id="status"></a> Viewing PXF Status on the Command Line
+
 The `pxf cluster status` command displays the status of the PXF Service instance on all hosts in your Greenplum Database cluster. `pxf status` displays the status of the PXF Service instance on the local Greenplum host.
 
 Only the `gpadmin` user can request the status of the PXF Service.
@@ -38,4 +45,82 @@ Perform the following procedure to request the PXF status of your Greenplum Data
     ```shell
     gpadmin@gpmaster$ pxf cluster status
     ```
+
+## <a id="about_rtm"></a> About PXF Service Runtime Monitoring
+
+PXF exposes the following HTTP actuator endpoints that you can use to monitor a running PXF Service on the local host:
+
+- `health` - Returns the status of the PXF Service.
+- `info` - Returns build information for the PXF Service.
+- `metrics` - Returns JVM, extended Tomcat, system, process, Log4j2, and PXF-specific metrics for the PXF Service.
+- `prometheus` - Returns all metrics in a format that can be scraped by a Prometheus server.
+
+Any user can access the HTTP endpoints and view the information that PXF returns.
+
+You can view the data associated with a specific endpoint by navigating to the desired URL in a browser window:
+
+``` pre
+http://localhost:5888/actuator/<endpoint>[/<name>]
+```
+
+For example, to view the build information for the PXF service running on `localhost`, query the `info` endpoint:
+
+``` pre
+http://localhost:5888/actuator/info
+```
+
+Sample JSON output:
+
+``` pre
+build:
+    version:       "6.0.0"
+    artifact:      "pxf-service"
+    name:          "pxf-service"
+    pxfApiVersion: "16"
+    group:         "org.greenplum.pxf"
+    time:          "2021-03-24T22:26:22.780Z"
+```
+
+Alternatively, you can use the `curl` command to examine the PXF information. For example, to view the status of the PXF Service running on `localhost`, query the `health` endpoint:
+
+``` shell
+gpadmin@gphost$ curl -S http://localhost:5888/actuator/health
+{"status":"UP","groups":["liveness","readiness"]}
+```
+
+### <a id="examine_metrics"></a> Examining PXF Metrics
+
+PXF exposes JVM, extended Tomcat, and system metrics via its integration with Spring Boot. Refer to [Supported Metrics](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-metrics-meter) in the Spring Boot documentation for more information about these metrics.
+
+PXF also exposes metrics that are specific to its processing, including:
+
+| Metric Name  | Description |
+|---------|-------------|
+| pxf.fragments.sent  | The number of fragments and the time that it takes to send data for a single fragment to Greenplum Database. |
+| pxf.records.sent  | The number of records that PXF sends to Greenplum Database. |
+| pxf.records.received  | The number of records that PXF receives from Greenplum Database. |
+| pxf.bytes.sent  | The number of bytes that PXF sends to Greenplum Database. |
+| pxf.bytes.received  | The number of bytes that PXF receives from Greenplum Database. |
+
+The information that PXF returns when you query a metric is the aggregate data collected since the last (re)start of the PXF Service.
+
+To view a list of all of the metrics (names) available from the PXF Service, query just the `metrics` actuator endpoint:
+
+``` pre
+http://localhost:5888/actuator/metrics
+```
+
+### <a id="filter_metrics"></a> Filtering Metric Data
+
+PXF tags all metrics that it returns with an `application` label; the value of this tag is always `pxf-service`.
+
+PXF tags its specific metrics with the additional labels: `user`, `segment`, `profile`, and `server`. All of these tags are present for each PXF metric.  PXF returns the tag value `unknown` when the value cannot be determined.
+
+You can use the tags to filter the information returned for PXF-specific metrics. For example, to examine the `pxf.records.received` metric for the PXF server named `hadoop1` located on `segment` 1 on the  local host:
+
+``` pre
+http://localhost:5888/actuator/metrics/pxf.records.received?tag=segment:1&tag=server:hadoop1
+```
+
+Certain metrics, such as `pxf.fragments.sent`, include an aditional tag named `outcome`; you can examine its value (`success` or `error`) to determine if all data for the fragment was sent. You can also use this tag to filter the aggregated data.
 


### PR DESCRIPTION
this PR adds some basic info about the new monitoring/metrics support to the existing "monitoring pxf" page.  i pulled this together pretty quickly, let me know if there is other info that we should include for the user.

doc review site link:  https://docs-lisa-pxf6-rtmon.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/monitor_pxf.html#about_rtm