### PR TITLE
docs - config a server to access a dell ecs s3-compatible obj store

### DIFF
--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Accessing Azure, Google Cloud Storage, MinIO, and S3 Object Stores
+title: Accessing Azure, Google Cloud Storage, and S3-Compatible Object Stores
 ---
 
 <!--
@@ -21,14 +21,14 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-PXF is installed with connectors to Azure Blob Storage, Azure Data Lake, Google Cloud Storage, MinIO, and S3 object stores.
+PXF is installed with connectors to Azure Blob Storage, Azure Data Lake, Google Cloud Storage, and AWS, MinIO, and Dell ECS S3-compatible object stores.
 
 ## <a id="objstore_prereq"></a>Prerequisites
 
 Before working with object store data using PXF, ensure that:
 
 - You have configured PXF, and PXF is running on each Greenplum Database host. See [Configuring PXF](instcfg_pxf.html) for additional information.
-- You have configured the PXF Object Store Connectors that you plan to use. Refer to [Configuring Connectors to Azure and Google Cloud Storage Object Stores](objstore_cfg.html) and [Configuring Connectors to MinIO and S3 Object Stores](s3_objstore_cfg.html) for instructions.
+- You have configured the PXF Object Store Connectors that you plan to use. Refer to [Configuring Connectors to Azure and Google Cloud Storage Object Stores](objstore_cfg.html) and [Configuring Connectors to MinIO, AWS S3, and Dell ECS Object Stores](s3_objstore_cfg.html) for instructions.
 - Time is synchronized between the Greenplum Database hosts and the external object store systems.
 
 
@@ -59,9 +59,9 @@ The PXF connectors to Azure expose the following profiles to read, and in many c
 | AvroSequenceFile | wasbs:AvroSequenceFile | adl:AvroSequenceFile | Read, Write |
 | [SequenceFile](objstore_seqfile.html) | wasbs:SequenceFile | adl:SequenceFile | Read, Write |
 
-Similarly, the PXF connectors to Google Cloud Storage, MinIO, and S3 expose these profiles:
+Similarly, the PXF connectors to Google Cloud Storage, and S3-compatible object stores expose these profiles:
 
-| Data Format | Google Cloud Storage | S3 or MinIO | Supported Operations |
+| Data Format | Google Cloud Storage | AWS S3, MinIO, or Dell ECS | Supported Operations |
 |-----|------|---------| ---------|
 | delimited single line [plain text](objstore_text.html) | gs:text | s3:text | Read, Write |
 | delimited single line comma-separated values of [plain text](objstore_text.html) | gs:csv | s3:csv | Read, Write |

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -21,7 +21,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-PXF is installed with connectors to Azure Blob Storage, Azure Data Lake, Google Cloud Storage, and AWS, MinIO, and Dell ECS S3-compatible object stores.
+PXF is installed with connectors to Azure Blob Storage, Azure Data Lake, Google Cloud Storage, AWS, MinIO, and Dell ECS S3-compatible object stores.
 
 ## <a id="objstore_prereq"></a>Prerequisites
 

--- a/docs/content/access_s3.html.md.erb
+++ b/docs/content/access_s3.html.md.erb
@@ -1,8 +1,8 @@
 ---
-title: About Accessing the S3 Object Store
+title: About Accessing the AWS S3 Object Store
 ---
 
-PXF is installed with a connector to the S3 object store. PXF supports the following additional runtime features with this connector:
+PXF is installed with a connector to the AWS S3 object store. PXF supports the following additional runtime features with this connector:
 
 - Overriding the S3 credentials specified in the server configuration by providing them in the `CREATE EXTERNAL TABLE` command DDL.
 - Using the Amazon S3 Select service to read certain CSV and Parquet data from S3.
@@ -13,8 +13,8 @@ If you are accessing an S3-compatible object store, you can override the credent
 
 | Custom Option  | Value Description |
 |-------|-------------------------------------|
-| accesskey    | The AWS account access key ID. |
-| secretkey    | The secret key associated with the AWS access key ID. |
+| accesskey    | The AWS S3 account access key ID. |
+| secretkey    | The secret key associated with the AWS S3 access key ID. |
 
 For example:
 <pre>CREATE EXTERNAL TABLE pxf_ext_tbl(name text, orders int)

--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -82,7 +82,7 @@ After you configure a PXF server, you publish the server name to Greenplum Datab
 To configure a PXF server, refer to the connector configuration topic:
 
 - To configure a PXF server for Hadoop, refer to [Configuring PXF Hadoop Connectors ](client_instcfg.html).
