### PR TITLE
Pin ansible community.general version to 4.8.1

### DIFF
--- a/concourse/ansible/ipa-multinode-hadoop/requirements.yml
+++ b/concourse/ansible/ipa-multinode-hadoop/requirements.yml
@@ -1,4 +1,5 @@
 ---
 collections:
-- community.general
+- name: community.general
+  version: 4.8.1
 - ansible.posix


### PR DESCRIPTION
community.general v5.0.0 seems to have API changes for the
`community.general.ipa_user` which causes issues for the Multinode IPA
cluster tests. For now, pin the version to 4.8.1.