### PR TITLE
Remove unused GPDB5 CENTOS7 MAPR image

### DIFF
--- a/concourse/docker/README.md
+++ b/concourse/docker/README.md
@@ -42,7 +42,6 @@ changes to `pxf-build-base` and is also in charge of tagging the images as
   </tr>
   <tr>
     <td>MapR on CentOS7</td>
-    <td> <a href="https://console.cloud.google.com/gcr/images/${GCR_PROJECT_ID}/GLOBAL/gpdb-pxf-dev/gpdb5-centos7-test-pxf-mapr">gpdb5-centos7-test-pxf-mapr</a> </td>
     <td> <a href="https://console.cloud.google.com/gcr/images/${GCR_PROJECT_ID}/GLOBAL/gpdb-pxf-dev/gpdb6-centos7-test-pxf-mapr">gpdb6-centos7-test-pxf-mapr</a> </td>
     <td> N/A </td>
   </tr>

--- a/concourse/docker/mapr/README.md
+++ b/concourse/docker/mapr/README.md
@@ -4,15 +4,6 @@ Build the docker images on your local system.
 
 ### CentOS 7
 
-#### Greenplum 5
-
-```
-docker build \
-  --build-arg=BASE_IMAGE=gcr.io/$GCR_PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf:latest \
-  --tag=gpdb5-centos7-test-pxf-mapr \
-  -f ~/workspace/pxf/concourse/docker/mapr/Dockerfile .
-```
-
 #### Greenplum 6
 
 ```

--- a/concourse/docker/mapr/cloudbuild.yaml
+++ b/concourse/docker/mapr/cloudbuild.yaml
@@ -5,31 +5,6 @@
 timeout: 2400s
 
 steps:
-# Builds the gpdb5-centos7-test-pxf-mapr-image image
-- name: 'gcr.io/cloud-builders/docker'
-  id: gpdb5-centos7-test-pxf-mapr-image-cache
-  entrypoint: 'bash'
-  args:
-  - '-c'
-  - |
-    mkdir -p /workspace/none
-    docker pull gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf-mapr:latest || exit 0
-  waitFor: ['-']
-
-- name: 'gcr.io/cloud-builders/docker'
-  id: gpdb5-centos7-test-pxf-mapr-image
-  args:
-  - 'build'
-  - '--build-arg=BASE_IMAGE=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf:latest'
-  - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf-mapr:$COMMIT_SHA'
-  - '--cache-from'
-  - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf-mapr:latest'
-  - '-f'
-  - 'concourse/docker/mapr/Dockerfile'
-  - '/workspace/none'
-  waitFor:
-    - gpdb5-centos7-test-pxf-mapr-image-cache
-
 # Builds the gpdb6-centos7-test-pxf-mapr-image image
 - name: 'gcr.io/cloud-builders/docker'
   id: gpdb6-centos7-test-pxf-mapr-image-cache
@@ -56,5 +31,4 @@ steps:
 
 # Push images to Cloud Build to Container Registry
 images:
-- 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf-mapr:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-test-pxf-mapr:$COMMIT_SHA'

--- a/concourse/pipelines/cloudbuild_pipeline.yml
+++ b/concourse/pipelines/cloudbuild_pipeline.yml
@@ -10,7 +10,7 @@ pxf_dev_mapr_image_check: &pxf_dev_mapr_image
       GOOGLE_CREDENTIALS: {{pxf-cloudbuild-service-account-key}}
       GOOGLE_PROJECT_ID: {{google-project-id}}
       GOOGLE_ZONE: {{google-zone}}
-      IMAGE_LIST: "gpdb5-centos7-test-pxf-mapr gpdb6-centos7-test-pxf-mapr"
+      IMAGE_LIST: "gpdb6-centos7-test-pxf-mapr"
     config:
       platform: linux
       inputs:


### PR DESCRIPTION
This image is not being used in any pipelines.