### PR TITLE
external-table: add simple cURL debug callback function

### DIFF
--- a/external-table/src/libchurl.h
+++ b/external-table/src/libchurl.h
@@ -138,11 +138,6 @@ void		churl_read_check_connectivity(CHURL_HANDLE handle);
  */
 void		churl_cleanup(CHURL_HANDLE handle, bool after_error);
 
-/*
- * Debug function - print the http headers
- */
-void		print_http_headers(CHURL_HEADERS headers);
-
 #define LOCAL_HOST_RESOLVE_STRING_FORMAT "localhost:%d:127.0.0.1"
 /* PORT can be at most five digits giving a total length for the resolve string
  * of 25 plus one for the trailing '\0'


### PR DESCRIPTION
Enable CURLOPT_VERBOSE if the client or log level is the DEBUG3 level
(or higher); when verbose logging is enabled, libcurl will call the
debug callback given by CURLOPT_DEBUGFUNCTION.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>

external-table: conditionally enable curl debug output

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>