### PR TITLE
pxf-hive: Catch TTransportException when working with metastore client

### DIFF
--- a/server/pxf-hive/build.gradle
+++ b/server/pxf-hive/build.gradle
@@ -72,6 +72,7 @@ dependencies {
      *******************************/
 
     testImplementation('org.springframework.boot:spring-boot-starter-test')
+    testImplementation('org.mockito:mockito-inline')
 }
 
 test {

--- a/server/pxf-hive/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientCompatibility1xx.java
+++ b/server/pxf-hive/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientCompatibility1xx.java
@@ -63,7 +63,7 @@ public class HiveMetaStoreClientCompatibility1xx extends HiveMetaStoreClient imp
                 throw ex;
             } catch (TTransportException transportException) {
                 /*
-                RetryingMetaStoreClient.java already contains logic to retry connecting to the metastore.
+                Propagate a TTransportException to allow RetryingMetaStoreClient (which proxies this class) to retry connecting to the metastore.
                 The number of retries can be set in the hive-site.xml using hive.metastore.failure.retries.
                  */
                 throw transportException;

--- a/server/pxf-hive/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientCompatibility1xx.java
+++ b/server/pxf-hive/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientCompatibility1xx.java
@@ -7,6 +7,7 @@ import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +61,12 @@ public class HiveMetaStoreClientCompatibility1xx extends HiveMetaStoreClient imp
             } catch (MetaException | NoSuchObjectException ex) {
                 LOG.debug("Original exception not re-thrown", e);
                 throw ex;
+            } catch (TTransportException transportException) {
+                /*
+                RetryingMetaStoreClient.java already contains logic to retry connecting to the metastore.
+                The number of retries can be set in the hive-site.xml using hive.metastore.failure.retries.
+                 */
+                throw transportException;
             } catch (Throwable t) {
                 LOG.warn("Unable to run compatibility for metastore client method get_table_req. Will rethrow original exception: ", t);
             }

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetastoreCompatibilityTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetastoreCompatibilityTest.java
@@ -230,7 +230,7 @@ public class HiveMetastoreCompatibilityTest {
                          }
                          return null;
                      },
