### PR TITLE
report exception class if there's no exception message

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/error/PxfRuntimeException.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/error/PxfRuntimeException.java
@@ -1,6 +1,7 @@
 package org.greenplum.pxf.api.error;
 
 import lombok.Getter;
+import org.apache.commons.lang.StringUtils;
 
 public class PxfRuntimeException extends RuntimeException {
 
@@ -20,7 +21,7 @@ public class PxfRuntimeException extends RuntimeException {
     }
 
     public PxfRuntimeException(Throwable cause) {
-        this(cause.getMessage(), cause);
+        this(StringUtils.defaultIfBlank(cause.getMessage(), cause.getClass().getName()), cause);
     }
 
     public PxfRuntimeException(String message, Throwable cause) {

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/error/PxfRuntimeExceptionTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/error/PxfRuntimeExceptionTest.java
@@ -1,0 +1,27 @@
+package org.greenplum.pxf.api.error;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PxfRuntimeExceptionTest {
+
+    @Test
+    public void testExplicitErrorMessage() {
+        PxfRuntimeException e = new PxfRuntimeException("message", new NullPointerException("dummy"));
+        assertEquals("message", e.getMessage());
+    }
+
+    @Test
+    public void testErrorMessageFromCause() {
+        PxfRuntimeException e = new PxfRuntimeException(new NullPointerException("message"));
+        assertEquals("message", e.getMessage());
+    }
+
+    @Test
+    public void testDefaultErrorMessageWhenCauseDoesNotHaveIt() {
+        PxfRuntimeException e = new PxfRuntimeException(new NullPointerException());
+        assertEquals("java.lang.NullPointerException", e.getMessage());
+    }
+
+}

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
@@ -2,6 +2,7 @@ package org.greenplum.pxf.service.controller;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
+import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.api.error.PxfRuntimeException;
 import org.greenplum.pxf.service.utilities.ThrowingSupplier;
 
@@ -40,7 +41,7 @@ public abstract class PxfErrorReporter<T> {
             log.error(e.getMessage(), e);
             throw e;
         } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            log.error(StringUtils.defaultIfBlank(e.getMessage(), e.getClass().getName()), e);
             // wrap into PxfRuntimeException so that it can be handled by the PxfExceptionHandler
             throw new PxfRuntimeException(e);
         }


### PR DESCRIPTION
When an exception that does not have an error message (such as NPE) happens in PXF, Greenplum displays:

```
ERROR:  PXF server error : No message available  (seg0 slice1 127.0.0.1:6003 pid=93107)
HINT:  Check the PXF logs located in the '/opt/greenplum-pxf/logs' directory on host 'abcd' or 'set client_min_messages=LOG' for additional details.
```

This commit adds the exception class (such as `java.lang.NullPointerException`) in place of a missing message.
Then this is what Greenplum user will see:
```
ERROR:  PXF server error : java.lang.NullPointerException  (seg0 slice1 127.0.0.1:6003 pid=93107)
HINT:  Check the PXF logs located in the '/opt/greenplum-pxf/logs' directory on host 'abcd' or 'set client_min_messages=LOG' for additional details.
```