### PR TITLE
Update build and dev pipelines to include a mirrorless cluster test

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -1378,12 +1378,13 @@ jobs:
           terraform_source: ccp_src/google/
           vars:
             PLATFORM: centos7
+            WITH_MIRRORS: false
             number_of_nodes: ((number_of_gpdb_nodes))
             extra_nodes: 1
             segments_per_host: 4
             instance_type: n1-standard-4
             ccp_reap_minutes: 120
-            standby_master: true
+            standby_master: false
       - task: Generate Greenplum Cluster
         input_mapping:
           gpdb_rpm: gpdb_package
@@ -1402,6 +1403,13 @@ jobs:
       - in_parallel:
         - task: Initialize Greenplum
           file: ccp_src/ci/tasks/gpinitsystem.yml
+          params:
+            POSTGRES_CONF_ADDONS:
+            - wal_level=minimal
+            - max_wal_senders=0
+            - gp_dispatch_keepalives_idle=30
+            - gp_dispatch_keepalives_interval=10
+            - gp_dispatch_keepalives_count=4
         - task: Install Hadoop
           file: pxf_src/concourse/tasks/install_hadoop.yml
           image: gpdb[[gp_ver]]-pxf-dev-centos7-image

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -1195,12 +1195,13 @@ jobs:
           terraform_source: ccp_src/google/
           vars:
             PLATFORM: centos7
+            WITH_MIRRORS: false
             number_of_nodes: ((number_of_gpdb_nodes))
             extra_nodes: 1
             segments_per_host: 4
             instance_type: n1-standard-4
             ccp_reap_minutes: 120
-            standby_master: true
+            standby_master: false
       - task: Generate Greenplum Cluster
         input_mapping:
           gpdb_rpm: gpdb_package
@@ -1219,6 +1220,13 @@ jobs:
       - in_parallel:
         - task: Initialize Greenplum
           file: ccp_src/ci/tasks/gpinitsystem.yml
+          params:
+            POSTGRES_CONF_ADDONS:
+            - wal_level=minimal
+            - max_wal_senders=0
+            - gp_dispatch_keepalives_idle=30
+            - gp_dispatch_keepalives_interval=10
+            - gp_dispatch_keepalives_count=4
         - task: Install Hadoop
           file: pxf_src/concourse/tasks/install_hadoop.yml
           image: gpdb[[gp_ver]]-pxf-dev-centos7-image


### PR DESCRIPTION
* Modify the PXF-GP6-SECURE-MULTI-NO-IMPERS pipeline job to use a
mirrorless CCP cluster
  * CCP configuration was taken from [PR 13116][] in greenplum-db/gpdb
* Update PXF CLI tests to work with clusters that do not include a
standby master host

[PR 13116]: https://github.com/greenplum-db/gpdb/pull/13116

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>