### PR TITLE
Fix projection of boolean qualifiers whose attrs are not in SELECT list

### DIFF
--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/expected/query01.ans
@@ -56,9 +56,40 @@ SELECT colprojvalue FROM test_column_projection ORDER BY t0;
  t0|colprojvalue
 (10 rows)
 
--- Column Projection is not supported for boolean?
--- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
---
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|b2|colprojvalue
+ C  | t0|b2|colprojvalue
+ E  | t0|b2|colprojvalue
+ G  | t0|b2|colprojvalue
+ I  | t0|b2|colprojvalue
+(5 rows)
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+ t0 | a1 |     colprojvalue
+----+----+-----------------------
+ B  |  1 | t0|a1|b2|colprojvalue
+ D  |  3 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+       sqrt       |     colprojvalue
+------------------+-----------------------
+                1 | t0|a1|b2|colprojvalue
+ 1.73205080756888 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+       sqrt       |     colprojvalue
+------------------+-----------------------
+                1 | t0|a1|b2|colprojvalue
+ 1.73205080756888 | t0|a1|b2|colprojvalue
+ 2.23606797749979 | t0|a1|b2|colprojvalue
+ 2.64575131106459 | t0|a1|b2|colprojvalue
+                3 | t0|a1|b2|colprojvalue
+(5 rows)
+
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
  t0 |    colprojvalue
 ----+--------------------
@@ -196,9 +227,40 @@ SELECT colprojvalue FROM test_column_projection ORDER BY t0;
  t0|colprojvalue
 (10 rows)
 
--- Column Projection is not supported for boolean?
--- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
---
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|b2|colprojvalue
+ C  | t0|b2|colprojvalue
+ E  | t0|b2|colprojvalue
+ G  | t0|b2|colprojvalue
+ I  | t0|b2|colprojvalue
+(5 rows)
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+ t0 | a1 |     colprojvalue
+----+----+-----------------------
+ B  |  1 | t0|a1|b2|colprojvalue
+ D  |  3 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+       sqrt       |     colprojvalue
+------------------+-----------------------
+                1 | t0|a1|b2|colprojvalue
+ 1.73205080756888 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+       sqrt       |     colprojvalue
+------------------+-----------------------
+                1 | t0|a1|b2|colprojvalue
+ 1.73205080756888 | t0|a1|b2|colprojvalue
+ 2.23606797749979 | t0|a1|b2|colprojvalue
+ 2.64575131106459 | t0|a1|b2|colprojvalue
+                3 | t0|a1|b2|colprojvalue
+(5 rows)
+
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
  t0 |    colprojvalue
 ----+--------------------

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/sql/query01.sql
@@ -13,9 +13,14 @@ SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
 
 SELECT colprojvalue FROM test_column_projection ORDER BY t0;
 
--- Column Projection is not supported for boolean?
--- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
---
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
@@ -41,9 +46,14 @@ SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
 
 SELECT colprojvalue FROM test_column_projection ORDER BY t0;
 
--- Column Projection is not supported for boolean?
--- SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
---
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;

--- a/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/expected/query01.ans
@@ -41,6 +41,30 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+       sqrt       |          filtervalue
+------------------+-------------------------------
+                1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ 1.73205080756888 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+       sqrt       |   filtervalue
+------------------+------------------
+                1 | a2c16s4dtrueo0l2
+ 1.73205080756888 | a2c16s4dtrueo0l2
+ 2.23606797749979 | a2c16s4dtrueo0l2
+ 2.64575131106459 | a2c16s4dtrueo0l2
+                3 | a2c16s4dtrueo0l2
+(5 rows)
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue
 ----+----+----+---------------------------------------------
@@ -95,6 +119,30 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  F  |  5 | f  | a2c16s4dtrueo0l2
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
+(5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+       sqrt       |          filtervalue
+------------------+-------------------------------
+                1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ 1.73205080756888 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+       sqrt       |   filtervalue
+------------------+------------------
+                1 | a2c16s4dtrueo0l2
+ 1.73205080756888 | a2c16s4dtrueo0l2
+ 2.23606797749979 | a2c16s4dtrueo0l2
+ 2.64575131106459 | a2c16s4dtrueo0l2
+                3 | a2c16s4dtrueo0l2
 (5 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;

--- a/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/sql/query01.sql
@@ -13,6 +13,12 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -28,6 +34,12 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
+SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 

--- a/external-table/src/pxffilters.c
+++ b/external-table/src/pxffilters.c
@@ -1427,6 +1427,12 @@ extractPxfAttributes(List *quals, bool *qualsAreSupported)
 					append_attr_from_var((Var *) expr->arg, attributes);
 				break;
 			}
+			case T_Var:
+			{
+				attributes        =
+					append_attr_from_var((Var*) node, attributes);
+				break;
+			}
 			default:
 			{
 				/*

--- a/external-table/src/pxfheaders.c
+++ b/external-table/src/pxfheaders.c
@@ -384,6 +384,7 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 	TupleDesc		tupdesc;
 
 	initStringInfo(&formatter);
+	attrs_used = NULL;
 	number = 0;
 
 #if PG_VERSION_NUM >= 90400
@@ -418,9 +419,9 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 			int attno = lfirst_int(lc1);
 			if (attno > InvalidAttrNumber)
 			{
-				add_projection_index_header(headers,
-											formatter, attno - 1, long_number);
-				number++;
+				attrs_used =
+					bms_add_member(attrs_used,
+									attno - FirstLowInvalidHeapAttributeNumber);
 			}
 		}
 
@@ -433,7 +434,6 @@ add_projection_desc_httpheader(CHURL_HEADERS headers,
 	}
 #endif
 
-	attrs_used = NULL;
 
 #if PG_VERSION_NUM >= 90400
 	for (i = 0; i < projInfo->pi_numSimpleVars; i++)

--- a/fdw/pxf_deparse.c
+++ b/fdw/pxf_deparse.c
@@ -73,5 +73,6 @@ classifyConditions(PlannerInfo *root,
 
 		/* for now, just assume that all WHERE clauses are OK on remote */
 		*remote_conds = lappend(*remote_conds, ri);
+		*local_conds = lappend(*local_conds, ri);
 	}
 }

