### PR TITLE
Update README and setup for automation tests

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -48,6 +48,10 @@ If you wish to run with cache
 make OFFLINE=true
 ```
 
+Note: if you get an error saying that the jar does not exist, ensure that you have
+a) installed the PXF server, and
+b) only have 1 jar file inside `/usr/local/pxf/application/`
+
 ### Project structure
 _**src/main/java**_ - contains related classes and utilities for the test
 

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -73,6 +73,9 @@ public class Gpdb extends DbSystemObject {
 
 		connect();
 
+		// Create the extensions if they don't exist
+		createExtension("pxf", true);
+
 		ReportUtils.stopLevel(report);
 	}
 
@@ -132,6 +135,10 @@ public class Gpdb extends DbSystemObject {
 
 		runQuery(createStatement, ignoreFail, false);
 		runQuery("ALTER DATABASE " + schemaName + " SET bytea_output TO 'escape'", ignoreFail, false);
+	}
+
+	private void createExtension(String extensionName, boolean ignoreFail) throws Exception {
+		runQuery("CREATE EXTENSION IF NOT EXISTS " + extensionName, ignoreFail, false);
 	}
 
 	@Override

--- a/automation/tincrepo/main/mpp/lib/PSQL.py
+++ b/automation/tincrepo/main/mpp/lib/PSQL.py
@@ -54,7 +54,7 @@ class PSQL(Command):
             if not os.path.exists(sql_file):
                 raise PSQLException('SQL file %s does not exist. ' %sql_file)
 
-            cmd_str = '%s psql %s %s %s %s %s -f %s' \
+            cmd_str = '%s psql %s %s %s %s %s --no-psqlrc -f %s' \
                 % (PGOPTIONS, dbname_option, username_option, hostname_option, port_option,
                    flags, sql_file)
 


### PR DESCRIPTION
This commit does the following:
- Update README
- Add --no-psqlrc flag to for easier testing
- Add function that creates the pxf extension when running automation
  testing

Co-authored-by: Ashuka Xue <axue@vmware.com>
Co-authored-by: Bradford Boyle <bradfordb@vmware.com>