### PR TITLE
Docs: Github references on docs

### DIFF
--- a/docs/content/index.html.md.erb
+++ b/docs/content/index.html.md.erb
@@ -20,6 +20,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
+<% exclude_repo_link %>
 
 The Greenplum Platform Extension Framework (PXF) provides parallel, high throughput data access and federated queries across heterogeneous data sources via built-in connectors that map a Greenplum Database external table definition to an external data source. PXF has its roots in the Apache HAWQ project.
 


### PR DESCRIPTION
Added references to Github repository so a user can raise a PR/Issue against the documentation pages.

Review site: https://mireia-pxf-github.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-2/release/index.html