### PR TITLE
bump Apache http component versions in automation to match shipped ones

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.4</version>
+            <version>4.5.13</version>
         </dependency>
 
         <dependency>
@@ -247,14 +247,8 @@
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.9</version>
+            <version>4.4.14</version>
         </dependency>
 
         <!--Google Dependencies-->


### PR DESCRIPTION
Upgrading Apache http component versions to match the versions that we ship and stop reporting fantom vulnerability. This PR replaces automated PR https://github.com/greenplum-db/pxf/pull/648 by removing duplicate dependency definition and adjusting an `httpcore` component version as well.