### PR TITLE
Bumped ORC version to 1.6.13 to get a fix for ORC-1065

### DIFF
--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -28,4 +28,4 @@ awsJavaSdk=1.11.801
 springBootVersion=2.5.12
 org.gradle.daemon=true
 org.gradle.parallel=false
-orcVersion=1.6.8
+orcVersion=1.6.13


### PR DESCRIPTION
On some occasions PXF fails with the following error if the query against a Hive ORC table is performed from the same session. The first query succeeds, but the second fails. It seems it is related to ORC-1065 that is fixed in ORC 1.6.13.

Ideally we should include an integration test case if we manage to reproduce the issue.

```
java.io.IOException: java.lang.RuntimeException: ORC split generation failed with exception: 28325
        at org.greenplum.pxf.service.FragmenterService.getFragmentsFromCache(FragmenterService.java:147) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.FragmenterService.getFragmentsForSegment(FragmenterService.java:78) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.controller.ReadServiceImpl.writeStream(ReadServiceImpl.java:85) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.controller.ReadServiceImpl.lambda$null$0(ReadServiceImpl.java:58) ~[classes!/:6.3.1]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
        at javax.security.auth.Subject.doAs(Subject.java:361) ~[?:?]
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1906) ~[hadoop-common-2.10.1.jar!/:?]
        at org.greenplum.pxf.service.security.BaseSecurityService.doAs(BaseSecurityService.java:122) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.controller.BaseServiceImpl.processData(BaseServiceImpl.java:74) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.controller.ReadServiceImpl.lambda$readData$1(ReadServiceImpl.java:58) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.controller.PxfErrorReporter.invokeWithErrorHandling(PxfErrorReporter.java:26) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.controller.ReadServiceImpl.readData(ReadServiceImpl.java:58) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.rest.PxfReadResource.lambda$produceResponse$0(PxfReadResource.java:53) ~[classes!/:6.3.1]
        at org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBodyReturnValueHandler$StreamingResponseBodyTask.call(StreamingResponseBodyReturnValueHandler.java:111) ~[spring-webmvc-5.3.4.jar!/:5.3.4]
        at org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBodyReturnValueHandler$StreamingResponseBodyTask.call(StreamingResponseBodyReturnValueHandler.java:98) ~[spring-webmvc-5.3.4.jar!/:5.3.4]
        at org.springframework.web.context.request.async.WebAsyncManager.lambda$startCallableProcessing$4(WebAsyncManager.java:337) ~[spring-web-5.3.4.jar!/:5.3.4]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
        at org.greenplum.pxf.service.spring.PxfContextMdcLogEnhancerDecorator.lambda$decorate$0(PxfContextMdcLogEnhancerDecorator.java:27) ~[classes!/:6.3.1]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: java.lang.RuntimeException: ORC split generation failed with exception: 28325
        at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat.generateSplitsInfo(OrcInputFormat.java:1731) ~[hive-exec-2.3.8-core.jar!/:2.3.8]
        at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat.getSplits(OrcInputFormat.java:1817) ~[hive-exec-2.3.8-core.jar!/:2.3.8]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.fetchMetaData(HiveDataFragmenter.java:316) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.fetchMetaDataForSimpleTable(HiveDataFragmenter.java:278) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.fetchMetaDataForSimpleTable(HiveDataFragmenter.java:270) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.fetchTableMetaData(HiveDataFragmenter.java:220) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.getFragments(HiveDataFragmenter.java:131) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.service.FragmenterService.lambda$null$0(FragmenterService.java:119) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.utilities.GSSFailureHandler.execute(GSSFailureHandler.java:64) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.utilities.GSSFailureHandler.execute(GSSFailureHandler.java:99) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.FragmenterService.lambda$getFragmentsFromCache$1(FragmenterService.java:118) ~[classes!/:6.3.1]
        at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4904) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3628) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2336) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2295) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2208) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache.get(LocalCache.java:4053) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4899) ~[guava-20.0.jar!/:?]
        at org.greenplum.pxf.service.FragmenterService.getFragmentsFromCache(FragmenterService.java:114) ~[classes!/:6.3.1]
        ... 21 more
Caused by: java.lang.IndexOutOfBoundsException: 28325
        at java.nio.HeapByteBuffer.get(HeapByteBuffer.java:169) ~[?:?]
        at org.apache.orc.impl.ReaderImpl.extractFileTail(ReaderImpl.java:715) ~[orc-core-1.6.8.jar!/:1.6.8]
        at org.apache.hadoop.hive.ql.io.orc.LocalCache.getAndValidate(LocalCache.java:103) ~[hive-exec-2.3.8-core.jar!/:2.3.8]
        at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat$ETLSplitStrategy.getSplits(OrcInputFormat.java:798) ~[hive-exec-2.3.8-core.jar!/:2.3.8]
        at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat$ETLSplitStrategy.runGetSplitsSync(OrcInputFormat.java:916) ~[hive-exec-2.3.8-core.jar!/:2.3.8]
        at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat$ETLSplitStrategy.generateSplitWork(OrcInputFormat.java:885) ~[hive-exec-2.3.8-core.jar!/:2.3.8]
        at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat.scheduleSplits(OrcInputFormat.java:1759) ~[hive-exec-2.3.8-core.jar!/:2.3.8]
        at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat.generateSplitsInfo(OrcInputFormat.java:1703) ~[hive-exec-2.3.8-core.jar!/:2.3.8]
        at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat.getSplits(OrcInputFormat.java:1817) ~[hive-exec-2.3.8-core.jar!/:2.3.8]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.fetchMetaData(HiveDataFragmenter.java:316) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.fetchMetaDataForSimpleTable(HiveDataFragmenter.java:278) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.fetchMetaDataForSimpleTable(HiveDataFragmenter.java:270) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.fetchTableMetaData(HiveDataFragmenter.java:220) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.plugins.hive.HiveDataFragmenter.getFragments(HiveDataFragmenter.java:131) ~[pxf-hive-6.3.1.jar!/:?]
        at org.greenplum.pxf.service.FragmenterService.lambda$null$0(FragmenterService.java:119) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.utilities.GSSFailureHandler.execute(GSSFailureHandler.java:64) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.utilities.GSSFailureHandler.execute(GSSFailureHandler.java:99) ~[classes!/:6.3.1]
        at org.greenplum.pxf.service.FragmenterService.lambda$getFragmentsFromCache$1(FragmenterService.java:118) ~[classes!/:6.3.1]
        at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4904) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3628) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2336) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2295) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2208) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache.get(LocalCache.java:4053) ~[guava-20.0.jar!/:?]
        at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4899) ~[guava-20.0.jar!/:?]
        at org.greenplum.pxf.service.FragmenterService.getFragmentsFromCache(FragmenterService.java:114) ~[classes!/:6.3.1]
        ... 21 more
```