### PR TITLE
Fix bug when modifying PXF's classpath in automation

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/components/cluster/PhdCluster.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/cluster/PhdCluster.java
@@ -79,7 +79,8 @@ public abstract class PhdCluster extends ShellSystemObject {
 	public void addPathToPxfClassPath(String path) throws Exception {
 		String content = "export PXF_LOADER_PATH=file:" + path;
 		// path to local fetch pxf class file
-		File pathToLocalClassPathFile = new File(getPxfBase() + "/conf", getPxfConfigurationFile());
+
+		File pathToLocalClassPathFile = new File(getPathToLocalPxfConfDirectory(), getPxfConfigurationFile());
 		ReportUtils.report(report, getClass(), "Add " + content + " to PXF class path (" + pathToLocalClassPathFile.getAbsolutePath() + ")");
 		// read file content
 		String pxfClasspathContent = new String(Files.readAllBytes(Paths.get(pathToLocalClassPathFile.getAbsolutePath())));

--- a/concourse/settings/pxf-multinode-params.yml
+++ b/concourse/settings/pxf-multinode-params.yml
@@ -2,6 +2,6 @@ enable-impersonation-multinode: true
 number_of_gpdb_nodes: 3
 tf-bucket-path: clusters-google/
 no_of_files: 10000
-pxf-jvm-opts: "-Xmx512m -Xms512m"
+pxf-jvm-opts: "-Xmx2g -Xms2g"
 kerberos-enabled: true
 dataproc-image-version: "1.4"


### PR DESCRIPTION
PXF's automation test framework includes a helper method
(`addPathToPxfClassPath`) that modifies pxf-env.sh to set
`PXF_LOADER_PATH`. The problem is that the methods reads the content of
pxf-env.sh from $PXF_BASE/conf on the local host which may not be the
same as the file on a multinode cluster. Since the remote configuration
is copied down from the remote cluster to a temporary working directory,
the helper method should load pxf-env.sh from this location.

Additionally, this commit increases the size of PXF heap for multinode
tests. The original heap size of 512 MB was too small for some of our
tests but this wasn't noticed until now because the automation framework
modified pxf-env.sh without preserving any changes made to it during the
installation and setup of PXF on the multinode cluster.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>