### PR TITLE
Add JsonProtocolHandler to use HdfsFileFragmenter for multi-line JSON

### DIFF
--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/HdfsFileFragmenter.java
@@ -47,7 +47,7 @@ public class HdfsFileFragmenter extends HdfsDataFragmenter {
         }
 
         fragments = Arrays.stream(fileStatusArray)
-                .map(fileStatus -> new Fragment(fileStatus.getPath().toUri().toString()))
+                .map(fileStatus -> new Fragment(fileStatus.getPath().toUri().toString(), new HcfsFragmentMetadata(0, fileStatus.getLen())))
                 .collect(Collectors.toList());
         LOG.debug("Total number of fragments = {}", fragments.size());
 

--- a/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonProtocolHandler.java
+++ b/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonProtocolHandler.java
@@ -35,14 +35,7 @@ public class JsonProtocolHandler implements ProtocolHandler {
         return context.getResolver();
     }
 
-
-    private boolean useMultilineJson(RequestContext context) {
-        String identifier = context.getOption("identifier");
-
-        if (isNotEmpty(identifier)) {
-            return true;
-        }
-
-        return false;
+    public boolean useMultilineJson(RequestContext context) {
+        return isNotEmpty(context.getOption("identifier"));
     }
 }

--- a/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonProtocolHandler.java
+++ b/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonProtocolHandler.java
@@ -2,9 +2,10 @@ package org.greenplum.pxf.plugins.json;
 
 import org.greenplum.pxf.api.model.ProtocolHandler;
 import org.greenplum.pxf.api.model.RequestContext;
