### PR TITLE
docs - replace broken link

### DIFF
--- a/docs/content/jdbc_pxf_trino.html.md.erb
+++ b/docs/content/jdbc_pxf_trino.html.md.erb
@@ -40,7 +40,7 @@ This procedure will typically be performed by the Greenplum Database administrat
 
 1. Download the Trino JDBC driver and place it under `$PXF_BASE/lib`.
    If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), make sure you use the updated location.
-   See [Trino Documentation - JDBC Driver](https://trino.io/docs/current/installation/jdbc.html) for instructions on downloading the Trino JDBC driver.
+   See [Trino Documentation - JDBC Driver](https://trino.io/docs/current/client/jdbc.html#installing) for instructions on downloading the Trino JDBC driver.
    The following example downloads the driver and places it under `$PXF_BASE/lib`:
 
     1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum master:


### PR DESCRIPTION
link to trino jdbc driver topic now 404s, replace with correct link