### PR TITLE
Use yum instead of rpm to install GPDB from an RPM package

### DIFF
--- a/concourse/scripts/build.bash
+++ b/concourse/scripts/build.bash
@@ -16,7 +16,7 @@ function install_gpdb() {
     if command -v rpm; then
         pkg_file=$(find "${GPDB_PKG_DIR}" -name "greenplum-db-${GPDB_VERSION}-rhel*-x86_64.rpm")
         echo "Installing RPM ${pkg_file}..."
-        rpm --quiet -ivh "${pkg_file}" >/dev/null
+        yum -y -d1 "${pkg_file}"
     elif command -v apt-get; then
         # apt-get wants a full path
         pkg_file=$(find "${PWD}/${GPDB_PKG_DIR}" -name "greenplum-db-${GPDB_VERSION}-ubuntu18.04-amd64.deb")

--- a/concourse/scripts/build.bash
+++ b/concourse/scripts/build.bash
@@ -16,7 +16,7 @@ function install_gpdb() {
     if command -v rpm; then
         pkg_file=$(find "${GPDB_PKG_DIR}" -name "greenplum-db-${GPDB_VERSION}-rhel*-x86_64.rpm")
         echo "Installing RPM ${pkg_file}..."
-        yum -y -d1 "${pkg_file}"
+        yum -y -d1 install "${pkg_file}"
     elif command -v apt-get; then
         # apt-get wants a full path
         pkg_file=$(find "${PWD}/${GPDB_PKG_DIR}" -name "greenplum-db-${GPDB_VERSION}-ubuntu18.04-amd64.deb")

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -154,7 +154,7 @@ function install_gpdb_package() {
 			return 1
 		fi
 		echo "Installing ${pkg_file}..."
-		rpm --quiet -ivh "${pkg_file}" >/dev/null
+		yum -y -d1 install "${pkg_file}"
 
 		# We can't use service sshd restart as service is not installed on CentOS 7.
 		/usr/sbin/sshd &
@@ -315,7 +315,7 @@ function install_pxf_package() {
 			return 1
 		fi
 		echo "Installing ${pkg_file}..."
-		rpm --quiet -ivh "${pkg_file}" >/dev/null
+		yum -y -d1 install "${pkg_file}"
 	elif [[ ${TARGET_OS} == ubuntu ]]; then
 		# install PXF DEB
 		pkg_file=$(find pxf_package -name 'pxf-gp*amd64.deb')

--- a/dev/install_greenplum.bash
+++ b/dev/install_greenplum.bash
@@ -16,7 +16,7 @@ if [[ -f /etc/centos-release ]]; then
     fi
 
     echo "Installing GPDB from ${LATEST_RPM} ..."
-    sudo rpm --quiet -ivh "${LATEST_RPM}"
+    sudo yum -y -d1 install "${LATEST_RPM}"
 
 else
     ARTIFACT_OS="ubuntu"


### PR DESCRIPTION
If the runtime container is missing any dependencies required by the
GPDB package, then the rpm command will fail with `error: Failed
dependencies:`. If yum is used to install the package, then missing
dependencies will be resolved and installed.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>