### PR TITLE
docs - misc updates and upgrade info for new stdout/err logging

### DIFF
--- a/docs/content/cfg_logging.html.md.erb
+++ b/docs/content/cfg_logging.html.md.erb
@@ -13,7 +13,12 @@ PXF manages its service-level logging, and supports the following log levels (mo
 - debug
 - trace
 
-The default configuration for the PXF Service logs at the `info` and more severe levels. For some third-party libraries, the PXF Service logs at the `warn` or `error` and more severe levels to reduce verbosity. Log messages are written to the `$PXF_LOGDIR/pxf-service.log` file. You can change the PXF log directory if you choose.
+The default configuration for the PXF Service logs at the `info` and more severe levels. For some third-party libraries, the PXF Service logs at the `warn` or `error` and more severe levels to reduce verbosity.
+
+- PXF captures messages written to `stdout` and `stderr` and writes them to the `$PXF_LOGDIR/pxf-app.out` file. This file may contain service start-up messages that PXF logs before logging is fully configured. The file may also contain debug output.
+- Messages that PXF logs after start-up are written to the `$PXF_LOGDIR/pxf-service.log` file.
+
+You can change the PXF log directory if you choose.
 
 Client-level logging is managed by the Greenplum Database client; this topic details configuring logging for a `psql` client.
 
@@ -21,7 +26,7 @@ Enabling more verbose service- or client-level logging for PXF may aid troublesh
 
 ## <a id="cfglogdir"></a>Configuring the Log Directory
 
-The default PXF logging configuration writes log messages to `$PXF_LOGDIR/pxf-service.log`, where the default log directory is `PXF_LOGDIR=$PXF_BASE/logs`.
+The default PXF logging configuration writes log messages to `$PXF_LOGDIR`, where the default log directory is `PXF_LOGDIR=$PXF_BASE/logs`.
 
 To change the PXF log directory, you must update the `$PXF_LOGDIR` property in the `pxf-env.sh` configuration file, synchronize the configuration change to the Greenplum Database cluster, and then restart PXF:
 
@@ -48,7 +53,7 @@ To change the PXF log directory, you must update the `$PXF_LOGDIR` property in t
 
 ## <a id="pxfsvclogmsg"></a>Configuring Service-Level Logging
 
-PXF utilizes Apache Log4j 2 for service-level logging. PXF Service-related log messages are captured in `$PXF_LOGDIR/pxf-service.log`. The default configuration for the PXF Service logs at the `info` and more severe levels.
+PXF utilizes Apache Log4j 2 for service-level logging. PXF Service-related log messages are captured in `$PXF_LOGDIR/pxf-app.out` and `$PXF_LOGDIR/pxf-service.log`. The default configuration for the PXF Service logs at the `info` and more severe levels.
 
 You can change the log level for the PXF Service on a single Greenplum Database host, or on all hosts in the Greenplum cluster.
 

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -40,7 +40,7 @@ Most PXF error messages include a `HINT` that you can use to resolve the error, 
 
 ## <a id="pxf-loggin"></a>PXF Logging
 
-Refer to the [Logging](cfg_logging.html) topic for more information about logging levels, configuration, and the `pxf-service.log` log file.
+Refer to the [Logging](cfg_logging.html) topic for more information about logging levels, configuration, and the `pxf-app.out` and `pxf-service.log` log files.
 
 
 ## <a id="pxf-timezonecfg"></a>Addressing PXF JDBC Connector Time Zone Errors

--- a/docs/content/upgrade_6.html.md.erb
+++ b/docs/content/upgrade_6.html.md.erb
@@ -94,6 +94,26 @@ After you install the new version of PXF, perform the following procedure:
         </property>
         ```
 
+1. (Recommended) **If you are upgrading <i>from</i> PXF version 6.2.2 or earlier <i>to</i> PXF version 6.2.3 or later**, update your `$PXF_BASE/conf/pxf-log4j2.xml` file to fully configure the logging changes introduced in version 6.2.3:
+
+    1. Remove the following line from the initial `<Properties>` block:
+    
+        ``` pre
+        <Property name="PXF_LOG_LEVEL">${bundle:pxf-application:pxf.log.level}</Property>
+        ```
+
+    1. Change the following line:
+
+        ``` pre
+        <Logger name="org.greenplum.pxf" level="${env:PXF_LOG_LEVEL:-${sys:PXF_LOG_LEVEL:-info}}"/>
+        ```
+
+        to:
+
+        ``` pre
+        <Logger name="org.greenplum.pxf" level="${env:PXF_LOG_LEVEL:-${spring:pxf.log.level}}"/>
+        ```
+
 1. Synchronize the PXF configuration from the master host to the standby master and each Greenplum Database segment host. For example:
 
     ``` shell


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/720.  the PR includes changes to the template pxf-log4j2.xml file.

pxf now now logs early startup messages (before log4j is configured) to $PXF_LOGDIR/pxf-app.out.  add related info to the logging topic.  also need a section in the upgrade guide for pxf-log4j2.xml changes.

doc review site links (behind vpn):
- logging topic - https://docs-lisa-pxf-v623.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-2/using/cfg_logging.html
- upgrade topic (step 6) - https://docs-lisa-pxf-v623.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-2/using/upgrade_6.html#pxfup