### PR TITLE
Upgrade ruby to 2.7 for hadoop-cluster-cleaner pipeline

### DIFF
--- a/concourse/pipelines/hadoop-cluster-cleaner.yml
+++ b/concourse/pipelines/hadoop-cluster-cleaner.yml
@@ -53,7 +53,7 @@ jobs:
         type: registry-image
         source:
           repository: ruby
-          tag: "2.3"
+          tag: "2.7"
       inputs:
       - name: ccp_src
       - name: pxf_src


### PR DESCRIPTION
The CCP repear was recently updated to require the use of ruby 2.7.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>