### PR TITLE
Bump postgresql version from 42.3.3 to 42.4.1

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -197,7 +197,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.3</version>
+            <version>42.4.1</version>
         </dependency>
 
         <dependency>

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -103,10 +103,10 @@ configure(javaProjects) {
             dependency("org.mortbay.jetty:jetty-util:6.1.26")
             dependency("org.objenesis:objenesis:2.1")
 
-            // ---- bump postgres to 42.3.3 for CVE-2022-21724 fixes
-            // more details: https://nvd.nist.gov/vuln/detail/CVE-2022-21724
-            // revert once springboot provided postgresql is upgraded to bundle postgresql:42.3.3+
-            dependency("org.postgresql:postgresql:42.3.3")
+            // ---- bump postgresql to 42.4.1 for CVE-2022-31197 fixes
+            // more details: https://nvd.nist.gov/vuln/detail/CVE-2022-31197
+            // revert once springboot provided postgresql is upgraded to bundle postgresql:42.4.1+
+            dependency("org.postgresql:postgresql:42.4.1")
 
             dependency("org.simplify4u:slf4j-mock:2.1.0")
             dependency("org.threeten:threeten-extra:1.5.0")


### PR DESCRIPTION
The version upgrade is due to a CVE that was described in another PR: https://github.com/greenplum-db/pxf/pull/843 That PR will be closed in favor of the current one as we also need to make a change to the Gradle build to distribute the new version of the PXF dependency.