--- a/regression/expected/FDW_FilterPushDownTest.out
+++ b/regression/expected/FDW_FilterPushDownTest.out
@@ -3,6 +3,29 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
+CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
+CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
+CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
+explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+                                                             QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=50000.00..50000.00 rows=1000 width=32) (actual time=25.552..25.554 rows=1 loops=1)
+   ->  Foreign Scan on foreign_tb_test  (cost=50000.00..50000.00 rows=334 width=32) (actual time=0.369..0.371 rows=1 loops=1)
+         Filter: ((NOT v_bool) AND (v_text = '5'::text))
+ Planning time: 3.438 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 111K bytes avg x 3 workers, 138K bytes max (seg1).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 25.723 ms
+(9 rows)
+
+select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+ v_text 
+--------
+ 5
+(1 row)
+
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator

--- a/regression/expected/FDW_FilterPushDownTest.out
+++ b/regression/expected/FDW_FilterPushDownTest.out
@@ -3,29 +3,6 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
-CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
-CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
-CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
-explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
-                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=50000.00..50000.00 rows=1000 width=32) (actual time=25.552..25.554 rows=1 loops=1)
-   ->  Foreign Scan on foreign_tb_test  (cost=50000.00..50000.00 rows=334 width=32) (actual time=0.369..0.371 rows=1 loops=1)
-         Filter: ((NOT v_bool) AND (v_text = '5'::text))
- Planning time: 3.438 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 111K bytes avg x 3 workers, 138K bytes max (seg1).
- Memory used:  128000kB
- Optimizer: Postgres query optimizer
- Execution time: 25.723 ms
-(9 rows)
-
-select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
- v_text 
---------
- 5
-(1 row)
-
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator
@@ -74,6 +51,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue          
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
@@ -129,6 +113,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue          
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
@@ -207,6 +198,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue          
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
 ----+----+----+---------------------------------------------
@@ -261,6 +259,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue          
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 

--- a/regression/expected/FilterPushDownTest.out
+++ b/regression/expected/FilterPushDownTest.out
@@ -3,29 +3,6 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
-create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
-insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
-CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
-explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
-                                                          QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..469.21 rows=237038 width=8) (actual time=12.759..12.760 rows=1 loops=1)
-   ->  External Scan on tb_test_t_pxf  (cost=0.00..462.14 rows=79013 width=8) (actual time=12.051..12.079 rows=1 loops=1)
-         Filter: ((v_text = '5'::text) AND (NOT v_bool))
- Planning time: 6.030 ms
-   (slice0)    Executor memory: 132K bytes.
-   (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).
- Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA)
- Execution time: 13.066 ms
-(9 rows)
-
-select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
- v_text 
---------
- 5
-(1 row)
-
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)
     LOCATION (E'pxf://dummy_path?FRAGMENTER=org.greenplum.pxf.diagnostic.FilterVerifyFragmenter&ACCESSOR=org.greenplum.pxf.diagnostic.UserDataVerifyAccessor&RESOLVER=org.greenplum.pxf.plugins.hdfs.StringPassResolver')
@@ -67,6 +44,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
@@ -122,6 +106,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
@@ -197,6 +188,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 
 ----+----+----+---------------------------------------------
