### PR TITLE
Docs: Removed references to branded documentation pages from OSS pages

### DIFF
--- a/docs/content/upgrade_5_to_6.html.md.erb
+++ b/docs/content/upgrade_5_to_6.html.md.erb
@@ -36,7 +36,7 @@ Perform this procedure before you upgrade to a new version of PXF:
 
 ## <a id="pxfinst"></a>Step 2: Installing PXF 6.x
 
-1. Follow the steps outlined in [Installing PXF 6.x](../release/installing_pxf.html), and identify and note the new PXF version number.
+1. Install PXF 6.x and identify and note the new PXF version number.
 
 1. Check out the new installation layout in [About the PXF Installation and Configuration Directories](about_pxf_dir.html).
 

--- a/docs/content/upgrade_6.html.md.erb
+++ b/docs/content/upgrade_6.html.md.erb
@@ -42,7 +42,7 @@ Perform this procedure before you upgrade to a new version of PXF 6.x:
 
 ## <a id="pxfinst"></a>Step 2: Installing the New PXF 6.x
 
-Follow the steps outlined in [Installing PXF 6.x](../release/installing_pxf.html), and identify and note the new PXF version number.
+Install PXF 6.x and identify and note the new PXF version number.
 
 
 ## <a id="pxfup"></a>Step 3: Completing the Upgrade to a Newer PXF 6.x


### PR DESCRIPTION
A couple of pages available in OSS documentation had references to the installation guide, which is only available for branded docs, I have rephrased them and removed the references.