### PR TITLE
ADBDEV-3060: Incorrect work bool data type in query to pxf foreign table

### DIFF
--- a/external-table/src/pxffilters.c
+++ b/external-table/src/pxffilters.c
@@ -1427,6 +1427,12 @@ extractPxfAttributes(List *quals, bool *qualsAreSupported)
 					append_attr_from_var((Var *) expr->arg, attributes);
 				break;
 			}
+			case T_Var:
+			{
+				attributes        =
+					append_attr_from_var((Var*) node, attributes);
+				break;
+			}
 			default:
 			{
 				/*

--- a/fdw/pxf_deparse.c
+++ b/fdw/pxf_deparse.c
@@ -73,5 +73,6 @@ classifyConditions(PlannerInfo *root,
 
 		/* for now, just assume that all WHERE clauses are OK on remote */
 		*remote_conds = lappend(*remote_conds, ri);
+		*local_conds = lappend(*local_conds, ri);
 	}
 }

--- a/regression/expected/FDW_FilterPushDownTest.out
+++ b/regression/expected/FDW_FilterPushDownTest.out
@@ -3,6 +3,29 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
+CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
+CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
+CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
+explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+                                                             QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=50000.00..50000.00 rows=1000 width=32) (actual time=25.552..25.554 rows=1 loops=1)
+   ->  Foreign Scan on foreign_tb_test  (cost=50000.00..50000.00 rows=334 width=32) (actual time=0.369..0.371 rows=1 loops=1)
+         Filter: ((NOT v_bool) AND (v_text = '5'::text))
+ Planning time: 3.438 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 111K bytes avg x 3 workers, 138K bytes max (seg1).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 25.723 ms
+(9 rows)
+
+select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+ v_text 
+--------
+ 5
+(1 row)
+
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator

--- a/regression/expected/FilterPushDownTest.out
+++ b/regression/expected/FilterPushDownTest.out
@@ -3,6 +3,29 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
+create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
+insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
+CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+                                                          QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..469.21 rows=237038 width=8) (actual time=12.759..12.760 rows=1 loops=1)
+   ->  External Scan on tb_test_t_pxf  (cost=0.00..462.14 rows=79013 width=8) (actual time=12.051..12.079 rows=1 loops=1)
+         Filter: ((v_text = '5'::text) AND (NOT v_bool))
+ Planning time: 6.030 ms
+   (slice0)    Executor memory: 132K bytes.
+   (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 13.066 ms
+(9 rows)
+
+select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+ v_text 
+--------
+ 5
+(1 row)
+
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)
     LOCATION (E'pxf://dummy_path?FRAGMENTER=org.greenplum.pxf.diagnostic.FilterVerifyFragmenter&ACCESSOR=org.greenplum.pxf.diagnostic.UserDataVerifyAccessor&RESOLVER=org.greenplum.pxf.plugins.hdfs.StringPassResolver')

--- a/regression/sql/FDW_FilterPushDownTest.sql
+++ b/regression/sql/FDW_FilterPushDownTest.sql
@@ -6,6 +6,12 @@
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
 
+CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
+CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
+CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
+explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator

--- a/regression/sql/FilterPushDownTest.sql
+++ b/regression/sql/FilterPushDownTest.sql
@@ -6,6 +6,12 @@
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
 
+create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
+insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
+CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)


### PR DESCRIPTION
Query on pxf external tables or pxf fdw does not correct work with bool variable pushdown. When pushdowning the results filtered twice: once - on remote pxf part and again - in local gpdb part. But if bool variable is not in select-statement and is in where-statement, then it is not returned from remote pxf part and local gpdb part can not filter by it. This leads to incorrect results.
Steps to reproduce this problem on external table:
```sql
create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
create extension pxf;
CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
                                                           QUERY PLAN                                                            
---------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..469.21 rows=237038 width=8) (actual time=100.480..100.480 rows=0 loops=1)
   ->  External Scan on tb_test_t_pxf  (cost=0.00..462.14 rows=79013 width=8) (never executed)
         Filter: ((v_text = '5'::text) AND (NOT v_bool))
 Planning time: 47.138 ms
   (slice0)    Executor memory: 132K bytes.
   (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 107.201 ms
(9 rows)
INFO:  extractPxfAttributes: unsupported node tag 303, unable to extract attribute from qualifier  (seg0 slice1 172.19.0.2:5434 pid=7094)
CONTEXT:  External table tb_test_t_pxf
INFO:  extractPxfAttributes: unsupported node tag 303, unable to extract attribute from qualifier  (seg1 slice1 172.19.0.2:5435 pid=7095)
CONTEXT:  External table tb_test_t_pxf
INFO:  extractPxfAttributes: unsupported node tag 303, unable to extract attribute from qualifier  (seg2 slice1 172.19.0.2:5436 pid=7096)
CONTEXT:  External table tb_test_t_pxf
 v_text 
--------
(0 rows)
```
And on pxf fwd:
```sql
create extension pxf_fdw;
CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
                                                              QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=50000.00..50000.00 rows=1000 width=32) (actual time=124.892..124.892 rows=0 loops=1)
   ->  Foreign Scan on foreign_tb_test  (cost=50000.00..50000.00 rows=334 width=32) (never executed)
         Filter: ((NOT v_bool) AND (v_text = '5'::text))
 Planning time: 16.251 ms
   (slice0)    Executor memory: 59K bytes.
   (slice1)    Executor memory: 132K bytes avg x 3 workers, 138K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Postgres query optimizer
 Execution time: 125.806 ms
(9 rows)
 v_text 
--------
(0 rows)
```
This happens because `Filter: (NOT b2)` is `T_BoolExpr` consists of `T_Var` which is not supported by pxf pushdown (before this PR).

The problem for external tables was solved by adding `T_Var` for returning from pxf part, and for fdw was solved by setting WHERE clauses are OK on local.

Also a small bug in external tables (wrong total count of return values) was solved.