### PR TITLE
ci: include PXF major version in cloud storage path

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -534,7 +534,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
-    versioned_file: ((pxf-build-bucket-prefix))/snapshots/pxf-gp[[gp_ver]].el7.tar.gz
+    versioned_file: ((pxf-build-bucket-prefix))/snapshots/pxf6/pxf-gp[[gp_ver]].el7.tar.gz
 {% endfor %}
 
 {% set gp_ver = 6 %}
@@ -544,7 +544,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
-    versioned_file: ((pxf-build-bucket-prefix))/snapshots/pxf-gp[[gp_ver]]-ubuntu18.04.tar.gz
+    versioned_file: ((pxf-build-bucket-prefix))/snapshots/pxf6/pxf-gp[[gp_ver]]-ubuntu18.04.tar.gz
 
 - name: pxf_gp[[gp_ver]]_tarball_rhel8
   type: gcs
@@ -552,7 +552,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
-    versioned_file: ((pxf-build-bucket-prefix))/snapshots/pxf-gp[[gp_ver]].el8.tar.gz
+    versioned_file: ((pxf-build-bucket-prefix))/snapshots/pxf6/pxf-gp[[gp_ver]].el8.tar.gz
 {% set gp_ver = None %}
 
 ## ---------- Auxiliary Resources ----------

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -310,7 +310,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
-    versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf-gp[[gp_ver]].el7.tar.gz
+    versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf6/pxf-gp[[gp_ver]].el7.tar.gz
 {% endfor %}
 
 {% set gp_ver = 6 %}
@@ -320,7 +320,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
-    versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf-gp[[gp_ver]]-ubuntu18.04.tar.gz
+    versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf6/pxf-gp[[gp_ver]]-ubuntu18.04.tar.gz
 {% set gp_ver = None %}
 
 {% for gp_ver in range(6, 7) %}
@@ -330,7 +330,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
-    versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf-gp[[gp_ver]].el8.tar.gz
+    versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf6/pxf-gp[[gp_ver]].el8.tar.gz
 {% endfor %}
 
 ## ---------- Auxiliary Resources ----------

--- a/concourse/pipelines/templates/external-table-tpl.yml
+++ b/concourse/pipelines/templates/external-table-tpl.yml
@@ -99,7 +99,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: {{data-gpdb-ud-google-json-key}}
-    versioned_file: prod/snapshots/pxf-gpdb6-SNAPSHOT-rhel6-x86_64.tar.gz
+    versioned_file: prod/snapshots/pxf6/pxf-gpdb6-SNAPSHOT-rhel6-x86_64.tar.gz
 
 - name: pxf_tarball_gpdb6_rhel7
   type: gcs
@@ -107,7 +107,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: {{data-gpdb-ud-google-json-key}}
-    versioned_file: prod/snapshots/pxf-gpdb6-SNAPSHOT-rhel7-x86_64.tar.gz
+    versioned_file: prod/snapshots/pxf6/pxf-gpdb6-SNAPSHOT-rhel7-x86_64.tar.gz
 
 - name: pxf_tarball_gpdb6_ubuntu18
   type: gcs
@@ -115,7 +115,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: {{data-gpdb-ud-google-json-key}}
-    versioned_file: prod/snapshots/pxf-gpdb6-SNAPSHOT-ubuntu18.04-x86_64.tar.gz
+    versioned_file: prod/snapshots/pxf6/pxf-gpdb6-SNAPSHOT-ubuntu18.04-x86_64.tar.gz
 
 ## ======================================================================
 ## ANCHORS

--- a/concourse/pipelines/templates/perf_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/perf_pipeline-tpl.yml
@@ -146,7 +146,7 @@ resources:
   source:
     bucket: data-gpdb-ud-pxf-build
     json_key: ((pxf-storage-service-account-key))
-    versioned_file: perf/snapshots/pxf-gp6.el[[redhat_major_version]].tar.gz
+    versioned_file: perf/snapshots/pxf6/pxf-gp6.el[[redhat_major_version]].tar.gz
 
 - name: singlecluster
   type: gcs


### PR DESCRIPTION
The build pipelines for PXF 5.16 and 6 use the same path for storing
snapshot tarballs. The pipelines can distinguish artifacts produced by
the different pipelines by correlating the files generation with the CI
job that produced the artifact. CI jobs outside of the build pipelines
cannot distinguish between snapshot builds of PXF 5.16 and 6 and will
randomly get one or the other depending on which ran last.

This commit moves PXF snapshot tarballs to be stored in a location that
includes the PXF major version. This will allow downstream consumers of
snapshot builds to select which PXF major version to pull.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>