### PR TITLE
Reinstall glibc-common in OEL container images

### DIFF
--- a/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
@@ -19,7 +19,9 @@ RUN curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERS
     && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
     && rm -f /tmp/apache-maven.tar.gz \
     && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
-    && yum install -y rpm-build python-devel glibc-common sudo && yum clean all \
+    # explicitly reinstall glibc-common to add back deleted charmaps
+    && yum reinstall -y glibc-common \
+    && yum install -y rpm-build python-devel sudo && yum clean all \
     && cd /tmp && /usr/bin/pip install --upgrade pip==20.2.4 \
     && /usr/bin/pip install psi paramiko --no-cache-dir
 


### PR DESCRIPTION
A change in upstream Oracle Linux images means that charmap files that
are normally included with the glibc-common package are removed from the
container image. When running `localedef` to generate additional
encodings, the command would fail with the following error message:

```console
character map file `CP1251' not found: No such file or directory
cannot read character map directory `/usr/share/i18n/charmaps': No such file or directory
```

Running `yum install glib-common` is not sufficient as `yum` reports
that the package is already installed. Reinstalling the package forces
yum` to re-download and unpack the RPM and restore the missing charmap
files.

Co-authored-by: Bradford D. Boyle <bradfordb@vmware.com>
Co-authored-by: Ashuka Xue <axue@vmware.com>