### PR TITLE
docs: Update table of Avro type mappings

### DIFF
--- a/docs/content/hdfs_avro.html.md.erb
+++ b/docs/content/hdfs_avro.html.md.erb
@@ -42,7 +42,7 @@ To represent Avro primitive data types and Avro arrays of primitive types in Gre
 
 Avro supports other complex data types including arrays of non-primitive types, maps, records, enumerations, and fixed types. Map top-level fields of these complex data types to the Greenplum Database `text` type. While PXF does not natively support reading these types, you can create Greenplum Database functions or application code to extract or further process subcomponents of these complex data types.
 
-Avro supports logical data types including decimal, date, time, and duration types. You must similarly map these data types to the Greenplum Database `text` type.
+Avro supports logical data types including date, decimal, duration, time, timestamp, and uuid types.
 
 ### <a id="datatype_map_read "></a>Read Mapping
 

--- a/docs/content/hdfs_avro.html.md.erb
+++ b/docs/content/hdfs_avro.html.md.erb
@@ -64,10 +64,16 @@ PXF uses the following data type mapping when reading Avro data:
 | Complex type: Map, Record, or Enum  | text, with delimiters inserted between collection items, mapped key-value pairs, and record data.   |
 | Complex type: Fixed     | bytea (supported for read operations only).   |
 | Union      | Follows the above conventions for primitive or complex data types, depending on the union; must contain 2 elements, one of which must be null.  |
-| Logical type: date | int |
-| Logical type: time-millis, timestamp-millis, or local-timestamp-millis | int |
-| Logical type: time-micros, timestamp-micros, or local-timestamp-micros | long |
+| Logical type: Date | date |
+| Logical type: Decimal | decimal or numeric |
 | Logical type: duration | bytea |
+| Logical type: Time (millisecond precision) | time (time without time zone) |
+| Logical type: Time (microsecond precision) | time (time without time zone) |
+| Logical type: Timestamp (millisecond precision) | timestamp (with or without time zone) |
+| Logical type: Timestamp (microsecond precision) | timestamp (with or without time zone) |
+| Logical type: Local Timestamp (millisecond precision) | timestamp (with or without time zone) |
+| Logical type: Local Timestamp (microsecond precision) | timestamp (with or without time zone) |
+| Logical type: UUID | UUID |
 
 ### <a id="datatype_map_Write"></a>Write Mapping
 


### PR DESCRIPTION
PR #703 added support for reading several Avro logical types to
corresponding GPDB column types. Previously, logical types were read in
using the underlying physical storage type (e.g., int for time-millis).
This updates the table of type mappings when reading data in from Avro
files.

When writing Avro files out, if no schema is provided PXF will store the
data as strings.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>