@@ -251,6 +249,13 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
  H  |  7 | f  | a2c16s4dtrueo0l2
  J  |  9 | f  | a2c16s4dtrueo0l2
 (5 rows)
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+ t0 | a1 |          filtervalue
+----+----+-------------------------------
+ B  |  1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+(2 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
  t0 | a1 | b2 |                 filtervalue                 

--- a/regression/expected/FilterPushDownTest.out
+++ b/regression/expected/FilterPushDownTest.out
@@ -3,6 +3,29 @@
 -----------------------------------------------------
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
+create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
+insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
+CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+                                                          QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..469.21 rows=237038 width=8) (actual time=12.759..12.760 rows=1 loops=1)
+   ->  External Scan on tb_test_t_pxf  (cost=0.00..462.14 rows=79013 width=8) (actual time=12.051..12.079 rows=1 loops=1)
+         Filter: ((v_text = '5'::text) AND (NOT v_bool))
+ Planning time: 6.030 ms
+   (slice0)    Executor memory: 132K bytes.
+   (slice1)    Executor memory: 130K bytes avg x 3 workers, 130K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 13.066 ms
+(9 rows)
+
+select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+ v_text 
+--------
+ 5
+(1 row)
+
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)
     LOCATION (E'pxf://dummy_path?FRAGMENTER=org.greenplum.pxf.diagnostic.FilterVerifyFragmenter&ACCESSOR=org.greenplum.pxf.diagnostic.UserDataVerifyAccessor&RESOLVER=org.greenplum.pxf.plugins.hdfs.StringPassResolver')

--- a/regression/sql/FDW_FilterPushDownTest.sql
+++ b/regression/sql/FDW_FilterPushDownTest.sql
@@ -5,13 +5,6 @@
 
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
-
-CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
-CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
-CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
-explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
-select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
-
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator
@@ -40,6 +33,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -55,6 +50,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
@@ -98,6 +95,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -113,6 +112,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 

--- a/regression/sql/FDW_FilterPushDownTest.sql
+++ b/regression/sql/FDW_FilterPushDownTest.sql
@@ -6,6 +6,12 @@
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
 
+CREATE SERVER loopback FOREIGN DATA WRAPPER jdbc_pxf_fdw OPTIONS (jdbc_driver 'org.postgresql.Driver', db_url 'jdbc:postgresql://localhost:5432/gpadmin');
+CREATE USER MAPPING FOR CURRENT_USER SERVER loopback;
+CREATE FOREIGN TABLE foreign_tb_test (id int,  v_text text, v_bool bool) SERVER loopback OPTIONS ( resource 'public.tb_test_t' );
+explain analyze select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+select v_text from foreign_tb_test where v_text = '5' and  v_bool = false ;
+
 CREATE FOREIGN DATA WRAPPER pxf_filter_push_down_fdw
     HANDLER pxf_fdw_handler
     VALIDATOR pxf_fdw_validator

--- a/regression/sql/FilterPushDownTest.sql
+++ b/regression/sql/FilterPushDownTest.sql
@@ -6,12 +6,6 @@
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
 
-create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
-insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
-CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
-explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
-select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
-
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)
@@ -31,6 +25,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -46,6 +42,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
@@ -84,6 +82,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, 
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
@@ -99,6 +99,8 @@ SELECT * FROM test_filter WHERE  t0 = 'B' AND (a1 = 1 OR a1 = 10) ORDER BY t0, a
 SELECT * FROM test_filter WHERE  t0 = 'B' OR (a1 >= 0 AND a1 <= 2) ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
+
+SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 

--- a/regression/sql/FilterPushDownTest.sql
+++ b/regression/sql/FilterPushDownTest.sql
@@ -6,6 +6,12 @@
 -- Check that the filter is being pushed down. We create an external table
 -- that returns the filter being sent from the C-side
 
+create table tb_test_t(id serial primary key,  v_text text, v_bool bool);
+insert into tb_test_t(v_text, v_bool) select v::text, false from generate_series(1, 20) v;
+CREATE EXTERNAL TABLE tb_test_t_pxf(id int,  v_text text, v_bool bool) LOCATION('pxf://public.tb_test_t?PROFILE=JDBC&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://localhost:5432/gpadmin&USER=gpadmin') FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+explain analyze select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+select v_text from tb_test_t_pxf where v_text = '5' and  v_bool = false ;
+
 DROP EXTERNAL TABLE IF EXISTS test_filter CASCADE;
 
 CREATE EXTERNAL TABLE test_filter (t0 text, a1 integer, b2 boolean, filterValue text)


### PR DESCRIPTION
This PR extends the PR https://github.com/greenplum-db/pxf/pull/873 with small fixes. The original PR identified the issue and provided fixes for it.

The overall changes:
- boolean condition (e.g. `col = false`) qualifiers were not properly supported when parsing the quals to determine `attrs` used. This resulted in these `attrs` not being projected unless the `attr` was also in `SELECT` clause
- accounting of projected `attrs` is fixed such that the exact number of http headers for projected attributes is sent to PXF and the potential for accounting for the same attribute multiple times is removed
- for FDW `quals` are added as `local conditions` so they can be parsed and `attrs` can be extracted from them. Perhaps we need to review whether we still need to keep them as `remote conditions` as well.

Note: `targetList` having a functional expression is happening primarily with Planner, while ORCA just reports the boolean `attr` as a `simpleVar`.  