### PR TITLE
Docs: specified examples for PXF_BASE path with and without relocation

### DIFF
--- a/docs/content/jdbc_pxf_mysql.html.md.erb
+++ b/docs/content/jdbc_pxf_mysql.html.md.erb
@@ -86,18 +86,18 @@ This procedure will typically be performed by the Greenplum Database administrat
     ```
 1. Download the MySQL JDBC driver and place it under `$PXF_BASE/lib`. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), make sure you use the updated location. You can download a MySQL JDBC driver from your preferred download location. The following example downloads the driver from Maven Central and places it under `$PXF_BASE/lib`:
 
-    1. If you did not relocate `$PXF_BASE`, run the following:
+    1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum master:
 
         ```shell
-        $ cd /usr/local/pxf-gp<version>/lib
-        $ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
+        gpadmin@gpmaster$ cd /usr/local/pxf-gp<version>/lib
+        gpadmin@gpmaster$ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
         ```
 
-    2. If you relocated `$PXF_BASE`, run the following:
+    2. If you relocated `$PXF_BASE`, run the following from the Greenplum master:
 
         ```shell
-        $ cd $PXF_BASE/lib
-        $ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
+        gpadmin@gpmaster$ cd $PXF_BASE/lib
+        gpadmin@gpmaster$ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
         ```
 
 1. Synchronize the PXF configuration, and then restart PXF:

--- a/docs/content/jdbc_pxf_mysql.html.md.erb
+++ b/docs/content/jdbc_pxf_mysql.html.md.erb
@@ -86,10 +86,19 @@ This procedure will typically be performed by the Greenplum Database administrat
     ```
 1. Download the MySQL JDBC driver and place it under `$PXF_BASE/lib`. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), make sure you use the updated location. You can download a MySQL JDBC driver from your preferred download location. The following example downloads the driver from Maven Central and places it under `$PXF_BASE/lib`:
 
-    ```shell
-    $ cd /usr/local/pxf-gp<version>/lib
-    $ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
-    ```
+    1. If you did not relocate `$PXF_BASE`, run the following:
+
+        ```shell
+        $ cd /usr/local/pxf-gp<version>/lib
+        $ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
+        ```
+
+    2. If you relocated `$PXF_BASE`, run the following:
+
+        ```shell
+        $ cd $PXF_BASE/lib
+        $ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
+        ```
 
 1. Synchronize the PXF configuration, and then restart PXF:
 

--- a/docs/content/jdbc_pxf_oracle.html.md.erb
+++ b/docs/content/jdbc_pxf_oracle.html.md.erb
@@ -82,9 +82,17 @@ This procedure will typically be performed by the Greenplum Database administrat
 
 1. Download the Oracle JDBC driver and place it under `$PXF_BASE/lib` of your Greenplum Database master host. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), make sure you use the updated location. You can download a Oracle JDBC driver from your preferred download location. The following example places a driver downloaded from Oracle webiste under `$PXF_BASE/lib` of the Greenplum Database master:
 
-    ```shell
-    $ scp ojdbc10.jar gpadmin@gpmaster:/usr/local/pxf-gp<version>/lib/
-    ```
+    1. If you did not relocate `$PXF_BASE`, run the following:
+
+        ```shell
+        $ scp ojdbc10.jar gpadmin@gpmaster:/usr/local/pxf-gp<version>/lib/
+        ```
+
+    2. If you relocated `$PXF_BASE`, run the following:
+
+        ```shell
+        $ scp ojdbc10.jar gpadmin@gpmaster:$PXF_BASE/lib/
+        ```
 
 1. Synchronize the PXF configuration, and then restart PXF: 
 

--- a/docs/content/jdbc_pxf_oracle.html.md.erb
+++ b/docs/content/jdbc_pxf_oracle.html.md.erb
@@ -82,16 +82,16 @@ This procedure will typically be performed by the Greenplum Database administrat
 
 1. Download the Oracle JDBC driver and place it under `$PXF_BASE/lib` of your Greenplum Database master host. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), make sure you use the updated location. You can download a Oracle JDBC driver from your preferred download location. The following example places a driver downloaded from Oracle webiste under `$PXF_BASE/lib` of the Greenplum Database master:
 
