### PR TITLE
linked pxf prepare and migrate to utility ref

### DIFF
--- a/docs/content/about_pxf_dir.html.md.erb
+++ b/docs/content/about_pxf_dir.html.md.erb
@@ -44,7 +44,7 @@ Refer to [Configuring PXF](instcfg_pxf.html) and [Starting PXF](cfginitstart_pxf
 
 If you require that `$PXF_BASE` reside in a directory distinct from `$PXF_HOME`, you can change it from the default location to a location of your choosing after you install PXF 6.x.
 
-PXF provides the `pxf [cluster] prepare` command to prepare a new `$PXF_BASE` location. The command copies the runtime and configuration directories identified above to the file system location that you specify in a `PXF_BASE` environment variable.
+PXF provides the [pxf [cluster] prepare](ref/pxf-cluster.html) command to prepare a new `$PXF_BASE` location. The command copies the runtime and configuration directories identified above to the file system location that you specify in a `PXF_BASE` environment variable.
 
 For example, to relocate `$PXF_BASE` to the `/path/to/dir` directory on all Greenplum hosts, run the command as follows:
 

--- a/docs/content/upgrade_5_to_6.html.md.erb
+++ b/docs/content/upgrade_5_to_6.html.md.erb
@@ -61,7 +61,7 @@ After you install the new version of PXF, perform the following procedure:
 1. Auto-migrate your PXF 5.x configuration to PXF 6.x `$PXF_BASE`:
 
     1. Recall your PXF 5.x `$PXF_CONF` setting.
-    2. Run the `migrate` command. You must provide `PXF_CONF`. If you relocated `$PXF_BASE`, provide that setting as well.
+    2. Run the `migrate` command (see [pxf cluster migrate](ref/pxf-cluster.html)). You must provide `PXF_CONF`. If you relocated `$PXF_BASE`, provide that setting as well.
 
         ``` shell
         gpadmin@gpmaster$ PXF_CONF=/path/to/dir pxf cluster migrate


### PR DESCRIPTION
Added links to utility reference page in places that mentioned pxf migrate and pxf prepare.