### PR TITLE
Use Google Cloud Storage instead of S3 in perf-10g pipeline

### DIFF
--- a/concourse/settings/perf-settings-10g.yml
+++ b/concourse/settings/perf-settings-10g.yml
@@ -5,7 +5,7 @@ folder-prefix: perf
 perf-scale: "10"
 
 enable-impersonation-multinode: true
-pxf-jvm-opts: "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heap_dump -Xmx2g -Xms1g"
+pxf-jvm-opts: "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heap_dump -Xmx8g -Xms8g"
 perf-ccp-reap-minutes: 120
 
 perf-gpdb-number-of-nodes: 4
@@ -26,9 +26,9 @@ perf-trigger-stop: 12:40 PM
 perf-benchmark-concurrency: 10
 perf-benchmark-hadoop: true
 perf-benchmark-adl: false
-perf-benchmark-s3: true
-perf-benchmark-s3-extension: true
-perf-benchmark-gcs: false
+perf-benchmark-s3: false
+perf-benchmark-s3-extension: false
+perf-benchmark-gcs: true
 perf-benchmark-gphdfs: false
 perf-benchmark-wasb: false
 perf-sleep-before-destroy: 10


### PR DESCRIPTION
Using GCS instead of S3 for the perf-10g pipeline avoids sending a large amount of traffic outside of the GCP project and incurring Network Cloud NAT Data Processing fees. The heap size of the PXF JVM needed to be increased from 2 GB to 8 GB in order to avoid OOM errors. One potential reason for needing an increased heap size when writing to GCS instead of S3 is that the S3 Hadoop client library will write data to local temporary files before asynchronously uploading them.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>