### PR TITLE
Fix the inconsistency between rows count in external table and ORC file

### DIFF
--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedResolver.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedResolver.java
@@ -277,11 +277,21 @@ public class ORCVectorizedResolver extends BasePlugin implements ReadVectorizedR
                 cachedBatch.add(new ArrayList<>(columnDescriptors.size()));
             }
         } else {
-            // Reset the internal lists
-            for (int i = 0; i < batchSize; i++) {
-                // clear does not reclaim back the internal arrays of the arraylists
-                // this is what we prefer
-                cachedBatch.get(i).clear();
+            // Need to be reallocated when batchSize is not equal to the size of the existing cacheBatch,
+            // otherwise we will read more rows which we do not expect.
+            if (batchSize != cachedBatch.size()){
+                cachedBatch = new ArrayList<>(batchSize);
+
+                for (int i = 0; i < batchSize; i++) {
+                    cachedBatch.add(new ArrayList<>(columnDescriptors.size()));
+                }
+            } else {
+                // Reset the internal lists
+                for (int i = 0; i < batchSize; i++) {
+                    // clear does not reclaim back the internal arrays of the arraylists
+                    // this is what we prefer
+                    cachedBatch.get(i).clear();
+                }
             }
         }
 


### PR DESCRIPTION
As we know, use the PXF HDFS connector `hdfs:orc` profile to read ORC-format data and read 1024 rows of data at a time.

However, when the rows of data in ORC file is greater than 1024, it will result in the inconsistency between the number of rows in the external table of GPDB and the ORC file. In this case, the number of rows in the external table is always a multiple of 1024.

For example:

| ORC Data (row) | external table(row) | multiple(externalTable/1024) |
| -------------- | ------------------- | ---------------------------- |
| 1025           | 2048                | 2                            |
| 2050           | 3072                | 3                            |

Reason: When the last read data is less than 1024 rows, such as 30 rows, only the first 30 rows of data in cachedBatch are cleared, and the subsequent data are not cleared, but are still written to the external table.