### PR TITLE
Bring back Hive Tests for JDK 11

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -807,7 +807,7 @@ jobs:
     params:
       ACCESS_KEY_ID: ((tf-machine-access-key-id))
       GP_VER: [[gp_ver]]
-      GROUP: cloud-access-and-hdfs,hbase,hcfs,jdbc,profile,pushdown
+      GROUP: gpdb,proxy,profile
       RUN_JDK_VERSION: 11
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
       TARGET_OS: centos

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -612,7 +612,7 @@ jobs:
     params:
       ACCESS_KEY_ID: ((tf-machine-access-key-id))
       GP_VER: [[gp_ver]]
-      GROUP: cloud-access-and-hdfs,hbase,hcfs,jdbc,profile,pushdown
+      GROUP: gpdb,proxy,profile
       RUN_JDK_VERSION: 11
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
       TARGET_OS: centos


### PR DESCRIPTION
With https://github.com/greenplum-db/pxf/pull/343, we upgraded to Hive
Client 2.3.7 which contained a fix that allowed users to use JDK 11.

This commit brings back the Hive tests to the necessary concourse
pipelines that seem to have gotten lost during the refactoring process.