### PR TITLE
Fixed NullPointerException in GSS failure handling retry logic

### DIFF
--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadBridge.java
@@ -60,7 +60,8 @@ public class ReadBridge extends BaseBridge {
      */
     @Override
     public boolean beginIteration() throws Exception {
-        return failureHandler.execute(context.getConfiguration(), "begin iteration", accessor::openForRead, this::beforeRetryCallback);
+        // using lambda and not a method reference accessor::openForRead as the accessor will be changed by the retry function
+        return failureHandler.execute(context.getConfiguration(), "begin iteration", () -> accessor.openForRead(), this::beforeRetryCallback);
     }
 
     protected Deque<Writable> makeOutput(OneRow oneRow) throws Exception {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/WriteBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/WriteBridge.java
@@ -56,7 +56,8 @@ public class WriteBridge extends BaseBridge {
      */
     @Override
     public boolean beginIteration() throws Exception {
-        return failureHandler.execute(context.getConfiguration(), "begin iteration", accessor::openForWrite, this::beforeRetryCallback);
+        // using lambda and not a method reference accessor::openForRead as the accessor will be changed by the retry function
+        return failureHandler.execute(context.getConfiguration(), "begin iteration", () -> accessor.openForWrite(), this::beforeRetryCallback);
     }
 
     /*

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadBridgeTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadBridgeTest.java
@@ -1,0 +1,143 @@
+package org.greenplum.pxf.service.bridge;
+
+import org.apache.hadoop.conf.Configuration;
+import org.greenplum.pxf.api.model.Accessor;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.service.utilities.BasePluginFactory;
+import org.greenplum.pxf.service.utilities.GSSFailureHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ReadBridgeTest {
+
+    private ReadBridge bridge;
+    private RequestContext context;
+    private Configuration configuration;
+    private GSSFailureHandler handler;
+
+    @Mock
+    private BasePluginFactory mockPluginFactory;
+    @Mock
+    private Accessor mockAccessor1;
+    @Mock
+    private Accessor mockAccessor2;
+    @Mock
+    private Accessor mockAccessor3;
+
+    @BeforeEach
+    public void setup() {
+        handler = new GSSFailureHandler();
+        context = new RequestContext();
+        configuration = new Configuration();
+        configuration.set("hadoop.security.authentication", "kerberos");
+        context.setConfiguration(configuration);
+        context.setAccessor("org.greenplum.pxf.api.model.Accessor");
+        context.setAccessor("org.greenplum.pxf.api.model.Resolver");
+    }
+
+    @Test
+    public void testBeginIterationFailureNoRetries() throws Exception {
+        when(mockPluginFactory.getPlugin(context, context.getAccessor())).thenReturn(mockAccessor1);
+        when(mockAccessor1.openForRead()).thenThrow(new IOException("Something Else"));
+
+        // constructor will call into mock factories, that's why we do not create ReadBridge in @Before method
+        bridge = new ReadBridge(mockPluginFactory, context, handler);
+        Exception e = assertThrows(IOException.class, () -> bridge.beginIteration());
+        assertEquals("Something Else", e.getMessage());
+
+        verify(mockPluginFactory).getPlugin(context, context.getAccessor());
+        verify(mockPluginFactory).getPlugin(context, context.getResolver());
+        verify(mockAccessor1).openForRead();
+        verifyNoMoreInteractions(mockPluginFactory, mockAccessor1);
+    }
+
+    @Test
+    public void testBeginIterationGSSFailureRetriedOnce() throws Exception {
+        when(mockPluginFactory.getPlugin(context, context.getAccessor()))
+                .thenReturn(mockAccessor1)
+                .thenReturn(mockAccessor2);
+        when(mockAccessor1.openForRead()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor2.openForRead()).thenReturn(true);
+
+        // constructor will call into mock factories, that's why we do not create ReadBridge in @Before method
+        bridge = new ReadBridge(mockPluginFactory, context, handler);
+        boolean result = bridge.beginIteration();
+        assertTrue(result);
+
+        verify(mockPluginFactory, times(2)).getPlugin(context, context.getAccessor());
+        verify(mockPluginFactory, times(1)).getPlugin(context, context.getResolver());
+        InOrder inOrder = inOrder(mockAccessor1, mockAccessor2);
+        inOrder.verify(mockAccessor1).openForRead(); // first  attempt on accessor #1
+        inOrder.verify(mockAccessor2).openForRead(); // second attempt on accessor #2
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(mockPluginFactory);
+    }
+
+    @Test
+    public void testBeginIterationGSSFailureRetriedTwice() throws Exception {
+        when(mockPluginFactory.getPlugin(context, context.getAccessor()))
+                .thenReturn(mockAccessor1)
+                .thenReturn(mockAccessor2)
+                .thenReturn(mockAccessor3);
+        when(mockAccessor1.openForRead()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor2.openForRead()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor3.openForRead()).thenReturn(true);
+
+        // constructor will call into mock factories, that's why we do not create ReadBridge in @Before method
+        bridge = new ReadBridge(mockPluginFactory, context, handler);
+        boolean result = bridge.beginIteration();
+        assertTrue(result);
+
+        verify(mockPluginFactory, times(3)).getPlugin(context, context.getAccessor());
+        verify(mockPluginFactory, times(1)).getPlugin(context, context.getResolver());
+        InOrder inOrder = inOrder(mockAccessor1, mockAccessor2, mockAccessor3);
+        inOrder.verify(mockAccessor1).openForRead(); // first  attempt on accessor #1
+        inOrder.verify(mockAccessor2).openForRead(); // second attempt on accessor #2
+        inOrder.verify(mockAccessor3).openForRead(); // third attempt on accessor #3
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(mockPluginFactory);
+    }
+
+    @Test
+    public void testBeginIterationGSSFailureAfterMaxRetries() throws Exception {
+        configuration.set("pxf.sasl.connection.retries", "2");
+        when(mockPluginFactory.getPlugin(context, context.getAccessor()))
+                .thenReturn(mockAccessor1)
+                .thenReturn(mockAccessor2)
+                .thenReturn(mockAccessor3);
+        when(mockAccessor1.openForRead()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor2.openForRead()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor3.openForRead()).thenThrow(new IOException("GSS initiate failed"));
+
+        // constructor will call into mock factories, that's why we do not create ReadBridge in @Before method
+        bridge = new ReadBridge(mockPluginFactory, context, handler);
+        Exception e = assertThrows(IOException.class, () -> bridge.beginIteration());
+        assertEquals("GSS initiate failed", e.getMessage());
+
+        verify(mockPluginFactory, times(3)).getPlugin(context, context.getAccessor());
+        verify(mockPluginFactory, times(1)).getPlugin(context, context.getResolver());
+        InOrder inOrder = inOrder(mockAccessor1, mockAccessor2, mockAccessor3);
+        inOrder.verify(mockAccessor1).openForRead(); // first  attempt on accessor #1
+        inOrder.verify(mockAccessor2).openForRead(); // second attempt on accessor #2
+        inOrder.verify(mockAccessor3).openForRead(); // third attempt on accessor #3
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(mockPluginFactory);
+    }
+
+}

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/WriteBridgeTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/WriteBridgeTest.java
@@ -1,0 +1,143 @@
+package org.greenplum.pxf.service.bridge;
+
+import org.apache.hadoop.conf.Configuration;
+import org.greenplum.pxf.api.model.Accessor;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.service.utilities.BasePluginFactory;
+import org.greenplum.pxf.service.utilities.GSSFailureHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class WriteBridgeTest {
+
+    private WriteBridge bridge;
+    private RequestContext context;
+    private Configuration configuration;
+    private GSSFailureHandler handler;
+
+    @Mock
+    private BasePluginFactory mockPluginFactory;
+    @Mock
+    private Accessor mockAccessor1;
+    @Mock
+    private Accessor mockAccessor2;
+    @Mock
+    private Accessor mockAccessor3;
+
+    @BeforeEach
+    public void setup() {
+        handler = new GSSFailureHandler();
+        context = new RequestContext();
+        configuration = new Configuration();
+        configuration.set("hadoop.security.authentication", "kerberos");
+        context.setConfiguration(configuration);
+        context.setAccessor("org.greenplum.pxf.api.model.Accessor");
+        context.setAccessor("org.greenplum.pxf.api.model.Resolver");
+    }
+
+    @Test
+    public void testBeginIterationFailureNoRetries() throws Exception {
+        when(mockPluginFactory.getPlugin(context, context.getAccessor())).thenReturn(mockAccessor1);
+        when(mockAccessor1.openForWrite()).thenThrow(new IOException("Something Else"));
+
+        // constructor will call into mock factories, that's why we do not create WriteBridge in @Before method
+        bridge = new WriteBridge(mockPluginFactory, context, handler);
+        Exception e = assertThrows(IOException.class, () -> bridge.beginIteration());
+        assertEquals("Something Else", e.getMessage());
+
+        verify(mockPluginFactory).getPlugin(context, context.getAccessor());
+        verify(mockPluginFactory).getPlugin(context, context.getResolver());
+        verify(mockAccessor1).openForWrite();
+        verifyNoMoreInteractions(mockPluginFactory, mockAccessor1);
+    }
+
+    @Test
+    public void testBeginIterationGSSFailureRetriedOnce() throws Exception {
+        when(mockPluginFactory.getPlugin(context, context.getAccessor()))
+                .thenReturn(mockAccessor1)
+                .thenReturn(mockAccessor2);
+        when(mockAccessor1.openForWrite()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor2.openForWrite()).thenReturn(true);
+
+        // constructor will call into mock factories, that's why we do not create WriteBridge in @Before method
+        bridge = new WriteBridge(mockPluginFactory, context, handler);
+        boolean result = bridge.beginIteration();
+        assertTrue(result);
+
+        verify(mockPluginFactory, times(2)).getPlugin(context, context.getAccessor());
+        verify(mockPluginFactory, times(1)).getPlugin(context, context.getResolver());
+        InOrder inOrder = inOrder(mockAccessor1, mockAccessor2);
+        inOrder.verify(mockAccessor1).openForWrite(); // first  attempt on accessor #1
+        inOrder.verify(mockAccessor2).openForWrite(); // second attempt on accessor #2
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(mockPluginFactory);
+    }
+
+    @Test
+    public void testBeginIterationGSSFailureRetriedTwice() throws Exception {
+        when(mockPluginFactory.getPlugin(context, context.getAccessor()))
+                .thenReturn(mockAccessor1)
+                .thenReturn(mockAccessor2)
+                .thenReturn(mockAccessor3);
+        when(mockAccessor1.openForWrite()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor2.openForWrite()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor3.openForWrite()).thenReturn(true);
+
+        // constructor will call into mock factories, that's why we do not create WriteBridge in @Before method
+        bridge = new WriteBridge(mockPluginFactory, context, handler);
+        boolean result = bridge.beginIteration();
+        assertTrue(result);
+
+        verify(mockPluginFactory, times(3)).getPlugin(context, context.getAccessor());
+        verify(mockPluginFactory, times(1)).getPlugin(context, context.getResolver());
+        InOrder inOrder = inOrder(mockAccessor1, mockAccessor2, mockAccessor3);
+        inOrder.verify(mockAccessor1).openForWrite(); // first  attempt on accessor #1
+        inOrder.verify(mockAccessor2).openForWrite(); // second attempt on accessor #2
+        inOrder.verify(mockAccessor3).openForWrite(); // third attempt on accessor #3
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(mockPluginFactory);
+    }
+
+    @Test
+    public void testBeginIterationGSSFailureAfterMaxRetries() throws Exception {
+        configuration.set("pxf.sasl.connection.retries", "2");
+        when(mockPluginFactory.getPlugin(context, context.getAccessor()))
+                .thenReturn(mockAccessor1)
+                .thenReturn(mockAccessor2)
+                .thenReturn(mockAccessor3);
+        when(mockAccessor1.openForWrite()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor2.openForWrite()).thenThrow(new IOException("GSS initiate failed"));
+        when(mockAccessor3.openForWrite()).thenThrow(new IOException("GSS initiate failed"));
+
+        // constructor will call into mock factories, that's why we do not create WriteBridge in @Before method
+        bridge = new WriteBridge(mockPluginFactory, context, handler);
+        Exception e = assertThrows(IOException.class, () -> bridge.beginIteration());
+        assertEquals("GSS initiate failed", e.getMessage());
+
+        verify(mockPluginFactory, times(3)).getPlugin(context, context.getAccessor());
+        verify(mockPluginFactory, times(1)).getPlugin(context, context.getResolver());
+        InOrder inOrder = inOrder(mockAccessor1, mockAccessor2, mockAccessor3);
+        inOrder.verify(mockAccessor1).openForWrite(); // first  attempt on accessor #1
+        inOrder.verify(mockAccessor2).openForWrite(); // second attempt on accessor #2
+        inOrder.verify(mockAccessor3).openForWrite(); // third attempt on accessor #3
+        inOrder.verifyNoMoreInteractions();
+        verifyNoMoreInteractions(mockPluginFactory);
+    }
+
+}


### PR DESCRIPTION
This is a port of a similar fix done in branch-5.16: https://github.com/greenplum-db/pxf/pull/693