### PR TITLE
Update ORC to v1.6.8

### DIFF
--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -29,11 +29,4 @@ awsJavaSdk=1.11.801
 springBootVersion=2.4.3
 org.gradle.daemon=true
 org.gradle.parallel=false
-# ORC versions 1.6.x have breaking changes with
-# org.apache.hadoop.hive.ql.io.orc.ReaderImpl because
-# org.apache.orc.impl.ReaderImpl removes the types property which is used to
-# create the object inspector:
-# this.inspector = OrcStruct.createObjectInspector(0, types);
-# The types property is being restored at some point in newer (unreleased as of
-# now) versions of ORC 1.6. Check when version 1.6.6 is released
-orcVersion=1.5.12
+orcVersion=1.6.8


### PR DESCRIPTION
According to [ORC-669][], the breaking changes in ReaderImpl has been
fixed in ORC v1.6.6 and above.

[ORC-669]: https://issues.apache.org/jira/browse/ORC-669

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>