-                     // second run through
+                     // second run through (retry 1 = success)
                      invocation ->  {
                          if (invocation.getMethod().getName().equals("get_table_req")) {
                              GetTableResult tempRes = new GetTableResult(hiveTable);
@@ -267,7 +267,7 @@ public class HiveMetastoreCompatibilityTest {
                 when(mockSocket.isOpen()).thenReturn(true));
              MockedConstruction<ThriftHiveMetastore.Client> thriftHiveMetastoreClientMockedConstruction = mockConstructionWithAnswer(ThriftHiveMetastore.Client.class,
                      // first run through
-                     invocation ->  {
+                     invocation -> {
                          if (invocation.getMethod().getName().equals("get_table_req")) {
                              throw new TApplicationException("fallback 1");
                          } else if (invocation.getMethod().getName().equals("get_table")) {
@@ -275,8 +275,8 @@ public class HiveMetastoreCompatibilityTest {
                          }
                          return null;
                      },
-                     // second run through
-                     invocation ->  {
+                     // second run through (retry 1)
+                     invocation -> {
                          if (invocation.getMethod().getName().equals("get_table_req")) {
                              throw new TApplicationException("fallback 2");
                          } else if (invocation.getMethod().getName().equals("get_table")) {
@@ -284,8 +284,8 @@ public class HiveMetastoreCompatibilityTest {
                          }
                          return null;
                      },
-                     // third run through
-                     invocation ->  {
+                     // third run through (retry 2)
+                     invocation -> {
                          if (invocation.getMethod().getName().equals("get_table_req")) {
                              throw new TApplicationException("fallback 3");
                          } else if (invocation.getMethod().getName().equals("get_table")) {
@@ -293,17 +293,18 @@ public class HiveMetastoreCompatibilityTest {
                          }
                          return null;
                      },
-                     // ??? run through (this seems to be skipped when running the test?
-                     invocation ->  {
+                     // placebo run through
+                     // the second to last invocation keeps getting skipped so place this here as a placebo
+                     invocation -> {
                          if (invocation.getMethod().getName().equals("get_table_req")) {
-                             throw new TApplicationException("fallback ?????");
+                             throw new TApplicationException("fallback ???");
                          } else if (invocation.getMethod().getName().equals("get_table")) {
-                             throw new TTransportException("oops. where's the metastore? ?????");
+                             throw new TTransportException("oops. where's the metastore? ???");
                          }
                          return null;
                      },
-                     // final run through
-                     invocation ->  {
+                     // final run through (retry 3 = success)
+                     invocation -> {
                          if (invocation.getMethod().getName().equals("get_table_req")) {
                              throw new TApplicationException("fallback");
                          } else if (invocation.getMethod().getName().equals("get_table")) {
@@ -311,7 +312,6 @@ public class HiveMetastoreCompatibilityTest {
                          }
                          return null;
                      }
-
              )) {
             Configuration configuration = new Configuration();
             HiveConf hiveConf = new HiveConf(configuration, HiveConf.class);

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetastoreCompatibilityTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveMetastoreCompatibilityTest.java
@@ -1,0 +1,206 @@
+package org.greenplum.pxf.plugins.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClientCompatibility1xx;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
+import org.apache.thrift.TApplicationException;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransportException;
+import org.greenplum.pxf.api.model.Metadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class HiveMetastoreCompatibilityTest {
+
+    private HiveMetaStoreClientCompatibility1xx hiveCompatiblityClient;
+    private HiveClientWrapper hiveClientWrapper;
+    private HiveClientWrapper.HiveClientFactory hiveClientFactory;
+    private ThriftHiveMetastore.Client mockThriftClient;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    public void setup() throws MetaException {
+        mockThriftClient = mock(ThriftHiveMetastore.Client.class);
+        hiveClientFactory = new HiveClientWrapper.HiveClientFactory();
+        hiveClientWrapper = new HiveClientWrapper();
+        hiveClientWrapper.setHiveClientFactory(hiveClientFactory);
+    }
+
+    @Test
+    public void getTableMetaException() throws Exception {
+
+        String name = "orphan";
+
+        try (MockedStatic<HiveMetaStore> hiveMetaStoreMockedStatic = mockStatic(HiveMetaStore.class)) {
+            hiveMetaStoreMockedStatic.when(() -> HiveMetaStore.newRetryingHMSHandler(any(String.class), any(), any(Boolean.class)))
+                    .thenReturn(mockThriftClient);
+
+            when(mockThriftClient.get_table_req(any())).thenThrow(new MetaException("some meta failure"));
+
+            Configuration configuration = new Configuration();
+            hiveCompatiblityClient = new HiveMetaStoreClientCompatibility1xx(new HiveConf(configuration, HiveConf.class));
+            Exception e = assertThrows(MetaException.class,
+                    () -> hiveCompatiblityClient.getTable("default", name));
+            assertEquals("some meta failure", e.getMessage());
+        }
+    }
+
+    @Test
+    public void getTableNoSuchObjectException() throws Exception {
+
+        String name = "orphan";
+
+        try (MockedStatic<HiveMetaStore> hiveMetaStoreMockedStatic = mockStatic(HiveMetaStore.class)) {
+            hiveMetaStoreMockedStatic.when(() -> HiveMetaStore.newRetryingHMSHandler(any(String.class), any(), any(Boolean.class)))
+                    .thenReturn(mockThriftClient);
+
+            when(mockThriftClient.get_table_req(any())).thenThrow(new NoSuchObjectException("where's my table"));
+
+            Configuration configuration = new Configuration();
+            hiveCompatiblityClient = new HiveMetaStoreClientCompatibility1xx(new HiveConf(configuration, HiveConf.class));
+            Exception e = assertThrows(NoSuchObjectException.class,
+                    () -> hiveCompatiblityClient.getTable("default", name));
+            assertEquals("where's my table", e.getMessage());
+        }
+    }
+
+    @Test
+    public void getTableFallback() throws Exception {
+
+        String name = "orphan";
+        Table hiveTable = new Table();
+        hiveTable.setTableName(name);
+        hiveTable.setTableType("MANAGED_TABLE");
+
+        try (MockedStatic<HiveMetaStore> hiveMetaStoreMockedStatic = mockStatic(HiveMetaStore.class)) {
+            hiveMetaStoreMockedStatic.when(() -> HiveMetaStore.newRetryingHMSHandler(any(String.class), any(), any(Boolean.class)))
+                    .thenReturn(mockThriftClient);
+
+            when(mockThriftClient.get_table_req(any())).thenThrow(new TApplicationException("fallback"));
+            when(mockThriftClient.get_table("default", name)).thenReturn(hiveTable);
+
+            Configuration configuration = new Configuration();
+            hiveCompatiblityClient = new HiveMetaStoreClientCompatibility1xx(new HiveConf(configuration, HiveConf.class));
+            Table resultTable = hiveCompatiblityClient.getTable("default", name);
+            assertEquals(name, resultTable.getTableName());
+        }
+    }
+
+    @Test
+    public void getTableFailedToConnectToMetastoreFallback() throws Exception {
+
+        String name = "orphan";
+
+        try (MockedStatic<HiveMetaStore> hiveMetaStoreMockedStatic = mockStatic(HiveMetaStore.class)) {
+            hiveMetaStoreMockedStatic.when(() -> HiveMetaStore.newRetryingHMSHandler(any(String.class), any(), any(Boolean.class)))
+                    .thenReturn(mockThriftClient);
+
+            when(mockThriftClient.get_table_req(any())).thenThrow(new TApplicationException("fallback"));
+            when(mockThriftClient.get_table("default", name)).thenThrow(new TTransportException("oops. where's the metastore?"));
+
+            Configuration configuration = new Configuration();
+            hiveCompatiblityClient = new HiveMetaStoreClientCompatibility1xx(new HiveConf(configuration, HiveConf.class));
+            Exception e = assertThrows(TTransportException.class,
+                    () -> hiveCompatiblityClient.getTable("default", name));
+            assertEquals("oops. where's the metastore?", e.getMessage());
+        }
+    }
+
+    @Test
+    public void getTableFailedToConnectToMetastore() throws Exception {
+
+        String name = "orphan";
+
+        try (MockedStatic<HiveMetaStore> hiveMetaStoreMockedStatic = mockStatic(HiveMetaStore.class)) {
+            hiveMetaStoreMockedStatic.when(() -> HiveMetaStore.newRetryingHMSHandler(any(String.class), any(), any(Boolean.class)))
+                    .thenReturn(mockThriftClient);
+
+            when(mockThriftClient.get_table_req(any())).thenThrow(new TTransportException("oops. where's the metastore?"));
+
+            Configuration configuration = new Configuration();
+            hiveCompatiblityClient = new HiveMetaStoreClientCompatibility1xx(new HiveConf(configuration, HiveConf.class));
+            Exception e = assertThrows(TTransportException.class,
+                    () -> hiveCompatiblityClient.getTable("default", name));
+            assertEquals("oops. where's the metastore?", e.getMessage());
+        }
+    }
+
+    @Test
+    public void getTableFailedToConnectToMetastoreNoRetries() throws Exception {
+
+        String name = "orphan";
+        Table hiveTable = new Table();
+        hiveTable.setTableName(name);
+        hiveTable.setTableType("MANAGED_TABLE");
+
+        try (MockedStatic<HiveMetaStore> hiveMetaStoreMockedStatic = mockStatic(HiveMetaStore.class)) {
+            hiveMetaStoreMockedStatic.when(() -> HiveMetaStore.newRetryingHMSHandler(any(String.class), any(), any(Boolean.class)))
+                    .thenReturn(mockThriftClient);
+
+            when(mockThriftClient.get_table_req(any())).thenThrow(new TApplicationException("fallback"));
+            when(mockThriftClient.get_table("default", name))
+                    .thenThrow(new TTransportException("oops. where's the metastore? 1"))
+                    .thenThrow(new TTransportException("oops. where's the metastore? 2"))
+                    .thenThrow(new TTransportException("oops. where's the metastore? 3"))
+                    .thenReturn(hiveTable);
+
+            Configuration configuration = new Configuration();
+            HiveConf hiveConf = new HiveConf(configuration, HiveConf.class);
+            hiveConf.setIntVar(HiveConf.ConfVars.METASTORETHRIFTFAILURERETRIES, 0);
+
+            IMetaStoreClient client = hiveClientFactory.initHiveClient(hiveConf);
+
+            Exception e = assertThrows(TTransportException.class,
+                    () -> hiveClientWrapper.getHiveTable(client, new Metadata.Item("default", name)));
+            assertEquals("oops. where's the metastore? 1", e.getMessage());
+        }
+    }
+
+    @Test
+    public void getTableFailedToConnectToMetastoreFiveFailedRetries() throws Exception {
+
+        String name = "orphan";
+        Table hiveTable = new Table();
+        hiveTable.setTableName(name);
+        hiveTable.setTableType("MANAGED_TABLE");
+
+        try (MockedConstruction<TSocket> tSocketMockedConstruction = mockConstruction(TSocket.class, (mockSocket, context) ->
+                when(mockSocket.isOpen()).thenReturn(true));
+             MockedConstruction<ThriftHiveMetastore.Client> thriftHiveMetastoreClientMockedConstruction = mockConstruction(ThriftHiveMetastore.Client.class,
+                (mockClient, context) -> {
+                    when(mockClient.get_table_req(any())).thenThrow(new TApplicationException("fallback"));
+                    when(mockClient.get_table("default", name))
+                            .thenThrow(new TTransportException("oops. where's the metastore?"));
+                }
+        )) {
+            Configuration configuration = new Configuration();
+            HiveConf hiveConf = new HiveConf(configuration, HiveConf.class);
+            hiveConf.setIntVar(HiveConf.ConfVars.METASTORETHRIFTFAILURERETRIES, 5);
+            hiveConf.setVar(HiveConf.ConfVars.METASTOREURIS, "test://test:1234");
+
+            IMetaStoreClient client = hiveClientFactory.initHiveClient(hiveConf);
+
+            Exception e = assertThrows(TTransportException.class,
+                    () -> hiveClientWrapper.getHiveTable(client, new Metadata.Item("default", name)));
+            assertEquals("oops. where's the metastore?", e.getMessage());
+            assertEquals(6, thriftHiveMetastoreClientMockedConstruction.constructed().size());
+            assertEquals(6, tSocketMockedConstruction.constructed().size());
+        }
+    }
+}


### PR DESCRIPTION
Catching TTransportExceptions in the HiveMetastoreClientCompatibility1xx
allow PXF to retry connecting to the Hive metastore if necessary. The
default number of retries is 1 and can be set in the hive-site.xml using
`hive.metastore.failure.retries`.