-    1. If you did not relocate `$PXF_BASE`, run the following:
+    1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum master:
 
         ```shell
-        $ scp ojdbc10.jar gpadmin@gpmaster:/usr/local/pxf-gp<version>/lib/
+        gpadmin@gpmaster$ scp ojdbc10.jar gpadmin@gpmaster:/usr/local/pxf-gp<version>/lib/
         ```
 
-    2. If you relocated `$PXF_BASE`, run the following:
+    2. If you relocated `$PXF_BASE`, run the following from the Greenplum master:
 
         ```shell
-        $ scp ojdbc10.jar gpadmin@gpmaster:$PXF_BASE/lib/
+        gpadmin@gpmaster$ scp ojdbc10.jar gpadmin@gpmaster:$PXF_BASE/lib/
         ```
 
 1. Synchronize the PXF configuration, and then restart PXF: 

--- a/docs/content/jdbc_pxf_trino.html.md.erb
+++ b/docs/content/jdbc_pxf_trino.html.md.erb
@@ -41,18 +41,18 @@ This procedure will typically be performed by the Greenplum Database administrat
    See [Trino Documentation - JDBC Driver](https://trino.io/docs/current/installation/jdbc.html) for instructions on downloading the Trino JDBC driver.
    The following example downloads the driver and places it under `$PXF_BASE/lib`:
 
-    1. If you did not relocate `$PXF_BASE`, run the following:
+    1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum master:
 
         ```shell
-        $ cd /usr/local/pxf-gp<version>/lib
-        $ wget <url-to-trino-jdbc-driver>
+        gpadmin@gpmaster$ cd /usr/local/pxf-gp<version>/lib
+        gpadmin@gpmaster$ wget <url-to-trino-jdbc-driver>
         ```
 
-    2. If you relocated `$PXF_BASE`, run the following:
+    2. If you relocated `$PXF_BASE`, run the following from the Greenplum master:
 
         ```shell
-        $ cd $PXF_BASE/lib
-        $ wget <url-to-trino-jdbc-driver>
+        gpadmin@gpmaster$ cd $PXF_BASE/lib
+        gpadmin@gpmaster$ wget <url-to-trino-jdbc-driver>
         ```
 
 1. Synchronize the PXF configuration, and then restart PXF:

--- a/docs/content/jdbc_pxf_trino.html.md.erb
+++ b/docs/content/jdbc_pxf_trino.html.md.erb
@@ -41,10 +41,19 @@ This procedure will typically be performed by the Greenplum Database administrat
    See [Trino Documentation - JDBC Driver](https://trino.io/docs/current/installation/jdbc.html) for instructions on downloading the Trino JDBC driver.
    The following example downloads the driver and places it under `$PXF_BASE/lib`:
 
-    ```shell
-    $ cd /usr/local/pxf-gp<version>/lib
-    $ wget <url-to-trino-jdbc-driver>
-    ```
+    1. If you did not relocate `$PXF_BASE`, run the following:
+
+        ```shell
+        $ cd /usr/local/pxf-gp<version>/lib
+        $ wget <url-to-trino-jdbc-driver>
+        ```
+
+    2. If you relocated `$PXF_BASE`, run the following:
+
+        ```shell
+        $ cd $PXF_BASE/lib
+        $ wget <url-to-trino-jdbc-driver>
+        ```
 
 1. Synchronize the PXF configuration, and then restart PXF:
 


### PR DESCRIPTION
It was brought to Docs attention that the section https://gpdb.docs.pivotal.io/pxf/6-2/using/jdbc_pxf_oracle.html could do with further clarification for locating $PXF_BASE for both cases, when it was been relocated and when it has not.
Adding an extra option to step 1 when configuring JDBC connectors for MySQL, Oracle and Trino, so we distinguish the path to specify when PXF_BASE has been relocated and when it has not.
Please let me know if you think this explanation is necessary or if it should be done differently. Thanks!
Preview: https://mireia-pxf-jdbc.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-2/using/jdbc_pxf.html