### PR TITLE
Update shell scripts to use a more consistent style

### DIFF
--- a/server/pxf-service/src/scripts/kill-pxf.sh
+++ b/server/pxf-service/src/scripts/kill-pxf.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-log() {
-  echo "=====> $(date) $* <======" >> "${PXF_LOGDIR}/pxf-oom.log"
+function log() {
+    echo "=====> $(date) $* <======" >> "${PXF_LOGDIR}/pxf-oom.log"
 }
 
-_main() {
-  sleep 1
-  log 'Stopping PXF'
-  "${PXF_HOME}/bin/pxf" stop && return
-  # "insurance policy":
-  local PID=$1
-  if [[ -n $PID ]]; then
-    ps "$1" >/dev/null && kill -9 "$1"
-  fi
+function _main() {
+    sleep 1
+    log 'Stopping PXF'
+    "${PXF_HOME}/bin/pxf" stop && return
+    # "insurance policy":
+    local PID=$1
+    if [[ -n $PID ]]; then
+        ps "$1" >/dev/null && kill -9 "$1"
+    fi
 }
 
 log 'PXF Out of memory detected'

--- a/server/pxf-service/src/scripts/merge-pxf-config.sh
+++ b/server/pxf-service/src/scripts/merge-pxf-config.sh
@@ -19,8 +19,8 @@ echoYellow() { echo $'\e[0;33m'"$1"$'\e[0m'; }
 
 # print error message and return with error code
 function fail() {
-  echoRed "ERROR: $1"
-  exit 1
+    echoRed "ERROR: $1"
+    exit 1
 }
 
 # FILE1 -ef FILE2  True if file1 is a hard link to file2.
@@ -33,7 +33,7 @@ header_added_to_properties=false
 header_added_to_env=false
 
 function addHeader() {
-  echo "
+    echo "
 
 ######################################################
 # The properties below were added by the pxf migrate
@@ -43,63 +43,63 @@ function addHeader() {
 }
 
 function ensureHeaderAddedToProperties() {
-  if [[ $header_added_to_properties == false ]]; then
-    header_added_to_properties=true
-    addHeader "${PXF_BASE}/conf/pxf-application.properties"
-  fi
+    if [[ $header_added_to_properties == false ]]; then
+        header_added_to_properties=true
+        addHeader "${PXF_BASE}/conf/pxf-application.properties"
+    fi
 }
 
 function ensureHeaderAddedToEnv() {
-  if [[ $header_added_to_env == false ]]; then
-    header_added_to_env=true
-    addHeader "${PXF_BASE}/conf/pxf-env.sh"
-  fi
+    if [[ $header_added_to_env == false ]]; then
+        header_added_to_env=true
+        addHeader "${PXF_BASE}/conf/pxf-env.sh"
+    fi
 }
 
 # Add the value to the pxf-env.sh file
 function addToEnv() {
-  local var=$1
-  echoGreen " - Migrating $var=${!var} to "${PXF_BASE}/conf/pxf-env.sh""
-  ensureHeaderAddedToEnv
-  echo "export $var=\"${!var}\"" >> "${PXF_BASE}/conf/pxf-env.sh"
+    local var=$1
+    echoGreen " - Migrating $var=${!var} to "${PXF_BASE}/conf/pxf-env.sh""
+    ensureHeaderAddedToEnv
+    echo "export $var=\"${!var}\"" >> "${PXF_BASE}/conf/pxf-env.sh"
 }
 
 # Add the value to the pxf-application.properties file
 function addToProperties() {
-  local var=$1
-  local newName=$2
-  echoGreen " - Migrating $var=${!var} to '${PXF_BASE}/conf/pxf-application.properties' as \"$newName\""
-  ensureHeaderAddedToProperties
-  echo "$newName=${!var}" >> "${PXF_BASE}/conf/pxf-application.properties"
+    local var=$1
+    local newName=$2
+    echoGreen " - Migrating $var=${!var} to '${PXF_BASE}/conf/pxf-application.properties' as \"$newName\""
+    ensureHeaderAddedToProperties
+    echo "$newName=${!var}" >> "${PXF_BASE}/conf/pxf-application.properties"
 }
 
 # If the default/pxf-site.xml file does not exist copy it from template
 # then add the value to pxf-site.xml if the existing value is different from
 # the default value
 function addToDefaultPxfSite() {
-  local var=$1
-  local propertyName=$2
-  local defaultValue=$3
+    local var=$1
+    local propertyName=$2
+    local defaultValue=$3
 
-  if [[ ! -f ${PXF_BASE}/servers/default/pxf-site.xml ]]; then
-    echoGreen " - Creating pxf-site.xml in ${PXF_BASE}/servers/default/"
-    cp "${PXF_HOME}/templates/pxf-site.xml" "${PXF_BASE}/servers/default/pxf-site.xml"
-  fi
+    if [[ ! -f ${PXF_BASE}/servers/default/pxf-site.xml ]]; then
+        echoGreen " - Creating pxf-site.xml in ${PXF_BASE}/servers/default/"
+        cp "${PXF_HOME}/templates/pxf-site.xml" "${PXF_BASE}/servers/default/pxf-site.xml"
+    fi
 
-  existingValue=$(sed -ne "/<name>${propertyName}<\/name>/{n;s/.*<value>\(.*\)<\/value>.*/\1/p;q;}" "${PXF_BASE}/servers/default/pxf-site.xml")
-  if [[ "${existingValue}" == "${defaultValue}" ]]; then
-    echoGreen " - Migrating $var=${!var} to '${PXF_BASE}/servers/default/pxf-site.xml' as \"$propertyName\""
-    sed -i "/<name>${propertyName}<\/name>/ {n;s|<value>.*</value>|<value>${!var}</value>|g;}" "${PXF_BASE}/servers/default/pxf-site.xml"
-  else
-    echoYellow " - Not migrating $var=${!var} because the existing value (${existingValue}) is not the default value (${defaultValue}) in ${PXF_BASE}/servers/default/pxf-site.xml"
-  fi
+    existingValue=$(sed -ne "/<name>${propertyName}<\/name>/{n;s/.*<value>\(.*\)<\/value>.*/\1/p;q;}" "${PXF_BASE}/servers/default/pxf-site.xml")
+    if [[ "${existingValue}" == "${defaultValue}" ]]; then
+        echoGreen " - Migrating $var=${!var} to '${PXF_BASE}/servers/default/pxf-site.xml' as \"$propertyName\""
+        sed -i "/<name>${propertyName}<\/name>/ {n;s|<value>.*</value>|<value>${!var}</value>|g;}" "${PXF_BASE}/servers/default/pxf-site.xml"
+    else
+        echoYellow " - Not migrating $var=${!var} because the existing value (${existingValue}) is not the default value (${defaultValue}) in ${PXF_BASE}/servers/default/pxf-site.xml"
+    fi
 }
 
 function warnRemovedProperties() {
-  local var=$1
-  # We don't migrate removed properties because the configuration has changed
-  echoYellow "The $var property has been removed and it won't be automatically migrated."
-  echoYellow "Please refer to documentation to perform manual migration for impersonation and Kerberos principals"
+    local var=$1
+    # We don't migrate removed properties because the configuration has changed
+    echoYellow "The $var property has been removed and it won't be automatically migrated."
+    echoYellow "Please refer to documentation to perform manual migration for impersonation and Kerberos principals"
 }
 
 # Properties migrated to pxf-env.sh

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -28,9 +28,9 @@ WORKING_DIR="$(pwd)"
 cd "$(dirname "$0")" || exit 1
 script_file=$(pwd)/$(basename "$0")
 while [[ -L "$script_file" ]]; do
-  script_file=$(readlink "$script_file")
-  cd "$(dirname "$script_file")" || exit 1
-  script_file=$(pwd)/$(basename "$script_file")
+    script_file=$(readlink "$script_file")
+    cd "$(dirname "$script_file")" || exit 1
+    script_file=$(pwd)/$(basename "$script_file")
 done
 
 parent_script_dir="$( (cd "$( dirname "${script_file}" )/.." && pwd -P) )"
@@ -78,38 +78,41 @@ jarfile="${PXF_HOME}/application/pxf-app-_PXF_VERSION_.jar"
 pid_file="${PXF_RUNDIR}/${identity}.pid"
 
 # ANSI Colors
-echoRed() { echo $'\e[0;31m'"$1"$'\e[0m'; }
-echoGreen() { echo $'\e[0;32m'"$1"$'\e[0m'; }
-echoYellow() { echo $'\e[0;33m'"$1"$'\e[0m'; }
+function echoRed() {
+    echo $'\e[0;31m'"$1"$'\e[0m';
+    }
 
-function validate_user()
-{
+function echoGreen() {
+    echo $'\e[0;32m'"$1"$'\e[0m';
+}
+
+function echoYellow() {
+    echo $'\e[0;33m'"$1"$'\e[0m';
+}
+
+function validate_user() {
     [[ $EUID == 0 ]] && fail 'Cannot run as root user'
 }
 
-function checkPermissions()
-{
+function checkPermissions() {
     touch "$pid_file" &> /dev/null || { echoRed "ERROR: Operation not permitted (cannot access pid file: '$pid_file')"; return 4; }
     [[ -d "$PXF_LOGDIR" ]] || { echoRed "ERROR: Operation not permitted (log directory does not exist: '$PXF_LOGDIR')"; return 4; }
 }
 
-function checkJavaHome()
-{
+function checkJavaHome() {
     # Find Java
     [[ -x ${JAVA_HOME}/bin/java ]] || fail "\$JAVA_HOME=$JAVA_HOME is invalid. Set \$JAVA_HOME in your environment before running PXF commands."
     javaexe="$JAVA_HOME/bin/java"
 }
 
 # print error message and return with error code
-function fail()
-{
+function fail() {
     echoRed "ERROR: $1"
     exit 1
 }
 
 # print error message and provide a hint
-function failWithHint()
-{
+function failWithHint() {
     echoRed    "ERROR: $1"
     echoYellow "HINT:  $2"
     exit 1
@@ -119,8 +122,7 @@ function failWithHint()
 # waitForSpringBoot waits for spring boot to finish loading
 # for given attempts number.
 #
-function waitForSpringBoot()
-{
+function waitForSpringBoot() {
     attempts=0
     max_attempts=$1 # number of attempts to connect
     echo_after_attempts=$2 # only start echoing after this number of attempts
@@ -146,8 +148,7 @@ function waitForSpringBoot()
 # checkWebapp checks if PXF is up for $1 attempts and then
 # verifies PXF webapp is functional
 #
-function checkWebapp()
-{
+function checkWebapp() {
     waitForSpringBoot "$1" "$2" || return 1
 
     curlResponse=$($curl -s "http://localhost:${PXF_PORT}/actuator/health")
@@ -157,14 +158,12 @@ function checkWebapp()
 }
 
 # determines whether the application is running
-function isRunning()
-{
+function isRunning() {
     ps -o pid,command -p "$1" | grep 'pxf-app' &> /dev/null
 }
 
 # creates the runtime directory structure inside $PXF_BASE
-function createPxfBaseDirectories()
-{
+function createPxfBaseDirectories() {
     install -m 744 -d "${PXF_BASE}/conf"
     install -m 744 -d "${PXF_BASE}/lib"
     install -m 744 -d "${PXF_BASE}/lib/native"
@@ -176,24 +175,21 @@ function createPxfBaseDirectories()
 }
 
 # copies configuration files inside $PXF_BASE
-function copyConfigurationFilesToPxfBase()
-{
+function copyConfigurationFilesToPxfBase() {
     cp -Lv "${PXF_HOME}/conf/pxf-application.properties" "${PXF_BASE}/conf"
     cp -Lv "${PXF_HOME}/conf/pxf-env.sh"                 "${PXF_BASE}/conf"
     cp -Lv "${PXF_HOME}/conf/pxf-log4j2.xml"             "${PXF_BASE}/conf"
     cp -Lv "${PXF_HOME}/conf/pxf-profiles.xml"           "${PXF_BASE}/conf"
 }
 
-function validate_system()
-{
+function validate_system() {
     # validate curl
     if ! curl=$(command -v curl); then
         fail 'curl is not installed, please install'
     fi
 }
 
-function printUsage()
-{
+function printUsage() {
     local normal bold
     normal=$(tput sgr0)
     bold=$(tput bold)
@@ -208,8 +204,7 @@ function printUsage()
 }
 
 # doHelp handles the help command
-function doHelp()
-{
+function doHelp() {
     local normal bold
     normal=$(tput sgr0)
     bold=$(tput bold)
@@ -240,16 +235,14 @@ function doHelp()
     exit 0
 }
 
-function promptUser()
-{
+function promptUser() {
     echoGreen "$1"
     read -r answer
     [[ $answer == y || $answer == Y ]]
 }
 
 # doReset handles the reset command
-function doReset()
-{
+function doReset() {
     echoYellow '*****************************************************************************'
     echoYellow '* DEPRECATION NOTICE:'
     echoYellow '* The "pxf [cluster] reset" command is deprecated and will be removed'
@@ -257,8 +250,7 @@ function doReset()
     echoYellow '*****************************************************************************'
 }
 
-function installExternalTableExtension()
-{
+function installExternalTableExtension() {
     if [[ -d ${parent_script_dir}/gpextable ]]; then
         if [[ -z "${GPHOME}" ]]; then
             echoYellow 'WARNING: environment variable GPHOME is not set, skipping install of Greenplum External Table PXF Extension'
@@ -287,8 +279,7 @@ function installExternalTableExtension()
 }
 
 # doInit handles the init command
-function doInit()
-{
+function doInit() {
     echoYellow '*****************************************************************************'
     echoYellow '* DEPRECATION NOTICE:'
     echoYellow '* The "pxf [cluster] init" command is deprecated and will be removed'
@@ -302,8 +293,7 @@ function doInit()
 }
 
 # doPrepare prepares PXF_BASE outside of PXF_HOME
-function doPrepare()
-{
+function doPrepare() {
     # FILE1 -ef FILE2  True if file1 is a hard link to file2.
     [[ ! $PXF_HOME -ef $PXF_BASE ]] || failWithHint "'pxf [cluster] prepare' requires a \$PXF_BASE value different from your PXF installation directory." "Use 'PXF_BASE=<YOUR_PXF_BASE_DIRECTORY> pxf [cluster] prepare'."
 
@@ -324,14 +314,12 @@ function doPrepare()
 }
 
 # run the migration script on a shell with minimal environment variables loaded
-function migrateMergeConfiguration()
-{
+function migrateMergeConfiguration() {
     env -i "$BASH" -c "PXF_HOME=$PXF_HOME PXF_BASE=$PXF_BASE PXF_CONF=$PXF_CONF $PXF_HOME/bin/merge-pxf-config.sh"
 }
 
 # doMigrate migrates old configurations of PXF to a Spring Boot based configuration of PXF
-function doMigrate()
-{
+function doMigrate() {
     # Validate PXF_CONF
     [[ -n "$PXF_CONF" ]] || failWithHint "The \$PXF_CONF environment variable is not specified. Specify the \$PXF_CONF location of your old PXF installation" "Use 'PXF_CONF=<YOUR_PXF_CONF_DIRECTORY> [PXF_BASE=<YOUR_PXF_BASE_DIRECTORY>] pxf [cluster] migrate'."
 
@@ -374,15 +362,13 @@ function doMigrate()
 # after start, uses checkWebapp to verify the PXF webapp was loaded
 # successfully
 #
-function doStart()
-{
+function doStart() {
     checkJavaHome
     warnUserEnvScript
     do_start
 }
 
-function do_start()
-{
+function do_start() {
     if [[ -f "$pid_file" ]]; then
         pid=$(cat "$pid_file")
         isRunning "$pid" && { echoYellow "PXF is already running [pid=$pid]"; return 0; }
@@ -427,8 +413,7 @@ function do_start()
 # the -force flag is passed to catalina.sh to enable force-stopping
 # the JVM
 #
-function doStop()
-{
+function doStop() {
     checkJavaHome
     warnUserEnvScript
 
@@ -442,15 +427,15 @@ function doStop()
 
     # first try endpoint (assume it might be disabled)
     if $curl --max-time 5 --silent -X POST "localhost:$PXF_PORT/actuator/shutdown" | grep "Shutting down, bye..." > /dev/null; then
-      for i in $(seq 1 $STOP_WAIT_TIME); do
-        if isRunning "$pid"; then
-          sleep 1
-        else
-          echoGreen "PXF stopped [pid=$pid]"
-          rm -f $pid_file
-          return 0
-        fi
-      done
+        for i in $(seq 1 $STOP_WAIT_TIME); do
+            if isRunning "$pid"; then
+                sleep 1
+            else
+                echoGreen "PXF stopped [pid=$pid]"
+                rm -f $pid_file
+                return 0
+            fi
+        done
     fi
 
     # second try a nice kill and if that doesn't work force kill
@@ -458,23 +443,21 @@ function doStop()
     rm -f $pid_file
 }
 
-function do_stop()
-{
-  local killcmd=(kill)
-  [[ $3 == -f ]] && killcmd+=(-9)
-  killcmd+=("$1")
-  "${killcmd[@]}" &> /dev/null || { echoRed "Unable to terminate process $1"; return 1; }
-  for i in $(seq 1 $STOP_WAIT_TIME); do
-    isRunning "$1" || { echoGreen "PXF stopped [$1]"; rm -f "$2"; return 0; }
-    [[ $i -eq STOP_WAIT_TIME/2 ]] && "${killcmd[@]}" &> /dev/null
-    sleep 1
-  done
-  echoRed "Unable to terminate process $1";
-  return 1;
+function do_stop() {
+    local killcmd=(kill)
+    [[ $3 == -f ]] && killcmd+=(-9)
+    killcmd+=("$1")
+    "${killcmd[@]}" &> /dev/null || { echoRed "Unable to terminate process $1"; return 1; }
+    for i in $(seq 1 $STOP_WAIT_TIME); do
+        isRunning "$1" || { echoGreen "PXF stopped [$1]"; rm -f "$2"; return 0; }
+        [[ $i -eq STOP_WAIT_TIME/2 ]] && "${killcmd[@]}" &> /dev/null
+        sleep 1
+    done
+    echoRed "Unable to terminate process $1"
+    return 1
 }
 
-function doStatus()
-{
+function doStatus() {
     checkJavaHome
     warnUserEnvScript
     checkWebapp 1 0 || return 1
@@ -482,8 +465,7 @@ function doStatus()
     return 0
 }
 
-function doSync()
-{
+function doSync() {
     local target_host=$1
     if [[ -z $target_host ]]; then
         fail 'A destination hostname must be provided'
@@ -492,8 +474,7 @@ function doSync()
     rsync -az${DELETE:+ --delete} -e "ssh -o StrictHostKeyChecking=no" "$PXF_BASE"/{conf,lib,servers} "${target_host}:$PXF_BASE"
 }
 
-function doCluster()
-{
+function doCluster() {
     local cmd=$2
     # Go CLI handles unset PXF_BASE when appropriate
     if [[ ${cmd} != init ]] && [[ ${cmd} != prepare ]]; then
@@ -502,10 +483,9 @@ function doCluster()
     "${parent_script_dir}/bin/pxf-cli" "$@"
 }
 
-function warnUserEnvScript()
-{
-   local user_env_script=${PXF_BASE}/conf/pxf-env.sh
-   [[ -f $user_env_script ]] || echoYellow "WARNING: failed to find ${user_env_script}, default parameters will be used"
+function warnUserEnvScript() {
+    local user_env_script=${PXF_BASE}/conf/pxf-env.sh
+    [[ -f $user_env_script ]] || echoYellow "WARNING: failed to find ${user_env_script}, default parameters will be used"
 }
 
 pxf_script_command=$1

--- a/server/pxf-service/src/scripts/pxf-post-gpupgrade
+++ b/server/pxf-service/src/scripts/pxf-post-gpupgrade
@@ -6,9 +6,9 @@ set -o errexit
 cd "$(dirname "$0")" || exit 1
 script_file=$(pwd)/$(basename "$0")
 while [[ -L "$script_file" ]]; do
-	script_file=$(readlink "$script_file")
-	cd "$(dirname "$script_file")" || exit 1
-	script_file=$(pwd)/$(basename "$script_file")
+    script_file=$(readlink "$script_file")
+    cd "$(dirname "$script_file")" || exit 1
+    script_file=$(pwd)/$(basename "$script_file")
 done
 parent_script_dir="$( (cd "$(dirname "${script_file}")/.." && pwd -P))"
 
@@ -52,14 +52,14 @@ echo "PXF compiled against GPDB major version '${pxf_gpdb_major_version}'" >>"${
 echo "Running GPDB cluster is version '${gp_version}'" >>"${log_file}"
 
 if [[ "${pxf_gpdb_major_version}" != "${gp_version%%.*}" ]]; then
-	echo "ERROR: This version of PXF only works with GPDB ${pxf_gpdb_major_version}+ but the targeted GPDB cluster is ${gp_version}" | tee -a "${log_file}"
-	exit 1
+    echo "ERROR: This version of PXF only works with GPDB ${pxf_gpdb_major_version}+ but the targeted GPDB cluster is ${gp_version}" | tee -a "${log_file}"
+    exit 1
 fi
 
 if [[ "${gp_version}" = 5* ]]; then
-	master_data_dir_query="SELECT fselocation FROM pg_catalog.pg_filespace_entry WHERE fsedbid = 1 AND fsefsoid = (SELECT oid FROM pg_catalog.pg_filespace WHERE fsname = 'pg_system')"
+    master_data_dir_query="SELECT fselocation FROM pg_catalog.pg_filespace_entry WHERE fsedbid = 1 AND fsefsoid = (SELECT oid FROM pg_catalog.pg_filespace WHERE fsname = 'pg_system')"
 else
-	master_data_dir_query="SELECT datadir FROM pg_catalog.gp_segment_configuration WHERE dbid = 1"
+    master_data_dir_query="SELECT datadir FROM pg_catalog.gp_segment_configuration WHERE dbid = 1"
 fi
 export MASTER_DATA_DIRECTORY="${MASTER_DATA_DIRECTORY:-$(psql --no-align --tuples-only --command "${master_data_dir_query}")}"
 echo "GPDB master data directory is '${MASTER_DATA_DIRECTORY}'" >>"${log_file}"
@@ -68,31 +68,31 @@ PXF_HOME_REGEX="(.*:)*\/gpextable.*"
 dynamic_library_path="$(gpconfig --show dynamic_library_path | grep 'Master.*value:' | sed -e 's/Master.*value: \(.*\)/\1/')"
 
 if [[ ! "${dynamic_library_path}" =~ $PXF_HOME_REGEX ]]; then
-	echo "GUC 'dynamic_library_path=${dynamic_library_path}' does not contain \$PXF_HOME/gpextable" >>"${log_file}"
-	echo "Skipping removing it from 'dynamic_library_path'" >>"${log_file}"
+    echo "GUC 'dynamic_library_path=${dynamic_library_path}' does not contain \$PXF_HOME/gpextable" >>"${log_file}"
+    echo "Skipping removing it from 'dynamic_library_path'" >>"${log_file}"
 else
-	echo "Removing '${PXF_HOME}/gpextable' from 'dynamic_library_path=${dynamic_library_path}'" >>"${log_file}"
-	new_dynamic_library_path="$(echo -n "${dynamic_library_path}" | perl -n -e 'print join(":", grep(!/.*gpextable.*/, split(":", $_)))')"
-	# for GPDB 5, must `\`-escape dollar-sign ($) in the value passed to gpconfig
-	if [[ "${gp_version}" = 5* ]]; then
-		new_dynamic_library_path="${new_dynamic_library_path//$/\\$}"
-	fi
-	{
-		echo "New value for 'dynamic_library_path' is '${new_dynamic_library_path}'"
-		gpconfig --change dynamic_library_path --value "${new_dynamic_library_path}"
-		gpstop -u
-	} &>>"${log_file}"
+    echo "Removing '${PXF_HOME}/gpextable' from 'dynamic_library_path=${dynamic_library_path}'" >>"${log_file}"
+    new_dynamic_library_path="$(echo -n "${dynamic_library_path}" | perl -n -e 'print join(":", grep(!/.*gpextable.*/, split(":", $_)))')"
+    # for GPDB 5, must `\`-escape dollar-sign ($) in the value passed to gpconfig
+    if [[ "${gp_version}" = 5* ]]; then
+        new_dynamic_library_path="${new_dynamic_library_path//$/\\$}"
+    fi
+    {
+        echo "New value for 'dynamic_library_path' is '${new_dynamic_library_path}'"
+        gpconfig --change dynamic_library_path --value "${new_dynamic_library_path}"
+        gpstop -u
+    } &>>"${log_file}"
 fi
 
 echo "Updating PXF function definitions" >>"${log_file}"
 psql --no-align --tuples-only --command "SELECT datname FROM pg_catalog.pg_database WHERE datname != 'template0';" | while read -r dbname; do
-	echo -n "checking if database '${dbname}' has PXF extension installed... " >>"${log_file}"
-	if ! psql --dbname="${dbname}" --no-align --tuples-only --command "SELECT extname FROM pg_catalog.pg_extension WHERE extname = 'pxf'" | grep . &>/dev/null; then
-		echo "skipping database '${dbname}'" >>"${log_file}"
-		continue
-	fi
-	echo "updating PXF extension UDFs in database '${dbname}'" >>"${log_file}"
-	psql --dbname="${dbname}" --set ON_ERROR_STOP=on &>>"${log_file}" <<-END_OF_SQL
+    echo -n "checking if database '${dbname}' has PXF extension installed... " >>"${log_file}"
+    if ! psql --dbname="${dbname}" --no-align --tuples-only --command "SELECT extname FROM pg_catalog.pg_extension WHERE extname = 'pxf'" | grep . &>/dev/null; then
+        echo "skipping database '${dbname}'" >>"${log_file}"
+        continue
+    fi
+    echo "updating PXF extension UDFs in database '${dbname}'" >>"${log_file}"
+    psql --dbname="${dbname}" --set ON_ERROR_STOP=on &>>"${log_file}" <<-END_OF_SQL
 		CREATE OR REPLACE FUNCTION pg_catalog.pxf_write() RETURNS integer
 		AS '${PXF_HOME}/gpextable/pxf', 'pxfprotocol_export'
 		LANGUAGE C STABLE;

--- a/server/pxf-service/src/scripts/pxf-pre-gpupgrade
+++ b/server/pxf-service/src/scripts/pxf-pre-gpupgrade
@@ -6,9 +6,9 @@ set -o errexit
 cd "$(dirname "$0")" || exit 1
 script_file=$(pwd)/$(basename "$0")
 while [[ -L "$script_file" ]]; do
-	script_file=$(readlink "$script_file")
-	cd "$(dirname "$script_file")" || exit 1
-	script_file=$(pwd)/$(basename "$script_file")
+    script_file=$(readlink "$script_file")
+    cd "$(dirname "$script_file")" || exit 1
+    script_file=$(pwd)/$(basename "$script_file")
 done
 parent_script_dir="$( (cd "$(dirname "${script_file}")/.." && pwd -P))"
 
@@ -52,14 +52,14 @@ echo "PXF compiled against GPDB major version '${pxf_gpdb_major_version}'" >>"${
 echo "Running GPDB cluster is version '${gp_version}'" >>"${log_file}"
 
 if [[ "${pxf_gpdb_major_version}" != "${gp_version%%.*}" ]]; then
-	echo "ERROR: This version of PXF only works with GPDB ${pxf_gpdb_major_version}+ but the targeted GPDB cluster is ${gp_version}" | tee -a "${log_file}"
-	exit 1
+    echo "ERROR: This version of PXF only works with GPDB ${pxf_gpdb_major_version}+ but the targeted GPDB cluster is ${gp_version}" | tee -a "${log_file}"
+    exit 1
 fi
 
 if [[ "${gp_version}" = 5* ]]; then
-	master_data_dir_query="SELECT fselocation FROM pg_catalog.pg_filespace_entry WHERE fsedbid = 1 AND fsefsoid = (SELECT oid FROM pg_catalog.pg_filespace WHERE fsname = 'pg_system')"
+    master_data_dir_query="SELECT fselocation FROM pg_catalog.pg_filespace_entry WHERE fsedbid = 1 AND fsefsoid = (SELECT oid FROM pg_catalog.pg_filespace WHERE fsname = 'pg_system')"
 else
-	master_data_dir_query="SELECT datadir FROM pg_catalog.gp_segment_configuration WHERE dbid = 1"
+    master_data_dir_query="SELECT datadir FROM pg_catalog.gp_segment_configuration WHERE dbid = 1"
 fi
 export MASTER_DATA_DIRECTORY="${MASTER_DATA_DIRECTORY:-$(psql --no-align --tuples-only --command "${master_data_dir_query}")}"
 echo "GPDB master data directory is '${MASTER_DATA_DIRECTORY}'" >>"${log_file}"
@@ -68,31 +68,31 @@ PXF_HOME_REGEX="(.*:)*\/gpextable.*"
 dynamic_library_path="$(gpconfig --show dynamic_library_path | grep 'Master.*value:' | sed -e 's/Master.*value: \(.*\)/\1/')"
 
 if [[ "${dynamic_library_path}" =~ $PXF_HOME_REGEX ]]; then
-	echo "GUC 'dynamic_library_path=${dynamic_library_path}' already contains \$PXF_HOME/gpextable" >>"${log_file}"
-	echo "Skipping adding '${PXF_HOME}/gpextable' to 'dynamic_library_path'" >>"${log_file}"
+    echo "GUC 'dynamic_library_path=${dynamic_library_path}' already contains \$PXF_HOME/gpextable" >>"${log_file}"
+    echo "Skipping adding '${PXF_HOME}/gpextable' to 'dynamic_library_path'" >>"${log_file}"
 else
-	echo "Adding '${PXF_HOME}/gpextable' to 'dynamic_library_path=${dynamic_library_path}'" >>"${log_file}"
-	new_dynamic_library_path="${PXF_HOME}/gpextable:${dynamic_library_path}"
-	# for GPDB 5, must `\`-escape dollar-sign ($) in the value passed to gpconfig
-	if [[ "${gp_version}" = 5* ]]; then
-		new_dynamic_library_path="${new_dynamic_library_path//$/\\$}"
-	fi
-	{
-		echo "New value for 'dynamic_library_path' is '${new_dynamic_library_path}'"
-		gpconfig --change dynamic_library_path --value "${new_dynamic_library_path}"
-		gpstop -u
-	} &>>"${log_file}"
+    echo "Adding '${PXF_HOME}/gpextable' to 'dynamic_library_path=${dynamic_library_path}'" >>"${log_file}"
+    new_dynamic_library_path="${PXF_HOME}/gpextable:${dynamic_library_path}"
+    # for GPDB 5, must `\`-escape dollar-sign ($) in the value passed to gpconfig
+    if [[ "${gp_version}" = 5* ]]; then
+        new_dynamic_library_path="${new_dynamic_library_path//$/\\$}"
+    fi
+    {
+        echo "New value for 'dynamic_library_path' is '${new_dynamic_library_path}'"
+        gpconfig --change dynamic_library_path --value "${new_dynamic_library_path}"
+        gpstop -u
+    } &>>"${log_file}"
 fi
 
 echo "Updating PXF function definitions" >>"${log_file}"
 psql --no-align --tuples-only --command "SELECT datname FROM pg_catalog.pg_database WHERE datname != 'template0';" | while read -r dbname; do
-	echo -n "checking if database '${dbname}' has PXF extension installed... " >>"${log_file}"
-	if ! psql --dbname="${dbname}" --no-align --tuples-only --command "SELECT extname FROM pg_catalog.pg_extension WHERE extname = 'pxf'" | grep . &>/dev/null; then
-		echo "skipping database '${dbname}'" >>"${log_file}"
-		continue
-	fi
-	echo "updating PXF extension UDFs in database '${dbname}'" >>"${log_file}"
-	psql --dbname="${dbname}" --set ON_ERROR_STOP=on &>>"${log_file}" <<-END_OF_SQL
+    echo -n "checking if database '${dbname}' has PXF extension installed... " >>"${log_file}"
+    if ! psql --dbname="${dbname}" --no-align --tuples-only --command "SELECT extname FROM pg_catalog.pg_extension WHERE extname = 'pxf'" | grep . &>/dev/null; then
+        echo "skipping database '${dbname}'" >>"${log_file}"
+        continue
+    fi
+    echo "updating PXF extension UDFs in database '${dbname}'" >>"${log_file}"
+    psql --dbname="${dbname}" --set ON_ERROR_STOP=on &>>"${log_file}" <<-END_OF_SQL
 		CREATE OR REPLACE FUNCTION pg_catalog.pxf_write() RETURNS integer
 		AS 'pxf', 'pxfprotocol_export'
 		LANGUAGE C STABLE;


### PR DESCRIPTION
* All functions should use the `function` keyword, with the opening brace on the same line as the function name
* Indents should be four spaces
  * Indents for "Here Documents" where the redirection operator is `<<-` should use tabs since bash only removes leading tab characters
* Style can be checked with [`shfmt`][0] however it should not be used to actually adjust the formatting since its not possible to preserve the de-facto conventions of spaces around redirect operators and padding for alignment

    ```sh
    shfmt --diff --indent 4 --case-indent <script-file>
    ```

[0]: https://github.com/mvdan/sh

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>