### PR TITLE
docs - indent all lines in echo commands

### DIFF
--- a/docs/content/hdfs_fileasrow.html.md.erb
+++ b/docs/content/hdfs_fileasrow.html.md.erb
@@ -108,9 +108,9 @@ Perform the following procedure to create 3 sample text files in an HDFS directo
 
     ``` shell
     $ echo 'Prague,Jan,101,4875.33
-Rome,Mar,87,1557.39
-Bangalore,May,317,8936.99
-Beijing,Jul,411,11600.67' > /tmp/file2.txt
+    Rome,Mar,87,1557.39
+    Bangalore,May,317,8936.99
+    Beijing,Jul,411,11600.67' > /tmp/file2.txt
     ```
 
     This file has multiple lines.
@@ -119,15 +119,15 @@ Beijing,Jul,411,11600.67' > /tmp/file2.txt
 
     ``` shell
     $ echo '"4627 Star Rd.
-San Francisco, CA  94107":Sept:2017
-"113 Moon St.
-San Diego, CA  92093":Jan:2018
-"51 Belt Ct.
-Denver, CO  90123":Dec:2016
-"93114 Radial Rd.
-Chicago, IL  60605":Jul:2017
-"7301 Brookview Ave.
-Columbus, OH  43213":Dec:2018' > /tmp/file3.txt
+    San Francisco, CA  94107":Sept:2017
+    "113 Moon St.
+    San Diego, CA  92093":Jan:2018
+    "51 Belt Ct.
+    Denver, CO  90123":Dec:2016
+    "93114 Radial Rd.
+    Chicago, IL  60605":Jul:2017
+    "7301 Brookview Ave.
+    Columbus, OH  43213":Dec:2018' > /tmp/file3.txt
     ```
 
     This file includes embedded line feeds.

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -68,9 +68,9 @@ Perform the following procedure to create a sample text file, copy the file to H
 
     ``` shell
     $ echo 'Prague,Jan,101,4875.33
-Rome,Mar,87,1557.39
-Bangalore,May,317,8936.99
-Beijing,Jul,411,11600.67' > /tmp/pxf_hdfs_simple.txt
+    Rome,Mar,87,1557.39
+    Bangalore,May,317,8936.99
+    Beijing,Jul,411,11600.67' > /tmp/pxf_hdfs_simple.txt
     ```
 
     Note the use of the comma `,` to separate the four data fields.

--- a/docs/content/nfs_pxf.html.md.erb
+++ b/docs/content/nfs_pxf.html.md.erb
@@ -137,9 +137,9 @@ In this example, you:
 
     ``` shell
     $ echo 'Prague,Jan,101,4875.33
-Rome,Mar,87,1557.39
-Bangalore,May,317,8936.99
-Beijing,Jul,411,11600.67' > /mnt/extdata/pxffs/ex1/somedata.csv
+    Rome,Mar,87,1557.39
+    Bangalore,May,317,8936.99
+    Beijing,Jul,411,11600.67' > /mnt/extdata/pxffs/ex1/somedata.csv
     ```
 
 ### <a id="ex_create_server"></a>Create the Network File System Server

--- a/docs/content/objstore_text.html.md.erb
+++ b/docs/content/objstore_text.html.md.erb
@@ -90,9 +90,9 @@ To run this example, you must:
 
     ``` shell
     $ echo 'Prague,Jan,101,4875.33
-Rome,Mar,87,1557.39
-Bangalore,May,317,8936.99
-Beijing,Jul,411,11600.67' > /tmp/pxf_s3_simple.txt
+    Rome,Mar,87,1557.39
+    Bangalore,May,317,8936.99
+    Beijing,Jul,411,11600.67' > /tmp/pxf_s3_simple.txt
     ```
 
     Note the use of the comma `,` to separate the four data fields.


### PR DESCRIPTION
each text line in an echo command should be indented to the same character location as the codeblock backticks.  the current content works, but is probably not markdown-compliant.