### PR TITLE
set default MySQL fetchSize to Integer.MIN_VALUE

### DIFF
--- a/server/pxf-service/src/templates/templates/jdbc-site.xml
+++ b/server/pxf-service/src/templates/templates/jdbc-site.xml
@@ -78,7 +78,11 @@
     <property>
         <name>jdbc.statement.fetchSize</name>
         <value>1000</value>
-        <description>Number of rows that should be fetched at a time during read. Default is 1000</description>
+        <description>
+            Number of rows that should be fetched at a time during read. Default is 1000 for all drivers other than MySQL.
+            For the MySQL JDBC driver, the default value is set to -2147483648 (Integer.MIN_VALUE) to enable streaming
+            read and avoid bringing the complete ResultSet into PXF memory.
+        </description>
     </property>
     -->
 


### PR DESCRIPTION
MySQL JDBC driver brings the complete ResultSet in PXF memory before returning it to PXF which causes PXF OutOfMemory errors when retrieving large datasets. The solution is to either use streaming mode by setting the `fetchSize` to `Integer.MIN_VALUE` (-2147483648) or use `useCursorFetch` property along with desired `fetchSize` to enable cursor fetch, which results in setting up temporary table on the server. Testing showed that using streaming is more performant and hence preferable. To allow customers use PXF with MySQL out of the box without additional tweaking, the default `fetchSize` for MySQL JDBC driver is now set to Integer.MIN_VALUE.  