### PR TITLE
docs - troubleshooting topic for orc no vectorize returning all nulls

### DIFF
--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -144,7 +144,7 @@ By default, PXF does not bundle the LZO compression library. If the Hadoop clust
 
 ## <a id="hiveorcnulls"></a>Reading from a Hive table STORED AS ORC Returns NULLs
 
-If you are using PXF to read from a Hive table `STORED AS ORC` and all columns are returned as NULLs, there may be a case sensitivity issue between the column names specified in the Hive table definition and those specified in the ORC embedded schema definition.
+If you are using PXF to read from a Hive table `STORED AS ORC` and all columns are returned as NULLs, there may be a case sensitivity issue between the column names specified in the Hive table definition and those specified in the ORC embedded schema definition. This might happen if the table has been created and populated by another system such as Spark.
 
 The workaround described in this section applies when all of the following hold true:
 

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -154,6 +154,8 @@ The workaround described in this section applies when all of the following hold 
 
 To remedy this situation, perform the following procedure:
 
+1. Log in to the Greenplum Database master host.
+
 1. Identify the name of your Hadoop PXF server configuration.
 
 1. Locate the `hive-site.xml` configuration file in the server configuration directory. For example, if `$PXF_BASE` is `/usr/local/pxf-gp6` and the server name is `<server_name`, this file is located here:

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -142,3 +142,47 @@ By default, PXF does not bundle the LZO compression library. If the Hadoop clust
 
 1. Re-run the query.
 
+## <a id="hiveorcnulls"></a>Reading from a Hive table STORED AS ORC Returns NULLs
+
+If you are using PXF to read from a Hive table `STORED AS ORC` and all columns are returned as NULLs, there may be a case sensitivity issue between the column names specified in the Hive table definition and those specified in the ORC embedded schema definition.
+
+The workaround described in this section applies when all of the following hold true:
+
+- The Greenplum Database PXF external table that you created specifies the `hive:orc` profile.
+- The Greenplum Database PXF external table that you created specifies the `VECTORIZE=false` (the default) setting.
+- There is a case mis-match between the column names specified in the Hive table schema and the column names specified in the ORC embedded schema.
+
+To remedy this situation, perform the following procedure:
+
+1. Identify the name of your Hadoop PXF server configuration.
+
+1. Locate the `hive-site.xml` configuration file in the server configuration directory. For example, if `$PXF_BASE` is `/usr/local/pxf-gp6` and the server name is `<server_name`, this file is located here:
+
+    ``` pre
+    /usr/local/pxf-gp6/servers/<server_name>/hive-site.xml
+    ```
+
+1. Add or update the following property definition in the `hive-site.xml` file, and then save and exit the editor:
+
+    ``` xml
+    <property>
+        <name>orc.schema.evolution.case.sensitive</name>
+        <value>false</value>
+        <description>A boolean flag to determine if the comparision of field names in schema evolution is case sensitive.</description>
+    </property>
+    ```
+
+1. Synchronize the PXF server configuration to your Greenplum Database cluster:
+
+    ``` shell
+    gpadmin@gpmaster$ pxf cluster sync
+    ````
+
+1. Restart PXF:
+
+    ``` shell
+    gpadmin@gpmaster$ pxf cluster restart
+    ````
+
+1. Try the query again.
+

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -144,7 +144,7 @@ By default, PXF does not bundle the LZO compression library. If the Hadoop clust
 
 ## <a id="hiveorcnulls"></a>Reading from a Hive table STORED AS ORC Returns NULLs
 
-If you are using PXF to read from a Hive table `STORED AS ORC` and all columns are returned as NULLs, there may be a case sensitivity issue between the column names specified in the Hive table definition and those specified in the ORC embedded schema definition. This might happen if the table has been created and populated by another system such as Spark.
+If you are using PXF to read from a Hive table `STORED AS ORC` and one or more columns that have values are returned as NULLs, there may be a case sensitivity issue between the column names specified in the Hive table definition and those specified in the ORC embedded schema definition. This might happen if the table has been created and populated by another system such as Spark.
 
 The workaround described in this section applies when all of the following hold true:
 

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -158,7 +158,7 @@ To remedy this situation, perform the following procedure:
 
 1. Identify the name of your Hadoop PXF server configuration.
 
-1. Locate the `hive-site.xml` configuration file in the server configuration directory. For example, if `$PXF_BASE` is `/usr/local/pxf-gp6` and the server name is `<server_name`, this file is located here:
+1. Locate the `hive-site.xml` configuration file in the server configuration directory. For example, if `$PXF_BASE` is `/usr/local/pxf-gp6` and the server name is `<server_name>`, this file is located here:
 
     ``` pre
     /usr/local/pxf-gp6/servers/<server_name>/hive-site.xml

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -180,11 +180,5 @@ To remedy this situation, perform the following procedure:
     gpadmin@gpmaster$ pxf cluster sync
     ````
 
-1. Restart PXF:
-
-    ``` shell
-    gpadmin@gpmaster$ pxf cluster restart
-    ````
-
 1. Try the query again.
 

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -151,14 +151,27 @@ The workaround described in this section applies when all of the following hold 
 - The Greenplum Database PXF external table that you created specifies the `hive:orc` profile.
 - The Greenplum Database PXF external table that you created specifies the `VECTORIZE=false` (the default) setting.
 - There is a case mis-match between the column names specified in the Hive table schema and the column names specified in the ORC embedded schema.
+- You confirm that the field names in the ORC embedded schema are not all in lowercase by performing the following tasks:
+    1. Run `DESC FORMATTED <table-name>` in the `hive` subsystem and note the returned `location`; for example, `location:hdfs://namenode/hive/warehouse/<table-name>`.
+    1. List the ORC files comprising the table by running the following command:
 
-To remedy this situation, perform the following procedure:
+        ``` shell
+        $ hdfs dfs -ls <location>
+        ```
+    1. Dump each ORC file with the following command. For example, if the first step returned `hdfs://namenode/hive/warehouse/hive_orc_tbl1, run:`
+
+        ``` shell
+        $ hive --orcfiledump /hive/warehouse/hive_orc_tbl1/<orc-file> > dump.out
+        ```
+    1. Examine the output, specifically the value of `Type` (sample output: `Type: struct<COL0:int,COL1:string>`). If the field names are not all lowercase, continue with the workaround below.
+
+*To remedy this situation, perform the following procedure*:
 
 1. Log in to the Greenplum Database master host.
 
 1. Identify the name of your Hadoop PXF server configuration.
 
-1. Locate the `hive-site.xml` configuration file in the server configuration directory. For example, if `$PXF_BASE` is `/usr/local/pxf-gp6` and the server name is `<server_name>`, this file is located here:
+1. Locate the `hive-site.xml` configuration file in the server configuration directory. For example, if `$PXF_BASE` is `/usr/local/pxf-gp6` and the server name is `<server_name>`, the file is located here:
 
     ``` pre
     /usr/local/pxf-gp6/servers/<server_name>/hive-site.xml


### PR DESCRIPTION
add troubleshooting topic for external table created `hive:orc`, VECTORIZE=false, and table query returns all nulls.

pulled this together quickly.  it wasn't clear to me if the case of the columns in the greenplum external table definition were a factor as well.

doc review site link (behind vpn):  https://docs-lisa-pxf-hnvnulls.sc2-04-pcf1-apps.oc.vmware.com/pxf/6-3/using/troubleshooting_pxf.html#hiveorcnulls