### PR TITLE
bump log4j2 version to 2.15.0

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -93,6 +93,17 @@ configure(javaProjects) {
             dependency("org.apache.commons:commons-compress:1.20")
             dependency("org.apache.htrace:htrace-core:3.1.0-incubating")
             dependency("org.apache.htrace:htrace-core4:4.0.1-incubating")
+
+            // --- bump log4j2 to 2.15.0 for CVE-2021-44228 fix, revert once
+            // org.springframework.boot:spring-boot-starter-log4j2 is upgraded to bundle log4j2:2.15.0+
+            dependencySet(group:"org.apache.logging.log4j", version:"2.15.0") {
+                entry("log4j-jul")
+                entry("log4j-api")
+                entry("log4j-core")
+            }
+            dependency("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+            // --- end of CVE patch
+
             dependency("org.apache.zookeeper:zookeeper:3.4.6")
             dependency("org.codehaus.woodstox:stax2-api:3.1.4")
             dependency("org.datanucleus:datanucleus-api-jdo:4.2.4")


### PR DESCRIPTION
CVE: https://access.redhat.com/security/cve/cve-2021-44228 indicated vulnerability with Log4j2 version below 2.15.0. This commit bumps the version of Log4J2 components to 2.15.0 to avoid the vulnerability.

Verified the actual versions shipped in PXF Boot JAR after the commit has been built:
```
 → jar -tvf /usr/local/pxf/application/pxf-app-6.2.1-SNAPSHOT.jar | grep log4j
 24231 Fri Dec 10 16:54:10 PST 2021 BOOT-INF/lib/log4j-slf4j-impl-2.15.0.jar
 23805 Wed Jun 30 11:02:54 PDT 2021 BOOT-INF/lib/log4j-over-slf4j-1.7.31.jar
1789769 Fri Dec 10 16:54:10 PST 2021 BOOT-INF/lib/log4j-core-2.15.0.jar
 30947 Fri Dec 10 16:54:10 PST 2021 BOOT-INF/lib/log4j-jul-2.15.0.jar
301804 Fri Dec 10 16:54:10 PST 2021 BOOT-INF/lib/log4j-api-2.15.0.jar
```

Note: `log4j-over-slf4j-1.7.31.jar` follows separate versioning