### PR TITLE
Create /workspace/none when building the GP6 Centos7 MAPR image

### DIFF
--- a/concourse/docker/mapr/cloudbuild.yaml
+++ b/concourse/docker/mapr/cloudbuild.yaml
@@ -12,6 +12,7 @@ steps:
   args:
   - '-c'
   - |
+    mkdir -p /workspace/none
     docker pull gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-test-pxf-mapr:latest || exit 0
   waitFor: ['-']
 


### PR DESCRIPTION
The GPDB5 CENTOS7 MAPR job used to create a directory called
/workspace/none when creating the image. With the removal of the unused
GPDB5 CENTOS7 MAPR image with commit 0e577d6, this directory is no
longer being made. We need to create it for the GPDB6 CENTOS7 MAPR
image.

The line to be readded in the gp6 job is https://github.com/greenplum-db/pxf/pull/656/files#diff-7ec99f34bfa66507259bd29cca0410b85f9109bbe30c8b73a1346a2e0f82d5a8L15