### PR TITLE
Bumped Log4j2 to version 2.17.1

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -94,14 +94,15 @@ configure(javaProjects) {
             dependency("org.apache.htrace:htrace-core:3.1.0-incubating")
             dependency("org.apache.htrace:htrace-core4:4.0.1-incubating")
 
-            // --- bump log4j2 to 2.17.0 for CVE-2021-44228, CVE-2021-45046, and CVE-2021-45105 fixes, revert once
-            // org.springframework.boot:spring-boot-starter-log4j2 is upgraded to bundle log4j2:2.17.0+
-            dependencySet(group:"org.apache.logging.log4j", version:"2.17.0") {
+            // --- bump log4j2 to 2.17.1 for CVE-2021-44228, CVE-2021-45046, and CVE-2021-45105 fixes,
+            // more details: https://logging.apache.org/log4j/2.x/security.html
+            // revert once org.springframework.boot:spring-boot-starter-log4j2 is upgraded to bundle log4j2:2.17.1+
+            dependencySet(group:"org.apache.logging.log4j", version:"2.17.1") {
                 entry("log4j-jul")
                 entry("log4j-api")
                 entry("log4j-core")
             }
-            dependency("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+            dependency("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
             // --- end of CVE patch
 
             dependency("org.apache.zookeeper:zookeeper:3.4.6")


### PR DESCRIPTION
The most recent recommendation is to upgrade Log4J2 to 2.17.1 to mitigate additional security risks: https://logging.apache.org/log4j/2.x/security.html