### PR TITLE
Fix: In case of UnsupportedOperationException, Add an error message.

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoAccessor.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoAccessor.java
@@ -34,7 +34,7 @@ public class DemoAccessor extends BasePlugin implements Accessor {
     private int rowNumber;
     private int fragmentNumber;
     private static final int NUM_ROWS = 2;
-    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Demo accessor does not support write operation";
 
     @Override
     public boolean openForRead() {

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoAccessor.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoAccessor.java
@@ -34,6 +34,7 @@ public class DemoAccessor extends BasePlugin implements Accessor {
     private int rowNumber;
     private int fragmentNumber;
     private static final int NUM_ROWS = 2;
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
 
     @Override
     public boolean openForRead() {
@@ -91,7 +92,7 @@ public class DemoAccessor extends BasePlugin implements Accessor {
      */
     @Override
     public boolean openForWrite() throws Exception {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -103,7 +104,7 @@ public class DemoAccessor extends BasePlugin implements Accessor {
      */
     @Override
     public boolean writeNextObject(OneRow onerow) throws Exception {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -113,6 +114,6 @@ public class DemoAccessor extends BasePlugin implements Accessor {
      */
     @Override
     public void closeForWrite() throws Exception {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoResolver.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoResolver.java
@@ -65,6 +65,6 @@ public class DemoResolver extends BasePlugin implements Resolver {
      */
     @Override
     public OneRow setFields(List<OneField> record) throws Exception {
-        throw new UnsupportedOperationException("Current operation is not supported");
+        throw new UnsupportedOperationException("Demo resolver does not support write operation");
     }
 }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoResolver.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/examples/DemoResolver.java
@@ -65,6 +65,6 @@ public class DemoResolver extends BasePlugin implements Resolver {
      */
     @Override
     public OneRow setFields(List<OneField> record) throws Exception {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Current operation is not supported");
     }
 }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseFragmenter.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseFragmenter.java
@@ -14,6 +14,8 @@ public class BaseFragmenter extends BasePlugin implements Fragmenter {
 
     @Override
     public FragmentStats getFragmentStats() throws Exception {
-        throw new UnsupportedOperationException("Current fragmenter does not support getFragmentStats");
+
+        String profile = context.getProfile();
+        throw new UnsupportedOperationException(String.format("Profile '%s' does not support statistics for fragments", profile));
     }
 }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseFragmenter.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseFragmenter.java
@@ -14,6 +14,6 @@ public class BaseFragmenter extends BasePlugin implements Fragmenter {
 
     @Override
     public FragmentStats getFragmentStats() throws Exception {
-        throw new UnsupportedOperationException("Current operation is not supported");
+        throw new UnsupportedOperationException("Current fragmenter does not support getFragmentStats");
     }
 }

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseFragmenter.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/BaseFragmenter.java
@@ -14,6 +14,6 @@ public class BaseFragmenter extends BasePlugin implements Fragmenter {
 
     @Override
     public FragmentStats getFragmentStats() throws Exception {
-        throw new UnsupportedOperationException("Operation getFragmentStats is not supported");
+        throw new UnsupportedOperationException("Current operation is not supported");
     }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoAccessorTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoAccessorTest.java
@@ -76,12 +76,12 @@ public class DemoAccessorTest {
     @Test
     public void testWriteIsNotSupported() {
         Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
-        assertEquals("Write operation is not supported", e.getMessage());
+        assertEquals("Demo accessor does not support write operation", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(new OneRow()));
-        assertEquals("Write operation is not supported", e.getMessage());
+        assertEquals("Demo accessor does not support write operation", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
-        assertEquals("Write operation is not supported", e.getMessage());
+        assertEquals("Demo accessor does not support write operation", e.getMessage());
     }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoAccessorTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoAccessorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DemoAccessorTest {
 
@@ -70,5 +71,17 @@ public class DemoAccessorTest {
             assertEquals(String.format("OneRow:0.%d->fragment1 row%d,value1,value2", i, i + 1), row.toString());
         }
         assertNull(accessor.readNextObject());
+    }
+
+    @Test
+    public void testWriteIsNotSupported() {
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
+        assertEquals("Write operation is not supported", e.getMessage());
+
+        e = assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(new OneRow()));
+        assertEquals("Write operation is not supported", e.getMessage());
+
+        e = assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
+        assertEquals("Write operation is not supported", e.getMessage());
     }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
@@ -102,4 +102,11 @@ public class DemoResolverTest {
                 () -> textResolver.setFields(Arrays.asList(field, field)));
     }
 
+    @Test
+    public void testSetFieldsIsUnsupported() {
+      Exception e = assertThrows(UnsupportedOperationException.class,
+                () -> customResolver.setFields(null));
+
+      assertEquals("Current operation is not supported", e.getMessage());
+    }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/DemoResolverTest.java
@@ -107,6 +107,6 @@ public class DemoResolverTest {
       Exception e = assertThrows(UnsupportedOperationException.class,
                 () -> customResolver.setFields(null));
 
-      assertEquals("Current operation is not supported", e.getMessage());
+      assertEquals("Demo resolver does not support write operation", e.getMessage());
     }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseFragmenterTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseFragmenterTest.java
@@ -1,5 +1,6 @@
 package org.greenplum.pxf.api.model;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,11 +11,24 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BaseFragmenterTest {
 
+    RequestContext context;
+    BaseFragmenter baseFragmenter;
+
+    @BeforeEach
+    public void setup() {
+        context = new RequestContext();
+        context.setProfile("noprofile");
+
+        baseFragmenter = new BaseFragmenter();
+        baseFragmenter.setRequestContext(context);
+    }
+
     @Test
     public void testGetFragmentStatsIsUnsupported() {
+
         Exception e = assertThrows(UnsupportedOperationException.class,
-                () -> new BaseFragmenter().getFragmentStats());
-        assertEquals("Current fragmenter does not support getFragmentStats", e.getMessage());
+                () -> baseFragmenter.getFragmentStats());
+        assertEquals("Profile 'noprofile' does not support statistics for fragments", e.getMessage());
     }
 
     @Test

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseFragmenterTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseFragmenterTest.java
@@ -14,7 +14,7 @@ public class BaseFragmenterTest {
     public void testGetFragmentStatsIsUnsupported() {
         Exception e = assertThrows(UnsupportedOperationException.class,
                 () -> new BaseFragmenter().getFragmentStats());
-        assertEquals("Operation getFragmentStats is not supported", e.getMessage());
+        assertEquals("Current operation is not supported", e.getMessage());
     }
 
     @Test

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseFragmenterTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/BaseFragmenterTest.java
@@ -14,7 +14,7 @@ public class BaseFragmenterTest {
     public void testGetFragmentStatsIsUnsupported() {
         Exception e = assertThrows(UnsupportedOperationException.class,
                 () -> new BaseFragmenter().getFragmentStats());
-        assertEquals("Current operation is not supported", e.getMessage());
+        assertEquals("Current fragmenter does not support getFragmentStats", e.getMessage());
     }
 
     @Test

--- a/server/pxf-diagnostic/src/main/java/org/greenplum/pxf/diagnostic/UserDataVerifyAccessor.java
+++ b/server/pxf-diagnostic/src/main/java/org/greenplum/pxf/diagnostic/UserDataVerifyAccessor.java
@@ -18,6 +18,7 @@ public class UserDataVerifyAccessor extends BasePlugin implements Accessor {
 
     private int counter = 0;
     private char firstColumn = 'A';
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
 
     @Override
     public boolean openForRead() {
@@ -51,16 +52,16 @@ public class UserDataVerifyAccessor extends BasePlugin implements Accessor {
 
     @Override
     public boolean openForWrite() {
-        throw new UnsupportedOperationException("openForWrite method is not implemented");
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     @Override
     public boolean writeNextObject(OneRow onerow) {
-        throw new UnsupportedOperationException("writeNextObject method is not implemented");
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     @Override
     public void closeForWrite() {
-        throw new UnsupportedOperationException("closeForWrite method is not implemented");
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 }

--- a/server/pxf-diagnostic/src/main/java/org/greenplum/pxf/diagnostic/UserDataVerifyAccessor.java
+++ b/server/pxf-diagnostic/src/main/java/org/greenplum/pxf/diagnostic/UserDataVerifyAccessor.java
@@ -18,7 +18,7 @@ public class UserDataVerifyAccessor extends BasePlugin implements Accessor {
 
     private int counter = 0;
     private char firstColumn = 'A';
-    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "UserDataVerifyAccessor does not support write operation";
 
     @Override
     public boolean openForRead() {

--- a/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseAccessor.java
+++ b/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseAccessor.java
@@ -77,7 +77,7 @@ public class HBaseAccessor extends BasePlugin implements Accessor {
 
     private static final TreeVisitor PRUNER = new SupportedOperatorPruner(SUPPORTED_OPERATORS);
     private static final TreeTraverser TRAVERSER = new TreeTraverser();
-    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "HBase accessor does not support write operation.";
 
     private HBaseTupleDescription tupleDescription;
     private Connection connection;

--- a/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseAccessor.java
+++ b/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseAccessor.java
@@ -77,6 +77,7 @@ public class HBaseAccessor extends BasePlugin implements Accessor {
 
     private static final TreeVisitor PRUNER = new SupportedOperatorPruner(SUPPORTED_OPERATORS);
     private static final TreeTraverser TRAVERSER = new TreeTraverser();
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
 
     private HBaseTupleDescription tupleDescription;
     private Connection connection;
@@ -152,7 +153,7 @@ public class HBaseAccessor extends BasePlugin implements Accessor {
      */
     @Override
     public boolean openForWrite() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -163,7 +164,7 @@ public class HBaseAccessor extends BasePlugin implements Accessor {
      */
     @Override
     public boolean writeNextObject(OneRow onerow) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -171,7 +172,7 @@ public class HBaseAccessor extends BasePlugin implements Accessor {
      */
     @Override
     public void closeForWrite() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**

--- a/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseResolver.java
+++ b/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseResolver.java
@@ -96,7 +96,7 @@ public class HBaseResolver extends BasePlugin implements Resolver {
      */
     @Override
     public OneRow setFields(List<OneField> record) {
-        throw new UnsupportedOperationException("Current operation is not supported");
+        throw new UnsupportedOperationException("HBase resolver does not support write operation.");
     }
 
     /**

--- a/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseResolver.java
+++ b/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseResolver.java
@@ -96,7 +96,7 @@ public class HBaseResolver extends BasePlugin implements Resolver {
      */
     @Override
     public OneRow setFields(List<OneField> record) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Current operation is not supported");
     }
 
     /**

--- a/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseResolver.java
+++ b/server/pxf-hbase/src/main/java/org/greenplum/pxf/plugins/hbase/HBaseResolver.java
@@ -96,7 +96,7 @@ public class HBaseResolver extends BasePlugin implements Resolver {
      */
     @Override
     public OneRow setFields(List<OneField> record) {
-        throw new UnsupportedOperationException("HBase resolver does not support write operation.");
+        throw new UnsupportedOperationException("HBase resolver does not support write operation");
     }
 
     /**

--- a/server/pxf-hbase/src/test/java/org/greenplum/pxf/plugins/hbase/HBaseResolverTest.java
+++ b/server/pxf-hbase/src/test/java/org/greenplum/pxf/plugins/hbase/HBaseResolverTest.java
@@ -98,4 +98,12 @@ public class HBaseResolverTest {
                 "Unsupported data type should throw exception");
         assertEquals("Unsupported data type point", e.getMessage());
     }
+
+    @Test
+    public void testSetFieldsIsUnsupported() {
+        Exception e = assertThrows(UnsupportedOperationException.class,
+                () -> new HBaseResolver().setFields(null));
+
+        assertEquals("Current operation is not supported", e.getMessage());
+    }
 }

--- a/server/pxf-hbase/src/test/java/org/greenplum/pxf/plugins/hbase/HBaseResolverTest.java
+++ b/server/pxf-hbase/src/test/java/org/greenplum/pxf/plugins/hbase/HBaseResolverTest.java
@@ -104,6 +104,6 @@ public class HBaseResolverTest {
         Exception e = assertThrows(UnsupportedOperationException.class,
                 () -> new HBaseResolver().setFields(null));
 
-        assertEquals("Current operation is not supported", e.getMessage());
+        assertEquals("HBase resolver does not support write operation", e.getMessage());
     }
 }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessor.java
@@ -36,7 +36,7 @@ import java.util.Queue;
  */
 public class QuotedLineBreakAccessor extends HdfsAtomicDataAccessor {
 
-    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported for text:multi profile";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Profile '%s' does not support write operation.";
 
     private boolean fileAsRow;
     private boolean firstLine, lastLine;
@@ -158,7 +158,7 @@ public class QuotedLineBreakAccessor extends HdfsAtomicDataAccessor {
      */
     @Override
     public boolean openForWrite() {
-        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
+        throw new UnsupportedOperationException(String.format(UNSUPPORTED_ERR_MESSAGE, context.getProfile()));
     }
 
     /**
@@ -169,7 +169,7 @@ public class QuotedLineBreakAccessor extends HdfsAtomicDataAccessor {
      */
     @Override
     public boolean writeNextObject(OneRow onerow) {
-        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
+        throw new UnsupportedOperationException(String.format(UNSUPPORTED_ERR_MESSAGE, context.getProfile()));
     }
 
     /**
@@ -177,6 +177,6 @@ public class QuotedLineBreakAccessor extends HdfsAtomicDataAccessor {
      */
     @Override
     public void closeForWrite() {
-        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
+        throw new UnsupportedOperationException(String.format(UNSUPPORTED_ERR_MESSAGE, context.getProfile()));
     }
 }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessor.java
@@ -35,11 +35,15 @@ import java.util.Queue;
  * multi-line records, that are read from a single source (non-parallel).
  */
 public class QuotedLineBreakAccessor extends HdfsAtomicDataAccessor {
+
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
+
     private boolean fileAsRow;
     private boolean firstLine, lastLine;
     private int skipHeaderCount;
     BufferedReader reader;
     Queue<String> lineQueue;
+
 
     @Override
     public void afterPropertiesSet() {
@@ -155,7 +159,7 @@ public class QuotedLineBreakAccessor extends HdfsAtomicDataAccessor {
      */
     @Override
     public boolean openForWrite() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -166,7 +170,7 @@ public class QuotedLineBreakAccessor extends HdfsAtomicDataAccessor {
      */
     @Override
     public boolean writeNextObject(OneRow onerow) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -174,6 +178,6 @@ public class QuotedLineBreakAccessor extends HdfsAtomicDataAccessor {
      */
     @Override
     public void closeForWrite() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessor.java
@@ -36,14 +36,13 @@ import java.util.Queue;
  */
 public class QuotedLineBreakAccessor extends HdfsAtomicDataAccessor {
 
-    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported for text:multi profile";
 
     private boolean fileAsRow;
     private boolean firstLine, lastLine;
     private int skipHeaderCount;
     BufferedReader reader;
     Queue<String> lineQueue;
-
 
     @Override
     public void afterPropertiesSet() {

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedAccessor.java
@@ -57,6 +57,7 @@ public class ORCVectorizedAccessor extends BasePlugin implements Accessor {
     private static final TreeTraverser TRAVERSER = new TreeTraverser();
 
     static final String MAP_BY_POSITION_OPTION = "MAP_BY_POSITION";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
 
     /**
      * True if the accessor accesses the columns defined in the
@@ -144,17 +145,17 @@ public class ORCVectorizedAccessor extends BasePlugin implements Accessor {
 
     @Override
     public boolean openForWrite() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     @Override
     public boolean writeNextObject(OneRow onerow) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     @Override
     public void closeForWrite() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedResolver.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedResolver.java
@@ -127,6 +127,8 @@ public class ORCVectorizedResolver extends BasePlugin implements ReadVectorizedR
 
     private List<List<OneField>> cachedBatch;
 
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Current operation is not supported";
+
     /**
      * {@inheritDoc}
      */
@@ -201,7 +203,7 @@ public class ORCVectorizedResolver extends BasePlugin implements ReadVectorizedR
      */
     @Override
     public List<OneField> getFields(OneRow row) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -209,7 +211,7 @@ public class ORCVectorizedResolver extends BasePlugin implements ReadVectorizedR
      */
     @Override
     public OneRow setFields(List<OneField> record) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorTest.java
@@ -421,16 +421,19 @@ public class QuotedLineBreakAccessorTest {
 
     @Test
     public void testWriteIsNotSupported() throws Exception {
+        context.setProfile("text:multi");
+        accessor.setRequestContext(context);
+
         prepareTest("csv/simple.csv", false);
 
         Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
-        assertEquals("Write operation is not supported for text:multi profile", e.getMessage());
+        assertEquals("Profile 'text:multi' does not support write operation.", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(new OneRow()));
-        assertEquals("Write operation is not supported for text:multi profile", e.getMessage());
+        assertEquals("Profile 'text:multi' does not support write operation.", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
-        assertEquals("Write operation is not supported for text:multi profile", e.getMessage());
+        assertEquals("Profile 'text:multi' does not support write operation.", e.getMessage());
     }
 
     private void prepareTest(String resourceName, boolean fileAsRow) throws Exception {

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorTest.java
@@ -419,6 +419,20 @@ public class QuotedLineBreakAccessorTest {
         accessor.closeForRead();
     }
 
+    @Test
+    public void testWriteIsNotSupported() throws Exception {
+        prepareTest("csv/simple.csv", false);
+
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
+        assertEquals("Write operation is not supported", e.getMessage());
+
+        e = assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(new OneRow()));
+        assertEquals("Write operation is not supported", e.getMessage());
+
+        e = assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
+        assertEquals("Write operation is not supported", e.getMessage());
+    }
+
     private void prepareTest(String resourceName, boolean fileAsRow) throws Exception {
         if (fileAsRow) {
             context.addOption("FILE_AS_ROW", "true");

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/QuotedLineBreakAccessorTest.java
@@ -424,13 +424,13 @@ public class QuotedLineBreakAccessorTest {
         prepareTest("csv/simple.csv", false);
 
         Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
-        assertEquals("Write operation is not supported", e.getMessage());
+        assertEquals("Write operation is not supported for text:multi profile", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(new OneRow()));
-        assertEquals("Write operation is not supported", e.getMessage());
+        assertEquals("Write operation is not supported for text:multi profile", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
-        assertEquals("Write operation is not supported", e.getMessage());
+        assertEquals("Write operation is not supported for text:multi profile", e.getMessage());
     }
 
     private void prepareTest(String resourceName, boolean fileAsRow) throws Exception {

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedAccessorTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedAccessorTest.java
@@ -124,9 +124,14 @@ class ORCVectorizedAccessorTest extends ORCVectorizedBaseTest {
 
     @Test
     public void testOrcWriteIsNotSupported() {
-        assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
-        assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(new OneRow()));
-        assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
+        assertEquals("Write operation is not supported", e.getMessage());
+
+        e = assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(new OneRow()));
+        assertEquals("Write operation is not supported", e.getMessage());
+
+        e = assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
+        assertEquals("Write operation is not supported", e.getMessage());
     }
 
     private void runTestScenarioReadOrcTypesFile(int expectedNumCols) throws IOException {

--- a/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedResolverTest.java
+++ b/server/pxf-hdfs/src/test/java/org/greenplum/pxf/plugins/hdfs/orc/ORCVectorizedResolverTest.java
@@ -326,8 +326,11 @@ class ORCVectorizedResolverTest extends ORCVectorizedBaseTest {
 
     @Test
     public void testUnsupportedFunctionality() {
-        assertThrows(UnsupportedOperationException.class, () -> resolver.getFields(new OneRow()));
-        assertThrows(UnsupportedOperationException.class, () -> resolver.setFields(Collections.singletonList(new OneField())));
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> resolver.getFields(new OneRow()));
+        assertEquals("Current operation is not supported", e.getMessage());
+
+        e = assertThrows(UnsupportedOperationException.class, () -> resolver.setFields(Collections.singletonList(new OneField())));
+        assertEquals("Current operation is not supported", e.getMessage());
     }
 
     private void assertDataReturned(Object[][] expected, List<List<OneField>> fieldsForBatch) {

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
@@ -96,7 +96,7 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
     private static final Logger LOG = LoggerFactory.getLogger(HiveAccessor.class);
     private static final String PXF_PPD_HIVE = "pxf.ppd.hive";
     private static final String HIVE_DEFAULT_PARTITION = "__HIVE_DEFAULT_PARTITION__";
-    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported for Hive";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Hive accessor does not support write operation.";
 
     private List<HivePartition> partitions;
     private int skipHeaderCount;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
@@ -96,6 +96,7 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
     private static final Logger LOG = LoggerFactory.getLogger(HiveAccessor.class);
     private static final String PXF_PPD_HIVE = "pxf.ppd.hive";
     private static final String HIVE_DEFAULT_PARTITION = "__HIVE_DEFAULT_PARTITION__";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
 
     private List<HivePartition> partitions;
     private int skipHeaderCount;
@@ -309,7 +310,7 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
      */
     @Override
     public boolean openForWrite() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -320,7 +321,7 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
      */
     @Override
     public boolean writeNextObject(OneRow onerow) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -328,7 +329,7 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
      */
     @Override
     public void closeForWrite() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
@@ -96,7 +96,7 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
     private static final Logger LOG = LoggerFactory.getLogger(HiveAccessor.class);
     private static final String PXF_PPD_HIVE = "pxf.ppd.hive";
     private static final String HIVE_DEFAULT_PARTITION = "__HIVE_DEFAULT_PARTITION__";
-    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Write operation is not supported for Hive";
 
     private List<HivePartition> partitions;
     private int skipHeaderCount;

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
@@ -150,7 +150,7 @@ public class HiveResolver extends BasePlugin implements Resolver {
      */
     @Override
     public OneRow setFields(List<OneField> record) {
-        throw new UnsupportedOperationException("Current operation is not supported");
+        throw new UnsupportedOperationException("Hive resolver does not support write operation.");
     }
 
     public int getNumberOfPartitions() {

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveResolver.java
@@ -150,7 +150,7 @@ public class HiveResolver extends BasePlugin implements Resolver {
      */
     @Override
     public OneRow setFields(List<OneField> record) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Current operation is not supported");
     }
 
     public int getNumberOfPartitions() {

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
@@ -293,13 +293,13 @@ class HiveAccessorTest {
         accessor = new HiveAccessor(null, new HiveUtilities(), serializationService);
 
         Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
-        assertEquals("Write operation is not supported for Hive", e.getMessage());
+        assertEquals("Hive accessor does not support write operation.", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(null));
-        assertEquals("Write operation is not supported for Hive", e.getMessage());
+        assertEquals("Hive accessor does not support write operation.", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
-        assertEquals("Write operation is not supported for Hive", e.getMessage());
+        assertEquals("Hive accessor does not support write operation.", e.getMessage());
     }
 
     @SuppressWarnings("unchecked")

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
@@ -293,13 +293,13 @@ class HiveAccessorTest {
         accessor = new HiveAccessor(null, new HiveUtilities(), serializationService);
 
         Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
-        assertEquals("Write operation is not supported", e.getMessage());
+        assertEquals("Write operation is not supported for Hive", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(null));
-        assertEquals("Write operation is not supported", e.getMessage());
+        assertEquals("Write operation is not supported for Hive", e.getMessage());
 
         e = assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
-        assertEquals("Write operation is not supported", e.getMessage());
+        assertEquals("Write operation is not supported for Hive", e.getMessage());
     }
 
     @SuppressWarnings("unchecked")

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
@@ -27,6 +27,7 @@ import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -285,6 +286,20 @@ class HiveAccessorTest {
         assertEquals(COLUMN_NAMES, jobConf.get("columns"));
         assertEquals(COLUMN_TYPES, jobConf.get("columns.types"));
         assertNull(jobConf.get("sarg.pushdown"));
+    }
+
+    @Test
+    public void testWriteIsNotSupported() {
+        accessor = new HiveAccessor(null, new HiveUtilities(), serializationService);
+
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.openForWrite());
+        assertEquals("Write operation is not supported", e.getMessage());
+
+        e = assertThrows(UnsupportedOperationException.class, () -> accessor.writeNextObject(null));
+        assertEquals("Write operation is not supported", e.getMessage());
+
+        e = assertThrows(UnsupportedOperationException.class, () -> accessor.closeForWrite());
+        assertEquals("Write operation is not supported", e.getMessage());
     }
 
     @SuppressWarnings("unchecked")

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveResolverTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveResolverTest.java
@@ -176,6 +176,6 @@ public class HiveResolverTest {
         resolver = new HiveResolver(mockHiveUtilities);
 
         Exception e = assertThrows(UnsupportedOperationException.class, () -> resolver.setFields(null));
-        assertEquals("Current operation is not supported", e.getMessage());
+        assertEquals("Hive resolver does not support write operation.", e.getMessage());
     }
 }

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveResolverTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveResolverTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 public class HiveResolverTest {
@@ -167,5 +169,13 @@ public class HiveResolverTest {
         List<OneField> output = resolver.getFields(row);
 
         assertThat(output.get(0).toString()).isEqualTo("{\"line1\":{\"number\":1000,\"street_name\":\"a really \\\"fancy\\\" string\"},\"line2\":{\"city\":\"plain string\",\"zipcode\":1001}}");
+    }
+
+    @Test
+    public void testSetFieldsIsNotSupported() {
+        resolver = new HiveResolver(mockHiveUtilities);
+
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> resolver.setFields(null));
+        assertEquals("Current operation is not supported", e.getMessage());
     }
 }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/PartitionType.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/partitioning/PartitionType.java
@@ -110,6 +110,8 @@ public enum PartitionType {
         }
     },
     ENUM {
+        private static final String UNSUPPORTED_ERR_MESSAGE = "Current operation is not supported";
+
         @Override
         protected List<? extends BasePartition> generate(String column, String range, String interval) {
             // Parse RANGE
@@ -135,32 +137,32 @@ public enum PartitionType {
 
         @Override
         BasePartition createPartition(String column, Object start, Object end) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
         }
 
         @Override
         Object parseRange(String value) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
         }
 
         @Override
         Interval parseInterval(String interval) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
         }
 
         @Override
         boolean isLessThan(Object rangeStart, Object rangeEnd) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
         }
 
         @Override
         Object next(Object start, Object end, Interval interval) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
         }
 
         @Override
         String getValidIntervalFormat() {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
         }
     };
 

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/PartitionTypeTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/partitioning/PartitionTypeTest.java
@@ -56,38 +56,44 @@ public class PartitionTypeTest {
 
     @Test
     public void unsupportedCreatePartitionForEnum() {
-        assertThrows(UnsupportedOperationException.class,
+        Exception e = assertThrows(UnsupportedOperationException.class,
             () -> PartitionType.ENUM.createPartition(null, null, null));
+        assertEquals("Current operation is not supported", e.getMessage());
     }
 
     @Test
     public void unsupportedParseRangeForEnum() {
-        assertThrows(UnsupportedOperationException.class,
+        Exception e = assertThrows(UnsupportedOperationException.class,
             () -> PartitionType.ENUM.parseRange(null));
+        assertEquals("Current operation is not supported", e.getMessage());
     }
 
     @Test
     public void unsupportedParseInterval() {
-        assertThrows(UnsupportedOperationException.class,
+        Exception e = assertThrows(UnsupportedOperationException.class,
             () -> PartitionType.ENUM.parseInterval(null));
+        assertEquals("Current operation is not supported", e.getMessage());
 
     }
 
     @Test
     public void unsupportedIsLessThan() {
-        assertThrows(UnsupportedOperationException.class,
+        Exception e = assertThrows(UnsupportedOperationException.class,
             () -> PartitionType.ENUM.isLessThan(null, null));
+        assertEquals("Current operation is not supported", e.getMessage());
     }
 
     @Test
     public void unsupportedNext() {
-        assertThrows(UnsupportedOperationException.class,
+        Exception e = assertThrows(UnsupportedOperationException.class,
             () -> PartitionType.ENUM.next(null, null, null));
+        assertEquals("Current operation is not supported", e.getMessage());
     }
 
     @Test
     public void unsupportedGetValidIntervalFormat() {
-        assertThrows(UnsupportedOperationException.class, PartitionType.ENUM::getValidIntervalFormat);
+        Exception e = assertThrows(UnsupportedOperationException.class, PartitionType.ENUM::getValidIntervalFormat);
+        assertEquals("Current operation is not supported", e.getMessage());
     }
 
     @Test

--- a/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonAccessor.java
+++ b/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonAccessor.java
@@ -43,7 +43,7 @@ public class JsonAccessor extends HdfsSplittableDataAccessor {
 
     public static final String IDENTIFIER_PARAM = "IDENTIFIER";
     public static final String RECORD_MAX_LENGTH_PARAM = "MAXLENGTH";
-    private static final String UNSUPPORTED_ERR_MESSAGE = "Write for JSON is not supported";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "JSON accessor does not support write operation.";
 
     /**
      * If provided indicates the member name which will be used to determine the encapsulating json object to return.

--- a/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonAccessor.java
+++ b/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonAccessor.java
@@ -43,6 +43,7 @@ public class JsonAccessor extends HdfsSplittableDataAccessor {
 
     public static final String IDENTIFIER_PARAM = "IDENTIFIER";
     public static final String RECORD_MAX_LENGTH_PARAM = "MAXLENGTH";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "Write for JSON is not supported";
 
     /**
      * If provided indicates the member name which will be used to determine the encapsulating json object to return.
@@ -94,8 +95,8 @@ public class JsonAccessor extends HdfsSplittableDataAccessor {
      * @throws Exception if opening the resource failed
      */
     @Override
-    public boolean openForWrite() throws Exception {
-        throw new UnsupportedOperationException();
+    public boolean openForWrite() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -106,8 +107,8 @@ public class JsonAccessor extends HdfsSplittableDataAccessor {
      * @throws Exception writing to the resource failed
      */
     @Override
-    public boolean writeNextObject(OneRow onerow) throws Exception {
-        throw new UnsupportedOperationException();
+    public boolean writeNextObject(OneRow onerow) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     /**
@@ -116,7 +117,7 @@ public class JsonAccessor extends HdfsSplittableDataAccessor {
      * @throws Exception if closing the resource failed
      */
     @Override
-    public void closeForWrite() throws Exception {
-        throw new UnsupportedOperationException();
+    public void closeForWrite() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 }

--- a/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonResolver.java
+++ b/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonResolver.java
@@ -123,7 +123,7 @@ public class JsonResolver extends BasePlugin implements Resolver {
      */
     @Override
     public OneRow setFields(List<OneField> record) throws UnsupportedOperationException {
-        throw new UnsupportedOperationException("Current operation is not supported");
+        throw new UnsupportedOperationException("JSON resolver does not support write operation.");
     }
 
     /**

--- a/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonResolver.java
+++ b/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonResolver.java
@@ -123,7 +123,7 @@ public class JsonResolver extends BasePlugin implements Resolver {
      */
     @Override
     public OneRow setFields(List<OneField> record) throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Current operation is not supported");
     }
 
     /**

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonResolverTest.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonResolverTest.java
@@ -409,7 +409,7 @@ public class JsonResolverTest {
         resolver.setRequestContext(context);
         resolver.afterPropertiesSet();
         Exception e = assertThrows(UnsupportedOperationException.class, () -> resolver.setFields(null));
-        assertEquals("Current operation is not supported", e.getMessage());
+        assertEquals("JSON resolver does not support write operation.", e.getMessage());
     }
 
     // helper functions for testing

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonResolverTest.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonResolverTest.java
@@ -408,7 +408,8 @@ public class JsonResolverTest {
         context.setMetadata(null);
         resolver.setRequestContext(context);
         resolver.afterPropertiesSet();
-        assertThrows(UnsupportedOperationException.class, () -> resolver.setFields(null));
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> resolver.setFields(null));
+        assertEquals("Current operation is not supported", e.getMessage());
     }
 
     // helper functions for testing

--- a/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3SelectAccessor.java
+++ b/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3SelectAccessor.java
@@ -46,7 +46,7 @@ public class S3SelectAccessor extends BasePlugin implements Accessor {
     public static final String FILE_HEADER_INFO_IGNORE = "IGNORE";
     public static final String FILE_HEADER_INFO_USE = "USE";
     public static final String JSON_TYPE = "JSON-TYPE";
-    private static final String UNSUPPORTED_ERR_MESSAGE = "S3 Select does not support writing";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "S3 Select accessor does not support write operation.";
 
     private AtomicBoolean isResultComplete;
     private AmazonS3 s3Client;

--- a/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3SelectAccessor.java
+++ b/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3SelectAccessor.java
@@ -46,6 +46,7 @@ public class S3SelectAccessor extends BasePlugin implements Accessor {
     public static final String FILE_HEADER_INFO_IGNORE = "IGNORE";
     public static final String FILE_HEADER_INFO_USE = "USE";
     public static final String JSON_TYPE = "JSON-TYPE";
+    private static final String UNSUPPORTED_ERR_MESSAGE = "S3 Select does not support writing";
 
     private AtomicBoolean isResultComplete;
     private AmazonS3 s3Client;
@@ -317,16 +318,16 @@ public class S3SelectAccessor extends BasePlugin implements Accessor {
 
     @Override
     public boolean openForWrite() {
-        throw new UnsupportedOperationException("S3 Select does not support writing");
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     @Override
     public boolean writeNextObject(OneRow onerow) {
-        throw new UnsupportedOperationException("S3 Select does not support writing");
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 
     @Override
     public void closeForWrite() {
-        throw new UnsupportedOperationException("S3 Select does not support writing");
+        throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
     }
 }

--- a/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3SelectAccessorTest.java
+++ b/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3SelectAccessorTest.java
@@ -214,21 +214,21 @@ public class S3SelectAccessorTest {
     public void testFailsOnOpenForWrite() {
         Exception e = assertThrows(UnsupportedOperationException.class,
                 () -> new S3SelectAccessor().openForWrite());
-        assertEquals("S3 Select does not support writing", e.getMessage());
+        assertEquals("S3 Select accessor does not support write operation.", e.getMessage());
     }
 
     @Test
     public void testFailsOnWriteNextObject() {
         Exception e = assertThrows(UnsupportedOperationException.class,
                 () -> new S3SelectAccessor().writeNextObject(new OneRow()));
-        assertEquals("S3 Select does not support writing", e.getMessage());
+        assertEquals("S3 Select accessor does not support write operation.", e.getMessage());
     }
 
     @Test
     public void testFailsOnCloseForWrite() {
         Exception e = assertThrows(UnsupportedOperationException.class,
                 () -> new S3SelectAccessor().closeForWrite());
-        assertEquals("S3 Select does not support writing", e.getMessage());
+        assertEquals("S3 Select accessor does not support write operation.", e.getMessage());
     }
 
     private RequestContext getDefaultRequestContext() {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadBridge.java
@@ -150,7 +150,7 @@ public class ReadBridge extends BaseBridge {
      */
     @Override
     public boolean setNext(DataInputStream inputStream) {
-        throw new UnsupportedOperationException("Current operation is not supported");
+        throw new UnsupportedOperationException("Write operation is not supported.");
     }
 
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/ReadBridge.java
@@ -150,7 +150,7 @@ public class ReadBridge extends BaseBridge {
      */
     @Override
     public boolean setNext(DataInputStream inputStream) {
-        throw new UnsupportedOperationException("setNext is not implemented");
+        throw new UnsupportedOperationException("Current operation is not supported");
     }
 
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/SimpleBridgeFactory.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/SimpleBridgeFactory.java
@@ -28,7 +28,7 @@ public class SimpleBridgeFactory implements BridgeFactory {
         if (context.getRequestType() == RequestContext.RequestType.WRITE_BRIDGE) {
             bridge = new WriteBridge(pluginFactory, context, failureHandler);
         } else if (context.getRequestType() != RequestContext.RequestType.READ_BRIDGE) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("Current Operation is not supported");
         } else if (context.getStatsSampleRatio() > 0) {
             bridge = new ReadSamplingBridge(pluginFactory, context, failureHandler);
         } else if (Utilities.aggregateOptimizationsSupported(context)) {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/WriteBridge.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/bridge/WriteBridge.java
@@ -99,7 +99,7 @@ public class WriteBridge extends BaseBridge {
      */
     @Override
     public Writable getNext() {
-        throw new UnsupportedOperationException("getNext is not implemented");
+        throw new UnsupportedOperationException("Current operation is not supported");
     }
 
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
@@ -40,11 +40,6 @@ public abstract class PxfErrorReporter<T> {
             // let PxfRuntimeException and Error propagate themselves
             log.error(e.getMessage(), e);
             throw e;
-        } catch (UnsupportedOperationException e) {
-            String errorMessage = e.getStackTrace()[0] != null ? e.getStackTrace()[0].getMethodName() : "Current Operation";
-            errorMessage = errorMessage + " is not implemented";
-            log.error(errorMessage, e);
-            throw new PxfRuntimeException(errorMessage, e );
         } catch (Exception e) {
             log.error(StringUtils.defaultIfBlank(e.getMessage(), e.getClass().getName()), e);
             // wrap into PxfRuntimeException so that it can be handled by the PxfExceptionHandler

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
@@ -40,6 +40,9 @@ public abstract class PxfErrorReporter<T> {
             // let PxfRuntimeException and Error propagate themselves
             log.error(e.getMessage(), e);
             throw e;
+        } catch (UnsupportedOperationException e) {
+            log.error(e.getStackTrace()[0].getMethodName()+" is not implemented" , e);
+            throw new PxfRuntimeException(e.getStackTrace()[0].getMethodName()+" is not implemented", e );
         } catch (Exception e) {
             log.error(StringUtils.defaultIfBlank(e.getMessage(), e.getClass().getName()), e);
             // wrap into PxfRuntimeException so that it can be handled by the PxfExceptionHandler

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
@@ -41,8 +41,10 @@ public abstract class PxfErrorReporter<T> {
             log.error(e.getMessage(), e);
             throw e;
         } catch (UnsupportedOperationException e) {
-            log.error(e.getStackTrace()[0].getMethodName()+" is not implemented" , e);
-            throw new PxfRuntimeException(e.getStackTrace()[0].getMethodName()+" is not implemented", e );
+            String errorMessage = e.getStackTrace()[0] != null ? e.getStackTrace()[0].getMethodName() : "Current Operation";
+            errorMessage = errorMessage + " is not implemented";
+            log.error(errorMessage, e);
+            throw new PxfRuntimeException(errorMessage, e );
         } catch (Exception e) {
             log.error(StringUtils.defaultIfBlank(e.getMessage(), e.getClass().getName()), e);
             // wrap into PxfRuntimeException so that it can be handled by the PxfExceptionHandler

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadBridgeTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadBridgeTest.java
@@ -145,6 +145,6 @@ public class ReadBridgeTest {
         bridge = new ReadBridge(mockPluginFactory, context, handler);
 
         Exception e = assertThrows(UnsupportedOperationException.class, () -> bridge.setNext(null));
-        assertEquals("Current operation is not supported", e.getMessage());
+        assertEquals("Write operation is not supported.", e.getMessage());
     }
 }

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadBridgeTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/ReadBridgeTest.java
@@ -140,4 +140,11 @@ public class ReadBridgeTest {
         verifyNoMoreInteractions(mockPluginFactory);
     }
 
+    @Test
+    public void testSetNextIsNotSupported() {
+        bridge = new ReadBridge(mockPluginFactory, context, handler);
+
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> bridge.setNext(null));
+        assertEquals("Current operation is not supported", e.getMessage());
+    }
 }

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/WriteBridgeTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/bridge/WriteBridgeTest.java
@@ -140,4 +140,11 @@ public class WriteBridgeTest {
         verifyNoMoreInteractions(mockPluginFactory);
     }
 
+    @Test
+    public void testGetNextIsNotSupported() {
+        bridge = new WriteBridge(mockPluginFactory, context, handler);
+
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> bridge.getNext());
+        assertEquals("Current operation is not supported", e.getMessage());
+    }
 }


### PR DESCRIPTION
There are places in the code where we are throwing `UnsupportedOperationException` without any error message  and the empty error message isn't very useful to the user. For eg: `ERROR:  PXF server error : No message available`

This PR adds error messages to the places where we are throwing `UnsupportedOperationException` 