### PR TITLE
docs - for the pxf.fragmenter-cache.expiration property

### DIFF
--- a/docs/content/config_files.html.md.erb
+++ b/docs/content/config_files.html.md.erb
@@ -23,8 +23,9 @@ The `pxf-application.properties` file exposes these PXF Service application conf
 | pxf.task.pool.queue-capacity | The capacity of the core streaming thread pool queue. | 0 |
 | pxf.task.pool.max-size | The maximum allowed number of core streaming threads. | pxf.max.threads if set, or 200 |
 | [pxf.log.level](cfg_logging.html) | The log level for the PXF Service. | info  |
+| pxf.fragmenter-cache.expiration | The amount of time after which an entry expires and is removed from the fragment cache. | 10s (10 seconds) |
 
-To set a new value for a PXF Service application property, you may first need to uncomment the property in the `pxf-application.properties` file before you set the new value.
+To change the value of a PXF Service application property, you may first need to add the property to, or uncomment the property in, the `pxf-application.properties` file before you can set the new value.
 
 
 ## <a id="pxfenvsh"></a>pxf-env.sh


### PR DESCRIPTION
brief mention of the new property in the pxf pxf-application.properties config file docs.  also updated the statement about how to change a property value to include adding the property to the file.

docs for https://github.com/greenplum-db/pxf/pull/691.