-- To configure a PXF server for an  object store, refer to [Configuring Connectors to MinIO and S3 Object Stores](s3_objstore_cfg.html) and [Configuring Connectors to Azure and Google Cloud Storage Object Stores](objstore_cfg.html).
+- To configure a PXF server for an object store, refer to [Configuring Connectors to MinIO, AWS S3, and Dell ECS Object Stores](s3_objstore_cfg.html) and [Configuring Connectors to Azure and Google Cloud Storage Object Stores](objstore_cfg.html).
 - To configure a PXF JDBC server, refer to [Configuring the JDBC Connector ](jdbc_cfg.html).
 - [Configuring a PXF Network File System Server](nfs_pxf.html#ex_fscfg) describes the process of configuring a PXF server for network file system access.
 

--- a/docs/content/index.html.md.erb
+++ b/docs/content/index.html.md.erb
@@ -37,7 +37,7 @@ The Greenplum Platform Extension Framework (PXF) provides parallel, high through
 
     This set of topics describe the PXF Hadoop connectors, the data types they support, and the profiles that you can use to read from and write to HDFS.
 
--   [Accessing Azure, Google Cloud Storage, MinIO, and S3 Object Stores with PXF](access_objstore.html)
+-   [Accessing Azure, Google Cloud Storage, and S3-Compatible Object Stores with PXF](access_objstore.html)
 
     This set of topics describe the PXF object storage connectors, the data types they support, and the profiles that you can use to read data from and write data to the object stores.
 

--- a/docs/content/intro_pxf.html.md.erb
+++ b/docs/content/intro_pxf.html.md.erb
@@ -40,7 +40,7 @@ Your Greenplum Database deployment consists of a master host, a standby master h
 
 ## <a id="more"></a> About Connectors, Servers, and Profiles
 
-*Connector* is a generic term that encapsulates the implementation details required to read from or write to an external data store. PXF provides built-in connectors to Hadoop (HDFS, Hive, HBase), object stores (Azure, Google Cloud Storage, and MinIO, AWS S3 and Dell ECS), and SQL databases (via JDBC).
+*Connector* is a generic term that encapsulates the implementation details required to read from or write to an external data store. PXF provides built-in connectors to Hadoop (HDFS, Hive, HBase), object stores (Azure, Google Cloud Storage, MinIO, AWS S3, and Dell ECS), and SQL databases (via JDBC).
 
 A PXF *Server* is a named configuration for a connector. A server definition provides the information required for PXF to access an external data source. This configuration information is data-store-specific, and may include server location, access credentials, and other relevant properties.
 

--- a/docs/content/intro_pxf.html.md.erb
+++ b/docs/content/intro_pxf.html.md.erb
@@ -40,7 +40,7 @@ Your Greenplum Database deployment consists of a master host, a standby master h
 
 ## <a id="more"></a> About Connectors, Servers, and Profiles
 
-*Connector* is a generic term that encapsulates the implementation details required to read from or write to an external data store. PXF provides built-in connectors to Hadoop (HDFS, Hive, HBase), object stores (Azure, Google Cloud Storage, MinIO, S3), and SQL databases (via JDBC).
+*Connector* is a generic term that encapsulates the implementation details required to read from or write to an external data store. PXF provides built-in connectors to Hadoop (HDFS, Hive, HBase), object stores (Azure, Google Cloud Storage, and MinIO, AWS S3 and Dell ECS), and SQL databases (via JDBC).
 
 A PXF *Server* is a named configuration for a connector. A server definition provides the information required for PXF to access an external data source. This configuration information is data-store-specific, and may include server location, access credentials, and other relevant properties.
 

--- a/docs/content/s3_objstore_cfg.html.md.erb
+++ b/docs/content/s3_objstore_cfg.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Configuring Connectors to MinIO and S3 Object Stores (Optional)
+title: Configuring Connectors to MinIO, AWS S3, and Dell ECS Object Stores (Optional)
 ---
 
 You can use PXF to access S3-compatible object stores. This topic describes how to configure the PXF connectors to these external data sources.
@@ -10,7 +10,7 @@ You can use PXF to access S3-compatible object stores. This topic describes how 
 
 To access data in an object store, you must provide a server location and client credentials. When you configure a PXF object store connector, you add at least one named PXF server configuration for the connector as described in [Configuring PXF Servers](cfg_server.html).
 
-PXF provides a configuration file template for each object store connector. These template files are located in the `<PXF_INSTALL_DIR>/templates/` directory.
+PXF provides a configuration file template for most object store connectors. These template files are located in the `<PXF_INSTALL_DIR>/templates/` directory.
 
 
 ## <a id="minio_cfg"></a>MinIO Server Configuration
@@ -22,6 +22,8 @@ The template configuration file for MinIO is `<PXF_INSTALL_DIR>/templates/minio-
 | fs.s3a.endpoint | The MinIO S3 endpoint to which to connect. | Your endpoint. |
 | fs.s3a.access.key | The MinIO account access key. | Your MinIO user name. |
 | fs.s3a.secret.key | The MinIO secret key associated with the access key. | Your MinIO password. |
+| fs.s3a.fast.upload | Property that governs fast upload; the default value is `false`. | Set to `true` to enable fast upload. |
+| fs.s3a.path.style.access | Property that governs file specification via paths; the default value is `false`. | Set to `true` to enable path style access. |
 
 ## <a id="s3_cfg"></a>S3 Server Configuration
 
@@ -191,4 +193,18 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_BASE
     ``` shell
     gpadmin@gpmaster$ pxf cluster sync
     ```
+
+## <a id="ecs_cfg"></a>Dell ECS Server Configuration
+
+There is no template server configuration file for Dell ECS. You can use the MinIO server configuration template, `<PXF_INSTALL_DIR>/templates/minio-site.xml`.
+
+When you configure a Dell ECS server, you must provide the following server configuration properties and replace the template values with your credentials:
+
+| Property       | Description                                | Value |
+|----------------|--------------------------------------------|------ |
+| fs.s3a.endpoint | The Dell ECS S3 endpoint to which to connect. | Your ECS endpoint. |
+| fs.s3a.access.key | The Dell ECS account access key. | Your ECS user name. |
+| fs.s3a.secret.key | The Dell ECS secret key associated with the access key. | Your ECS secret key1. |
+| fs.s3a.fast.upload | Property that governs fast upload; the default value is `false`. | Set to `true` to enable fast upload. |
+| fs.s3a.path.style.access | Property that governs file specification via paths; the default value is `false`. | Set to `true` to enable path style access. |
 


### PR DESCRIPTION
include a dell ECS section in the s3 obj store config docs.  also use the term S3-compatible in some situations, and list out all three in others, both in content and topic titles.

the new dell ecs topic instructs the user to use the minio template.