### PR TITLE
Bump log4j2 version to 2.16.0

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -94,14 +94,14 @@ configure(javaProjects) {
             dependency("org.apache.htrace:htrace-core:3.1.0-incubating")
             dependency("org.apache.htrace:htrace-core4:4.0.1-incubating")
 
-            // --- bump log4j2 to 2.15.0 for CVE-2021-44228 fix, revert once
-            // org.springframework.boot:spring-boot-starter-log4j2 is upgraded to bundle log4j2:2.15.0+
-            dependencySet(group:"org.apache.logging.log4j", version:"2.15.0") {
+            // --- bump log4j2 to 2.16.0 for CVE-2021-44228 and CVE-2021-45046 fixes, revert once
+            // org.springframework.boot:spring-boot-starter-log4j2 is upgraded to bundle log4j2:2.16.0+
+            dependencySet(group:"org.apache.logging.log4j", version:"2.16.0") {
                 entry("log4j-jul")
                 entry("log4j-api")
                 entry("log4j-core")
             }
-            dependency("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+            dependency("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
             // --- end of CVE patch
 
             dependency("org.apache.zookeeper:zookeeper:3.4.6")


### PR DESCRIPTION
A new CVE was raised related to Log4J2:  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046
Mitigation is to upgrade to 2.16.0 or remove the JndiLookup class from the log4j-core JAR.

Also, since at this moment PXF uses `org.slf4j:slf4j-api:1.7.31` and hence from the description in https://lists.apache.org/thread/d6v4r6nosxysyq9rvnr779336yf0woz4 can continue using the artifact `log4j-slf4j-impl-2.16.0.jar` and does not need to switch to`log4j-slf4j18-impl-2.16.0.jar`