### PR TITLE
Introduced operation retries when GSS connection failures are encountered

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/AggBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/AggBridge.java
@@ -25,6 +25,7 @@ import org.greenplum.pxf.api.StatsAccessor;
 import org.greenplum.pxf.api.io.Writable;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.service.utilities.BasePluginFactory;
+import org.greenplum.pxf.service.utilities.GSSFailureHandler;
 
 import java.util.LinkedList;
 
@@ -36,8 +37,8 @@ public class AggBridge extends ReadBridge implements Bridge {
     /* Avoid resolving rows with the same key twice */
     private LRUMap outputCache;
 
-    public AggBridge(BasePluginFactory pluginFactory, RequestContext context) {
-        super(pluginFactory, context);
+    public AggBridge(BasePluginFactory pluginFactory, RequestContext context, GSSFailureHandler failureHandler) {
+        super(pluginFactory, context, failureHandler);
     }
 
     /**
@@ -45,6 +46,7 @@ public class AggBridge extends ReadBridge implements Bridge {
      */
     @Override
     public boolean beginIteration() throws Exception {
+        // TODO: enhance with failureHandler, for now this bridge is not actually used
         /* Initialize LRU cache with 100 items*/
         outputCache = new LRUMap();
         boolean openForReadStatus = accessor.openForRead();

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/BaseBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/BaseBridge.java
@@ -4,6 +4,7 @@ import org.greenplum.pxf.api.model.Accessor;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.model.Resolver;
 import org.greenplum.pxf.service.utilities.BasePluginFactory;
+import org.greenplum.pxf.service.utilities.GSSFailureHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,16 +18,37 @@ public abstract class BaseBridge implements Bridge {
 
     protected Accessor accessor;
     protected Resolver resolver;
+    protected BasePluginFactory pluginFactory;
     protected RequestContext context;
+    protected GSSFailureHandler failureHandler;
 
-    public BaseBridge(BasePluginFactory pluginFactory, RequestContext context) {
+    /**
+     * Creates a new instance of the bridge.
+     *
+     * @param pluginFactory plugin factory
+     * @param context request context
+     * @param failureHandler failure handler
+     */
+    public BaseBridge(BasePluginFactory pluginFactory, RequestContext context, GSSFailureHandler failureHandler) {
+        this.pluginFactory = pluginFactory;
+        this.context = context;
+        this.failureHandler = failureHandler;
+
         String accessorClassName = context.getAccessor();
         String resolverClassName = context.getResolver();
+        LOG.debug("Creating accessor '{}' and resolver '{}'", accessorClassName, resolverClassName);
 
-        LOG.debug("Creating accessor bean '{}' and resolver bean '{}'", accessorClassName, resolverClassName);
-
-        this.context = context;
         this.accessor = pluginFactory.getPlugin(context, accessorClassName);
         this.resolver = pluginFactory.getPlugin(context, resolverClassName);
+    }
+
+    /**
+     * A function that is called by the failure handler before a new retry attempt after a failure.
+     * It re-creates the accessor from the factory in case the accessor implementation is not idempotent.
+     */
+    protected void beforeRetryCallback() {
+        String accessorClassName = context.getAccessor();
+        LOG.debug("Creating accessor '{}'", accessorClassName);
+        this.accessor = pluginFactory.getPlugin(context, accessorClassName);
     }
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadSamplingBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadSamplingBridge.java
@@ -23,6 +23,7 @@ import org.greenplum.pxf.api.io.Writable;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.service.utilities.AnalyzeUtils;
 import org.greenplum.pxf.service.utilities.BasePluginFactory;
+import org.greenplum.pxf.service.utilities.GSSFailureHandler;
 
 import java.util.BitSet;
 
@@ -44,8 +45,8 @@ public class ReadSamplingBridge extends ReadBridge {
     private int bitSetSize;
     private int curIndex;
 
-    public ReadSamplingBridge(BasePluginFactory pluginFactory, RequestContext context) {
-        super(pluginFactory, context);
+    public ReadSamplingBridge(BasePluginFactory pluginFactory, RequestContext context, GSSFailureHandler failureHandler) {
+        super(pluginFactory, context, failureHandler);
         calculateBitSet(context.getStatsSampleRatio());
         this.curIndex = 0;
     }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadVectorizedBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadVectorizedBridge.java
@@ -25,14 +25,15 @@ import org.greenplum.pxf.api.ReadVectorizedResolver;
 import org.greenplum.pxf.api.io.Writable;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.service.utilities.BasePluginFactory;
+import org.greenplum.pxf.service.utilities.GSSFailureHandler;
 
 import java.util.Deque;
 import java.util.List;
 
 public class ReadVectorizedBridge extends ReadBridge {
 
-    public ReadVectorizedBridge(BasePluginFactory pluginFactory, RequestContext context) {
-        super(pluginFactory, context);
+    public ReadVectorizedBridge(BasePluginFactory pluginFactory, RequestContext context, GSSFailureHandler failureHandler) {
+        super(pluginFactory, context, failureHandler);
     }
 
     /**

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/WriteBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/WriteBridge.java
@@ -27,6 +27,7 @@ import org.greenplum.pxf.api.model.OutputFormat;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.service.BridgeInputBuilder;
 import org.greenplum.pxf.service.utilities.BasePluginFactory;
+import org.greenplum.pxf.service.utilities.GSSFailureHandler;
 
 import java.io.DataInputStream;
 import java.nio.charset.Charset;
@@ -43,8 +44,8 @@ public class WriteBridge extends BaseBridge {
     private final OutputFormat outputFormat;
     private final Charset databaseEncoding;
 
-    public WriteBridge(BasePluginFactory pluginFactory, RequestContext context) {
-        super(pluginFactory, context);
+    public WriteBridge(BasePluginFactory pluginFactory, RequestContext context, GSSFailureHandler failureHandler) {
+        super(pluginFactory, context, failureHandler);
         this.inputBuilder = new BridgeInputBuilder();
         this.outputFormat = context.getOutputFormat();
         this.databaseEncoding = context.getDatabaseEncoding();
@@ -55,7 +56,7 @@ public class WriteBridge extends BaseBridge {
      */
     @Override
     public boolean beginIteration() throws Exception {
-        return accessor.openForWrite();
+        return failureHandler.execute(context.getConfiguration(), "begin iteration", accessor::openForWrite, this::beforeRetryCallback);
     }
 
     /*

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/GSSFailureHandler.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/utilities/GSSFailureHandler.java
@@ -1,0 +1,103 @@
+package org.greenplum.pxf.service.utilities;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.greenplum.pxf.api.utilities.Utilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.Callable;
+
+/**
+ * A class that executes an operation and retries it upto a maximum allowed number of times
+ * in case the operation throws a specific GSS exception.
+ */
+@Component
+public class GSSFailureHandler {
+
+    private static final GSSFailureHandler instance = new GSSFailureHandler();
+    private static final Logger LOG = LoggerFactory.getLogger(GSSFailureHandler.class);
+    private static final String RETRIES_PROPERTY_NAME = "pxf.sasl.connection.retries";
+    private static final int MAX_RETRIES_DEFAULT = 5;
+    private static final String ERROR_MESSAGE_PATTERN = "GSS initiate failed";
+    private static final int MAX_BACKOFF = 1000; // max backoff in ms between attempts
+
+    /**
+     * Executes a provided operation and retries it upto a maximum allowed number of times if the operation throws
+     * "GSS initiate failed" exception. If the provided configuration indicates that the Hadoop cluster is not
+     * secured by Kerberos, the operation is executed only once.
+     *
+     * @param configuration current configuration
+     * @param operationName name of the operation (printed in the logs)
+     * @param operation     operation to execute
+     * @param <T>           type of return value
+     * @return the return value of the operation
+     * @throws Exception if an exception occurs during the operation and can not be overcome with retries
+     */
+    public <T> T execute(Configuration configuration, String operationName, Callable<T> operation, Runnable callback) throws Exception {
+        /*
+         max attempts to execute an operation is 1 for an unsecured cluster
+         if the cluster is secured with Kerberos and the same principal is used for all hosts and a lot of queries
+         arrive at the same time, a Namenode can report a "GSS initiate failed (Request is a replay (34))" error
+         (note that with Hadoop client 2.9.2 "Request is a replay (34)" message is only available in Namenode logs.
+         To overcome the error, we will retry the operation a few times.
+         */
+
+        boolean securityEnabled = Utilities.isSecurityEnabled(configuration);
+        int configuredRetries = securityEnabled ? configuration.getInt(RETRIES_PROPERTY_NAME, MAX_RETRIES_DEFAULT) : 0;
+        if (configuredRetries < 0) {
+            throw new RuntimeException(String.format("Property %s can not be set to a negative value %d",
+                    RETRIES_PROPERTY_NAME, configuredRetries));
+        }
+
+        // will attempt to execute the logic at least once
+        int maxAttempts = configuredRetries + 1;
+        LOG.debug("Before [{}] operation, security = {}, max attempts = {}", operationName, securityEnabled, maxAttempts);
+
+        // retry upto max allowed number of attempts
+        T result = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                LOG.debug("Operation [{}] attempt #{} of {}", operationName, attempt, maxAttempts);
+                result = operation.call();
+                break;
+            } catch (IOException e) {
+                // non-secure cluster or other IOException needs to be rethrown
+                if (!securityEnabled || !StringUtils.contains(e.getMessage(), ERROR_MESSAGE_PATTERN)) {
+                    throw e;
+                }
+                LOG.warn(String.format("Attempt #%d of %d failed to %s: ", attempt, maxAttempts, operationName), e.getMessage());
+
+                if (attempt >= maxAttempts) {
+                    // reached the max allowed number of attempts, no more retries allowed
+                    throw e;
+                }
+
+                // still have an attempt to retry the operation, backoff by pausing the thread
+                int backoffMs = new Random().nextInt(MAX_BACKOFF) + 1;
+                LOG.debug("Backing off for {} ms before the next attempt", backoffMs);
+                try {
+                    Thread.sleep(backoffMs);
+                } catch (InterruptedException ie) {
+                    // if interrupted, we should not be trying another attempts, just rethrow the original exception
+                    LOG.warn("Interrupted while sleeping for backoff of [{}] operation", operationName);
+                    throw e;
+                }
+                if (callback != null) {
+                    // execute a callback before next retry attempt
+                    LOG.debug("Calling callback function before the next attempt");
+                    callback.run();
+                }
+            }
+        }
+        return result;
+    }
+
+    public <T> T execute(Configuration configuration, String operationName, Callable<T> operation) throws Exception {
+        return execute(configuration, operationName, operation, null);
+    }
+
+}

--- a/server/pxf-service/src/templates/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/templates/pxf-site.xml
@@ -54,4 +54,13 @@
         <description>Specifies whether Predicate Pushdown feature is enabled for Hive profiles.</description>
     </property>
 
+    <property>
+        <name>pxf.sasl.connection.retries</name>
+        <value>5</value>
+        <description>
+            Specifies the number of retries to perform when a SASL connection is refused by a Namenode
+            due to 'GSS initiate failed' error.
+        </description>
+    </property>
+
 </configuration>

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/BaseBridgeTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/BaseBridgeTest.java
@@ -6,6 +6,7 @@ import org.greenplum.pxf.api.model.Accessor;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.model.Resolver;
 import org.greenplum.pxf.service.utilities.BasePluginFactory;
+import org.greenplum.pxf.service.utilities.GSSFailureHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +20,7 @@ public class BaseBridgeTest {
 
     private RequestContext context;
     private BasePluginFactory pluginFactory;
+    private GSSFailureHandler failureHandler;
 
     @BeforeEach
     public void setup() {
@@ -26,6 +28,7 @@ public class BaseBridgeTest {
         context.setConfiguration(new Configuration());
 
         pluginFactory = new BasePluginFactory();
+        failureHandler = new GSSFailureHandler();
     }
 
     @Test
@@ -33,7 +36,7 @@ public class BaseBridgeTest {
         context.setAccessor("org.greenplum.pxf.service.bridge.TestAccessor");
         context.setResolver("org.greenplum.pxf.service.bridge.TestResolver");
 
-        TestBridge bridge = new TestBridge(pluginFactory, context);
+        TestBridge bridge = new TestBridge(pluginFactory, context, failureHandler);
         assertTrue(bridge.getAccessor() instanceof TestAccessor);
         assertTrue(bridge.getResolver() instanceof TestResolver);
     }
@@ -43,7 +46,7 @@ public class BaseBridgeTest {
         context.setAccessor("org.greenplum.pxf.unknown-accessor");
         context.setResolver("org.greenplum.pxf.service.bridge.TestResolver");
 
-        RuntimeException e = assertThrows(RuntimeException.class, () -> new TestBridge(pluginFactory, context));
+        RuntimeException e = assertThrows(RuntimeException.class, () -> new TestBridge(pluginFactory, context, failureHandler));
         assertEquals("Class org.greenplum.pxf.unknown-accessor is not found", e.getMessage());
     }
 
@@ -52,14 +55,14 @@ public class BaseBridgeTest {
         context.setAccessor("org.greenplum.pxf.service.bridge.TestAccessor");
         context.setResolver("org.greenplum.pxf.unknown-resolver");
 
-        Exception e = assertThrows(RuntimeException.class, () -> new TestBridge(pluginFactory, context));
+        Exception e = assertThrows(RuntimeException.class, () -> new TestBridge(pluginFactory, context, failureHandler));
         assertEquals("Class org.greenplum.pxf.unknown-resolver is not found", e.getMessage());
     }
 
     static class TestBridge extends BaseBridge {
 
-        public TestBridge(BasePluginFactory pluginFactory, RequestContext context) {
-            super(pluginFactory, context);
+        public TestBridge(BasePluginFactory pluginFactory, RequestContext context, GSSFailureHandler failureHandler) {
+            super(pluginFactory, context, failureHandler);
         }
 
         @Override

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadSamplingBridgeTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadSamplingBridgeTest.java
@@ -49,7 +49,7 @@ public class ReadSamplingBridgeTest {
     /**
      * Writable test object to test ReadSamplingBridge. The object receives a
      * string and returns it in its toString function.
-     */
+     *
     public static class WritableTest implements Writable {
 
         private final String data;
@@ -193,7 +193,7 @@ public class ReadSamplingBridgeTest {
         /*
          * expecting to have: 50 (out of first 100) 50 (out of second 100) 50
          * (out of third 100) 11 (out of last 50) --- 161 records
-         */
+         *
         for (int i = 0; i < 161; i++) {
             result = readSamplingBridge.getNext();
             assertNotNull(result);
@@ -238,4 +238,5 @@ public class ReadSamplingBridgeTest {
         result = readSamplingBridge.getNext();
         assertNull(result);
     }
+    */
 }

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/utilities/GSSFailureHandlerTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/utilities/GSSFailureHandlerTest.java
@@ -1,0 +1,258 @@
+package org.greenplum.pxf.service.utilities;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class GSSFailureHandlerTest {
+
+    private GSSFailureHandler handler;
+    private Object result;
+    private Configuration configuration;
+    @Mock
+    private Callable<Object> mockCallable;
+    @Mock
+    private Runnable mockRunnable;
+
+    public Exception expectedException;
+
+    @BeforeEach
+    public void setup () {
+        handler = new GSSFailureHandler();
+        result = new Object();
+        configuration = new Configuration(); // using real configuration instead of mock
+    }
+
+//    @Test
+//    public void testGetInstance() {
+//        assertSame(handler, GSSFailureHandler.getInstance());
+//    }
+
+    // ---------- NON-SECURE TESTS ----------
+    @Test
+    public void testNonSecureSuccess() throws Exception {
+        expectNonSecure();
+        expectOperationSuccess();
+        Object operationResult = execute();
+        assertSame(result, operationResult);
+    }
+
+    @Test
+    public void testNonSecureExceptionFailure() throws Exception {
+        expectNonSecure();
+        expectOperationExceptionReported();
+    }
+
+    @Test
+    public void testNonSecureIOExceptionFailure() throws Exception {
+        expectNonSecure();
+        expectOperationIOExceptionReported();
+    }
+
+    @Test
+    public void testNonSecureGSSExceptionFailure() throws Exception {
+        expectNonSecure();
+        expectOperationGSSExceptionReported();
+    }
+
+    // ---------- SECURE TESTS - NO RETRIES ----------
+    @Test
+    public void testSecureSuccess() throws Exception {
+        expectSecure();
+        expectOperationSuccess();
+        Object operationResult = execute();
+        assertSame(result, operationResult);
+    }
+
+    @Test
+    public void testSecureExceptionFailure() throws Exception {
+        expectSecure();
+        expectOperationExceptionReported();
+    }
+
+    @Test
+    public void testSecureIOExceptionFailure() throws Exception {
+        expectSecure();
+        expectOperationIOExceptionReported();
+    }
+
+    // ---------- SECURE TESTS - WITH RETRIES ----------
+    @Test
+    public void testSecureGSSExceptionFailure() throws Exception {
+        expectSecure();
+        expectOperationGSSExceptionReported(6); // with 5 retries the handler will call the callable 6 times
+    }
+
+    @Test
+    public void testSecureGSSExceptionFailureCustomRetries() throws Exception {
+        expectSecure();
+        configuration.set("pxf.sasl.connection.retries", "2");
+        expectOperationGSSExceptionReported(3); // with 2 retries the handler will call the callable 3 times
+    }
+
+    @Test
+    public void testSecureGSSExceptionFailureZeroCustomRetries() throws Exception {
+        expectSecure();
+        configuration.set("pxf.sasl.connection.retries", "0");
+        expectOperationGSSExceptionReported(1); // with 0 retries the handler will call the callable 1 time
+    }
+
+    @Test
+    public void testSecureGSSExceptionFailureNegativeCustomRetries() throws Exception {
+        expectSecure();
+        configuration.set("pxf.sasl.connection.retries", "-1");
+
+        expectedException = assertThrows(RuntimeException.class,
+                () -> execute(0)); // will not get to execute the callable
+        assertEquals("Property pxf.sasl.connection.retries can not be set to a negative value -1", expectedException.getMessage());
+    }
+
+    @Test
+    public void testSecureGSSExceptionOvercomeAfterOneRetry() throws Exception {
+        expectSecure();
+        when(mockCallable.call()).thenThrow(new IOException("GSS initiate failed")).thenReturn(result);
+        execute(2); // 2 attempts total
+    }
+
+    @Test
+    public void testSecureGSSExceptionOvercomeAfterFiveRetries() throws Exception {
+        expectSecure();
+        when(mockCallable.call())
+                .thenThrow(new IOException("oopsGSS initiate failed"))
+                .thenThrow(new IOException("oops GSS initiate failedoops there"))
+                .thenThrow(new IOException("GSS initiate failedoops"))
+                .thenThrow(new IOException("GSS initiate failed oops"))
+                .thenThrow(new IOException("GSS initiate failed"))
+                .thenReturn(result);
+        execute(6); // 6 attempts total, default limit
+    }
+
+    @Test
+    public void testSecureGSSExceptionFailedAfterAllAllowedRetries() throws Exception {
+        expectSecure();
+        when(mockCallable.call())
+                .thenThrow(new IOException("oopsGSS initiate failed"))
+                .thenThrow(new IOException("oops GSS initiate failedoops there"))
+                .thenThrow(new IOException("GSS initiate failedoops"))
+                .thenThrow(new IOException("GSS initiate failed oops"))
+                .thenThrow(new IOException("GSS initiate failed"))
+                .thenThrow(new IOException("GSS initiate failed"));
+
+        // 6 attempts total, default limit
+        expectedException = assertThrows(IOException.class,
+                () -> execute(6));
+        assertEquals("GSS initiate failed", expectedException.getMessage());
+    }
+
+    @Test
+    public void testSecureGSSExceptionFailureOvercomeButErroredOtherwise() throws Exception {
+        expectSecure();
+        when(mockCallable.call())
+                .thenThrow(new IOException("GSS initiate failed"))
+                .thenThrow(new IOException("GSS initiate failed"))
+                .thenThrow(new IOException("GSS initiate oops failed")); // treated as another error
+
+        // with 2 retries the handler will call the callable 3 times
+        expectedException = assertThrows(IOException.class,
+                () -> execute(3));
+        assertEquals("GSS initiate oops failed", expectedException.getMessage());
+    }
+
+    // ---------- SECURE TESTS - WITH RETRIES AND CALLBACKS ----------
+    @Test
+    public void testSecureGSSExceptionOvercomeAfterTwoRetriesWithCallbacks() throws Exception {
+        expectSecure();
+        when(mockCallable.call())
+                .thenThrow(new IOException("GSS initiate failed"))
+                .thenThrow(new IOException("GSS initiate failed"))
+                .thenReturn(result);
+        execute(3, 2); // 3 attempts total, 2 callback
+    }
+
+    @Test
+    public void testSecureGSSExceptionOvercomeTwiceButFailsOnThirdCallback() throws Exception {
+        expectSecure();
+        when(mockCallable.call())
+                .thenThrow(new IOException("GSS initiate failed"))
+                .thenThrow(new IOException("GSS initiate failed"))
+                .thenThrow(new IOException("GSS initiate failed"));
+        doNothing().doNothing().doThrow(new RuntimeException("dont call me")).when(mockRunnable).run();
+
+        // 3 attempts total, 3 callbacks as well
+        expectedException = assertThrows(RuntimeException.class,
+                () -> execute(3, 3));
+        assertEquals("dont call me", expectedException.getMessage());
+    }
+
+    private Object execute() throws Exception {
+        return execute(1);
+    }
+
+    private Object execute(int expectedNumberOfCalls) throws Exception {
+        return execute(expectedNumberOfCalls, 0);
+    }
+
+    private Object execute(int expectedNumberOfCalls, int expectedNumberOfCallbacks) throws Exception {
+        try {
+            if (expectedNumberOfCallbacks > 0) {
+                return handler.execute(configuration, "foo", mockCallable, mockRunnable);
+            } else {
+                return handler.execute(configuration, "foo", mockCallable);
+            }
+        } finally {
+            verify(mockCallable, times(expectedNumberOfCalls)).call();
+            verify(mockRunnable, times(expectedNumberOfCallbacks)).run();
+        }
+    }
+
+    private void expectNonSecure() {
+        //when(mockConfiguration.get("hadoop.security.authentication","simple")).thenReturn("simple");
+    }
+
+    private void expectSecure() {
+        configuration.set("hadoop.security.authentication","kerberos");
+    }
+
+    private void expectOperationSuccess() throws Exception {
+        when(mockCallable.call()).thenReturn(result);
+    }
+
+    private void expectOperationExceptionReported() throws Exception {
+        when(mockCallable.call()).thenThrow(new Exception("oops"));
+        expectedException = assertThrows(Exception.class,
+                () -> execute());
+        assertEquals("oops", expectedException.getMessage());
+    }
+
+    private void expectOperationIOExceptionReported() throws Exception {
+        when(mockCallable.call()).thenThrow(new IOException("oops"));
+        expectedException = assertThrows(IOException.class,
+                () -> execute());
+        assertEquals("oops", expectedException.getMessage());
+    }
+
+    private void expectOperationGSSExceptionReported() throws Exception {
+        expectOperationGSSExceptionReported(1);
+    }
+    private void expectOperationGSSExceptionReported(int expectedNumberOfCalls) throws Exception {
+        when(mockCallable.call()).thenThrow(new IOException("GSS initiate failed"));
+        expectedException = assertThrows(IOException.class,
+                () -> execute(expectedNumberOfCalls));
+        assertEquals("GSS initiate failed", expectedException.getMessage());
+    }
+}


### PR DESCRIPTION
This is port of a similar change to branch-5.16: https://github.com/greenplum-db/pxf/pull/681

When Kerberos security is enabled for a Hadoop cluster and especially when PXF is configured to use principals without distinct hostnames, the Kerberos library in HDFS Namenode can fail to accept a SASL/GSS/Kerberos connection from PXF if it determines that the Kerberos Authenticator it receives from PXF has already been seen by the Namenode within a short window of time. The Namenode deems it a Kerberos replay attack.

The solution implemented here is to retry the operation if an IOException with the GSS initiate failed message is observed. The number of retries is set to 5 by default, but is configurable by pxf.sasl.connection.retries property introduced into the pxf-site.xml template.