### PR TITLE
Hive connector should clone SerDe properties per fragment

### DIFF
--- a/automation/jsystem.properties
+++ b/automation/jsystem.properties
@@ -13,5 +13,5 @@ reporter.classes=jsystem.extensions.report.html.LevelHtmlTestReporter;jsystem.fr
 resources.src=/home/gpadmin/workspace/pxf/automation/src/main/resources
 sutClassName=jsystem.framework.sut.SutImpl
 sutFile=default.xml
-tests.dir=/home/gpadmin/workspace/pxf/automation/target/test-classes
+tests.dir=/Users/adenissov/workspace/pxf/automation/target/test-classes
 tests.src=/home/gpadmin/workspace/pxf/automation/src/main/java

--- a/automation/jsystem.properties
+++ b/automation/jsystem.properties
@@ -13,5 +13,5 @@ reporter.classes=jsystem.extensions.report.html.LevelHtmlTestReporter;jsystem.fr
 resources.src=/home/gpadmin/workspace/pxf/automation/src/main/resources
 sutClassName=jsystem.framework.sut.SutImpl
 sutFile=default.xml
-tests.dir=/Users/adenissov/workspace/pxf/automation/target/test-classes
+tests.dir=/home/gpadmin/workspace/pxf/automation/target/test-classes
 tests.src=/home/gpadmin/workspace/pxf/automation/src/main/java

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -110,6 +110,36 @@ public abstract class TableFactory {
         return exTable;
     }
 