-import org.greenplum.pxf.plugins.hdfs.HcfsFragmentMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 /**
  * Implementation of ProtocolHandler for json protocol.
@@ -38,7 +39,7 @@ public class JsonProtocolHandler implements ProtocolHandler {
     private boolean useMultilineJson(RequestContext context) {
         String identifier = context.getOption("identifier");
 
-        if (!identifier.isEmpty()) {
+        if (isNotEmpty(identifier)) {
             return true;
         }
 

--- a/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonProtocolHandler.java
+++ b/server/pxf-json/src/main/java/org/greenplum/pxf/plugins/json/JsonProtocolHandler.java
@@ -1,0 +1,47 @@
+package org.greenplum.pxf.plugins.json;
+
+import org.greenplum.pxf.api.model.ProtocolHandler;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.plugins.hdfs.HcfsFragmentMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of ProtocolHandler for json protocol.
+ */
+public class JsonProtocolHandler implements ProtocolHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JsonProtocolHandler.class);
+    private static final String HCFS_FILE_FRAGMENTER = "org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter";
+
+    @Override
+    public String getFragmenterClassName(RequestContext context) {
+        String fragmenter = context.getFragmenter(); // default to fragmenter defined by the profile
+        if (useMultilineJson(context)) {
+            fragmenter = HCFS_FILE_FRAGMENTER;
+        }
+        LOG.debug("Determined to use {} fragmenter", fragmenter);
+        return fragmenter;
+    }
+
+    @Override
+    public String getAccessorClassName(RequestContext context) {
+        return context.getAccessor();
+    }
+
+    @Override
+    public String getResolverClassName(RequestContext context) {
+        return context.getResolver();
+    }
+
+
+    private boolean useMultilineJson(RequestContext context) {
+        String identifier = context.getOption("identifier");
+
+        if (!identifier.isEmpty()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonProtocolHandlerTest.java
+++ b/server/pxf-json/src/test/java/org/greenplum/pxf/plugins/json/JsonProtocolHandlerTest.java
@@ -1,0 +1,57 @@
+package org.greenplum.pxf.plugins.json;
+
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonProtocolHandlerTest {
+
+    private static final String FILE_FRAGMENTER = "org.greenplum.pxf.plugins.hdfs.HdfsFileFragmenter";
+    private static final String DEFAULT_ACCESSOR = "default-accessor";
+    private static final String DEFAULT_RESOLVER = "default-resolver";
+    private static final String DEFAULT_FRAGMENTER = "default-fragmenter";
+    private JsonProtocolHandler handler;
+    private RequestContext context;
+
+    @BeforeEach
+    public void before() {
+        handler = new JsonProtocolHandler();
+        context = new RequestContext();
+        context.setFragmenter("default-fragmenter");
+        context.setAccessor("default-accessor");
+        context.setResolver("default-resolver");
+        List<ColumnDescriptor> columns = new ArrayList<>();
+        columns.add(new ColumnDescriptor("c1", 1, 0, "INT", null, true)); // actual args do not matter
+        columns.add(new ColumnDescriptor("c2", 2, 0, "INT", null, true)); // actual args do not matter
+        context.setTupleDescription(columns);
+    }
+
+    @Test
+    public void testTextIdentifierOptionMissing() {
+        assertEquals(DEFAULT_FRAGMENTER, handler.getFragmenterClassName(context));
+        assertEquals(DEFAULT_ACCESSOR, handler.getAccessorClassName(context));
+        assertEquals(DEFAULT_RESOLVER, handler.getResolverClassName(context));
+    }
+
+    @Test
+    public void testWithEmptyIdentifier() {
+        context.addOption("IDENTIFIER", "");
+        assertEquals(DEFAULT_FRAGMENTER, handler.getFragmenterClassName(context));
+        assertEquals(DEFAULT_ACCESSOR, handler.getAccessorClassName(context));
+        assertEquals(DEFAULT_RESOLVER, handler.getResolverClassName(context));
+    }
+
+    @Test
+    public void testWithIdentifier() {
+        context.addOption("IDENTIFIER", "c1");
+        assertEquals(FILE_FRAGMENTER, handler.getFragmenterClassName(context));
+        assertEquals(DEFAULT_ACCESSOR, handler.getAccessorClassName(context));
+        assertEquals(DEFAULT_RESOLVER, handler.getResolverClassName(context));
+    }
+}

--- a/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3ProtocolHandler.java
+++ b/server/pxf-s3/src/main/java/org/greenplum/pxf/plugins/s3/S3ProtocolHandler.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.greenplum.pxf.plugins.s3.S3SelectAccessor.FILE_HEADER_INFO_IGNORE;
 import static org.greenplum.pxf.plugins.s3.S3SelectAccessor.FILE_HEADER_INFO_USE;
 
@@ -54,7 +55,7 @@ public class S3ProtocolHandler implements ProtocolHandler {
     @Override
     public String getFragmenterClassName(RequestContext context) {
         String fragmenter = context.getFragmenter(); // default to fragmenter defined by the profile
-        if (useS3Select(context)) {
+        if (useS3Select(context) || useMultilineJson(context)) {
             fragmenter = HCFS_FILE_FRAGMENTER;
         }
         LOG.debug("Determined to use {} fragmenter", fragmenter);
@@ -125,6 +126,10 @@ public class S3ProtocolHandler implements ProtocolHandler {
             default:
                 return false;
         }
+    }
+
+    public boolean useMultilineJson(RequestContext context) {
+        return isNotEmpty(context.getOption("identifier"));
     }
 
     /**

--- a/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3ProtocolHandlerTest.java
+++ b/server/pxf-s3/src/test/java/org/greenplum/pxf/plugins/s3/S3ProtocolHandlerTest.java
@@ -60,6 +60,8 @@ public class S3ProtocolHandlerTest {
     private static final String[] EXPECTED_RESOLVER_TEXT_AUTO_NO_BENEFIT_HAS_HEADER = {DEFAULT_RESOLVER, STRING_PASS_RESOLVER, STRING_PASS_RESOLVER, STRING_PASS_RESOLVER, DEFAULT_RESOLVER};
     private static final String[] EXPECTED_FRAGMENTER_TEXT_AUTO_NO_BENEFIT_HAS_HEADER = {DEFAULT_FRAGMENTER, FILE_FRAGMENTER, FILE_FRAGMENTER, FILE_FRAGMENTER, DEFAULT_FRAGMENTER};
 
+    private static final String[] EXPECTED_FRAGMENTER_MULTILINE = {FILE_FRAGMENTER, FILE_FRAGMENTER, FILE_FRAGMENTER, FILE_FRAGMENTER, FILE_FRAGMENTER};
+
     private S3ProtocolHandler handler;
     private RequestContext context;
 
@@ -413,6 +415,38 @@ public class S3ProtocolHandlerTest {
         context.addOption(S3SelectAccessor.COMPRESSION_TYPE, "foo");
         // EXPECTED_RESOLVER_GPDB_WRITABLE_OFF is used as its values are desirable as expected value
         verifyResolvers(context, EXPECTED_RESOLVER_GPDB_WRITABLE_OFF);
+    }
+
+    @Test
+    public void testTextIdentifierAndSelectOff() {
+        context.addOption("S3_SELECT", "off");
+        context.addOption("IDENTIFIER", "c1");
+        context.setOutputFormat(OutputFormat.TEXT);
+        verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_OFF);
+        verifyResolvers(context, EXPECTED_RESOLVER_TEXT_OFF);
+        verifyFragmenters(context, EXPECTED_FRAGMENTER_MULTILINE);
+    }
+
+    @Test
+    public void testTextIdentifierAndSelectOn() {
+        // s3 options should override multiline json fragmenter option
+        context.addOption("S3_SELECT", "on");
+        context.addOption("IDENTIFIER", "c1");
+        context.setOutputFormat(OutputFormat.TEXT);
+        verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_ON);
+        verifyResolvers(context, EXPECTED_RESOLVER_TEXT_ON);
+        verifyFragmenters(context, EXPECTED_FRAGMENTER_TEXT_ON);
+    }
+
+    @Test
+    public void testTextIdentifierAndSelectAuto() {
+        // s3 options should override multiline json fragmenter option
+        context.addOption("S3_SELECT", "auto");
+        context.addOption("IDENTIFIER", "c1");
+        context.setOutputFormat(OutputFormat.TEXT);
+        verifyAccessors(context, EXPECTED_ACCESSOR_TEXT_AUTO_NO_BENEFIT);
+        verifyResolvers(context, EXPECTED_RESOLVER_TEXT_AUTO_NO_BENEFIT);
+        verifyFragmenters(context, EXPECTED_FRAGMENTER_MULTILINE);
     }
 
     private void verifyFragmenters(RequestContext context, String[] expected) {

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -723,6 +723,7 @@ under the License.
             <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
         </plugins>
+        <handler>org.greenplum.pxf.plugins.json.JsonProtocolHandler</handler>
     </profile>
     <profile>
         <name>s3:json</name>

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -709,6 +709,7 @@ under the License.
             <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
         </plugins>
+        <handler>org.greenplum.pxf.plugins.json.JsonProtocolHandler</handler>
     </profile>
     <profile>
         <name>hdfs:json</name>
@@ -758,6 +759,7 @@ under the License.
             <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
         </plugins>
+        <handler>org.greenplum.pxf.plugins.json.JsonProtocolHandler</handler>
         <protocol>adl</protocol>
     </profile>
     <profile>
@@ -773,6 +775,7 @@ under the License.
             <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
         </plugins>
+        <handler>org.greenplum.pxf.plugins.json.JsonProtocolHandler</handler>
         <protocol>wasbs</protocol>
     </profile>
     <profile>
@@ -788,6 +791,7 @@ under the License.
             <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
         </plugins>
+        <handler>org.greenplum.pxf.plugins.json.JsonProtocolHandler</handler>
         <protocol>gs</protocol>
     </profile>
     <profile>
@@ -803,6 +807,7 @@ under the License.
             <accessor>org.greenplum.pxf.plugins.json.JsonAccessor</accessor>
             <resolver>org.greenplum.pxf.plugins.json.JsonResolver</resolver>
         </plugins>
+        <handler>org.greenplum.pxf.plugins.json.JsonProtocolHandler</handler>
     </profile>
 
     <!-- ==================== SEQUENCE FILE PROFILES ==================== -->


### PR DESCRIPTION
This commit adds a JsonProtocolHandler which will use the HdfsFileFragmenter if we detect that the multi-line JSON profile is being used. 