### PR TITLE
Enhanced logging to include fragment information and alignment changes

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
@@ -86,7 +86,7 @@ public abstract class BaseServiceImpl<T> extends PxfErrorReporter<T> {
         double rate = durationMs == 0 ? 0 : (1000.0 * recordCount / durationMs);
         double byteRate = durationMs == 0 ? 0 : (1000.0 * byteCount / durationMs);
 
-        log.info("{} {} operation [{} ms, {} record{}, {} records/sec, {} bytes, {} bytes/sec]",
+        log.info("{} {} operation [{} ms, {} record{}, {} records/sec, {} bytes, {} bytes/sec]{}",
                 status,
                 stats.getOperation().name().toLowerCase(),
                 durationMs,
@@ -94,7 +94,8 @@ public abstract class BaseServiceImpl<T> extends PxfErrorReporter<T> {
                 recordCount == 1 ? "" : "s",
                 String.format("%.2f", rate),
                 byteCount,
-                String.format("%.2f", byteRate));
+                String.format("%.2f", byteRate),
+                (exception == null) ? "" : " for " + result.getSourceName());
 
         // re-throw the exception if the operation failed
         if (exception != null) {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/OperationResult.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/OperationResult.java
@@ -15,4 +15,5 @@ import lombok.Setter;
 public class OperationResult {
     private Exception exception;
     private OperationStats stats;
+    private String sourceName;
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
@@ -80,10 +80,12 @@ public class ReadServiceImpl extends BaseServiceImpl<OperationStats> implements 
 
         // dataStream (and outputStream as the result) will close automatically at the end of the try block
         CountingOutputStream countingOutputStream = new CountingOutputStream(outputStream);
+        String sourceName = null;
         try {
             List<Fragment> fragments = fragmenterService.getFragmentsForSegment(context);
             for (int i = 0; i < fragments.size(); i++) {
                 Fragment fragment = fragments.get(i);
+                sourceName = fragment.getSourceName();
                 String profile = fragment.getProfile();
                 restoreOriginalValues = false;
                 if (StringUtils.isNotBlank(profile) &&
@@ -117,6 +119,7 @@ public class ReadServiceImpl extends BaseServiceImpl<OperationStats> implements 
             // the exception is not re-thrown but passed to the caller in the queryResult so that
             // the caller has a chance to inspect / report query stats before re-throwing the exception
             queryResult.setException(e);
+            queryResult.setSourceName(sourceName);
         } finally {
             queryResult.setStats(queryStats);
         }

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -51,4 +51,3 @@ pxf.task.pool.queue-capacity=0
 # logging
 logging.file.name=${pxf.logdir:/tmp}/pxf-service.log
 logging.file.path=${pxf.logdir:/tmp}
-logging.pattern.level=%5p [%X{sessionId}:%X{segmentId}]

--- a/server/pxf-service/src/templates/conf/pxf-log4j2.xml
+++ b/server/pxf-service/src/templates/conf/pxf-log4j2.xml
@@ -2,10 +2,10 @@
 <Configuration status="WARN">
 <Properties>
     <Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
-    <Property name="LOG_LEVEL_PATTERN">%5p [%X{sessionId}:%X{segmentId}]</Property>
-    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
+    <Property name="LOG_LEVEL_PATTERN">%5p [%X{sessionId}:%-3X{segmentId}]</Property>
+    <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS zzz</Property>
     <Property name="CONSOLE_LOG_PATTERN">%clr{%d{${LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
-    <Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+    <Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%-9.10t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
     <Property name="PXF_LOG_LEVEL">${bundle:pxf-application:pxf.log.level}</Property>
 </Properties>
 <Appenders>


### PR DESCRIPTION
For the PXF Logging, we have made these changes: 

- Added padding to the logs to address minor alignment issues. 
- In case of read failure, the logs will print the fragment information for which it failed. 