### PR TITLE
Disable AnalyzeUtilsTest:generateSamplingBitSetBig

### DIFF
--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/utilities/AnalyzeUtilsTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/utilities/AnalyzeUtilsTest.java
@@ -22,6 +22,7 @@ package org.greenplum.pxf.service.utilities;
 
 import org.greenplum.pxf.api.model.Fragment;
 import org.greenplum.pxf.api.model.RequestContext;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -49,6 +50,7 @@ public class AnalyzeUtilsTest {
     }
 
     @Test
+    @Disabled("flakey test due to java heap space (memory err)")
     public void generateSamplingBitSetBig() throws Exception {
         BitSet result = AnalyzeUtils.generateSamplingBitSet(1000000, 990000);
         assertEquals(result.cardinality(), 990000);


### PR DESCRIPTION
The above test has been failing intermittently due to not having enough
Java heap space for the test.
```
Caused by: java.lang.OutOfMemoryError: Java heap space
   at java.util.Arrays.copyOfRange(Arrays.java:3664
```