### PR TITLE
Remove the usage of gcloud beta component

### DIFF
--- a/concourse/scripts/cleanup_dataproc_cluster.bash
+++ b/concourse/scripts/cleanup_dataproc_cluster.bash
@@ -16,6 +16,6 @@ set -x
 PETNAME=$(< "${ENV_FILES_DIR}/name")
 # --quiet to avoid interactive prompts
 # lop off trailing '-m'
-gcloud beta dataproc clusters --quiet \
+gcloud dataproc clusters --quiet \
   delete "${PETNAME%-m}" \
   "--region=$REGION"

--- a/concourse/scripts/start_dataproc_cluster.bash
+++ b/concourse/scripts/start_dataproc_cluster.bash
@@ -42,7 +42,7 @@ PLAINTEXT=$(mktemp)
 PLAINTEXT_NAME=$(basename "$PLAINTEXT")
 
 # Initialize the dataproc service
-GCLOUD_COMMAND=(gcloud beta dataproc clusters
+GCLOUD_COMMAND=(gcloud dataproc clusters
   create "$CLUSTER_NAME"
   "--region=$REGION"
   --initialization-actions "$INITIALIZATION_SCRIPT"


### PR DESCRIPTION
Previously, the CCP images contained gcloud beta component. It  was also
using a default Dataproc image version of 1.2.

With Dataproc image version 1.2, PXF was required to use gcloud beta to
create kerberized Dataproc clusters for testing.

Recently, the CCP images removed the gcloud beta component [1]
and the default Dataproc image was bumped to 1.4 [2]  which allows for the
creation of kerberized clusters without the use of gcloud beta [3].

[1] https://github.com/pivotal/gp-image-baking/commit/1c0a7d55cbabdb4ff28a094771ccbd7b3e015012
[2] https://github.com/pivotal/gp-concourse-cluster-provisioner/commit/e5ebc411a6c50b8e3259ffa251d0e1cbb1a13b0e
[3] https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/security#create_a_kerberos_cluster

Co-authored-by: Ashuka Xue <axue@vmware.com>
Co-authored-by: Bradford Boyle <bradfordb@vmware.com>

(cherry picked from commit 332b0679e1300cb4974cb78588c10629ce606607)