### PR TITLE
Allow configuring connection timeout for data uploads to PXF

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/configuration/PxfServerProperties.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/configuration/PxfServerProperties.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 import org.springframework.boot.autoconfigure.task.TaskExecutionProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 /**
  * Configuration properties for PXF.
  */
@@ -47,6 +49,17 @@ public class PxfServerProperties {
          * Maximum number of headers allowed in the request
          */
         private int maxHeaderCount = 30000;
+
+        /**
+         * Whether upload requests will use the same read timeout as connectionTimeout
+         */
+        private boolean disableUploadTimeout = true; // default Tomcat setting
+
+        /**
+         * Timeout for reading data from upload requests, if disableUploadTimeout is set to false.
+         */
+        private Duration connectionUploadTimeout = Duration.ofMinutes(5); // 5 min is default Tomcat setting
+
     }
 
     public void setBase(String base) {

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/configuration/PxfServerPropertiesTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/configuration/PxfServerPropertiesTest.java
@@ -18,69 +18,83 @@ class PxfServerPropertiesTest {
 
     @Test
     public void testDefaults() {
-        assertThat(this.properties.getBase()).isNull();
-        assertThat(this.properties.getTomcat()).isNotNull();
-        assertThat(this.properties.getTomcat().getMaxHeaderCount()).isEqualTo(30000);
+        assertThat(properties.getBase()).isNull();
+        assertThat(properties.getTomcat()).isNotNull();
+        assertThat(properties.getTomcat().getMaxHeaderCount()).isEqualTo(30000);
+        assertThat(properties.getTomcat().isDisableUploadTimeout()).isTrue();
+        assertThat(properties.getTomcat().getConnectionUploadTimeout()).isEqualTo(Duration.ofMinutes(5));
     }
 
     @Test
     public void testPxfConfBinding() {
         bind("pxf.base", "/path/to/pxf/conf");
-        assertThat(this.properties.getBase()).isEqualTo("/path/to/pxf/conf");
+        assertThat(properties.getBase()).isEqualTo("/path/to/pxf/conf");
     }
 
     @Test
     public void testTomcatMaxHeaderCountBinding() {
         bind("pxf.tomcat.max-header-count", "50");
-        assertThat(this.properties.getTomcat().getMaxHeaderCount()).isEqualTo(50);
+        assertThat(properties.getTomcat().getMaxHeaderCount()).isEqualTo(50);
+    }
+
+    @Test
+    public void testTomcatDisableUploadTimeoutBinding() {
+        bind("pxf.tomcat.disable-upload-timeout", "false");
+        assertThat(properties.getTomcat().isDisableUploadTimeout()).isFalse();
+    }
+
+    @Test
+    public void testTomcatConnectionUploadTimeoutBinding() {
+        bind("pxf.tomcat.connection-upload-timeout", "2h");
+        assertThat(properties.getTomcat().getConnectionUploadTimeout()).isEqualTo(Duration.ofHours(2));
     }
 
     @Test
     public void testTaskExecutionThreadNamePrefixBinding() {
         bind("pxf.task.thread-name-prefix", "foo-bar");
-        assertThat(this.properties.getTask().getThreadNamePrefix()).isEqualTo("foo-bar");
+        assertThat(properties.getTask().getThreadNamePrefix()).isEqualTo("foo-bar");
     }
 
     @Test
     public void testTaskExecutionPoolCoreSizeBinding() {
         bind("pxf.task.pool.core-size", "50");
-        assertThat(this.properties.getTask().getPool().getCoreSize()).isEqualTo(50);
+        assertThat(properties.getTask().getPool().getCoreSize()).isEqualTo(50);
     }
 
     @Test
     public void testTaskExecutionPoolKeepAliveBinding() {
         bind("pxf.task.pool.keep-alive", "120s");
-        assertThat(this.properties.getTask().getPool().getKeepAlive()).isEqualTo(Duration.ofSeconds(120));
+        assertThat(properties.getTask().getPool().getKeepAlive()).isEqualTo(Duration.ofSeconds(120));
     }
 
     @Test
     public void testTaskExecutionPoolMaxSizeBinding() {
         bind("pxf.task.pool.max-size", "200");
-        assertThat(this.properties.getTask().getPool().getMaxSize()).isEqualTo(200);
+        assertThat(properties.getTask().getPool().getMaxSize()).isEqualTo(200);
     }
 
     @Test
     public void testTaskExecutionPoolQueueCapacityBinding() {
         bind("pxf.task.pool.queue-capacity", "5");
-        assertThat(this.properties.getTask().getPool().getQueueCapacity()).isEqualTo(5);
+        assertThat(properties.getTask().getPool().getQueueCapacity()).isEqualTo(5);
     }
 
     @Test
     public void testTaskExecutionPoolAllowCoreThreadTimeoutBinding() {
         bind("pxf.task.pool.allow-core-thread-timeout", "false");
-        assertThat(this.properties.getTask().getPool().isAllowCoreThreadTimeout()).isEqualTo(false);
+        assertThat(properties.getTask().getPool().isAllowCoreThreadTimeout()).isEqualTo(false);
     }
 
     @Test
     public void testTaskExecutionShutdownAwaitTerminationPeriodBinding() {
         bind("pxf.task.shutdown.await-termination-period", "20s");
-        assertThat(this.properties.getTask().getShutdown().getAwaitTerminationPeriod()).isEqualTo(Duration.ofSeconds(20));
+        assertThat(properties.getTask().getShutdown().getAwaitTerminationPeriod()).isEqualTo(Duration.ofSeconds(20));
     }
 
     @Test
     public void testTaskExecutionShutdownBinding() {
         bind("pxf.task.shutdown.await-termination", "true");
-        assertThat(this.properties.getTask().getShutdown().isAwaitTermination()).isEqualTo(true);
+        assertThat(properties.getTask().getShutdown().isAwaitTermination()).isEqualTo(true);
     }
 
     private void bind(String name, String value) {
@@ -89,6 +103,6 @@ class PxfServerPropertiesTest {
 
     private void bind(Map<String, String> map) {
         ConfigurationPropertySource source = new MapConfigurationPropertySource(map);
-        new Binder(source).bind("pxf", Bindable.ofInstance(this.properties));
+        new Binder(source).bind("pxf", Bindable.ofInstance(properties));
     }
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfTomcatCustomizer.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfTomcatCustomizer.java
@@ -8,12 +8,12 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.stereotype.Component;
 
 /**
- * The {@link PxfCustomContainer} class allows customizing application container
+ * The {@link PxfTomcatCustomizer} class allows customizing application container
  * properties that are not exposed through the application.properties file.
  * For example, setting the max header count or the http header size.
  */
 @Component
-public class PxfCustomContainer implements
+public class PxfTomcatCustomizer implements
         WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
 
     private final PxfServerProperties serverProperties;
@@ -23,18 +23,19 @@ public class PxfCustomContainer implements
      *
      * @param serverProperties the server properties
      */
-    public PxfCustomContainer(PxfServerProperties serverProperties) {
+    public PxfTomcatCustomizer(PxfServerProperties serverProperties) {
         this.serverProperties = serverProperties;
     }
 
     @Override
-    @SuppressWarnings("rawtypes")
     public void customize(TomcatServletWebServerFactory factory) {
         factory.addConnectorCustomizers(connector -> {
             ProtocolHandler handler = connector.getProtocolHandler();
             if (handler instanceof AbstractHttp11Protocol) {
-                AbstractHttp11Protocol protocol = (AbstractHttp11Protocol) handler;
-                protocol.setMaxHeaderCount(serverProperties.getTomcat().getMaxHeaderCount());
+                AbstractHttp11Protocol<?> protocolHandler = (AbstractHttp11Protocol<?>) handler;
+                protocolHandler.setMaxHeaderCount(serverProperties.getTomcat().getMaxHeaderCount());
+                protocolHandler.setDisableUploadTimeout(serverProperties.getTomcat().isDisableUploadTimeout());
+                protocolHandler.setConnectionUploadTimeout((int) serverProperties.getTomcat().getConnectionUploadTimeout().toMillis());
             }
         });
     }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfTomcatInitializationListener.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfTomcatInitializationListener.java
@@ -1,0 +1,49 @@
+package org.greenplum.pxf.service.spring;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.ProtocolHandler;
+import org.apache.coyote.http11.Http11NioProtocol;
+import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.boot.web.servlet.context.ServletWebServerInitializedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Logs Tomcat parameters after the Tomcat container has been initialized.
+ */
+@Component
+@Slf4j
+public class PxfTomcatInitializationListener implements ApplicationListener<ServletWebServerInitializedEvent> {
+
+    @Override
+    public void onApplicationEvent(ServletWebServerInitializedEvent event) {
+        WebServer server = event.getWebServer();
+        if (server instanceof TomcatWebServer) {
+            Connector connector = ((TomcatWebServer) server).getTomcat().getConnector();
+            log.info("Tomcat Connector   ={}", connector);
+            log.info("- protocol         ={}", connector.getProtocol());
+            log.info("- scheme           ={}", connector.getScheme());
+            log.info("- port             ={}", connector.getPort());
+            log.info("- localPort        ={}", connector.getLocalPort());
+            log.info("- asyncTimeout     ={}", connector.getAsyncTimeout());
+            log.info("- executorName     ={}", connector.getExecutorName());
+            log.info("- maxParameterCount={}", connector.getMaxParameterCount());
+            log.info("- maxPostSize      ={}", connector.getMaxPostSize());
+            log.info("- URIEncoding      ={}", connector.getURIEncoding());
+            log.info("- protocolhandler  ={}", connector.getProtocolHandlerClassName());
+            ProtocolHandler handler = connector.getProtocolHandler();
+            if (handler instanceof Http11NioProtocol) {
+                Http11NioProtocol nioHandler = (Http11NioProtocol) handler;
+                log.info("    - connectionTimeout     ={}", nioHandler.getConnectionTimeout());
+                log.info("    - disableUploadTmeout   ={}", nioHandler.getDisableUploadTimeout());
+                log.info("    - connectionUploadTmeout={}", nioHandler.getConnectionUploadTimeout());
+                log.info("    - maxHeaderCount        ={}", nioHandler.getMaxHeaderCount());
+                log.info("    - maxHttpHeaderSize     ={}", nioHandler.getMaxHttpHeaderSize());
+                log.info("    - maxThreads            ={}", nioHandler.getMaxThreads());
+                log.info("    - minSpareThreads       ={}", nioHandler.getMinSpareThreads());
+            }
+        }
+    }
+}

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -36,7 +36,7 @@ server.tomcat.connection-timeout=${pxf.connection.timeout:5m}
 server.tomcat.mbeanregistry.enabled=true
 pxf.tomcat.max-header-count=30000
 pxf.tomcat.disable-upload-timeout=false
-pxf.tomcat.connection-upload-timeout=${pxf.connection.upload-timeout:${pxf.connection.timeout:5m}}
+pxf.tomcat.connection-upload-timeout=${pxf.connection.upload-timeout:5m}
 
 # timeout (ms) for the request - 1 day
 # TODO: spring_boot_todo what value should we set here

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -35,6 +35,8 @@ server.tomcat.accept-count=100
 server.tomcat.connection-timeout=${pxf.connection.timeout:5m}
 server.tomcat.mbeanregistry.enabled=true
 pxf.tomcat.max-header-count=30000
+pxf.tomcat.disable-upload-timeout=false
+pxf.tomcat.connection-upload-timeout=${pxf.connection.upload-timeout:${pxf.connection.timeout:5m}}
 
 # timeout (ms) for the request - 1 day
 # TODO: spring_boot_todo what value should we set here

--- a/server/pxf-service/src/templates/conf/pxf-application.properties
+++ b/server/pxf-service/src/templates/conf/pxf-application.properties
@@ -9,6 +9,7 @@
 
 # Server connection timeout (-1 for infinite timeout)
 # pxf.connection.timeout=5m
+# pxf.connection.upload-timeout=5m
 
 # Threads
 # pxf.max.threads=200


### PR DESCRIPTION
Data can be read from PXF (via readable external tables) or written to PXF (via writable external tables). PXF uses Spring Boot with embedded Tomcat server to process these requests. The Tomcat server will set underlying socket timeout based on the `connectionTimeout` property which we currently expose in `pxf-application.properties` as `pxf.connection.timeout`. The same timeout is set for both `read` and `write` operations. However, when there is a lot of data to write to PXF, it might be necessary to set a longer timeout for `write` operations only.

This PR does a few things:
1. Sets `disableUploadTimeout` Tomcat property to `false`, thus making possible setting a separate timeout for `write` operations.
2. This effectively makes `pxf.connection.timeout` property manage the timeout for `read` (download) operations only. The default value continues to be set as `5 minutes`.
3. Introduces a new `pxf.connection.upload-timeout` property that manages the timeout for `write` (upload) operations only.
4. Logs into `pxf-service.log` file the actual parameters the Tomcat server has been initialized with when PXF starts.

Users that use PXF 6.0.0 or PXF 6.0.1 and set the custom value for `pxf.connection.timeout` to change the timeout for upload operations will now have to set this value for the new `pxf.connection.upload-timeout` property instead.