### PR TITLE
Redirect PXF stdout and stderr to files in PXF_LOGDIR

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -101,6 +101,7 @@ configure(javaProjects) {
                 entry("log4j-jul")
                 entry("log4j-api")
                 entry("log4j-core")
+                entry("log4j-spring-boot")
             }
             dependency("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
             // --- end of CVE patch

--- a/server/pxf-service/build.gradle
+++ b/server/pxf-service/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation("commons-collections:commons-collections")
     implementation("commons-lang:commons-lang")
     implementation("org.springframework.boot:spring-boot-starter-log4j2")
+    implementation("org.apache.logging.log4j:log4j-spring-boot")
     implementation('org.springframework.boot:spring-boot-starter-actuator')
     implementation('io.micrometer:micrometer-registry-prometheus')
 

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -50,5 +50,6 @@ pxf.task.pool.max-size=${pxf.max.threads:200}
 pxf.task.pool.queue-capacity=0
 
 # logging
+pxf.log.level=info
 logging.file.name=${pxf.logdir:/tmp}/pxf-service.log
 logging.file.path=${pxf.logdir:/tmp}

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -410,7 +410,7 @@ function do_start()
     echoGreen "   PXF_JVM_OPTS=${PXF_JVM_OPTS}"
     [[ $PXF_DEBUG == true ]] && echoGreen "   LOADER_PATH=${LOADER_PATH}"
 
-    "$javaexe" "${arguments[@]}" >> /dev/null 2>&1 &
+    "$javaexe" "${arguments[@]}" 1>>"${PXF_LOGDIR}/${identity}.out" 2>&1 &
     pid=$!
     disown $pid
     echo "$pid" > "$pid_file"

--- a/server/pxf-service/src/templates/conf/pxf-log4j2.xml
+++ b/server/pxf-service/src/templates/conf/pxf-log4j2.xml
@@ -6,7 +6,6 @@
     <Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS zzz</Property>
     <Property name="CONSOLE_LOG_PATTERN">%clr{%d{${LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
     <Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%-9.10t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
-    <Property name="PXF_LOG_LEVEL">${bundle:pxf-application:pxf.log.level}</Property>
 </Properties>
 <Appenders>
     <Console name="Console" target="SYSTEM_OUT" follow="true">
@@ -25,7 +24,7 @@
         <AppenderRef ref="RollingFile"/>
     </Root>
 
-    <Logger name="org.greenplum.pxf" level="${env:PXF_LOG_LEVEL:-${sys:PXF_LOG_LEVEL:-info}}"/>
+    <Logger name="org.greenplum.pxf" level="${env:PXF_LOG_LEVEL:-${spring:pxf.log.level}}"/>
 
     <!-- The levels below are tuned to provide minimal output, change to INFO or DEBUG to troubleshoot -->
     <Logger name="com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase" level="warn"/>


### PR DESCRIPTION
Most of log messages generated by PXF are captured by log4j and sent to
the configured log file. However, log messages from start-up before
log4j is fully configured are sent to stdout/stderr. Additionally, some
debug output (e.g., `-Dsun.security.krb5.debug=true`) are only sent to
stdout/stderr. Redirecting stdout/stderr of the JVM process will allow
for easier access to this debug info.

Additionally, this comment moves the default value for the log level
from pxf-log4j2.xml to pxf-application.properties. The `bundle` lookup
will throw an error if the key is not found in the file. To supress this
output, the key is uncommented in the properties file. Removing it from
the XML file prevents the default value from being specified in two
locations.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>