### PR TITLE
docs - update jdbc driver version number

### DIFF
--- a/docs/content/jdbc_cfg.html.md.erb
+++ b/docs/content/jdbc_cfg.html.md.erb
@@ -19,7 +19,7 @@ In previous releases of Greenplum Database, you may have specified the JDBC driv
 
 ## <a id="cfg_jar"></a>JDBC Driver JAR Registration
 
-PXF is bundled with the `postgresql-42.3.3.jar` JAR file. If you require a different JDBC driver, ensure that you install the JDBC driver JAR file for the external SQL database in the `$PXF_BASE/lib` directory on each Greenplum host. Be sure to install JDBC driver JAR files that are compatible with your JRE version. See [Registering PXF Library Dependencies](reg_jar_depend.html) for additional information.
+PXF is bundled with the `postgresql-42.4.1.jar` JAR file. If you require a different JDBC driver, ensure that you install the JDBC driver JAR file for the external SQL database in the `$PXF_BASE/lib` directory on each Greenplum host. Be sure to install JDBC driver JAR files that are compatible with your JRE version. See [Registering PXF Library Dependencies](reg_jar_depend.html) for additional information.
 
 ## <a id="cfg_server"></a>JDBC Server Configuration
 


### PR DESCRIPTION
the docs include a reference to the jdbc driver version; version 42.4.1 is bundled with pxf v6.4.