### PR TITLE
docs - replace  with <PXF_INSTALL_DIR>

### DIFF
--- a/docs/content/about_pxf_dir.html.md.erb
+++ b/docs/content/about_pxf_dir.html.md.erb
@@ -2,20 +2,20 @@
 title: About the PXF Installation and Configuration Directories
 ---
 
-This documentation uses `$PXF_HOME` to refer to the PXF installation directory. Its value depends on how you have installed PXF:
+This documentation uses `<PXF_INSTALL_DIR>` to refer to the PXF installation directory. Its value depends on how you have installed PXF:
 
  - If you installed PXF as part of Greenplum Database, its value is `$GPHOME/pxf`.
  - If you installed the PXF `rpm` or `deb` package, its value is `/usr/local/pxf-gp<greenplum-major-version>`, or the directory of your choosing (CentOS/RHEL only). 
 
-`$PXF_HOME` includes both the PXF executables and the PXF runtime configuration files and directories. In PXF 5.x, you needed to specify a `$PXF_CONF` directory for the runtime configuration when you initialized PXF. In PXF 6.x, however, no initialization is required: `$PXF_BASE` now identifies the runtime configuration directory, and the default `$PXF_BASE` is `$PXF_HOME`.
+`<PXF_INSTALL_DIR>` includes both the PXF executables and the PXF runtime configuration files and directories. In PXF 5.x, you needed to specify a `$PXF_CONF` directory for the runtime configuration when you initialized PXF. In PXF 6.x, however, no initialization is required: `$PXF_BASE` now identifies the runtime configuration directory, and the default `$PXF_BASE` is `<PXF_INSTALL_DIR>`.
 
 If you want to store your configuration and runtime files in a different location, see [Relocating $PXF_BASE](#movebase).
 
-<div class="note">This documentation uses the <code>$PXF_HOME</code> environment variable to reference the PXF installation directory. PXF uses this variable internally at runtime; it is not set in your shell environment, and will display as empty if you attempt to <code>echo</code> its value. Similarly, this documentation uses the <code>$PXF_BASE</code> environment variable to reference the PXF runtime configuration directory. PXF uses the variable internally. It only needs to be set in your shell environment if you explicitly relocate the directory.</div>
+<div class="note">This documentation uses <code>&lt;PXF_INSTALL_DIR></code> to reference the PXF installation directory. This documentation uses the <code>$PXF_BASE</code> environment variable to reference the PXF runtime configuration directory. PXF uses the variable internally. It only needs to be set in your shell environment if you explicitly relocate the directory.</div>
 
 ## <a id="installed"></a>PXF Installation Directories
 
-The following PXF files and directories are installed to `$PXF_HOME` when you install Greenplum Database or the PXF 6.x `rpm` or `deb` package:
+The following PXF files and directories are installed to `<PXF_INSTALL_DIR>` when you install Greenplum Database or the PXF 6.x `rpm` or `deb` package:
 
 | Directory | Description                                                                                                   |
 |--------------------------------|------------------------------------------------------------------------------------------|
@@ -42,7 +42,7 @@ Refer to [Configuring PXF](instcfg_pxf.html) and [Starting PXF](cfginitstart_pxf
 
 ## <a id="movebase"></a>Relocating $PXF_BASE
 
-If you require that `$PXF_BASE` reside in a directory distinct from `$PXF_HOME`, you can change it from the default location to a location of your choosing after you install PXF 6.x.
+If you require that `$PXF_BASE` reside in a directory distinct from `<PXF_INSTALL_DIR>`, you can change it from the default location to a location of your choosing after you install PXF 6.x.
 
 PXF provides the [pxf [cluster] prepare](ref/pxf-cluster.html) command to prepare a new `$PXF_BASE` location. The command copies the runtime and configuration directories identified above to the file system location that you specify in a `PXF_BASE` environment variable.
 
@@ -52,7 +52,7 @@ For example, to relocate `$PXF_BASE` to the `/path/to/dir` directory on all Gree
 gpadmin@gpmaster$ PXF_BASE=/path/to/dir pxf cluster prepare
 ```
 
-When your `$PXF_BASE` is different than `$PXF_HOME`, inform PXF by setting the `PXF_BASE` environment variable when you run a `pxf` command:
+When your `$PXF_BASE` is different than `<PXF_INSTALL_DIR>`, inform PXF by setting the `PXF_BASE` environment variable when you run a `pxf` command:
 
 ``` pre
 gpadmin@gpmaster$ PXF_BASE=/path/to/dir pxf cluster start

--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -22,10 +22,10 @@ A server configuration may include default settings for user access credentials 
 
 The configuration information for a PXF server resides in one or more `<connector>-site.xml` files in `$PXF_BASE/servers/<server_name>/`.
 
-PXF provides a template configuration file for each connector.  These server template configuration files are located in the `$PXF_HOME/templates/` directory after you install PXF:
+PXF provides a template configuration file for each connector.  These server template configuration files are located in the `<PXF_INSTALL_DIR>/templates/` directory after you install PXF:
 
 ```
-gpadmin@gpmaster$ ls $PXF_HOME/templates
+gpadmin@gpmaster$ ls <PXF_INSTALL_DIR>/templates
 adl-site.xml   hbase-site.xml  jdbc-site.xml    pxf-site.xml    yarn-site.xml
 core-site.xml  hdfs-site.xml   mapred-site.xml  s3-site.xml
 gs-site.xml    hive-site.xml   minio-site.xml   wasbs-site.xml

--- a/docs/content/cfginitstart_pxf.html.md.erb
+++ b/docs/content/cfginitstart_pxf.html.md.erb
@@ -27,7 +27,7 @@ PXF provides two management commands:
 - [`pxf cluster`](ref/pxf-cluster.html) - manage all PXF Service instances in the Greenplum Database cluster
 - [`pxf`](ref/pxf.html) - manage the PXF Service instance on a specific Greenplum Database host
 
-<div class="note">The procedures in this topic assume that you have added the <code>$PXF_HOME/bin</code> directory to your <code>$PATH</code>.</div>
+<div class="note">The procedures in this topic assume that you have added the <code>&lt;PXF_INSTALL_DIR>/bin</code> directory to your <code>$PATH</code>.</div>
 
 
 ## <a id="start_pxf"></a>Starting PXF

--- a/docs/content/hbase_pxf.html.md.erb
+++ b/docs/content/hbase_pxf.html.md.erb
@@ -12,7 +12,7 @@ This section describes how to use the PXF HBase connector.
 
 Before working with HBase table data, ensure that you have:
 
-- Copied `$PXF_HOME/share/pxf-hbase-*.jar` to each node in your HBase cluster, and that the location of this PXF JAR file is in the `$HBASE_CLASSPATH`. This configuration is required for the PXF HBase connector to support filter pushdown.
+- Copied `<PXF_INSTALL_DIR>/share/pxf-hbase-*.jar` to each node in your HBase cluster, and that the location of this PXF JAR file is in the `$HBASE_CLASSPATH`. This configuration is required for the PXF HBase connector to support filter pushdown.
 - Met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq).
 
 ## <a id="hbase_primer"></a>HBase Primer

--- a/docs/content/hive_jdbc_cfg.html.md.erb
+++ b/docs/content/hive_jdbc_cfg.html.md.erb
@@ -73,13 +73,13 @@ Perform the following procedure to configure a PXF JDBC server for Hive:
 4. Copy the PXF JDBC server template file to the server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/jdbc-site.xml .
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/jdbc-site.xml .
     ```
         
 4. When you access Hive secured with Kerberos, you also need to specify configuration properties in the `pxf-site.xml` file. *If this file does not yet exist in your server configuration*, copy the `pxf-site.xml` template file to the server config directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/pxf-site.xml .
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
         
 5. Open the `jdbc-site.xml` file in the editor of your choice and set the `jdbc.driver` and `jdbc.url` properties. Be sure to specify your Hive host, port, and database name:

--- a/docs/content/jdbc_cfg.html.md.erb
+++ b/docs/content/jdbc_cfg.html.md.erb
@@ -25,7 +25,7 @@ PXF is bundled with the `postgresql-42.3.3.jar` JAR file. If you require a diffe
 
 When you configure the PXF JDBC Connector, you add at least one named PXF server configuration for the connector as described in [Configuring PXF Servers](cfg_server.html). You can also configure one or more statically-defined queries to run against the remote SQL database.
 
-PXF provides a template configuration file for the JDBC Connector. This server template configuration file, located in `$PXF_HOME/templates/jdbc-site.xml`, identifies properties that you can configure to establish a connection to the external SQL database. The template also includes optional properties that you can set before executing query or insert commands in the external database session.
+PXF provides a template configuration file for the JDBC Connector. This server template configuration file, located in `<PXF_INSTALL_DIR>/templates/jdbc-site.xml`, identifies properties that you can configure to establish a connection to the external SQL database. The template also includes optional properties that you can set before executing query or insert commands in the external database session.
 
 The required properties in the `jdbc-site.xml` server template file follow:
 
@@ -355,7 +355,7 @@ In this procedure, you name and add a PXF JDBC server configuration for a Postgr
 4. Copy the PXF JDBC server template file to the server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/jdbc-site.xml $PXF_BASE/servers/pg_user1_testdb/
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/jdbc-site.xml $PXF_BASE/servers/pg_user1_testdb/
     ```
         
 5. Open the template server configuration file in the editor of your choice, and provide appropriate property values for your environment. For example, if you are configuring access to a PostgreSQL database named `testdb` on a PostgreSQL instance running on the host named `pgserverhost` for the user named `user1`:

--- a/docs/content/nfs_pxf.html.md.erb
+++ b/docs/content/nfs_pxf.html.md.erb
@@ -34,7 +34,7 @@ Before you use PXF to access files on a network file system, ensure that:
 
 Before you use PXF to access a file on a network file system, you must create a server configuration and then synchronize the PXF configuration to all Greenplum hosts.  This procedure will typically be performed by the Greenplum Database administrator.
 
-Use the server template configuration file `$PXF_HOME/templates/pxf-site.xml` when you configure a network file system server for PXF. This template file includes the mandatory property `pxf.fs.basePath` that you configure to identify the network file system share path. PXF considers the file path that you specify in a `CREATE EXTERNAL TABLE` `LOCATION` clause that uses this server to be relative to this share path.
+Use the server template configuration file `<PXF_INSTALL_DIR>/templates/pxf-site.xml` when you configure a network file system server for PXF. This template file includes the mandatory property `pxf.fs.basePath` that you configure to identify the network file system share path. PXF considers the file path that you specify in a `CREATE EXTERNAL TABLE` `LOCATION` clause that uses this server to be relative to this share path.
 
 PXF does not support user impersonation when you access a network file system; you must explicitly turn off user impersonation in a network file system server configuration.
 
@@ -57,7 +57,7 @@ PXF does not support user impersonation when you access a network file system; y
 4. Copy the PXF `pxf-site.xml` template file to the `nfssrvcfg` server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/pxf-site.xml $PXF_BASE/servers/nfssrvcfg/
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml $PXF_BASE/servers/nfssrvcfg/
     ```
 
 5. Open the template server configuration file in the editor of your choice, and uncomment and provide property values appropriate for your environment. For example, if the file system share point is the directory named `/mnt/extdata/pxffs`, uncomment and set these server properties:

--- a/docs/content/objstore_cfg.html.md.erb
+++ b/docs/content/objstore_cfg.html.md.erb
@@ -10,12 +10,12 @@ You can use PXF to access Azure Data Lake, Azure Blob Storage, and Google Cloud 
 
 To access data in an object store, you must provide a server location and client credentials. When you configure a PXF object store connector, you add at least one named PXF server configuration for the connector as described in [Configuring PXF Servers](cfg_server.html).
 
-PXF provides a template configuration file for each object store connector. These template files are located in the `$PXF_HOME/templates/` directory.
+PXF provides a template configuration file for each object store connector. These template files are located in the `<PXF_INSTALL_DIR>/templates/` directory.
 
 
 ### <a id="abs_cfg"></a>Azure Blob Storage Server Configuration
 
-The template configuration file for Azure Blob Storage is `$PXF_HOME/templates/wasbs-site.xml`. When you configure an Azure Blob Storage server, you must provide the following server configuration properties and replace the template value with your account name:
+The template configuration file for Azure Blob Storage is `<PXF_INSTALL_DIR>/templates/wasbs-site.xml`. When you configure an Azure Blob Storage server, you must provide the following server configuration properties and replace the template value with your account name:
 
 | Property       | Description                                | Value |
 |----------------|--------------------------------------------|-------|
@@ -26,7 +26,7 @@ The template configuration file for Azure Blob Storage is `$PXF_HOME/templates/w
 
 ### <a id="adl_cfg"></a>Azure Data Lake Server Configuration
 
-The template configuration file for Azure Data Lake is `$PXF_HOME/templates/adl-site.xml`. When you configure an Azure Data Lake server, you must provide the following server configuration properties and replace the template values with your credentials:
+The template configuration file for Azure Data Lake is `<PXF_INSTALL_DIR>/templates/adl-site.xml`. When you configure an Azure Data Lake server, you must provide the following server configuration properties and replace the template values with your credentials:
 
 | Property       | Description                                | Value |
 |----------------|--------------------------------------------|-------|
@@ -38,7 +38,7 @@ The template configuration file for Azure Data Lake is `$PXF_HOME/templates/adl-
 
 ### <a id="gcs_cfg"></a>Google Cloud Storage Server Configuration
 
-The template configuration file for Google Cloud Storage is `$PXF_HOME/templates/gs-site.xml`. When you configure a Google Cloud Storage server, you must provide the following server configuration properties and replace the template values with your credentials:
+The template configuration file for Google Cloud Storage is `<PXF_INSTALL_DIR>/templates/gs-site.xml`. When you configure a Google Cloud Storage server, you must provide the following server configuration properties and replace the template values with your credentials:
 
 | Property       | Description                                | Value |
 |----------------|--------------------------------------------|-------|
@@ -68,7 +68,7 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_BASE
 3. Copy the PXF template file for GCS to the server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/gs-site.xml $PXF_BASE/servers/gs_public/
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/gs-site.xml $PXF_BASE/servers/gs_public/
     ```
         
 4. Open the template server configuration file in the editor of your choice, and provide appropriate property values for your environment. For example, if your Google Cloud Storage key file is located in `/home/gpadmin/keys/gcs-account.key.json`:

--- a/docs/content/pxf_kerbhdfs.html.md.erb
+++ b/docs/content/pxf_kerbhdfs.html.md.erb
@@ -186,7 +186,7 @@ When you configure PXF for secure HDFS using an AD Kerberos KDC server, you will
 3. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/pxf-site.xml .
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 4. Open the `pxf-site.xml` file in the editor of your choice, and update the keytab and principal property settings, if required. Specify the location of the keytab file and the Kerberos principal, substituting your realm. For example:
@@ -298,7 +298,7 @@ When you configure PXF for secure HDFS using an MIT Kerberos KDC server, you wil
 4. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/pxf-site.xml .
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 5. Open the `pxf-site.xml` file in the editor of your choice, and update the keytab and principal property settings, if required. Specify the location of the keytab file and the Kerberos principal, substituting your realm. *The default values for these settings are identified below*:
@@ -364,7 +364,7 @@ By default, Kerberos constrained delegation is disabled for PXF. Perform the fol
 1. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/pxf-site.xml .
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 1. Open the `pxf-site.xml` file in the editor of your choice, locate the `pxf.service.kerberos-constrained.delegation` property, and set it as follows:

--- a/docs/content/pxfuserimpers.html.md.erb
+++ b/docs/content/pxfuserimpers.html.md.erb
@@ -103,7 +103,7 @@ Perform the following procedure to configure the Hadoop user:
 4. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/pxf-site.xml .
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 5. Open the `pxf-site.xml` file in the editor of your choice, and configure the Hadoop user name. When impersonation is disabled, this name identifies the Hadoop user identity that PXF will use to access the Hadoop system. When user impersonation is enabled for a non-secure Hadoop cluster, this name identifies the PXF proxy Hadoop user. For example, if you want to access Hadoop as the user `hdfsuser1`, uncomment the property and set it as follows:
@@ -139,7 +139,7 @@ PXF user impersonation is enabled by default for Hadoop servers. You can configu
 2. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/pxf-site.xml .
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 3. Open the `pxf-site.xml` file in the editor of your choice, and update the user impersonation property setting. For example, if you do not require user impersonation for this server configuration, set the `pxf.service.user.impersonation` property to `false`:

--- a/docs/content/s3_objstore_cfg.html.md.erb
+++ b/docs/content/s3_objstore_cfg.html.md.erb
@@ -10,12 +10,12 @@ You can use PXF to access S3-compatible object stores. This topic describes how 
 
 To access data in an object store, you must provide a server location and client credentials. When you configure a PXF object store connector, you add at least one named PXF server configuration for the connector as described in [Configuring PXF Servers](cfg_server.html).
 
-PXF provides a configuration file template for each object store connector. These template files are located in the `$PXF_HOME/templates/` directory.
+PXF provides a configuration file template for each object store connector. These template files are located in the `<PXF_INSTALL_DIR>/templates/` directory.
 
 
 ## <a id="minio_cfg"></a>Minio Server Configuration
 
-The template configuration file for Minio is `$PXF_HOME/templates/minio-site.xml`. When you configure a Minio server, you must provide the following server configuration properties and replace the template values with your credentials:
+The template configuration file for Minio is `<PXF_INSTALL_DIR>/templates/minio-site.xml`. When you configure a Minio server, you must provide the following server configuration properties and replace the template values with your credentials:
 
 | Property       | Description                                | Value |
 |----------------|--------------------------------------------|------ |
@@ -25,7 +25,7 @@ The template configuration file for Minio is `$PXF_HOME/templates/minio-site.xml
 
 ## <a id="s3_cfg"></a>S3 Server Configuration
 
-The template configuration file for S3 is `$PXF_HOME/templates/s3-site.xml`. When you configure an S3 server, you must provide the following server configuration properties and replace the template values with your credentials:
+The template configuration file for S3 is `<PXF_INSTALL_DIR>/templates/s3-site.xml`. When you configure an S3 server, you must provide the following server configuration properties and replace the template values with your credentials:
 
 | Property       | Description                                | Value |
 |----------------|--------------------------------------------|-------|
@@ -162,7 +162,7 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_BASE
 3. Copy the PXF template file for S3 to the server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp $PXF_HOME/templates/s3-site.xml $PXF_BASE/servers/s3srvcfg/
+    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/s3-site.xml $PXF_BASE/servers/s3srvcfg/
     ```
         
 4. Open the template server configuration file in the editor of your choice, and provide appropriate property values for your environment. For example:

--- a/docs/content/upgrade_5_to_6.html.md.erb
+++ b/docs/content/upgrade_5_to_6.html.md.erb
@@ -56,7 +56,7 @@ After you install the new version of PXF, perform the following procedure:
     gpadmin@gpmaster$ pxf version
     ```
 
-1. (Optional, Advanced) If you want to relocate `$PXF_BASE` outside of `$PXF_HOME`, perform the procedure described in [Relocating $PXF_BASE](about_pxf_dir.html#movebase).
+1. (Optional, Advanced) If you want to relocate `$PXF_BASE` outside of `<PXF_INSTALL_DIR>`, perform the procedure described in [Relocating $PXF_BASE](about_pxf_dir.html#movebase).
 
 1. Auto-migrate your PXF 5.x configuration to PXF 6.x `$PXF_BASE`:
 
@@ -138,7 +138,7 @@ After you install the new version of PXF, perform the following procedure:
     gpadmin@gpmaster$ pxf cluster register
     ```
 
-    The `register` command copies only the `pxf.control` extension file to the Greenplum cluster. In PXF 6.x, the PXF extension `.sql` file and library `pxf.so` reside in `$PXF_HOME/gpextable`. You may choose to remove these now-unused files from the Greenplum Database installation *on the Greenplum Database master host, the standby master host, and all segment hosts*. For example, to remove the files on the master host:
+    The `register` command copies only the `pxf.control` extension file to the Greenplum cluster. In PXF 6.x, the PXF extension `.sql` file and library `pxf.so` reside in `<PXF_INSTALL_DIR>/gpextable`. You may choose to remove these now-unused files from the Greenplum Database installation *on the Greenplum Database master host, the standby master host, and all segment hosts*. For example, to remove the files on the master host:
 
     ``` shell
     gpadmin@gpmaster$ rm $GPHOME/share/postgresql/extension/pxf--1.0.sql
@@ -161,9 +161,9 @@ After you install the new version of PXF, perform the following procedure:
     | `PXF_PRINCIPAL` configuration property | `pxf.service.kerberos.principal` property in the [pxf&#8209;site.xml](cfg_server.html#pxf-site) server configuration file |
     | `PXF_USER_IMPERSONATION` configuration property | `pxf.service.user.impersonation` property in the [pxf&#8209;site.xml](cfg_server.html#pxf-site) server configuration file |
 
-1. PXF 6.x distributes a single JAR file that includes all of its dependencies, and separately makes its HBase JAR file available in `$PXF_HOME/share`. If you have configured a PXF Hadoop server for HBase access, you must register the new `pxf-hbase-<version>.jar` with Hadoop and HBase as follows:
+1. PXF 6.x distributes a single JAR file that includes all of its dependencies, and separately makes its HBase JAR file available in `<PXF_INSTALL_DIR>/share`. If you have configured a PXF Hadoop server for HBase access, you must register the new `pxf-hbase-<version>.jar` with Hadoop and HBase as follows:
 
-    1. Copy `$PXF_HOME/share/pxf-hbase-<version>.jar` to each node in your HBase cluster.
+    1. Copy `<PXF_INSTALL_DIR>/share/pxf-hbase-<version>.jar` to each node in your HBase cluster.
     1. Add the location of this JAR to `$HBASE_CLASSPATH` on each HBase node.
     1. Restart HBase on each node.
 


### PR DESCRIPTION
PXF_HOME is not set in the users environment, its use in the docs is confusing.  replace $PXF_HOME with <PXF_INSTALL_DIR>.  (will deal with PXF_BASE in a separate PR.)

addresses: https://github.com/greenplum-db/sre-test/issues/277