### PR TITLE
ci: allow existing artifacts to remain if there is no pivnet product

### DIFF
--- a/concourse/scripts/get_product_files.bash
+++ b/concourse/scripts/get_product_files.bash
@@ -68,15 +68,15 @@ for ((i = 0; i < ${#product_files[@]}; i++)); do
 
 	if [[ -z "${id}" ]]; then
 		echo "Did not find '${file}' in product files for GPDB '${gpdb_version}'"
-		rhel_regex='^.*rhel7.*$'
-		ubuntu_regex='^.*ubuntu18.*$'
-		if [[ $file =~ ${ubuntu_regex} ]]; then
-			existing_file=$(find ${product_dirs[$i]}/ -name *ubuntu18*.rpm)
-		elif [[ $file =~ ${rhel_regex} ]]; then
-			existing_file=$(find ${product_dirs[$i]}/ -name *el7*.rpm)
-		else
-			existing_file=$(find ${product_dirs[$i]}/ -name *el8*.rpm)
-		fi
+
+		case "${file}" in
+			*rhel7*) existing_file="$(find ${product_dirs[$i]}/ -name *rhel7*.rpm)" ;;
+			*rhel8*) existing_file="$(find ${product_dirs[$i]}/ -name *rhel8*.rpm)" ;;
+			*ubuntu18*) existing_file="$(find ${product_dirs[$i]}/ -name *ubuntu18*.deb)" ;;
+			*)
+				echo "Unexpected file: ${file}"
+				exit 1;;
+		esac
 
 		echo "Keeping existing file: ${existing_file}"
 		continue

--- a/concourse/scripts/get_product_files.bash
+++ b/concourse/scripts/get_product_files.bash
@@ -68,12 +68,18 @@ for ((i = 0; i < ${#product_files[@]}; i++)); do
 
 	if [[ -z "${id}" ]]; then
 		echo "Did not find '${file}' in product files for GPDB '${gpdb_version}'"
-		os_regex='^.*rhel8.*$'
-		if [[ $file =~ ${os_regex} ]]; then
-			echo "RHEL 8 artifact unavailable for the given GPDB version. Keeping existing rpm: $(find ${product_dirs[$i]}/ -name *rhel8*.rpm)"
-			continue
+		rhel_regex='^.*rhel7.*$'
+		ubuntu_regex='^.*ubuntu18.*$'
+		if [[ $file =~ ${ubuntu_regex} ]]; then
+			existing_file=$(find ${product_dirs[$i]}/ -name *ubuntu18*.rpm)
+		elif [[ $file =~ ${rhel_regex} ]]; then
+			existing_file=$(find ${product_dirs[$i]}/ -name *el7*.rpm)
+		else
+			existing_file=$(find ${product_dirs[$i]}/ -name *el8*.rpm)
 		fi
-		exit 1
+
+		echo "Keeping existing file: ${existing_file}"
+		continue
 	fi
 	echo "Cleaning ${product_dirs[$i]} and downloading ${file} with id ${id} to ${product_dirs[$i]}..."
 	rm -f "${product_dirs[$i]}"/*.{rpm,deb}


### PR DESCRIPTION
In the case that there is no pivnet artifact to pull down, do not error out. Instead, keep whatever artifact was already present in the bucket.