### PR TITLE
docs - for new pxf.sasl.connection.retries property

### DIFF
--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -98,6 +98,7 @@ You configure properties in the `pxf-site.xml` file for a PXF server when one or
 - You want to enable/disable user impersonation on the remote Hadoop or external database system.
 - You will access a network file system with the server configuration.
 - You will access a remote Hadoop or object store file system with the server configuration, and you want to allow a user to access only a specific directory and subdirectories.
+- You will use a SASL connection to access an external data store with the server configuration.
 
 `pxf-site.xml` includes the following properties:
 
@@ -109,6 +110,7 @@ You configure properties in the `pxf-site.xml` file for a PXF server when one or
 | pxf.service.user.name | The log in user for the remote system. | This property is commented out by default. When the property is unset, the default value is the operating system user that starts the pxf process, typically `gpadmin`. When the property is set, the default value depends on the user impersonation setting and, if you are accessing Hadoop, whether or not you are accessing a Kerberos-secured cluster; see the [Use Cases and Configuration Scenarios](pxfuserimpers.html#pxf_cfg_scenarios) section in the *Configuring the Hadoop User, User Impersonation, and Proxying* topic. |
 | pxf.fs.basePath | Identifies the base path or share point on the remote file system. This property is applicable when the server configuration is used with a profile that accesses a file. | None; this property is commented out by default. |
 | pxf.ppd.hive<sup>1</sup> | Specifies whether or not predicate pushdown is enabled for queries on external tables that specify the `Hive`, `HiveRC`, and `HiveORC` profiles. | True; predicate pushdown is enabled. |
+| pxf.sasl.connection.retries | Specifies the maximum number of times that PXF retries a SASL connection request after a refused connection returns a `GSS initiate failed` error. | 5 |
 
 </br><sup>1</sup>&nbsp;Should you need to, you can override this setting on a per-table basis by specifying the `&PPD=<boolean>` option in the `LOCATION` clause when you create the external table.
 

--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -98,7 +98,6 @@ You configure properties in the `pxf-site.xml` file for a PXF server when one or
 - You want to enable/disable user impersonation on the remote Hadoop or external database system.
 - You will access a network file system with the server configuration.
 - You will access a remote Hadoop or object store file system with the server configuration, and you want to allow a user to access only a specific directory and subdirectories.
-- You will use a SASL connection to access an external data store with the server configuration.
 
 `pxf-site.xml` includes the following properties:
 

--- a/docs/content/upgrade_pxf_rpm.html.md.erb
+++ b/docs/content/upgrade_pxf_rpm.html.md.erb
@@ -107,7 +107,7 @@ After you install the new version of PXF, perform the following procedure:
 
             You may need to add this property block to the `pxf-site.xml` file.
 
-1. **If you are upgrading to PXF version 5.16.3 to resolve the erroneous replay attack issue in a Kerberos-secured environment and you want to change the default value of the new `pxf.sasl.connection.retries` property**, add the following to the `$PXF_CONF/servers/<server-name>/pxf-site.xml` file for your PXF Hadoop server:
+1. **If you are upgrading to PXF version 5.16.3 to resolve an erroneous replay attack issue in a Kerberos-secured environment and you want to change the default value of the new `pxf.sasl.connection.retries` property**, add the following to the `$PXF_CONF/servers/<server-name>/pxf-site.xml` file on your PXF server:
 
     ``` pre
     <property>

--- a/docs/content/upgrade_pxf_rpm.html.md.erb
+++ b/docs/content/upgrade_pxf_rpm.html.md.erb
@@ -107,6 +107,20 @@ After you install the new version of PXF, perform the following procedure:
 
             You may need to add this property block to the `pxf-site.xml` file.
 
+1. **If you are upgrading to PXF version 5.16.3 to resolve the erroneous replay attack issue in a Kerberos-secured environment**, add the following property to the `$PXF_CONF/servers/<server-name>/pxf-site.xml` file for your PXF Hadoop server:
+
+    ``` pre
+    <property>
+      <name>pxf.sasl.connection.retries</name>
+      <value>5</value>
+      <description>
+        Specifies the number of retries to perform when a SASL connection is refused by a Namenode due to 'GSS initiate failed' error.
+      </description>
+    </property>
+    ```
+
+    You may choose to update the default value.
+
 4. Synchronize the PXF configuration from the master host to the standby master and each Greenplum Database segment host. For example:
 
     ``` shell

--- a/docs/content/upgrade_pxf_rpm.html.md.erb
+++ b/docs/content/upgrade_pxf_rpm.html.md.erb
@@ -107,19 +107,17 @@ After you install the new version of PXF, perform the following procedure:
 
             You may need to add this property block to the `pxf-site.xml` file.
 
-1. **If you are upgrading to PXF version 5.16.3 to resolve the erroneous replay attack issue in a Kerberos-secured environment**, add the following property to the `$PXF_CONF/servers/<server-name>/pxf-site.xml` file for your PXF Hadoop server:
+1. **If you are upgrading to PXF version 5.16.3 to resolve the erroneous replay attack issue in a Kerberos-secured environment and you want to change the default value of the new `pxf.sasl.connection.retries` property**, add the following to the `$PXF_CONF/servers/<server-name>/pxf-site.xml` file for your PXF Hadoop server:
 
     ``` pre
     <property>
       <name>pxf.sasl.connection.retries</name>
-      <value>5</value>
+      <value><new-value></value>
       <description>
         Specifies the number of retries to perform when a SASL connection is refused by a Namenode due to 'GSS initiate failed' error.
       </description>
     </property>
     ```
-
-    You may choose to update the default value.
 
 4. Synchronize the PXF configuration from the master host to the standby master and each Greenplum Database segment host. For example:
 


### PR DESCRIPTION
the pxf.sasl.connection.retries  property is introduced to allow the user to specify the number of times PXF retries a connection request after a connection is rejected and returns a `GSS initiate failed` error.

in this PR:
- describe the new property
- add a step to the 5.x upgrade guide