### PR TITLE
HiveVectorizedORC profile should follow vectorized execution path

### DIFF
--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactory.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactory.java
@@ -46,10 +46,9 @@ public class ProfileFactory {
      */
     public static String get(InputFormat inputFormat, boolean hasComplexTypes, String userProfileName) {
         String profileName;
-        if (HIVE_ORC_VECTORIZED_PROFILE_OLD.equals(userProfileName))
-            // specialized Vectorized ORC profile is deprecated, fallback onto hive:orc profile
-            // that will apply vectorized execution logic if appropriate
-            return HIVE_ORC_PROFILE;
+        if (HIVE_ORC_VECTORIZED_PROFILE_OLD.equalsIgnoreCase(userProfileName))
+            // specialized Vectorized ORC profile is deprecated, but still needs to be supported for now
+            return userProfileName;
         if (inputFormat instanceof TextInputFormat && !hasComplexTypes) {
             profileName = HIVE_TEXT_PROFILE;
         } else if (inputFormat instanceof RCFileInputFormat) {

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactoryTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/utilities/ProfileFactoryTest.java
@@ -30,11 +30,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ProfileFactoryTest {
 
     @Test
-    public void get() throws Exception {
+    public void get() {
 
-        // if user specified vectorized ORC, no matter what the input format is, the profile should be used
+        // if user specified vectorized ORC, no matter what the input format is, the profile (as in parameter) should be used
         String profileName = ProfileFactory.get(new TextInputFormat(), false, "HiveVectorizedORC");
-        assertEquals("hive:orc", profileName);
+        assertEquals("HiveVectorizedORC", profileName);
+        profileName = ProfileFactory.get(new TextInputFormat(), false, "hivevectorizedorc");
+        assertEquals("hivevectorizedorc", profileName);
 
         // For TextInputFormat when table has no complex types, HiveText profile should be used
         profileName = ProfileFactory.get(new TextInputFormat(), false);


### PR DESCRIPTION
In PXF-6: specifying deprecated `HiveVectorizedORC` profile does not result in vectorized execution. 
