### PR TITLE
added Maven, Java 8 and pip install for GPDB7 docker images

### DIFF
--- a/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
@@ -32,7 +32,7 @@ RUN curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERS
     && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
     && yum install -y rpm-build python-devel jq sudo java-1.8.0-openjdk java-11-openjdk-devel && yum clean all \
     && cd /tmp && /usr/bin/pip install --upgrade pip==20.3.3 \
-    && /usr/bin/pip install psi paramiko --no-cache-dir
+    && /usr/bin/pip install paramiko --no-cache-dir
 
 # create user gpadmin since GPDB cannot run under root
 RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \

--- a/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
@@ -20,9 +20,19 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
     && chmod +x /opt/minio/bin/minio \
     && chown -R minio:minio /opt/minio
 
-# install java 8 and 11 and dependencies that are missing on the base images
-# java 8 is required to run hadoop. Do not use java 8 to build / run PXF
-RUN yum install -y rpm-build sudo java-1.8.0-openjdk java-11-openjdk-devel jq
+ARG MAVEN_VERSION=3.6.3
+ARG USER_HOME_DIR="/root"
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+# install dependencies that are missing on the base images
+RUN curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+    && mkdir -p /usr/share/maven \
+    && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+    && rm -f /tmp/apache-maven.tar.gz \
+    && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
+    && yum install -y rpm-build python-devel jq sudo java-1.8.0-openjdk java-11-openjdk-devel && yum clean all \
+    && cd /tmp && /usr/bin/pip install --upgrade pip==20.3.3 \
+    && /usr/bin/pip install psi paramiko --no-cache-dir
 
 # create user gpadmin since GPDB cannot run under root
 RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
@@ -61,7 +71,7 @@ RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
     && echo >> ~gpadmin/.pxfrc 'export GPHD_ROOT=/singlecluster' \
     && echo >> ~gpadmin/.pxfrc 'export PXF_HOME=/usr/local/pxf-gp7' \
     && echo >> ~gpadmin/.pxfrc 'export PXF_CONF=/home/gpadmin/pxf' \
-    && echo >> ~gpadmin/.pxfrc 'export JAVA_HOME=/usr/lib/jvm/java-11' \
+    && echo >> ~gpadmin/.pxfrc 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk' \
     && echo >> ~gpadmin/.pxfrc 'export PATH=${GPHOME}/bin:${PXF_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:$JAVA_HOME/bin:$PATH' \
     && ln -s ~gpadmin/.pxfrc ~root \
     && echo >> ~gpadmin/.bashrc 'source ~/.pxfrc' \

--- a/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
@@ -50,7 +50,7 @@ RUN locale-gen en_US.UTF-8 \
     && { ssh-keyscan localhost; ssh-keyscan 0.0.0.0; } >> /home/gpadmin/.ssh/known_hosts \
     && chown -R gpadmin:gpadmin /home/gpadmin \
     # install dependencies as gpadmin
-    && su gpadmin -c "pip install psi paramiko --no-cache-dir" \
+    && su gpadmin -c "pip install paramiko --no-cache-dir" \
     # configure gpadmin limits
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft core unlimited' \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nproc 131072' \

--- a/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
@@ -11,11 +11,22 @@ RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
     && tar -C /usr/local -xzf go.tgz && rm go.tgz \
     && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@v${GINKGO_VERSION}
 
-# install java 11 and dependencies that are missing on the base images
+# install dependencies that are missing on the base images
+# install a specific version of perl for tinc
+
+ARG MAVEN_VERSION=3.6.3
+ARG USER_HOME_DIR="/root"
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
 RUN apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y curl sudo openjdk-11-jdk jq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y python-dev curl sudo jq openjdk-8-jdk openjdk-11-jdk \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && mkdir -p /usr/share/maven /usr/share/maven/ref \
+    && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+    && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+    && rm -f /tmp/apache-maven.tar.gz \
+    && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
 # create user gpadmin since GPDB cannot run under root
 RUN locale-gen en_US.UTF-8 \
@@ -38,6 +49,8 @@ RUN locale-gen en_US.UTF-8 \
     && echo "gpadmin:password" | chpasswd 2> /dev/null \
     && { ssh-keyscan localhost; ssh-keyscan 0.0.0.0; } >> /home/gpadmin/.ssh/known_hosts \
     && chown -R gpadmin:gpadmin /home/gpadmin \
+    # install dependencies as gpadmin
+    && su gpadmin -c "pip install psi paramiko --no-cache-dir" \
     # configure gpadmin limits
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft core unlimited' \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nproc 131072' \
@@ -53,7 +66,7 @@ RUN locale-gen en_US.UTF-8 \
     && echo >> ~gpadmin/.pxfrc 'export GPHD_ROOT=/singlecluster' \
     && echo >> ~gpadmin/.pxfrc 'export PXF_HOME=/usr/local/pxf-gp7' \
     && echo >> ~gpadmin/.pxfrc 'export PXF_CONF=/home/gpadmin/pxf' \
-    && echo >> ~gpadmin/.pxfrc 'export JAVA_HOME=/usr/lib/jvm/jdk-11' \
+    && echo >> ~gpadmin/.pxfrc 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64' \
     && echo >> ~gpadmin/.pxfrc 'export PATH=${GPHOME}/bin:${PXF_HOME}/bin:${GOPATH}/bin:/usr/local/go/bin:$JAVA_HOME/bin:$PATH' \
     && ln -s ~gpadmin/.pxfrc ~root \
     && echo >> ~gpadmin/.bashrc 'source ~/.pxfrc' \


### PR DESCRIPTION
Since we will be running Tinc for testing FDW and external tables for GP7, we needed to add Maven and some python dependencies to run automation. Additionally, current images for GP7 were assuming PXF is compiled with Java11, this was probably experimental, we need to compile with Java 8 to support existing installations. So added Java 8 as well and set JAVA_HOME to use it.

Some changes, like `pip install` are a bit different between Centos and Ubuntu, but the logic is the same across Centos7 for gp6 and gp7 and Ubuntu for gp6 and gp7.