+    /**
+     * Prepares PXF Readable External Table for Hive ORC data using vectorized profile
+     *
+     * @param tableName external table name
+     * @param fields for external table
+     * @param hiveTable to direct to
+     * @param useProfile true to use Profile or false to use Fragmenter Accessor
+     *            Resolver
+     * @return PXF Readable External Table using "HiveVectorizedORC" profile
+     */
+    public static ReadableExternalTable getPxfHiveVectorizedOrcReadableTable(String tableName,
+                                                                   String[] fields,
+                                                                   HiveTable hiveTable,
+                                                                   boolean useProfile) {
+
+        ReadableExternalTable exTable = new ReadableExternalTable(tableName,
+                fields, hiveTable.getName(), "CUSTOM");
+
+        if (useProfile) {
+            exTable.setProfile("HiveVectorizedORC");
+        } else {
+            exTable.setFragmenter("org.greenplum.pxf.plugins.hive.HiveInputFormatFragmenter");
+            exTable.setAccessor("org.greenplum.pxf.plugins.hive.HiveORCVectorizedAccessor");
+            exTable.setResolver("org.greenplum.pxf.plugins.hive.HiveORCVectorizedResolver");
+        }
+        exTable.setFormatter("pxfwritable_import");
+
+        return exTable;
+    }
+
     public static void main(String[] args) {
         HiveTable t = new HiveTable("bin_data", null);
         ReadableExternalTable a = getPxfHiveRcReadableTable("hive_bin",

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveBaseTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveBaseTest.java
@@ -251,6 +251,7 @@ public class HiveBaseTest extends BaseFeature {
     static final String HIVE_ORC_TABLE = "hive_orc_table";
     static final String HIVE_ORC_SNAPPY_TABLE = "hive_orc_snappy";
     static final String HIVE_ORC_ZLIB_TABLE = "hive_orc_zlib";
+    static final String HIVE_ORC_MULTIFILE_TABLE = "hive_orc_multifile";
     static final String HIVE_PARQUET_TIMESTAMP_TABLE = "hive_parquet_timestamp";
     static final String HIVE_BINARY_TABLE = "hive_binary";
     static final String HIVE_COLLECTIONS_TABLE = "hive_collections_table";
@@ -272,6 +273,8 @@ public class HiveBaseTest extends BaseFeature {
     static final String PXF_HIVE_TEXT_TABLE = "pxf_hive_text";
     static final String PXF_HIVE_ORC_TABLE = "pxf_hive_orc_types";
     static final String PXF_HIVE_ORC_ZLIB_TABLE = "pxf_hive_orc_zlib";
+    static final String PXF_HIVE_ORC_MULTIFILE_TABLE = "pxf_hive_orc_multifile";
+    static final String PXF_HIVE_ORC_MULTIFILE_VECTORIZED_TABLE = "pxf_hive_orc_multifile_vectorized";
     static final String PXF_HIVE_PARQUET_TIMESTAMP_TABLE = "pxf_hive_parquet_timestamp";
     static final String PXF_HIVE_HETEROGEN_TABLE = "pxf_hive_heterogen";
     static final String GPDB_SMALL_DATA_TABLE = "gpdb_small_data";
@@ -301,6 +304,7 @@ public class HiveBaseTest extends BaseFeature {
     HiveTable hiveOrcAllTypes;
     HiveTable hiveOrcSnappyTable;
     HiveTable hiveOrcZlibTable;
+    HiveTable hiveOrcMultiFileTable;
     HiveTable hiveRcTable;
     HiveTable hiveRcForAlterTable;
     HiveTable hiveSequenceTable;
@@ -430,6 +434,19 @@ public class HiveBaseTest extends BaseFeature {
         hiveOrcAllTypes.setStoredAs(ORC);
         hive.createTableAndVerify(hiveOrcAllTypes);
         hive.insertData(hiveTypesTable, hiveOrcAllTypes);
+    }
+
+    void prepareOrcMultiFileData() throws Exception {
+
+        if (hiveOrcMultiFileTable != null)
+            return;
+        hiveOrcMultiFileTable = new HiveTable(HIVE_ORC_MULTIFILE_TABLE, HIVE_SMALLDATA_COLS);
+        hiveOrcMultiFileTable.setStoredAs(ORC);
+        hive.createTableAndVerify(hiveOrcMultiFileTable);
+        // insert data 3 times to produce 3 backing files (and 3 PXF fragments)
+        hive.insertData(hiveSmallDataTable, hiveOrcMultiFileTable);
+        hive.insertData(hiveSmallDataTable, hiveOrcMultiFileTable);
+        hive.insertData(hiveSmallDataTable, hiveOrcMultiFileTable);
     }
 
     void prepareOrcSnappyData() throws Exception {

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveOrcTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hive/HiveOrcTest.java
@@ -24,6 +24,12 @@ public class HiveOrcTest extends HiveBaseTest {
         createTable(exTable);
     }
 
+    protected void createExternalVectorizedTable(String tableName, String[] fields, HiveTable hiveTable) throws Exception {
+
+        exTable = TableFactory.getPxfHiveVectorizedOrcReadableTable(tableName, fields, hiveTable, true);
+        createTable(exTable);
+    }
+
     @Override
     void prepareData() throws Exception {
 
@@ -244,6 +250,34 @@ public class HiveOrcTest extends HiveBaseTest {
 
         runTincTest("pxf.features.hive.orc_zlib.runTest");
         runTincTest("pxf.features.hcatalog.hive_orc_zlib.runTest");
+    }
+
+    /**
+     * PXF on Hive ORC format with multiple ORC backing files
+     *
+     * @throws Exception if test fails to run
+     */
+    @Test(groups = { "hive", "hcatalog", "features", "gpdb", "security" })
+    public void storeAsOrcMultiFile() throws Exception {
+
+        prepareOrcMultiFileData();
+        createExternalTable(PXF_HIVE_ORC_MULTIFILE_TABLE, PXF_HIVE_SMALLDATA_COLS, hiveOrcMultiFileTable);
+
+        runTincTest("pxf.features.hive.orc_multifile.runTest");
+    }
+
+    /**
+     * PXF with HiveVectorizedORC deprecated profile on Hive ORC format with multiple ORC backing files
+     *
+     * @throws Exception if test fails to run
+     */
+    @Test(groups = { "hive", "hcatalog", "features", "gpdb", "security" })
+    public void storeAsOrcMultiFileGetVectorized() throws Exception {
+
+        prepareOrcMultiFileData();
+        createExternalVectorizedTable(PXF_HIVE_ORC_MULTIFILE_VECTORIZED_TABLE, PXF_HIVE_SMALLDATA_COLS, hiveOrcMultiFileTable);
+
+        runTincTest("pxf.features.hive.orc_multifile_vectorized.runTest");
     }
 
     /**

--- a/automation/tincrepo/main/pxf/features/hive/orc_multifile/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hive/orc_multifile/expected/query01.ans
@@ -1,0 +1,354 @@
+-- start_ignore
+-- end_ignore
+-- @description query01 for Hive ORC small data multifile
+-- query 10 times to make sure there are no race conditions across fragment processing
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+

--- a/automation/tincrepo/main/pxf/features/hive/orc_multifile/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hive/orc_multifile/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLConcurrencyTestCase
+
+class HiveOrcMultifile(SQLConcurrencyTestCase):
+    """
+    @product_version  gpdb: [2.0-]
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hive/orc_multifile/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/orc_multifile/sql/query01.sql
@@ -1,0 +1,12 @@
+-- @description query01 for Hive ORC small data multifile
+-- query 10 times to make sure there are no race conditions across fragment processing
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile ORDER BY t1;

--- a/automation/tincrepo/main/pxf/features/hive/orc_multifile_vectorized/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hive/orc_multifile_vectorized/expected/query01.ans
@@ -1,0 +1,354 @@
+-- start_ignore
+-- end_ignore
+-- @description query01 for Hive ORC small data multifile vectorized
+-- query 10 times to make sure there are no race conditions across fragment processing
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+  t1   |  t2  | num1 | dub1
+-------+------+------+------
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row1  | s_6  |    1 |    6
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row10 | s_15 |   10 |   15
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row2  | s_7  |    2 |    7
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row3  | s_8  |    3 |    8
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row4  | s_9  |    4 |    9
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row5  | s_10 |    5 |   10
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row6  | s_11 |    6 |   11
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row7  | s_12 |    7 |   12
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row8  | s_13 |    8 |   13
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+ row9  | s_14 |    9 |   14
+(30 rows)
+

--- a/automation/tincrepo/main/pxf/features/hive/orc_multifile_vectorized/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hive/orc_multifile_vectorized/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLConcurrencyTestCase
+
+class HiveOrcMultifileVectorized(SQLConcurrencyTestCase):
+    """
+    @product_version  gpdb: [2.0-]
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hive/orc_multifile_vectorized/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/orc_multifile_vectorized/sql/query01.sql
@@ -1,0 +1,12 @@
+-- @description query01 for Hive ORC small data multifile vectorized
+-- query 10 times to make sure there are no race conditions across fragment processing
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;
+SELECT * FROM pxf_hive_orc_multifile_vectorized ORDER BY t1;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
@@ -235,7 +235,9 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
         Properties properties;
         try {
             HiveFragmentMetadata metadata = context.getFragmentMetadata();
-            properties = metadata.getProperties();
+            // clone properties from the fragment metadata as they are shared across fragments and
+            // properties for the current fragment will be modified by Hive Resolvers and SerDe classes
+            properties = (Properties) metadata.getProperties().clone();
             if (inputFormat == null) {
                 String inputFormatClassName = properties.getProperty(FILE_INPUT_FORMAT);
                 this.inputFormat = hiveUtilities.makeInputFormat(inputFormatClassName, jobConf);

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenter.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenter.java
@@ -307,8 +307,7 @@ public class HiveDataFragmenter extends HdfsDataFragmenter {
             fragmenterForProfile = context.getFragmenter();
         }
 
-        FileInputFormat.setInputPaths(jobConf, new Path(
-                tablePartition.storageDesc.getLocation()));
+        FileInputFormat.setInputPaths(jobConf, new Path(tablePartition.storageDesc.getLocation()));
 
         InputSplit[] splits;
         try {
@@ -318,6 +317,10 @@ public class HiveDataFragmenter extends HdfsDataFragmenter {
             return;
         }
 
+        // the same properties object will be reused by all fragments (splits) for a given partition
+        // or the whole table if it is not partitioned. This is to avoid excessive memory consumption
+        // when there are a lot of splits (files) backing up the Hive table (partition).
+        // Care must be taken by fragment processors to not modify this object or make a clone of it, if needed.
         Properties properties = hiveClientWrapper.buildFragmentProperties(fragmenterForProfile, tablePartition);
         for (InputSplit split : splits) {
             FileSplit fileSplit = (FileSplit) split;


### PR DESCRIPTION
In PXF 6.0.0 fragment list is kept in memory. For Hive connector, each fragment refers to Hive SerDe table properties to save on memory consumption, however PXF Hive resolvers and Hive Deserializers are expected to update the properties as a part of their processing. When they overwrite existing keys, a race condition occurs if the SerDe properties are shared across fragments.

This PR addresses this problem by making sure the properties are cloned before being set in a `HiveMetadata` for the fragment and having the resulting metadata set to the `RequestContext`. This way each fragment will have its own copy of the properties to operate on during processing.