### PR TITLE
Added check if the PXF PID exists before trying a start/restart in PXF bash script.  

### DIFF
--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -159,6 +159,7 @@ function checkWebapp()
 # determines whether the application is running
 function isRunning()
 {
+    [[ -z "$1" ]] && { return 1; }
     ps -o pid,command -p "$1" | grep 'pxf-app' &> /dev/null
 }
 

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -89,6 +89,15 @@ function validate_user()
 
 function checkPermissions()
 {
+    # TODO
+    # Currently, in case of any error if PXF doesn't come up, the empty PID file created here remains.
+    # If the pxf is restarted again after the failure, this empty PID file will cause issues. For e.g.
+    # isRunning function will try to ps on the empty PID which will fail with the error "error: list of process IDs must follow -p"
+    # To avoid that we can either
+    # 1. Check if the PID exists in the isRunning function
+    # 2. Removes the PID file which is created here after checking for write permissions
+    # 3. Touch a file with another name to check for the write permissions in the directory
+    # 4. In case PXF doesn't come up for any reason, clean the stale PID
     touch "$pid_file" &> /dev/null || { echoRed "ERROR: Operation not permitted (cannot access pid file: '$pid_file')"; return 4; }
     [[ -d "$PXF_LOGDIR" ]] || { echoRed "ERROR: Operation not permitted (log directory does not exist: '$PXF_LOGDIR')"; return 4; }
 }


### PR DESCRIPTION
This is related to github issue https://github.com/greenplum-db/sre-test/issues/274

In case the PXF pid doesn't exists, the PXF specific error to be thrown and not the OS one. 

Currently if the pid doesn't exists, the command `ps -p ""` runs which returns `error: list of process IDs must follow -p` which is not very useful. 