### PR TITLE
docs - troubleshooting docs for hive metastore conn retry

### DIFF
--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -86,7 +86,7 @@ The `IGNORE_MISSING_PATH` custom option applies only to file-based profiles, inc
 
 ## <a id="hive-metastore"></a>Addressing Hive MetaStore Connection Errors
 
-The PXF Hive connector uses the Hive MetaStore to determine the HDFS locations of Hive tables. By default, PXF retries a failed connection to the Hive MetaStore a single time. If you encounter one of the following error messages or exceptions when accessing Hive via a PXF external table, consider increasing the retry count:
+The PXF Hive connector uses the Hive MetaStore to determine the HDFS locations of Hive tables. Starting in PXF version 6.2.1, PXF retries a failed connection to the Hive MetaStore a single time. If you encounter one of the following error messages or exceptions when accessing Hive via a PXF external table, consider increasing the retry count:
 
 - `Failed to connect to the MetaStore Server.`
 - `Could not connect to meta store ...`

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -83,3 +83,39 @@ FORMAT 'CUSTOM' (formatter = 'pxfwritable_import');
 
 The `IGNORE_MISSING_PATH` custom option applies only to file-based profiles, including `*:text`, `*:parquet`, `*:avro`, `*:json`, `*:AvroSequenceFile`, and `*:SequenceFile`. This option is *not available* when the external table specifies the `hbase`, `hive[:*]`, or `jdbc` profiles, or when reading from S3 using S3-Select.
 
+
+## <a id="hive-metastore"></a>Addressing Hive MetaStore Connection Errors
+
+The PXF Hive connector uses the Hive MetaStore to determine the HDFS locations of Hive tables. By default, PXF retries a failed connection to the Hive MetaStore a single time. If you encounter one of the following error messages or exceptions when accessing Hive via a PXF external table, consider increasing the retry count:
+
+- `Failed to connect to the MetaStore Server.`
+- `Could not connect to meta store ...`
+- `org.apache.thrift.transport.TTransportException: null`
+
+PXF uses the `hive-site.xml` `hive.metastore.failure.retries` property setting to identify the maximum number of times it will retry a failed connection to the Hive MetaStore. The `hive-site.xml` file resides in the configuration directory of the PXF server that you use to access Hive.
+
+Perform the following procedure to configure the number of Hive MetaStore connection retries that PXF will attempt; you may be required to add the `hive.metastore.failure.retries` property to the `hive-site.xml` file:
+
+1. Log in to the Greenplum Database master node.
+
+1. Identify the name of your Hive PXF server.
+
+1. Open the `$PXF_BASE/servers/<hive-server-name>/hive-site.xml` file in the editor of your choice, add the `hive.metastore.failure.retries` property if it does not already exist in the file, and set the value. For example, to configure 5 retries: 
+
+    ``` xml
+    <property>
+        <name>hive.metastore.failure.retries</name>
+        <value>5</value>
+    </property>
+    ```
+
+1. Save the file and exit the editor.
+
+1. Synchronize the PXF configuration to all hosts in your Greenplum Database cluster:
+
+    ``` shell
+    gpadmin@gpmaster$ pxf cluster sync
+    ```
+
+1. Re-run the failing SQL external table command.
+


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/726.

add a section to the troubleshooting topic identifying when and how to configure hive metastore connection retry.

doc review site link (behind vpn):  https://docs-lisa-pxf-hmetacon-retry.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-2/using/troubleshooting_pxf.html#hive-metastore