### PR TITLE
Bump go version go 1.17.6

### DIFF
--- a/concourse/docker/pxf-build-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-build-base/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
     args: [ './server/gradlew', '--gradle-user-home=/workspace/.gradle', '-Dorg.gradle.daemon=false', '-b', './server/build.gradle', 'test', 'stage' ]
     waitFor: [ 'untar-pxf-build-dependencies' ]
 
-  - name: golang:1.15.3
+  - name: golang:1.17.6
     id: golang-build
     entrypoint: 'bash'
     args:

--- a/concourse/docker/pxf-dev-base/README.md
+++ b/concourse/docker/pxf-dev-base/README.md
@@ -11,6 +11,16 @@ use the following command:
 
 For a list of images built by `cloudbuild` take a look [here](../README.md).
 
+You can run the entire cloudbuild using Google Cloud Build by doing the following:
+
+cd ~/workspace/pxf
+
+echo $(git rev-parse HEAD)
+
+gcloud builds submit . --config=concourse/docker/pxf-dev-base/cloudbuild.yaml \
+  --substitutions=_BASE_IMAGE_REPOSITORY=gcr.io/data-gpdb-public-images,COMMIT_SHA=<commit_sha>
+```
+
 This guide assumes the PXF repository lives under the `~/workspace/pxf`
 directory. The `cloudbuild.yaml` file produces the following docker images:
 

--- a/concourse/docker/pxf-dev-base/README.md
+++ b/concourse/docker/pxf-dev-base/README.md
@@ -12,18 +12,26 @@ use the following command:
 For a list of images built by `cloudbuild` take a look [here](../README.md).
 
 You can run the entire cloudbuild using Google Cloud Build by doing the following:
-
+```
 cd ~/workspace/pxf
 
-echo $(git rev-parse HEAD)
+gcloud builds submit . --config=concourse/docker/pxf-dev-base/cloudbuild.yaml \
+  --substitutions=_BASE_IMAGE_REPOSITORY=gcr.io/data-gpdb-public-images,COMMIT_SHA=dev-build-<name>
+
+-- or if you would like to modify the go and ginkgo versions, you can do so by doing the following --
 
 gcloud builds submit . --config=concourse/docker/pxf-dev-base/cloudbuild.yaml \
