### PR TITLE
downgraded Gradle to 6.8.2

### DIFF
--- a/server/gradle/wrapper/gradle-wrapper.properties
+++ b/server/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/server/pxf-hdfs/build.gradle
+++ b/server/pxf-hdfs/build.gradle
@@ -89,8 +89,8 @@ dependencies {
     implementation("org.mortbay.jetty:jetty-util")                   { transitive = false }
 
     // GCS jars and dependencies
-    implementation("com.google.cloud.bigdataoss:gcs-connector")      { transitive = false
-        artifact { classifier = "shaded" }                                                }
+    implementation("com.google.cloud.bigdataoss:gcs-connector:hadoop2-1.9.17:shaded")
+                                                                     { transitive = false }
 
     /*******************************
      * Test Dependencies

--- a/server/pxf-hive/build.gradle
+++ b/server/pxf-hive/build.gradle
@@ -26,8 +26,7 @@ dependencies {
     implementation("com.google.guava:guava")
     implementation("commons-codec:commons-codec")
     implementation("commons-lang:commons-lang")
-    implementation("org.apache.hive:hive-exec")                      { transitive = false
-        artifact { classifier = "core" }                                                  }
+    implementation("org.apache.hive:hive-exec:${hiveVersion}:core")  { transitive = false }
     implementation("org.apache.hive:hive-metastore")                 { transitive = false }
     implementation("org.apache.hive:hive-serde")                     { transitive = false }
     implementation("com.esotericsoftware:kryo")                      { transitive = false }


### PR DESCRIPTION
The license finder tool seems to have problems with Gradle 7 and the way classified dependencies are declared, so we are coming back to the version we used before 6.8.2 and we have to explicitly define the version in the dependencies that have classifiers as the newer DSL seems not to be supported in 6.8.2.