### PR TITLE
Upgrade jackson databind

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -267,7 +267,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.6</version>
         </dependency>
 
         <dependency>
@@ -279,7 +279,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR is based on PR #799 but includes updates to the other Jackson dependencies to use the same version (note: only databind has a 2.12.6.1 version, the rest are 2.12.6). Without the others being upgraded, the automation tests fail with a class not found error.

Closes #799.