### PR TITLE
Update bundled postgresql to 42.3.3

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -114,6 +114,12 @@ configure(javaProjects) {
             dependency("org.json:json:20090211")
             dependency("org.mortbay.jetty:jetty-util:6.1.26")
             dependency("org.objenesis:objenesis:2.1")
+
+            // ---- bump postgres to 42.3.3 for CVE-2022-21724 fixes
+            // more details: https://nvd.nist.gov/vuln/detail/CVE-2022-21724
+            // revert once springboot provided postgresql is upgraded to bundle postgresql:42.3.3+
+            dependency("org.postgresql:postgresql:42.3.3")
+
             dependency("org.simplify4u:slf4j-mock:2.1.0")
             dependency("org.threeten:threeten-extra:1.5.0")
             dependency("org.tukaani:xz:1.8")


### PR DESCRIPTION
This commit updates the postgresql bundled with PXF to 42.3.3 to
mitigate the following CVE: CVE-2022-21724