### PR TITLE
Docs: Added Avro topic for Hive

### DIFF
--- a/docs/content/hive_pxf.html.md.erb
+++ b/docs/content/hive_pxf.html.md.erb
@@ -495,15 +495,15 @@ hive> CREATE TABLE hive_avro_data_table (id int, name string, user_id string)
 Define the Greenplum Database external table:
 
 ```sql
-postgres=# CREATE EXTERNAL TABLE salesinfo_hiveavroprofile(id int, name text, user_id text)
-	LOCATION ('pxf://default.hive_avro_data_table?profile=Hive')
+postgres=# CREATE EXTERNAL TABLE userinfo_hiveavro(id int, name text, user_id text)
+	LOCATION ('pxf://default.hive_avro_data_table?profile=hive')
 	FORMAT 'custom' (FORMATTER='pxfwritable_import');
 ```
 
 And query the table:
 
 ```sql
-postgres=# SELECT * FROM salesinfo_hiveavroprofile;
+postgres=# SELECT * FROM userinfo_hiveavro;
 ```
 
 ## <a id="hive_complex"></a>Working with Complex Data Types

--- a/docs/content/hive_pxf.html.md.erb
+++ b/docs/content/hive_pxf.html.md.erb
@@ -481,6 +481,30 @@ And query the table:
 ``` sql
 postgres=# SELECT month, number_of_orders FROM pxf_parquet_table;
 ```
+## <a id="hive_avro"></a>Accessing Avro-Format Hive Tables
+
+The PXF `hive` profile supports accessing Hive tables that use the Avro storage format. Map the table columns using equivalent Greenplum Database data types. For example, if a Hive table is created in the `default` schema using:
+
+```sql
+hive> CREATE TABLE hive_avro_data_table (id int, name string, user_id string)
+	ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
+	STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
+	OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat';
+```
+
+Define the Greenplum Database external table:
+
+```sql
+postgres=# CREATE EXTERNAL TABLE salesinfo_hiveavroprofile(id int, name text, user_id text)
+	LOCATION ('pxf://default.hive_avro_data_table?profile=Hive')
+	FORMAT 'custom' (FORMATTER='pxfwritable_import');
+```
+
+And query the table:
+
+```sql
+postgres=# SELECT * FROM salesinfo_hiveavroprofile;
+```
 
 ## <a id="hive_complex"></a>Working with Complex Data Types
 


### PR DESCRIPTION
Added the section "Accessing Avro-Format Hive Table" to the Hive configuration page.
Based on this example: https://github.com/greenplum-db/pxf/blob/examples/examples/hdfs_hive/HIVE_HDFS_TEXT.md
Preview: https://mireia-hive-avro.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/hive_pxf.html