### PR TITLE
docs - remove refs to PXF cluster

### DIFF
--- a/docs/content/pxf_gpupgrade_post.html.md.erb
+++ b/docs/content/pxf_gpupgrade_post.html.md.erb
@@ -13,7 +13,7 @@ Perform the following steps after running `gpupgrade`:
 
 1. **If the `gpupgrade` process failed**:
 
-    1. Run the following commands to roll back your PXF cluster to its previous state (before you ran `pxf-pre-gpupgrade`):
+    1. Run the following commands to roll back your PXF installation to its previous state (before you ran `pxf-pre-gpupgrade`):
 
         ``` shell
         gpadmin@gpmaster$ export GPHOME=<greenplum5-install-dir>
@@ -22,7 +22,7 @@ Perform the following steps after running `gpupgrade`:
 
         **Note:** The `pxf-post-upgrade` script must connect to your running Greenplum Database 5.x cluster. By default, it attempts to connect to the `gpadmin` database on `localhost` on port `5432` as the `gpadmin` user, no password. If you need to customize these settings, refer to [Customizing the Greenplum Connection Parameters](#env) for instructions on setting environment variables for this purpose.
 
-    1. Restart the PXF cluster running in your Greenplum Database 5.x installation.
+    1. Restart the PXF that was running in your Greenplum Database 5.x installation.
 
         ``` shell
         gpadmin@gpmaster$ /usr/local/pxf-gp5/bin/pxf cluster start
@@ -34,7 +34,7 @@ Perform the following steps after running `gpupgrade`:
 
 1. **If the `gpupgrade` process succeeded, perform the remaining steps in this procedure.**
 
-1. Configure your PXF cluster as though it was a fresh install in Greenplum Database 6.x:
+1. Configure PXF as though it was a fresh install in Greenplum Database 6.x:
 
     ``` shell
     gpadmin@gpmaster$ export GPHOME=<greenplum6-install-dir>
@@ -57,7 +57,7 @@ Perform the following steps after running `gpupgrade`:
     gpadmin@gpmaster$ /usr/local/pxf-gp6/bin/pxf cluster sync
     ```
 
-1. Start the PXF cluster running in your Greenplum Database 6.x installation.
+1. Start the PXF installed for Greenplum Database 6.x.
 
     ``` shell
     gpadmin@gpmaster$ /usr/local/pxf-gp6/bin/pxf cluster start

--- a/docs/content/pxf_gpupgrade_pre.html.md.erb
+++ b/docs/content/pxf_gpupgrade_pre.html.md.erb
@@ -31,13 +31,13 @@ Before you run `gpupgrade`, perform the following steps:
 
     **Note:** The `pxf-pre-gpupgrade` script must connect to your running Greenplum Database 5.x cluster. By default, it attempts to connect to the `gpadmin` database on `localhost` on port `5432` as the `gpadmin` user (no password). If you need to customize these settings, refer to [Customizing the Greenplum Connection Parameters](#env) for instructions on setting environment variables for this purpose.
 
-1. Stop the PXF cluster; note that PXF external tables will be inaccessible during the Greenplum Database upgrade process.
+1. Stop PXF; note that PXF external tables will be inaccessible during the Greenplum Database upgrade process.
 
     ``` shell
     gpadmin@gpmaster$ /usr/local/pxf-gp5/bin/pxf cluster stop
     ```
 
-1. Your PXF cluster is ready for upgrading by `gpupgrade`; return to the `gpupgrade` documentation to upgrade from Greenplum Database 5.x to Greenplum Database 6.x.
+1. PXF is ready for upgrading by `gpupgrade`; return to the `gpupgrade` documentation to upgrade from Greenplum Database 5.x to Greenplum Database 6.x.
 
 
 ## <a id="env"></a>Customizing the Greenplum Connection Parameters


### PR DESCRIPTION
the newly-added pre/post upgrade topics include references to PXF cluster.  reword those.