### PR TITLE
Add unsupported exception in case of hive write

### DIFF
--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
@@ -45,6 +45,7 @@ import org.greenplum.pxf.api.filter.SupportedOperatorPruner;
 import org.greenplum.pxf.api.filter.ToStringTreeVisitor;
 import org.greenplum.pxf.api.filter.TreeTraverser;
 import org.greenplum.pxf.api.io.DataType;
+import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.utilities.ColumnDescriptor;
 import org.greenplum.pxf.api.utilities.SerializationService;
 import org.greenplum.pxf.api.utilities.SpringContext;
@@ -236,6 +237,8 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
         Properties properties;
         try {
             HiveFragmentMetadata metadata = context.getFragmentMetadata();
+            if(metadata == null && context.getRequestType().equals(RequestContext.RequestType.WRITE_BRIDGE))
+                throw new UnsupportedOperationException();
             // clone properties from the fragment metadata as they are shared across fragments and
             // properties for the current fragment will be modified by Hive Resolvers and SerDe classes
             properties = (Properties) metadata.getProperties().clone();
@@ -243,6 +246,8 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
                 String inputFormatClassName = properties.getProperty(FILE_INPUT_FORMAT);
                 this.inputFormat = hiveUtilities.makeInputFormat(inputFormatClassName, jobConf);
             }
+        } catch(UnsupportedOperationException e) {
+            throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
         } catch (Exception e) {
             throw new RuntimeException("Failed to initialize HiveAccessor", e);
         }

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveAccessor.java
@@ -215,7 +215,7 @@ public class HiveAccessor extends HdfsSplittableDataAccessor {
         super.afterPropertiesSet();
 
         // HiveAccessor requires fragment metadata which is available for read operations but not write operations
-        if(context.getRequestType() == RequestContext.RequestType.WRITE_BRIDGE)
+        if (context.getRequestType() == RequestContext.RequestType.WRITE_BRIDGE)
             throw new UnsupportedOperationException(UNSUPPORTED_ERR_MESSAGE);
 
         // determine if predicate pushdown is allowed by configuration

--- a/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
+++ b/server/pxf-hive/src/test/java/org/greenplum/pxf/plugins/hive/HiveAccessorTest.java
@@ -302,6 +302,15 @@ class HiveAccessorTest {
         assertEquals("Hive accessor does not support write operation.", e.getMessage());
     }
 
+    @Test
+    public void testWriteWithRequestContextAsWrite(){
+        accessor = new HiveAccessor(null, new HiveUtilities(), serializationService);
+        context.setRequestType(RequestContext.RequestType.WRITE_BRIDGE);
+        accessor.setRequestContext(context);
+        Exception e = assertThrows(UnsupportedOperationException.class, () -> accessor.afterPropertiesSet());
+        assertEquals("Hive accessor does not support write operation.", e.getMessage());
+    }
+
     @SuppressWarnings("unchecked")
     private void prepareReaderMocks() throws Exception {
         when(mockHiveUtilities.makeInputFormat(any(), any())).thenReturn(mockInputFormat);


### PR DESCRIPTION
`hive:text` does not support write. If we test if currently for write, It throws `NullPointerException` 

```

CREATE WRITABLE EXTERNAL TABLE hive_curl_partial_test_w(col1 text, col2 date) LOCATION ('pxf://curl_partial_test?profile=hive:text') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');

INSERT INTO hive_curl_partial_test_w (col1, col2) VALUES ('gp-row1', '2021-12-01');

```

pxf-servive.logs: 

```
Caused by: java.lang.NullPointerException
        at org.greenplum.pxf.plugins.hive.HiveAccessor.afterPropertiesSet(HiveAccessor.java:241) ~[pxf-hive-6.3.1-SNAPSHOT.jar!/:?]
        ... 78 more
```



This PR changes the exception it to `UnsupportedOperationException`