### PR TITLE
ci: fix up pivnet artifacts

### DIFF
--- a/concourse/scripts/get_product_files.bash
+++ b/concourse/scripts/get_product_files.bash
@@ -24,6 +24,7 @@ gpdb_version=$(
 )
 echo -e "Latest - ${VERSIONS_BEFORE_LATEST} GPDB version found:\n${GPDB_VERSION}X:\t${gpdb_version}"
 
+# get the string of product names and turn it into list with correct gpdb_version found above
 IFS=, read -ra product_files_GPDB_VERSION <<<"${LIST_OF_PRODUCTS}"
 for file in "${product_files_GPDB_VERSION[@]}"; do
 	: "product_files/Pivotal-Greenplum/${file/GPDB_VERSION/${gpdb_version}}" # replace with version we are set to grab
@@ -32,22 +33,28 @@ done
 
 IFS=, read -ra product_dirs <<<"${LIST_OF_DIRS}"
 
+# for this gpdb version, get the full list of product files
 product_files_json=$(pivnet --format=json product-files "--product-slug=${PRODUCT_SLUG}" --release-version "${gpdb_version}")
 for ((i = 0; i < ${#product_files[@]}; i++)); do
 	file=${product_files[$i]}
+	# find the version of GPDB already in the bucket
 	download_path=${product_dirs[$i]}/${file##*/}
+	# does the version in the bucket match what the list we pulled from pivnet?
 	[[ -e ${download_path} ]] || {
+	  # if it doesn't exist, look in the previous bucket for that version
 		echo "${download_path} does not exist, looking for version Latest - $((VERSIONS_BEFORE_LATEST - 1))"
 		new_version=$((VERSIONS_BEFORE_LATEST - 1))
 		# this assumes we are naming our paths with latest-X !
 		download_path=${download_path/latest-${VERSIONS_BEFORE_LATEST}\//latest-${new_version}/}
 	}
+	# if the version of gpdb exists in the i-1 bucket but not the i-th bucket, check the SHA
 	if [[ -e ${download_path} ]]; then
 		echo "Found file ${download_path}, checking sha256sum..."
 		sha256=$(jq <<<"${product_files_json}" -r --arg object_key "${file}" '.[] | select(.aws_object_key == $object_key).sha256')
 		sum=$(sha256sum "${download_path}" | cut -d' ' -f1)
 		if [[ ${sum} == "${sha256}" ]]; then
 			echo "Sum is equivalent, skipping download of ${file}..."
+			# if the SHAs match, bring the version of gpdb in the i-1 bucket into the i-th bucket
 			if [[ ! ${download_path} =~ ^${product_dirs[$i]} ]]; then
 				echo "Cleaning ${product_dirs[$i]} and copying file ${download_path} to ${product_dirs[$i]}..."
 				rm -f "${product_dirs[$i]}"/*.{rpm,deb}
@@ -56,8 +63,18 @@ for ((i = 0; i < ${#product_files[@]}; i++)); do
 			continue
 		fi
 	fi
+	# if the version doesn't exist in either i-1, i-th bucket or the SHAs don't match, download it from pivnet.
 	rm -f "${product_dirs[$i]}"/*.{rpm,deb}
 	id=$(jq <<<"${product_files_json}" -r --arg object_key "${file}" '.[] | select(.aws_object_key == $object_key).id')
+
+	if [[ -z "${id}" ]]; then
+		echo "Did not find '${file}' in product files for GPDB '${gpdb_version}'"
+		if [[ $file =~ ^.*rhel8.*$ ]]; then
+			echo "RHEL 8 artifact unavailable for the given GPDB version."
+			continue
+		fi
+		exit 1
+	fi
 	echo "Downloading ${file} with id ${id} to ${product_dirs[$i]}..."
 	pivnet download-product-files \
 		"--download-dir=${product_dirs[$i]}" \

--- a/concourse/scripts/get_product_files.bash
+++ b/concourse/scripts/get_product_files.bash
@@ -64,18 +64,18 @@ for ((i = 0; i < ${#product_files[@]}; i++)); do
 		fi
 	fi
 	# if the version doesn't exist in either i-1, i-th bucket or the SHAs don't match, download it from pivnet.
-	rm -f "${product_dirs[$i]}"/*.{rpm,deb}
 	id=$(jq <<<"${product_files_json}" -r --arg object_key "${file}" '.[] | select(.aws_object_key == $object_key).id')
 
 	if [[ -z "${id}" ]]; then
 		echo "Did not find '${file}' in product files for GPDB '${gpdb_version}'"
 		if [[ $file =~ ^.*rhel8.*$ ]]; then
-			echo "RHEL 8 artifact unavailable for the given GPDB version."
+			echo "RHEL 8 artifact unavailable for the given GPDB version. Keeping existing rpm: $(find ${product_dirs[$i]}/ -name *rhel8*.rpm)"
 			continue
 		fi
 		exit 1
 	fi
-	echo "Downloading ${file} with id ${id} to ${product_dirs[$i]}..."
+	echo "Cleaning ${product_dirs[$i]} and downloading ${file} with id ${id} to ${product_dirs[$i]}..."
+	rm -f "${product_dirs[$i]}"/*.{rpm,deb}
 	pivnet download-product-files \
 		"--download-dir=${product_dirs[$i]}" \
 		"--product-slug=${PRODUCT_SLUG}" \

--- a/concourse/scripts/get_product_files.bash
+++ b/concourse/scripts/get_product_files.bash
@@ -68,7 +68,8 @@ for ((i = 0; i < ${#product_files[@]}; i++)); do
 
 	if [[ -z "${id}" ]]; then
 		echo "Did not find '${file}' in product files for GPDB '${gpdb_version}'"
-		if [[ $file =~ ^.*rhel8.*$ ]]; then
+		os_regex='^.*rhel8.*$'
+		if [[ $file =~ ${os_regex} ]]; then
 			echo "RHEL 8 artifact unavailable for the given GPDB version. Keeping existing rpm: $(find ${product_dirs[$i]}/ -name *rhel8*.rpm)"
 			continue
 		fi


### PR DESCRIPTION
Existing Pivnet artifacts do not contain a RHEL 8 RPM, so continue using the existing RHEL 8 RPM until we can start automatically pulling down a newer RPM. 