### PR TITLE
Fix NullPointerException for ORC textMapper method when a column is repeating

### DIFF
--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedMappingFunctions.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedMappingFunctions.java
@@ -174,8 +174,8 @@ class ORCVectorizedMappingFunctions {
             rowId = m * rowIndex;
 
             value = bcv.noNulls || !bcv.isNull[rowId] ?
-                    new String(bcv.vector[rowIndex], bcv.start[rowIndex],
-                            bcv.length[rowIndex], StandardCharsets.UTF_8) : null;
+                    new String(bcv.vector[rowId], bcv.start[rowId],
+                            bcv.length[rowId], StandardCharsets.UTF_8) : null;
             result[rowIndex] = new OneField(oid, value);
         }
         return result;


### PR DESCRIPTION
If a column value of orc data is repeating and its type is string, an exception of NullPointerException will be thrown when reading it. 
This patch can solve the bug. 

Here is an example.
1. Create a CSV file named `sampledata.csv` in the `/tmp` directory:
```shell
echo 'Prague, Jan, 87, 0.00
Rome, Jan, 87, 1557.39
Bangalore, Jan, 87, 8936.99
Beijing, Jan, 87, 11600.67'> /tmp/sampledata.csv
```
2. Run the `orc-tools` `convert` command to convert `sampledata.csv` to the ORC file `/tmp/sampledata.orc`
```shell
java -jar /opt/orc-tools-1.6.2-uber.jar convert /tmp/sampledata.csv --schema 'struct<location:string,month:string,num_orders:string,total_sales:string>' -o /tmp/sampledata.orc
```

3. Copy the ORC file to HDFS. 
```shell
hdfs dfs -put /tmp/sampledata.orc /data/pxf_examples/
```
4. Create an external table 
```sql
CREATE EXTERNAL TABLE sample_orc(location text, month text, num_orders text, total_sales text)
            LOCATION ('pxf://data/pxf_examples/sampledata.orc?PROFILE=hdfs:orc')
          FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
```
5. Read the data by querying the sample_orc table, then it will throw java.lang.NullPointerException in pxf-service.log.

