### PR TITLE
Remove custom log prefix function in PXF CLI

### DIFF
--- a/cli/go/src/pxf-cli/cmd/root.go
+++ b/cli/go/src/pxf-cli/cmd/root.go
@@ -27,9 +27,6 @@ func Execute() {
 func init() {
 	// InitializeLogging must be called before we attempt to log with gplog.
 	gplog.InitializeLogging("pxf_cli", "")
-	gplog.SetLogPrefixFunc(func(s string) string {
-		return ""
-	})
 
 	rootCmd.SetHelpCommand(&cobra.Command{
 		Use:    "no-help",


### PR DESCRIPTION
The PXF CLI uses gp-common-go-libs for logging. This package includes
the ability to customize the log messages prefix. The default prefix
includes a timestamp and the log message level; for example

```
20220712:15:30:06 pxf_cli:bboyle:alpine:2225984-[INFO]:-Checking status of PXF servers on master host and 0 segment hosts...
```

The PXF CLI was setting the log message prefix to an emptry string
causing the previous example to be

```
Checking status of PXF servers on master host and 0 segment hosts...
```

This commit removes the customization of the log prefix in oder to
generate log files that include timestamps. This should allow for easier
correlation across PXF CLI, GPDB, and PXF service logs.

[0]: https://github.com/greenplum-db/gp-common-go-libs

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>