### PR TITLE
fix CURLOPT_RESOLVE optimization

### DIFF
--- a/external-table/src/libchurl.c
+++ b/external-table/src/libchurl.c
@@ -344,21 +344,19 @@ churl_init(const char *url, CHURL_HEADERS headers)
 	clear_error_buffer(context);
 
 /* Required for resolving localhost on some docker environments that
- * had intermittent networking issues when using pxf on HAWQ
- * However, CURLOPT_RESOLVE is only available in curl versions 7.21 and above */
-#ifdef CURLOPT_RESOLVE
+ * had intermittent networking issues when using pxf on HAWQ.
+ */
 	if (strstr(url, LocalhostIpV4) != NULL)
 	{
 		struct curl_slist *resolve_hosts = NULL;
-		char	   *pxf_host_entry = (char *) palloc0(strlen(PxfServiceAddress) + strlen(LocalhostIpV4Entry) + 1);
+		char	   *pxf_host_entry = (char *) palloc0(LOCAL_HOST_RESOLVE_STRING_MAX_LENGTH);
 
-		strcat(pxf_host_entry, PxfServiceAddress);
-		strcat(pxf_host_entry, LocalhostIpV4Entry);
+		snprintf(pxf_host_entry, LOCAL_HOST_RESOLVE_STRING_MAX_LENGTH, LOCAL_HOST_RESOLVE_STRING_FORMAT, get_pxf_port());
+		elog(DEBUG3, "adding CURLOPT_RESOLVE with entry '%s'", pxf_host_entry);
 		resolve_hosts = curl_slist_append(NULL, pxf_host_entry);
 		set_curl_option(context, CURLOPT_RESOLVE, resolve_hosts);
 		pfree(pxf_host_entry);
 	}
-#endif
 
 	set_curl_option(context, CURLOPT_URL, url);
 	set_curl_option(context, CURLOPT_VERBOSE, (const void *) FALSE);

--- a/external-table/src/libchurl.h
+++ b/external-table/src/libchurl.h
@@ -143,6 +143,11 @@ void		churl_cleanup(CHURL_HANDLE handle, bool after_error);
  */
 void		print_http_headers(CHURL_HEADERS headers);
 
+#define LOCAL_HOST_RESOLVE_STRING_FORMAT "localhost:%d:127.0.0.1"
+/* PORT can be at most five digits giving a total length for the resolve string
+ * of 25 plus one for the trailing '\0'
+ */
+#define LOCAL_HOST_RESOLVE_STRING_MAX_LENGTH 26
 #define LocalhostIpV4Entry ":127.0.0.1"
 #define LocalhostIpV4 "localhost"
 #define REST_HEADER_JSON_RESPONSE "Accept: application/json"

--- a/fdw/libchurl.h
+++ b/fdw/libchurl.h
@@ -143,6 +143,11 @@ void		churl_cleanup(CHURL_HANDLE handle, bool after_error);
  */
 void		print_http_headers(CHURL_HEADERS headers);
 
+#define LOCAL_HOST_RESOLVE_STRING_FORMAT "localhost:%d:127.0.0.1"
+/* PORT can be at most five digits giving a total length for the resolve string
+ * of 25 plus one for the trailing '\0'
+ */
+#define LOCAL_HOST_RESOLVE_STRING_MAX_LENGTH 26
 #define LocalhostIpV4Entry ":127.0.0.1"
 #define LocalhostIpV4 "localhost"
 #define REST_HEADER_JSON_RESPONSE "Accept: application/json"


### PR DESCRIPTION
You cannot `#ifdef` on `CURLOPT_RESOLVE` since it is an enum member; the
`#ifdef` is always false and the block is not compiled.

Using `CURLOPT_RESOLVE` to provide a custom host name to IP address
resolution for the case of `localhost` allows PXF to pre-populate the
DNS cache and avoid a lookup via `getaddrinfo`.

We have seen some RHEL7 environments where the call to `getaddrinfo`
fails and calls `abort` which causes the GPDB segments to panic.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>