### PR TITLE
docs - architectural changes in pxf 6

### DIFF
--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -25,19 +25,18 @@ PXF is compatible with Cloudera, Hortonworks Data Platform, MapR, and generic Ap
 
 ## <a id="hdfs_arch"></a>Architecture
 
-HDFS is the primary distributed storage mechanism used by Apache Hadoop. When a user or application performs a query on a PXF external table that references an HDFS file, the Greenplum Database master node dispatches the query to all segment hosts. Each segment instance contacts the PXF Service running on its host. When it receives the request from a segment instance, the PXF Service:
+HDFS is the primary distributed storage mechanism used by Apache Hadoop. When a user or application performs a query on a PXF external table that references an HDFS file, the Greenplum Database master node dispatches the query to all segment instances. Each segment instance contacts the PXF Service running on its host. When it receives the request from a segment instance, the PXF Service:
 
-1. Allocates a worker thread to serve the request from a segment.
+1. Allocates a worker thread to serve the request from the segment instance.
 2. Invokes the HDFS Java API to request metadata information for the HDFS file from the HDFS NameNode. 
-3. Provides the metadata information returned by the HDFS NameNode to the segment instance.  
 
 <span class="figtitleprefix">Figure: </span>PXF-to-Hadoop Architecture
 
 <img src="graphics/pxfarch.png" class="image" />
 
-A segment instance uses its Greenplum Database `gp_segment_id` and the file block information described in the metadata to assign itself a specific portion of the query data. The segment instance then sends a request to the PXF Service to read the assigned data. This data may reside on one or more HDFS DataNodes.
+A PXF worker thread works on behalf of a segment instance. A worker thread uses its Greenplum Database `gp_segment_id` and the file block information described in the metadata to assign itself a specific portion of the query data. This data may reside on one or more HDFS DataNodes.
 
-The PXF Service invokes the HDFS Java API to read the data and delivers it to the segment instance. The segment instance delivers its portion of the data to the Greenplum Database master node. This communication occurs across segment hosts and segment instances in parallel.
+The PXF Service invokes the HDFS Java API to read the data and delivers it to the worker thread. The thread delivers its portion of the data to the Greenplum Database master node. This communication occurs across segment hosts and segment instances in parallel.
 
 
 ## <a id="hadoop_prereq"></a>Prerequisites

--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -36,7 +36,7 @@ HDFS is the primary distributed storage mechanism used by Apache Hadoop. When a 
 
 A PXF worker thread works on behalf of a segment instance. A worker thread uses its Greenplum Database `gp_segment_id` and the file block information described in the metadata to assign itself a specific portion of the query data. This data may reside on one or more HDFS DataNodes.
 
-The PXF Service invokes the HDFS Java API to read the data and delivers it to the worker thread. The thread delivers its portion of the data to the Greenplum Database master node. This communication occurs across segment hosts and segment instances in parallel.
+The PXF worker thread invokes the HDFS Java API to read the data and delivers it to the segment instance. The segment instance delivers its portion of the data to the Greenplum Database master node. This communication occurs across segment hosts and segment instances in parallel.
 
 
 ## <a id="hadoop_prereq"></a>Prerequisites

--- a/docs/content/intro_pxf.html.md.erb
+++ b/docs/content/intro_pxf.html.md.erb
@@ -23,6 +23,7 @@ PXF bundles all of the Hadoop JAR files on which it depends, and supports the fo
 
 | PXF Version | Hadoop Version | Hive Server Version | HBase Server Version |
 |-------------|----------------|---------------------|-------------|
+| 6.0 | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
 | 5.9+ | 2.x, 3.1+ | 1.x, 2.x, 3.1+ | 1.3.2 |
 | 5.8 | 2.x | 1.x | 1.3.2 |
 


### PR DESCRIPTION
misc updates to the hdfs landing page to reflect the current/new pxf 6 architecture.  i *think* i captured this correctly, but not sure.

i'll revisit where we present this info in the docs in a future PR.