-  --substitutions=_BASE_IMAGE_REPOSITORY=gcr.io/data-gpdb-public-images,COMMIT_SHA=<commit_sha>
+--substitutions=_BASE_IMAGE_REPOSITORY=gcr.io/data-gpdb-public-images,_GO_VERSION=<test-version>,_GINKGO_VERSION=<test-version>,COMMIT_SHA=dev-build-<test-name>
 ```
 
 This guide assumes the PXF repository lives under the `~/workspace/pxf`
 directory. The `cloudbuild.yaml` file produces the following docker images:
 
+You can build these images individually by first setting these local variables: 
+```
+export GO_VERSION=1.17.6
+export GINKGO_VERSION=1.16.5
+```
 ## Greenplum 5 Images
 
 * Note: Greenplum 5 on CentOS 6 support has been deprecated, but images are
@@ -37,6 +45,7 @@ command to build the image:
     pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb5-centos7-build-test:latest \
+      --build-arg=GINKGO_VERSION=${GINKGO_VERSION} \
       --tag=gpdb5-centos7-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb5/centos7/Dockerfile \
       .
@@ -52,6 +61,8 @@ command to build the image:
     pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-centos7-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=GINKGO_VERSION=${GINKGO_VERSION} \
       --tag=gpdb6-centos7-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile \
       .
@@ -65,6 +76,8 @@ command to build the image:
     pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=GINKGO_VERSION=${GINKGO_VERSION} \
       --tag=gpdb6-ubuntu18.04-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile \
       .
@@ -78,6 +91,8 @@ following command to build the image:
     pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-oel7-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=GINKGO_VERSION=${GINKGO_VERSION} \
       --tag=gpdb6-oel7-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile \
       .
@@ -93,6 +108,8 @@ command to build the image:
     pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb7-centos7-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=GINKGO_VERSION=${GINKGO_VERSION} \
       --tag=gpdb7-centos7-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile \
       .
@@ -106,6 +123,8 @@ command to build the image:
     pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb7-ubuntu18.04-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=GINKGO_VERSION=${GINKGO_VERSION} \
       --tag=gpdb7-ubuntu18.04-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile \
       .

--- a/concourse/docker/pxf-dev-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-dev-base/cloudbuild.yaml
@@ -30,6 +30,7 @@ steps:
   args:
   - 'build'
   - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb5-centos7-build-test:latest'
+  - '--build-arg=GINKGO_VERSION=${_GINKGO_VERSION}'
   - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf:$COMMIT_SHA'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf:latest'
@@ -59,6 +60,8 @@ steps:
   args:
   - 'build'
   - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-centos7-test:latest'
+  - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=GINKGO_VERSION=${_GINKGO_VERSION}'
   - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-test-pxf:$COMMIT_SHA'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-test-pxf:latest'
@@ -84,6 +87,8 @@ steps:
   args:
   - 'build'
   - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-ubuntu18.04-test:latest'
+  - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=GINKGO_VERSION=${_GINKGO_VERSION}'
   - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-ubuntu18.04-test-pxf:$COMMIT_SHA'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-ubuntu18.04-test-pxf:latest'
@@ -109,6 +114,8 @@ steps:
   args:
   - 'build'
   - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-oel7-test:latest'
+  - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=GINKGO_VERSION=${_GINKGO_VERSION}'
   - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-oel7-test-pxf:$COMMIT_SHA'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-oel7-test-pxf:latest'
@@ -138,6 +145,8 @@ steps:
   args:
     - 'build'
     - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb7-centos7-test:latest'
+    - '--build-arg=GO_VERSION=${_GO_VERSION}'
+    - '--build-arg=GINKGO_VERSION=${_GINKGO_VERSION}'
     - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-centos7-test-pxf:$COMMIT_SHA'
     - '--cache-from'
     - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-centos7-test-pxf:latest'
@@ -163,6 +172,8 @@ steps:
   args:
     - 'build'
     - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb7-ubuntu18.04-test:latest'
+    - '--build-arg=GO_VERSION=${_GO_VERSION}'
+    - '--build-arg=GINKGO_VERSION=${_GINKGO_VERSION}'
     - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-ubuntu18.04-test-pxf:$COMMIT_SHA'
     - '--cache-from'
     - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-ubuntu18.04-test-pxf:latest'
@@ -171,6 +182,10 @@ steps:
     - '/workspace/build/'
   waitFor:
     - gpdb7-ubuntu18.04-test-pxf-image-cache
+
+substitutions:
+  _GO_VERSION: 1.17.6 # default values
+  _GINKGO_VERSION: 1.16.5 # default values
 
 # Push images to Cloud Build to Container Registry
 images:

--- a/concourse/docker/pxf-dev-base/gpdb5/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb5/centos7/Dockerfile
@@ -2,12 +2,10 @@ ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb5-centos7-build-test:latest
 
 FROM ${BASE_IMAGE}
 
+ARG GINKGO_VERSION
+
 # install Go utilities
-# FIXME: the GO version from the base image is 1.13.4. There is a plan to update to the latest go 1.17.5+, until then, we need to export GO111MODULE
-# the export GO111MODULE can be removed once go has been updated as the default in 1.16+ is auto (module aware)
-# we may also be able to use go install instead of the deprecated go get
-RUN export GO111MODULE=on \
-    && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo@v1.16.5
+RUN GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v${GINKGO_VERSION}
 
 # add Java 8, Java 11 and rpm-build
 RUN yum install -y rpm-build java-1.8.0-openjdk-devel && yum clean all \

--- a/concourse/docker/pxf-dev-base/gpdb5/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb5/centos7/Dockerfile
@@ -3,7 +3,11 @@ ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb5-centos7-build-test:latest
 FROM ${BASE_IMAGE}
 
 # install Go utilities
-RUN GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
+# FIXME: the GO version from the base image is 1.13.4. There is a plan to update to the latest go 1.17.5+, until then, we need to export GO111MODULE
+# the export GO111MODULE can be removed once go has been updated as the default in 1.16+ is auto (module aware)
+# we may also be able to use go install instead of the deprecated go get
+RUN export GO111MODULE=on \
+    && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 # add Java 8, Java 11 and rpm-build
 RUN yum install -y rpm-build java-1.8.0-openjdk-devel && yum clean all \

--- a/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE}
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
     && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 # add Java 11
 RUN wget -q https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz \

--- a/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
     && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
 

--- a/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
@@ -2,11 +2,14 @@ ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-centos7-test:latest
 
 FROM ${BASE_IMAGE}
 
+ARG GO_VERSION
+ARG GINKGO_VERSION
+
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v${GINKGO_VERSION}
 
 # add Java 11
 RUN wget -q https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz \

--- a/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
@@ -2,11 +2,14 @@ ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-oel7-test:latest
 
 FROM ${BASE_IMAGE}
 
+ARG GO_VERSION
+ARG GINKGO_VERSION
+
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v${GINKGO_VERSION}
 
 ARG MAVEN_VERSION=3.6.3
 ARG USER_HOME_DIR="/root"

--- a/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
     && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
 

--- a/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE}
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
     && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 ARG MAVEN_VERSION=3.6.3
 ARG USER_HOME_DIR="/root"

--- a/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile
@@ -2,11 +2,14 @@ ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test:latest
 
 FROM ${BASE_IMAGE}
 
+ARG GO_VERSION
+ARG GINKGO_VERSION
+
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v${GINKGO_VERSION}
 
 # install dependencies that are missing on the base images
 # install a specific version of perl for tinc

--- a/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE}
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
     && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 # install dependencies that are missing on the base images
 # install a specific version of perl for tinc

--- a/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
     && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
 

--- a/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://dl.google.com/go/go1.15.3.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
     && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
 

--- a/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
@@ -2,11 +2,14 @@ ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb7-centos7-test:latest
 
 FROM ${BASE_IMAGE}
 
+ARG GO_VERSION
+ARG GINKGO_VERSION
+
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v${GINKGO_VERSION}
 
 # add minio software
 RUN useradd -s /sbin/nologin -d /opt/minio minio \

--- a/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE}
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
     && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 # add minio software
 RUN useradd -s /sbin/nologin -d /opt/minio minio \

--- a/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE_IMAGE}
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
     && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 
 # install java 11 and dependencies that are missing on the base images
 RUN apt-get update -y \

--- a/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://dl.google.com/go/go1.15.3.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
     && GOPATH=/opt/go /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo
 

--- a/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
@@ -2,11 +2,14 @@ ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb7-ubuntu18.04-test:latest
 
 FROM ${BASE_IMAGE}
 
+ARG GO_VERSION
+ARG GINKGO_VERSION
+
 # install Go utilities
 RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
-    && wget -O go.tgz -q https://go.dev/dl/go1.17.6.linux-amd64.tar.gz \
+    && wget -O go.tgz -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
-    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+    && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v${GINKGO_VERSION}
 
 # install java 11 and dependencies that are missing on the base images
 RUN apt-get update -y \


### PR DESCRIPTION
CVE: https://nvd.nist.gov/vuln/detail/CVE-2021-44716 indicated a vulnerability with Go versions below 1.17.5. 
This PR bumps the version of Go components to 1.17.6 to avoid the vulnerability. 

This PR also pins the ginkgo version to 1.16.5 to avoid compatibility issues between go and ginkgo versions. 