### PR TITLE
explicitly specify HikariCP version as 3.4.5, since we ship it anyways

### DIFF
--- a/server/pxf-jdbc/build.gradle
+++ b/server/pxf-jdbc/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
     implementation(project(':pxf-api'))
     implementation("com.google.guava:guava")
-    implementation("com.zaxxer:HikariCP:3.4.2")
+    implementation("com.zaxxer:HikariCP:3.4.5")
     implementation("commons-collections:commons-collections")
     implementation("commons-io:commons-io")
     implementation("commons-lang:commons-lang")


### PR DESCRIPTION
Gradle rules pick HikariCP version 3.4.5 over 3.4.2 that was specified by our `build.gradle`, so the license finder was reporting both. This PR pins the version that we ship as the version specified in `build.gradle`, so that the license finder should now only report 1 version. No runtime impact is expected as we will continue shipping and using the same version 3.4.5 as before.