### PR TITLE
Update terraform concourse resource to version 0.11.15

### DIFF
--- a/concourse/pipelines/longevity_pipeline.yml
+++ b/concourse/pipelines/longevity_pipeline.yml
@@ -17,10 +17,12 @@ ccp_destroy_anchor: &ccp_destroy
 ## ======================================================================
 resource_types:
 - name: terraform
-  type: docker-image
+  type: registry-image
   source:
-    repository: ljfranklin/terraform-resource
-    tag: 0.11.14
+    repository: gcr.io/data-gpdb-ud/terraform-resource
+    tag: 0.11.15
+    username: _json_key
+    password: ((pxf-cloudbuild-service-account-key))
 
 - name: gcs
   type: docker-image

--- a/concourse/pipelines/perf_pipeline.yml
+++ b/concourse/pipelines/perf_pipeline.yml
@@ -77,10 +77,12 @@ set_failed_gpdb_anchor: &set_failed
 
 resource_types:
 - name: terraform
-  type: docker-image
+  type: registry-image
   source:
-    repository: ljfranklin/terraform-resource
-    tag: 0.11.14
+    repository: gcr.io/data-gpdb-ud/terraform-resource
+    tag: 0.11.15
+    username: _json_key
+    password: ((pxf-cloudbuild-service-account-key))
 
 - name: gcs
   type: registry-image

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -158,8 +158,10 @@ resource_types:
 - name: terraform
   type: registry-image
   source:
-    repository: ljfranklin/terraform-resource
-    tag: 0.11.14
+    repository: gcr.io/data-gpdb-ud/terraform-resource
+    tag: 0.11.15
+    username: _json_key
+    password: ((pxf-cloudbuild-service-account-key))
 
 - name: gcs
   type: registry-image

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -66,8 +66,10 @@ resource_types:
 - name: terraform
   type: registry-image
   source:
-    repository: ljfranklin/terraform-resource
-    tag: 0.11.14
+    repository: gcr.io/data-gpdb-ud/terraform-resource
+    tag: 0.11.15
+    username: _json_key
+    password: ((pxf-cloudbuild-service-account-key))
 {% endif %}
 
 - name: gcs


### PR DESCRIPTION
HashiCorp rotated their GPG key on or about 2021-04-22 and this means
that older version of terraform are no longer able to download and
verify provider plugins. The upstream maintainer of the
terraform-resource for Concourse has not published a updated container
image for the latest 0.11.x release of terraform (0.11.15).

This PR updates the CI pipelines to use an internally published version
of the Concourse resource that includes terraform 0.11.15.

[0]: https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512

Co-authored-by: Bradford D. Boyle <bradfordb@vmware.com>
Co-authored-by: Ashuka Xue <axue@vmware.com>