### PR TITLE
Upgrade ORC version to 1.6.13 to get a fix for ORC-1065

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -20,6 +20,7 @@
         <hdp.hadoop.version>2.10.1</hdp.hadoop.version>
         <hdp.hbase.version>1.3.2.1</hdp.hbase.version>
         <hdp.hive.version>1.1.0</hdp.hive.version>
+        <orc.version>1.6.13</orc.version>
         <snappy.java.version>1.1.1.7</snappy.java.version>
         <powermock.version>1.6.4</powermock.version>
     </properties>
@@ -460,6 +461,12 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
             <version>${hdp.hive.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.orc</groupId>
+            <artifactId>orc-core</artifactId>
+            <version>${orc.version}</version>
         </dependency>
 
         <dependency>

--- a/automation/tincrepo/main/pxf/features/hive/orc_large_data/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hive/orc_large_data/expected/query01.ans
@@ -1,0 +1,17 @@
+-- start_ignore
+-- end_ignore
+-- @description query01 for Hive ORC large data set
+SELECT COUNT(*) FROM pxf_hive_orc_large_data;
+ count
+-------
+  8192
+(1 row)
+
+-- query again for ETL error
+SELECT COUNT(*) FROM pxf_hive_orc_large_data;
+ count
+-------
+  8192
+(1 row)
+
+

--- a/automation/tincrepo/main/pxf/features/hive/orc_large_data/runTest.py
+++ b/automation/tincrepo/main/pxf/features/hive/orc_large_data/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLConcurrencyTestCase
+
+class HiveOrcLargeData(SQLConcurrencyTestCase):
+    """
+    @product_version  gpdb: [2.0-]
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/hive/orc_large_data/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hive/orc_large_data/sql/query01.sql
@@ -1,0 +1,4 @@
+-- @description query01 for Hive ORC large data set
+SELECT COUNT(*) FROM pxf_hive_orc_large_data;
+-- query again to make sure there is no error related to cached file metadata (ORC-1065)
+SELECT COUNT(*) FROM pxf_hive_orc_large_data;

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -28,4 +28,4 @@ awsJavaSdk=1.11.801
 springBootVersion=2.5.12
 org.gradle.daemon=true
 org.gradle.parallel=false
-orcVersion=1.6.8
+orcVersion=1.6.13


### PR DESCRIPTION
This test generates a large data set that is stored in a single ORC file
that is then read by PXF using the Hive ORC profile. This is intended to
cause OrcInputFormat.determineSplitStrategy to select the ETL split
strategy when using the default configuration of HYBRID. When the ETL
split strategy is used, a bug on the ORC library is encountered with
caching file footers (see [ORC-1065][] for more details.)

[ORC-1065]: https://issues.apache.org/jira/browse/ORC-1065

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>