### PR TITLE
Increase time for Ansible to wait for yum lockfile to be freed

### DIFF
--- a/concourse/ansible/ipa-multinode-hadoop/tasks/common.yml
+++ b/concourse/ansible/ipa-multinode-hadoop/tasks/common.yml
@@ -17,3 +17,4 @@
   ansible.builtin.yum:
     name: "*"
     state: latest
+    lock_timeout: 300

--- a/concourse/ansible/ipa-multinode-hadoop/tasks/hdfs.yml
+++ b/concourse/ansible/ipa-multinode-hadoop/tasks/hdfs.yml
@@ -5,6 +5,7 @@
     name: [gcc, java-1.8.0-openjdk, python3-devel, python3-setuptools, redhat-rpm-config]
     state: present
     update_cache: true
+    lock_timeout: 300
 
 - name: Create PXF shell config
   ansible.builtin.copy:

--- a/concourse/ansible/ipa-multinode-hadoop/tasks/ipa-client.yml
+++ b/concourse/ansible/ipa-multinode-hadoop/tasks/ipa-client.yml
@@ -4,6 +4,7 @@
     name: ['bind-utils', 'ipa-client', 'ipa-admintools', 'openldap-clients']
     state: present
     update_cache: true
+    lock_timeout: 300
 
 - name: Run IPA client installer
   ansible.builtin.shell:

--- a/concourse/ansible/ipa-multinode-hadoop/tasks/ipa-server.yml
+++ b/concourse/ansible/ipa-multinode-hadoop/tasks/ipa-server.yml
@@ -4,6 +4,8 @@
     name: ['ipa-server', 'ipa-server-dns', 'bind-dyndb-ldap', 'wget']
     state: present
     update_cache: true
+    lock_timeout: 300
+
 - name: configuring ipa-server
   ansible.builtin.shell:
     cmd: "ipa-server-install --unattended --ds-password {{ ipa_password }} --admin-password {{ ipa_password }} --domain {{ ansible_domain }} --realm {{ ansible_domain | upper }} --hostname={{ ansible_fqdn }} --no-host-dns --setup-kra --mkhomedir"

--- a/concourse/ansible/ipa-multinode-hadoop/tasks/nfs-client.yml
+++ b/concourse/ansible/ipa-multinode-hadoop/tasks/nfs-client.yml
@@ -5,6 +5,7 @@
     name: nfs-utils
     state: present
     update_cache: true
+    lock_timeout: 300
 
 - name: Mount shared edits directory
   become: true


### PR DESCRIPTION
Ansible tasks are occasionally failing in CI with the message
`yum lockfile is held by another process`. Ansible's built-in yum module
defaults to waiting for only 30 seconds before failing.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>