### PR TITLE
Docs: Added MySQL example

### DIFF
--- a/docs/content/jdbc_pxf.html.md.erb
+++ b/docs/content/jdbc_pxf.html.md.erb
@@ -394,7 +394,7 @@ This procedure will typically be performed by the Greenplum Database administrat
     ``` shell
     $ ssh gpadmin@<gpmaster>
     ```
-1. Download the MySQL JDBC driver and place it under `$PXF_HOME/lib`. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), you can also place the driver under `$PXF_BASE/lib`. You can download a MySQL JDBC driver from your preferred download location. The following example downloads the driver from Maven Central and places it under `$PXF_HOME/lib`:
+1. Download the MySQL JDBC driver and place it under `$PXF_BASE/lib`. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), make sure you use the updated location. You can download a MySQL JDBC driver from your preferred download location. The following example downloads the driver from Maven Central and places it under `$PXF_BASE/lib`:
 
     ```shell
     $ cd /usr/local/pxf-gp<version>/lib
@@ -460,8 +460,8 @@ Perform the following procedure to create a PXF external table that references t
     gpadmin=# SELECT * FROM names_in_mysql;
      id |   name    |   last   
     ----+-----------+----------
-    1 | John | Smith
-    2 | Mary | Blake
+      1 |   John    |   Smith
+      2 |   Mary    |   Blake
     (2 rows)    
     ```
 
@@ -487,11 +487,11 @@ Perform the following procedure to insert some data into the `names` MySQL table
 
     ``` sql
     gpadmin=#  SELECT * FROM names_in_mysql;
-     id |   name    |   last   
-    ----+-----------+----------
-      1 | John | Smith
-      2 | Mary | Blake
-      3 | Muhammad | Ali
+     id |   name     |   last   
+    ----+------------+--------
+      1 |   John     |   Smith
+      2 |   Mary     |   Blake
+      3 |   Muhammad |   Ali
     (3 rows)
     ```
 

--- a/docs/content/jdbc_pxf.html.md.erb
+++ b/docs/content/jdbc_pxf.html.md.erb
@@ -397,7 +397,7 @@ This procedure will typically be performed by the Greenplum Database administrat
 1. Download the MySQL JDBC driver and place it in the PXF user configuration directory under the `lib` subdirectory. You can download a MySQL JDBC driver from your preferred download location. For example, you can download it from Maven Central using the following command:
 
     ```shell
-    $ cd /usr/local/pxf-gp-<version>/lib
+    $ cd /usr/local/pxf-gp<version>/lib
     $ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
     ```
 
@@ -420,7 +420,7 @@ This procedure will typically be performed by the Greenplum Database administrat
         </property>
         <property>
             <name>jdbc.url</name>
-            <value>jdbc:mysql://mysqlserverhost:3306/mysql</value>
+            <value>jdbc:mysql://mysqlserverhost:3306/mysqltestdb</value>
             <description>The URL that the JDBC driver can use to connect to the database (e.g. jdbc:postgresql://localhost/postgres)</description>
         </property>
         <property>

--- a/docs/content/jdbc_pxf.html.md.erb
+++ b/docs/content/jdbc_pxf.html.md.erb
@@ -371,13 +371,13 @@ Perform the following steps to create a MySQL table named `names` in a database 
 5. Create a MySQL user named `mysql-user` and assign the password `my-secret-pw` to it:
 
     ``` sql
-    > CREATE USER 'mysql-user'@'localhost' IDENTIFIED BY 'my-secret-pw';
+    > CREATE USER 'mysql-user' IDENTIFIED BY 'my-secret-pw';
     ```
 
 6. Assign user `mysql-user` all privileges on table `names`, and exit the `mysql` subsystem:
 
     ``` sql
-    > GRANT ALL PRIVILEGES ON mysqltestdb.names TO 'mysql-user'@'localhost';
+    > GRANT ALL PRIVILEGES ON mysqltestdb.names TO 'mysql-user';
     > exit
     ```
 
@@ -394,7 +394,7 @@ This procedure will typically be performed by the Greenplum Database administrat
     ``` shell
     $ ssh gpadmin@<gpmaster>
     ```
-1. Download the MySQL JDBC driver and place it in the PXF user configuration directory under the `lib` subdirectory. You can download a MySQL JDBC driver from your preferred download location. For example, you can download it from Maven Central using the following command:
+1. Download the MySQL JDBC driver and place it under `$PXF_HOME/lib`. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), you can also place the driver under `$PXF_BASE/lib`. You can download a MySQL JDBC driver from your preferred download location. The following example downloads the driver from Maven Central and places it under `$PXF_HOME/lib`:
 
     ```shell
     $ cd /usr/local/pxf-gp<version>/lib
@@ -416,22 +416,22 @@ This procedure will typically be performed by the Greenplum Database administrat
         <property>
             <name>jdbc.driver</name>
             <value>com.mysql.jdbc.Driver</value>
-            <description>Class name of the JDBC driver (e.g. org.postgresql.Driver)</description>
+            <description>Class name of the JDBC driver</description>
         </property>
         <property>
             <name>jdbc.url</name>
             <value>jdbc:mysql://mysqlserverhost:3306/mysqltestdb</value>
-            <description>The URL that the JDBC driver can use to connect to the database (e.g. jdbc:postgresql://localhost/postgres)</description>
+            <description>The URL that the JDBC driver can use to connect to the database</description>
         </property>
         <property>
             <name>jdbc.user</name>
             <value>mysql-user</value>
-            <description>User name for connecting to the database (e.g. postgres)</description>
+            <description>User name for connecting to the database</description>
         </property>
         <property>
             <name>jdbc.password</name>
             <value>my-secret-pw</value>
-            <description>Password for connecting to the database (e.g. postgres)</description>
+            <description>Password for connecting to the database</description>
         </property>
     </configuration>  
     ```

--- a/docs/content/jdbc_pxf.html.md.erb
+++ b/docs/content/jdbc_pxf.html.md.erb
@@ -329,6 +329,172 @@ Perform the following procedure to insert some data into the `forpxf_table1` Pos
     (6 rows)
     ```
 
+### <a id="jdbc_example_mysql"></a>Example: Reading From and Writing to a MySQL Table
+
+In this example, you:
+
+- Create a MySQL database and table, and insert data into the table
+- Create a MySQL user and assign all privileges on the table to the user
+- Configure the PXF JDBC connector to access the MySQL database
+- Create a PXF readable external table that references the MySQL table
+- Read the data in the MySQL table
+- Create a PXF writable external table that references the MySQL table
+- Write data to the MySQL table
+- Read the data in the MySQL table again
+
+#### <a id="ex_create_pgtbl"></a>Create a MySQL Table
+
+Perform the following steps to create a MySQL table named `names` in a database named `mysqltestdb`, and grant a user named `mysql-user` all privileges on this table:
+
+1. Identify the host name and port of your MySQL server.
+
+2. Connect to the default MySQL database as the `root` user:
+
+    ``` shell
+    $ mysql -u root -p
+    ```
+
+3. Create a MySQL database named `mysqltestdb` and connect to this database:
+
+    ``` sql
+    > CREATE DATABASE mysqltestdb;
+    > USE mysqltestdb;
+    ```
+
+4. Create a table named `names` and insert some data into this table:
+
+    ``` sql
+    > CREATE TABLE names (id int, name varchar(64), last varchar(64));
+    > INSERT INTO names values (1, 'John', 'Smith'), (2, 'Mary', 'Blake');
+    ```
+
+5. Create a MySQL user named `mysql-user` and assign the password `my-secret-pw` to it:
+
+    ``` sql
+    > CREATE USER 'mysql-user'@'localhost' IDENTIFIED BY 'my-secret-pw';
+    ```
+
+6. Assign user `mysql-user` all privileges on table `names`, and exit the `mysql` subsystem:
+
+    ``` sql
+    > GRANT ALL PRIVILEGES ON mysqltestdb.names TO 'mysql-user'@'localhost';
+    > exit
+    ```
+
+    With these privileges, `mysql-user` can read from and write to the `names` table.
+
+#### <a id="ex_jdbconfig"></a>Configure the MySQL Connector
+
+You must create a JDBC server configuration for MySQL, download the MySQL driver JAR file to your system, copy the JAR file to the PXF user configuration directory, synchronize the PXF configuration, and then restart PXF.
+
+This procedure will typically be performed by the Greenplum Database administrator.
+
+1. Log in to the Greenplum Database master node:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    ```
+1. Download the MySQL JDBC driver and place it in the PXF user configuration directory under the `lib` subdirectory. You can download a MySQL JDBC driver from your preferred download location. For example, you can download it from Maven Central using the following command:
+
+    ```shell
+    $ cd /usr/local/pxf-gp-<version>/lib
+    $ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
+    ```
+
+1. Synchronize the PXF configuration, and then restart PXF: 
+
+    ```shell
+    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@gpmaster$ pxf cluster restart
+    ```
+
+2. Create a JDBC server configuration for MySQL as described in [Example Configuration Procedure](jdbc_cfg.html#cfg_proc), naming the server/directory `mysql`. The `jdbc-site.xml` file contents should look similar to the following (substitute your MySQL host system for `mysqlserverhost`):
+
+    ``` xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <configuration>
+        <property>
+            <name>jdbc.driver</name>
+            <value>com.mysql.jdbc.Driver</value>
+            <description>Class name of the JDBC driver (e.g. org.postgresql.Driver)</description>
+        </property>
+        <property>
+            <name>jdbc.url</name>
+            <value>jdbc:mysql://mysqlserverhost:3306/mysql</value>
+            <description>The URL that the JDBC driver can use to connect to the database (e.g. jdbc:postgresql://localhost/postgres)</description>
+        </property>
+        <property>
+            <name>jdbc.user</name>
+            <value>mysql-user</value>
+            <description>User name for connecting to the database (e.g. postgres)</description>
+        </property>
+        <property>
+            <name>jdbc.password</name>
+            <value>my-secret-pw</value>
+            <description>Password for connecting to the database (e.g. postgres)</description>
+        </property>
+    </configuration>  
+    ```
+
+3. Synchronize the PXF server configuration to the Greenplum Database cluster:
+
+    ``` shell
+    gpadmin@gpmaster$ pxf cluster sync
+    ```
+
+#### <a id="ex_readjdbc"></a>Read from the MySQL Table
+
+Perform the following procedure to create a PXF external table that references the `names` MySQL table that you created in the previous section, and read the data in the table:
+
+1. Create the PXF external table specifying the `jdbc` profile. For example:
+
+    ``` sql
+    gpadmin=# CREATE EXTERNAL TABLE names_in_mysql (id int, name text, last text)
+              LOCATION('pxf://names?PROFILE=jdbc&SERVER=mysql')
+              FORMAT 'CUSTOM' (formatter='pxfwritable_import');
+    ```
+
+2. Display all rows of the `names_in_mysql` table:
+
+    ``` sql
+    gpadmin=# SELECT * FROM names_in_mysql;
+     id |   name    |   last   
+    ----+-----------+----------
+    1 | John | Smith
+    2 | Mary | Blake
+    (2 rows)    
+    ```
+
+#### <a id="ex_writejdbc"></a>Write to the MySQL Table
+
+Perform the following procedure to insert some data into the `names` MySQL table and then read from the table. You must create a new external table for the write operation.
+
+1. Create a writable PXF external table specifying the `jdbc` profile. For example:
+
+    ``` sql
+    gpadmin=# CREATE WRITABLE EXTERNAL TABLE names_in_mysql_w (id int, name text, last text)
+              LOCATION('pxf://names?PROFILE=jdbc&SERVER=mysql')
+              FORMAT 'CUSTOM' (formatter='pxfwritable_export');
+    ```
+
+4. Insert some data into the `names_in_mysql_w` table. For example:
+
+    ``` sql
+    =# INSERT INTO names_in_mysql_w VALUES (3, 'Muhammad', 'Ali');
+    ```
+
+5. Use the `names_in_mysql` readable external table that you created in the previous section to view the new data in the `names` MySQL table:
+
+    ``` sql
+    gpadmin=#  SELECT * FROM names_in_mysql;
+     id |   name    |   last   
+    ----+-----------+----------
+      1 | John | Smith
+      2 | Mary | Blake
+      3 | Muhammad | Ali
+    (3 rows)
+    ```
+
 ## <a id="about_nq"></a>About Using Named Queries
 
 The PXF JDBC Connector allows you to specify a statically-defined query to run against the remote SQL database. Consider using a *named query* when:


### PR DESCRIPTION
I have added an example for accessing MySQL database via JDBC based on the example provided here:
https://github.com/greenplum-db/pxf/tree/cde7e455b63baea956a13c66af23f6ddadfffa43/server/pxf-jdbc

Preview: https://mireia-pxf-mysql.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-0/using/jdbc_pxf.html#jdbc_example_mysql

@lisakowen I added steps for downloading the jar and placing it under the lib directory, let me know if it makes sense to add it to the Postgresql example as well. 