### PR TITLE
ADBDEV-3096: Allow set Oracle parallel instructions

### DIFF
--- a/server/pxf-jdbc/build.gradle
+++ b/server/pxf-jdbc/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
     testImplementation("org.apache.parquet:parquet-pig")
     testImplementation('org.springframework.boot:spring-boot-starter-test')
+    testImplementation('org.mockito:mockito-inline')
 }
 
 test {

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DbProduct.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/DbProduct.java
@@ -19,6 +19,7 @@ package org.greenplum.pxf.plugins.jdbc.utils;
  * under the License.
  */
 
+import org.greenplum.pxf.plugins.jdbc.utils.oracle.OracleJdbcUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +59,7 @@ public enum DbProduct {
 
         @Override
         public String buildSessionQuery(String key, String value) {
-            return String.format("ALTER SESSION SET %s = %s", key, value);
+            return OracleJdbcUtils.buildSessionQuery(key, value);
         }
     },
 

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleJdbcUtils.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleJdbcUtils.java
@@ -1,0 +1,9 @@
+package org.greenplum.pxf.plugins.jdbc.utils.oracle;
+
+public class OracleJdbcUtils {
+    private static final OracleSessionQueryFactory sessionQueryFactory = new OracleSessionQueryFactory();
+
+    public static String buildSessionQuery(String property, String value) {
+        return sessionQueryFactory.create(property, value);
+    }
+}

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleJdbcUtils.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleJdbcUtils.java
@@ -1,8 +1,18 @@
 package org.greenplum.pxf.plugins.jdbc.utils.oracle;
 
+/**
+ * Utilities class to build Oracle session query
+ */
 public class OracleJdbcUtils {
     private static final OracleSessionQueryFactory sessionQueryFactory = new OracleSessionQueryFactory();
 
+    /**
+     * Build a query to set session-level variables for Oracle database
+     *
+     * @param property variable name
+     * @param value    variable value
+     * @return a query to set session-level variables
+     */
     public static String buildSessionQuery(String property, String value) {
         return sessionQueryFactory.create(property, value);
     }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParam.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParam.java
@@ -1,5 +1,11 @@
 package org.greenplum.pxf.plugins.jdbc.utils.oracle;
 
+import lombok.Data;
+
+/**
+ * Possible values for parallel session variables for Oracle database
+ */
+@Data
 public class OracleParallelSessionParam {
     private Clause clause;
     private StatementType statementType;
@@ -15,29 +21,5 @@ public class OracleParallelSessionParam {
         DML,
         DDL,
         QUERY
-    }
-
-    public void setClause(Clause clause) {
-        this.clause = clause;
-    }
-
-    public void setStatementType(StatementType statementType) {
-        this.statementType = statementType;
-    }
-
-    public void setDegreeOfParallelism(String degreeOfParallelism) {
-        this.degreeOfParallelism = degreeOfParallelism;
-    }
-
-    public Clause getClause() {
-        return clause;
-    }
-
-    public StatementType getStatementType() {
-        return statementType;
-    }
-
-    public String getDegreeOfParallelism() {
-        return degreeOfParallelism;
     }
 }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParam.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParam.java
@@ -1,0 +1,43 @@
+package org.greenplum.pxf.plugins.jdbc.utils.oracle;
+
+public class OracleParallelSessionParam {
+    private Clause clause;
+    private StatementType statementType;
+    private String degreeOfParallelism;
+
+    public enum Clause {
+        ENABLE,
+        DISABLE,
+        FORCE
+    }
+
+    public enum StatementType {
+        DML,
+        DDL,
+        QUERY
+    }
+
+    public void setClause(Clause clause) {
+        this.clause = clause;
+    }
+
+    public void setStatementType(StatementType statementType) {
+        this.statementType = statementType;
+    }
+
+    public void setDegreeOfParallelism(String degreeOfParallelism) {
+        this.degreeOfParallelism = degreeOfParallelism;
+    }
+
+    public Clause getClause() {
+        return clause;
+    }
+
+    public StatementType getStatementType() {
+        return statementType;
+    }
+
+    public String getDegreeOfParallelism() {
+        return degreeOfParallelism;
+    }
+}

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParamFactory.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParamFactory.java
@@ -1,0 +1,85 @@
+package org.greenplum.pxf.plugins.jdbc.utils.oracle;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.util.Strings;
+
+import java.util.HashMap;
+
+public class OracleParallelSessionParamFactory {
+    public OracleParallelSessionParam create(String property, String value, String delimiter) {
+        String[] values = splitValue(property, value, delimiter);
+
+        HashMap<String, String> map = getParallelSessionParam(values);
+        String clause = map.get("clause").toUpperCase();
+        String statementType = map.get("statement_type").toUpperCase();
+        String degreeOfParallelism = map.get("degree_of_parallelism");
+
+        OracleParallelSessionParam param = new OracleParallelSessionParam();
+        param.setClause(getClause(clause, property));
+        param.setStatementType(getStatementType(statementType, property));
+        param.setDegreeOfParallelism(getDegreeOfParallelism(degreeOfParallelism, property));
+        return param;
+    }
+
+    private String[] splitValue(String property, String value, String delimiter) {
+        validateValue(property, value);
+        String[] values = value.split(delimiter);
+        if (values.length < 2 || values.length > 3) {
+            throw new IllegalArgumentException(String.format(
+                    "The parameter '%s' in jdbc-site.xml has to contain at least 2 but not more then 3 values delimited by %s",
+                    property, delimiter)
+            );
+        }
+        return values;
+    }
+
+    private void validateValue(String property, String value) {
+        if (StringUtils.isBlank(value)) {
+            throw new IllegalArgumentException(String.format("The parameter '%s' is blank in jdbc-site.xml", property));
+        }
+    }
+
+    private HashMap<String, String> getParallelSessionParam(String[] values) {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("clause", values[0]);
+        params.put("statement_type", values[1]);
+        if (values.length == 3 && Strings.isNotBlank(values[2])) {
+            params.put("degree_of_parallelism", values[2]);
+        }
+        return params;
+    }
+
+    private OracleParallelSessionParam.Clause getClause(String clause, String property) {
+        try {
+            return OracleParallelSessionParam.Clause.valueOf(clause);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format(
+                    "The 'clause' value '%s' in the parameter '%s' is not valid", clause, property)
+            );
+        }
+    }
+
+    private OracleParallelSessionParam.StatementType getStatementType(String statementType, String property) {
+        try {
+            return OracleParallelSessionParam.StatementType.valueOf(statementType);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format(
+                    "The 'statement type' value '%s' in the parameter '%s' is not valid", statementType, property)
+            );
+        }
+    }
+
+    private String getDegreeOfParallelism(String degreeOfParallelism, String property) {
+        if (degreeOfParallelism == null) {
+            return Strings.EMPTY;
+        }
+        try {
+            Integer.parseInt(degreeOfParallelism);
+            return degreeOfParallelism;
+        } catch (NumberFormatException nfe) {
+            throw new IllegalArgumentException(String.format(
+                    "The 'degree of parallelism' value '%s' in the parameter '%s' is not valid", degreeOfParallelism, property)
+            );
+        }
+    }
+}

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParamFactory.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParamFactory.java
@@ -3,55 +3,67 @@ package org.greenplum.pxf.plugins.jdbc.utils.oracle;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.util.Strings;
 
-import java.util.HashMap;
-
+/**
+ * Factory class to create and validate Oracle parallel session parameters.
+ */
 public class OracleParallelSessionParamFactory {
+    /**
+     * Returns parallel session parameters to build Oracle session query
+     *
+     * @param property  variable name
+     * @param value     variable value
+     * @param delimiter delimiter which is used to split value to get session parameters
+     * @return An instance of {@link OracleParallelSessionParam} made from value
+     */
     public OracleParallelSessionParam create(String property, String value, String delimiter) {
         String[] values = splitValue(property, value, delimiter);
 
-        HashMap<String, String> map = getParallelSessionParam(values);
-        String clause = map.get("clause").toUpperCase();
-        String statementType = map.get("statement_type").toUpperCase();
-        String degreeOfParallelism = map.get("degree_of_parallelism");
+        String clause = values[0];
+        String statementType = values[1];
+        String degreeOfParallelism = (values.length == 3 && Strings.isNotBlank(statementType)) ? values[2] : null;
 
         OracleParallelSessionParam param = new OracleParallelSessionParam();
         param.setClause(getClause(clause, property));
         param.setStatementType(getStatementType(statementType, property));
-        param.setDegreeOfParallelism(getDegreeOfParallelism(degreeOfParallelism, property));
+        param.setDegreeOfParallelism(getDegreeOfParallelism(degreeOfParallelism, clause, property));
         return param;
     }
 
+    /**
+     * Split and validate value to get parallel session parameters
+     *
+     * @param property  variable name
+     * @param value     variable value
+     * @param delimiter delimiter which is used to split value to get session parameters
+     * @return string array with session parameters to build Clause, StatementType and DegreeOfParallelism
+     * @throws IllegalArgumentException if the session parameter is not valid
+     */
     private String[] splitValue(String property, String value, String delimiter) {
-        validateValue(property, value);
+        if (StringUtils.isBlank(value)) {
+            throw new IllegalArgumentException(String.format("The parameter '%s' is blank in jdbc-site.xml", property));
+        }
         String[] values = value.split(delimiter);
         if (values.length < 2 || values.length > 3) {
             throw new IllegalArgumentException(String.format(
-                    "The parameter '%s' in jdbc-site.xml has to contain at least 2 but not more then 3 values delimited by %s",
+                    "The parameter '%s' in jdbc-site.xml must contain at least 2 but not more than 3 values delimited by %s",
                     property, delimiter)
             );
         }
         return values;
     }
 
-    private void validateValue(String property, String value) {
-        if (StringUtils.isBlank(value)) {
-            throw new IllegalArgumentException(String.format("The parameter '%s' is blank in jdbc-site.xml", property));
-        }
-    }
-
-    private HashMap<String, String> getParallelSessionParam(String[] values) {
-        HashMap<String, String> params = new HashMap<>();
-        params.put("clause", values[0]);
-        params.put("statement_type", values[1]);
-        if (values.length == 3 && Strings.isNotBlank(values[2])) {
-            params.put("degree_of_parallelism", values[2]);
-        }
-        return params;
-    }
-
+    /**
+     * Return the first part of the
+     * parallel session parameter {@link org.greenplum.pxf.plugins.jdbc.utils.oracle.OracleParallelSessionParam.Clause}
+     *
+     * @param clause   string to build the first part (Clause) of the parallel session parameter
+     * @param property variable name
+     * @return An instance of {@link org.greenplum.pxf.plugins.jdbc.utils.oracle.OracleParallelSessionParam.Clause}
+     * @throws IllegalArgumentException if the Clause parameter is not valid
+     */
     private OracleParallelSessionParam.Clause getClause(String clause, String property) {
         try {
-            return OracleParallelSessionParam.Clause.valueOf(clause);
+            return OracleParallelSessionParam.Clause.valueOf(clause.toUpperCase());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(String.format(
                     "The 'clause' value '%s' in the parameter '%s' is not valid", clause, property)
@@ -59,9 +71,18 @@ public class OracleParallelSessionParamFactory {
         }
     }
 
+    /**
+     * Return the second part of the
+     * parallel session parameter {@link org.greenplum.pxf.plugins.jdbc.utils.oracle.OracleParallelSessionParam.StatementType}
+     *
+     * @param statementType string to build the second part (StatementType) of the parallel session parameter
+     * @param property      variable name
+     * @return An instance of {@link org.greenplum.pxf.plugins.jdbc.utils.oracle.OracleParallelSessionParam.StatementType}
+     * @throws IllegalArgumentException if the StatementType parameter is not valid
+     */
     private OracleParallelSessionParam.StatementType getStatementType(String statementType, String property) {
         try {
-            return OracleParallelSessionParam.StatementType.valueOf(statementType);
+            return OracleParallelSessionParam.StatementType.valueOf(statementType.toUpperCase());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(String.format(
                     "The 'statement type' value '%s' in the parameter '%s' is not valid", statementType, property)
@@ -69,8 +90,17 @@ public class OracleParallelSessionParamFactory {
         }
     }
 
-    private String getDegreeOfParallelism(String degreeOfParallelism, String property) {
-        if (degreeOfParallelism == null) {
+    /**
+     * Return the third part of the parallel session parameter
+     *
+     * @param degreeOfParallelism string to build the third part (DegreeOfParallelism) of the parallel session parameter
+     * @param clause              the value of the Clause session parameter
+     * @param property            variable name
+     * @return the degree of parallelism value
+     * @throws IllegalArgumentException if the DegreeOfParallelism parameter is not valid
+     */
+    private String getDegreeOfParallelism(String degreeOfParallelism, String clause, String property) {
+        if (degreeOfParallelism == null || !OracleParallelSessionParam.Clause.FORCE.name().equalsIgnoreCase(clause)) {
             return Strings.EMPTY;
         }
         try {

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleSessionQueryFactory.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleSessionQueryFactory.java
@@ -1,0 +1,32 @@
+package org.greenplum.pxf.plugins.jdbc.utils.oracle;
+
+import org.apache.logging.log4j.util.Strings;
+
+public class OracleSessionQueryFactory {
+    private static final String ORACLE_JDBC_SESSION_PARALLEL_PROPERTY_PREFIX = "alter_session_parallel";
+    private static final String ORACLE_JDBC_SESSION_PARALLEL_PROPERTY_DELIMITER = "\\.";
+    private final OracleParallelSessionParamFactory oracleSessionParamFactory = new OracleParallelSessionParamFactory();
+
+    public String create(String property, String value) {
+        if (property.contains(ORACLE_JDBC_SESSION_PARALLEL_PROPERTY_PREFIX)) {
+            return getParallelSessionCommand(property, value);
+        }
+        return String.format("ALTER SESSION SET %s = %s", property, value);
+    }
+
+    private String getParallelSessionCommand(String property, String value) {
+        OracleParallelSessionParam param = oracleSessionParamFactory.create(property,
+                value, ORACLE_JDBC_SESSION_PARALLEL_PROPERTY_DELIMITER);
+        return createParallelSessionCommand(param);
+    }
+
+    private String createParallelSessionCommand(OracleParallelSessionParam param) {
+        if (Strings.isNotEmpty(param.getDegreeOfParallelism())
+                && param.getClause() == OracleParallelSessionParam.Clause.FORCE) {
+            return String.format("ALTER SESSION %s PARALLEL %s PARALLEL %s",
+                    param.getClause(), param.getStatementType(), param.getDegreeOfParallelism());
+        } else {
+            return String.format("ALTER SESSION %s PARALLEL %s", param.getClause(), param.getStatementType());
+        }
+    }
+}

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParamFactoryTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParamFactoryTest.java
@@ -5,19 +5,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class OracleParallelSessionParamFactoryTest {
-
-    private final OracleParallelSessionParamFactory oracleParallelSessionParamFactory = new OracleParallelSessionParamFactory();
+    private static final OracleParallelSessionParamFactory oracleParallelSessionParamFactory = new OracleParallelSessionParamFactory();;
     private final String property = "jdbc.session.property.alter_session_parallel.1";
     private final String delimiter = "\\.";
-
-    @Test
-    void createWithClauseAndStatementAndDegreeOfParallelismSuccess() {
-        String value = "force.query.5";
-        OracleParallelSessionParam param = oracleParallelSessionParamFactory.create(property, value, delimiter);
-        assertEquals(param.getClause(), OracleParallelSessionParam.Clause.FORCE);
-        assertEquals(param.getStatementType(), OracleParallelSessionParam.StatementType.QUERY);
-        assertEquals(param.getDegreeOfParallelism(), "5");
-    }
 
     @Test
     void createWithClauseAndStatementSuccess() {
@@ -31,7 +21,15 @@ class OracleParallelSessionParamFactoryTest {
     @Test
     void createWithClauseAndStatementAndBlankDegreeOfParallelismSuccess() {
         String value = "disable.dml.  ";
-        String property = "jdbc.session.property.alter_session_parallel.1";
+        OracleParallelSessionParam param = oracleParallelSessionParamFactory.create(property, value, delimiter);
+        assertEquals(param.getClause(), OracleParallelSessionParam.Clause.DISABLE);
+        assertEquals(param.getStatementType(), OracleParallelSessionParam.StatementType.DML);
+        assertEquals(param.getDegreeOfParallelism(), "");
+    }
+
+    @Test
+    void createWithClauseAndStatementAndIgnoreDegreeOfParallelismSuccess() {
+        String value = "disable.dml.4";
         OracleParallelSessionParam param = oracleParallelSessionParamFactory.create(property, value, delimiter);
         assertEquals(param.getClause(), OracleParallelSessionParam.Clause.DISABLE);
         assertEquals(param.getStatementType(), OracleParallelSessionParam.StatementType.DML);
@@ -41,7 +39,6 @@ class OracleParallelSessionParamFactoryTest {
     @Test
     void createWithEmptyValue() {
         String value = "enable.dml.";
-        String property = "jdbc.session.property.alter_session_parallel.1";
         OracleParallelSessionParam param = oracleParallelSessionParamFactory.create(property, value, delimiter);
         assertEquals(param.getClause(), OracleParallelSessionParam.Clause.ENABLE);
         assertEquals(param.getStatementType(), OracleParallelSessionParam.StatementType.DML);
@@ -53,7 +50,7 @@ class OracleParallelSessionParamFactoryTest {
         String value = "fake_force.query.5";
         Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
-        String expectedMessage = "The 'clause' value 'FAKE_FORCE' in the parameter 'jdbc.session.property.alter_session_parallel.1' is not valid";
+        String expectedMessage = "The 'clause' value 'fake_force' in the parameter 'jdbc.session.property.alter_session_parallel.1' is not valid";
         String actualMessage = exception.getMessage();
         assertEquals(actualMessage, expectedMessage);
     }
@@ -63,7 +60,7 @@ class OracleParallelSessionParamFactoryTest {
         String value = "enable.fake_statement";
         Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
-        String expectedMessage = "The 'statement type' value 'FAKE_STATEMENT' in the parameter 'jdbc.session.property.alter_session_parallel.1' is not valid";
+        String expectedMessage = "The 'statement type' value 'fake_statement' in the parameter 'jdbc.session.property.alter_session_parallel.1' is not valid";
         String actualMessage = exception.getMessage();
         assertEquals(expectedMessage, actualMessage);
     }
@@ -83,7 +80,7 @@ class OracleParallelSessionParamFactoryTest {
         String value = "force.dml.number.70";
         Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
-        String expectedMessage = "The parameter 'jdbc.session.property.alter_session_parallel.1' in jdbc-site.xml has to contain at least 2 but not more then 3 values delimited by \\.";
+        String expectedMessage = "The parameter 'jdbc.session.property.alter_session_parallel.1' in jdbc-site.xml must contain at least 2 but not more than 3 values delimited by \\.";
         String actualMessage = exception.getMessage();
         assertEquals(expectedMessage, actualMessage);
     }
@@ -93,7 +90,7 @@ class OracleParallelSessionParamFactoryTest {
         String value = "force";
         Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
-        String expectedMessage = "The parameter 'jdbc.session.property.alter_session_parallel.1' in jdbc-site.xml has to contain at least 2 but not more then 3 values delimited by \\.";
+        String expectedMessage = "The parameter 'jdbc.session.property.alter_session_parallel.1' in jdbc-site.xml must contain at least 2 but not more than 3 values delimited by \\.";
         String actualMessage = exception.getMessage();
         assertEquals(expectedMessage, actualMessage);
     }

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParamFactoryTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleParallelSessionParamFactoryTest.java
@@ -1,0 +1,110 @@
+package org.greenplum.pxf.plugins.jdbc.utils.oracle;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OracleParallelSessionParamFactoryTest {
+
+    private final OracleParallelSessionParamFactory oracleParallelSessionParamFactory = new OracleParallelSessionParamFactory();
+    private final String property = "jdbc.session.property.alter_session_parallel.1";
+    private final String delimiter = "\\.";
+
+    @Test
+    void createWithClauseAndStatementAndDegreeOfParallelismSuccess() {
+        String value = "force.query.5";
+        OracleParallelSessionParam param = oracleParallelSessionParamFactory.create(property, value, delimiter);
+        assertEquals(param.getClause(), OracleParallelSessionParam.Clause.FORCE);
+        assertEquals(param.getStatementType(), OracleParallelSessionParam.StatementType.QUERY);
+        assertEquals(param.getDegreeOfParallelism(), "5");
+    }
+
+    @Test
+    void createWithClauseAndStatementSuccess() {
+        String value = "enable.ddl";
+        OracleParallelSessionParam param = oracleParallelSessionParamFactory.create(property, value, delimiter);
+        assertEquals(param.getClause(), OracleParallelSessionParam.Clause.ENABLE);
+        assertEquals(param.getStatementType(), OracleParallelSessionParam.StatementType.DDL);
+        assertEquals(param.getDegreeOfParallelism(), "");
+    }
+
+    @Test
+    void createWithClauseAndStatementAndBlankDegreeOfParallelismSuccess() {
+        String value = "disable.dml.  ";
+        String property = "jdbc.session.property.alter_session_parallel.1";
+        OracleParallelSessionParam param = oracleParallelSessionParamFactory.create(property, value, delimiter);
+        assertEquals(param.getClause(), OracleParallelSessionParam.Clause.DISABLE);
+        assertEquals(param.getStatementType(), OracleParallelSessionParam.StatementType.DML);
+        assertEquals(param.getDegreeOfParallelism(), "");
+    }
+
+    @Test
+    void createWithEmptyValue() {
+        String value = "enable.dml.";
+        String property = "jdbc.session.property.alter_session_parallel.1";
+        OracleParallelSessionParam param = oracleParallelSessionParamFactory.create(property, value, delimiter);
+        assertEquals(param.getClause(), OracleParallelSessionParam.Clause.ENABLE);
+        assertEquals(param.getStatementType(), OracleParallelSessionParam.StatementType.DML);
+        assertEquals(param.getDegreeOfParallelism(), "");
+    }
+
+    @Test
+    void createWithWrongClause() {
+        String value = "fake_force.query.5";
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
+        String expectedMessage = "The 'clause' value 'FAKE_FORCE' in the parameter 'jdbc.session.property.alter_session_parallel.1' is not valid";
+        String actualMessage = exception.getMessage();
+        assertEquals(actualMessage, expectedMessage);
+    }
+
+    @Test
+    void createWithWrongStatement() {
+        String value = "enable.fake_statement";
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
+        String expectedMessage = "The 'statement type' value 'FAKE_STATEMENT' in the parameter 'jdbc.session.property.alter_session_parallel.1' is not valid";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    void createWithWrongDegreeOfParallelism() {
+        String value = "force.dml.fake_number";
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
+        String expectedMessage = "The 'degree of parallelism' value 'fake_number' in the parameter 'jdbc.session.property.alter_session_parallel.1' is not valid";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    void createWithWrongValueMoreThen3() {
+        String value = "force.dml.number.70";
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
+        String expectedMessage = "The parameter 'jdbc.session.property.alter_session_parallel.1' in jdbc-site.xml has to contain at least 2 but not more then 3 values delimited by \\.";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    void createWithWrongValueLessThen2() {
+        String value = "force";
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
+        String expectedMessage = "The parameter 'jdbc.session.property.alter_session_parallel.1' in jdbc-site.xml has to contain at least 2 but not more then 3 values delimited by \\.";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    @Test
+    void createWithBlankValue() {
+        String value = " ";
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> oracleParallelSessionParamFactory.create(property, value, delimiter));
+        String expectedMessage = "The parameter 'jdbc.session.property.alter_session_parallel.1' is blank in jdbc-site.xml";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+}

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleSessionQueryFactoryTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleSessionQueryFactoryTest.java
@@ -1,0 +1,110 @@
+package org.greenplum.pxf.plugins.jdbc.utils.oracle;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+class OracleSessionQueryFactoryTest {
+    private final String property = "jdbc.session.property.alter_session_parallel.1";
+    private final String delimiter = "\\.";
+
+    @Test
+    @SuppressWarnings("try")
+    void createParallelSessionQueryWithForceAndDegreeOfParallelism() {
+        String value = "force.query.4";
+        String delimiter = "\\.";
+        String expectedResult = "ALTER SESSION FORCE PARALLEL QUERY PARALLEL 4";
+
+        OracleParallelSessionParam param = new OracleParallelSessionParam();
+        param.setClause(OracleParallelSessionParam.Clause.FORCE);
+        param.setStatementType(OracleParallelSessionParam.StatementType.QUERY);
+        param.setDegreeOfParallelism("4");
+
+        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
+                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
+            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+            String result = oracleSessionQueryFactory.create(property, value);
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("try")
+    void createParallelSessionQueryWithForce() {
+        String value = "force.dml";
+        String expectedResult = "ALTER SESSION FORCE PARALLEL DML";
+
+        OracleParallelSessionParam param = new OracleParallelSessionParam();
+        param.setClause(OracleParallelSessionParam.Clause.FORCE);
+        param.setStatementType(OracleParallelSessionParam.StatementType.DML);
+        param.setDegreeOfParallelism("");
+
+        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
+                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
+            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+            String result = oracleSessionQueryFactory.create(property, value);
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("try")
+    void createParallelSessionQueryWithEnable() {
+        String value = "enable.dml.2";
+        String expectedResult = "ALTER SESSION ENABLE PARALLEL DDL";
+
+        OracleParallelSessionParam param = new OracleParallelSessionParam();
+        param.setClause(OracleParallelSessionParam.Clause.ENABLE);
+        param.setStatementType(OracleParallelSessionParam.StatementType.DDL);
+        param.setDegreeOfParallelism("2");
+
+        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
+                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
+            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+            String result = oracleSessionQueryFactory.create(property, value);
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("try")
+    void createParallelSessionQueryWithDisable() {
+        String value = "disable.dml";
+        String expectedResult = "ALTER SESSION DISABLE PARALLEL DML";
+
+        OracleParallelSessionParam param = new OracleParallelSessionParam();
+        param.setClause(OracleParallelSessionParam.Clause.DISABLE);
+        param.setStatementType(OracleParallelSessionParam.StatementType.DML);
+        param.setDegreeOfParallelism("");
+
+        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
+                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
+            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+            String result = oracleSessionQueryFactory.create(property, value);
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("try")
+    void createNotParallelSessionQuery() {
+        String property = "STATISTICS_LEVEL";
+        String value = "TYPICAL";
+        String expectedResult = "ALTER SESSION SET STATISTICS_LEVEL = TYPICAL";
+
+        OracleParallelSessionParam param = new OracleParallelSessionParam();
+        param.setClause(OracleParallelSessionParam.Clause.ENABLE);
+        param.setStatementType(OracleParallelSessionParam.StatementType.DDL);
+        param.setDegreeOfParallelism("2");
+
+        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
+                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
+            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+            String result = oracleSessionQueryFactory.create(property, value);
+            assertEquals(expectedResult, result);
+        }
+    }
+}

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleSessionQueryFactoryTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/utils/oracle/OracleSessionQueryFactoryTest.java
@@ -1,91 +1,75 @@
 package org.greenplum.pxf.plugins.jdbc.utils.oracle;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mockConstruction;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class OracleSessionQueryFactoryTest {
-    private final String property = "jdbc.session.property.alter_session_parallel.1";
-    private final String delimiter = "\\.";
+    private static MockedConstruction<OracleParallelSessionParamFactory> mockedConstruction;
+    private static final String property = "jdbc.session.property.alter_session_parallel.1";
+    private static final String delimiter = "\\.";
+    private static final String value1 = "force.query.4";
+    private static final String value2 = "force.dml";
+    private static final String value3 = "enable.dml.2";
+    private static final String value4 = "disable.ddl";
+
+    @BeforeAll
+    public static void init() {
+        HashMap<String, OracleParallelSessionParam> params = createParams();
+        mockedConstruction = Mockito.mockConstruction(OracleParallelSessionParamFactory.class,
+                (mock, context) -> {
+                    when(mock.create(property, value1, delimiter)).thenReturn(params.get(value1));
+                    when(mock.create(property, value2, delimiter)).thenReturn(params.get(value2));
+                    when(mock.create(property, value3, delimiter)).thenReturn(params.get(value3));
+                    when(mock.create(property, value4, delimiter)).thenReturn(params.get(value4));
+                });
+    }
 
     @Test
     @SuppressWarnings("try")
     void createParallelSessionQueryWithForceAndDegreeOfParallelism() {
-        String value = "force.query.4";
-        String delimiter = "\\.";
         String expectedResult = "ALTER SESSION FORCE PARALLEL QUERY PARALLEL 4";
 
-        OracleParallelSessionParam param = new OracleParallelSessionParam();
-        param.setClause(OracleParallelSessionParam.Clause.FORCE);
-        param.setStatementType(OracleParallelSessionParam.StatementType.QUERY);
-        param.setDegreeOfParallelism("4");
-
-        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
-                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
-            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
-            String result = oracleSessionQueryFactory.create(property, value);
-            assertEquals(expectedResult, result);
-        }
+        OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+        String result = oracleSessionQueryFactory.create(property, value1);
+        assertEquals(expectedResult, result);
     }
 
     @Test
     @SuppressWarnings("try")
     void createParallelSessionQueryWithForce() {
-        String value = "force.dml";
         String expectedResult = "ALTER SESSION FORCE PARALLEL DML";
 
-        OracleParallelSessionParam param = new OracleParallelSessionParam();
-        param.setClause(OracleParallelSessionParam.Clause.FORCE);
-        param.setStatementType(OracleParallelSessionParam.StatementType.DML);
-        param.setDegreeOfParallelism("");
-
-        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
-                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
-            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
-            String result = oracleSessionQueryFactory.create(property, value);
-            assertEquals(expectedResult, result);
-        }
+        OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+        String result = oracleSessionQueryFactory.create(property, value2);
+        assertEquals(expectedResult, result);
     }
 
     @Test
     @SuppressWarnings("try")
     void createParallelSessionQueryWithEnable() {
-        String value = "enable.dml.2";
-        String expectedResult = "ALTER SESSION ENABLE PARALLEL DDL";
+        String expectedResult = "ALTER SESSION ENABLE PARALLEL DML";
 
-        OracleParallelSessionParam param = new OracleParallelSessionParam();
-        param.setClause(OracleParallelSessionParam.Clause.ENABLE);
-        param.setStatementType(OracleParallelSessionParam.StatementType.DDL);
-        param.setDegreeOfParallelism("2");
-
-        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
-                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
-            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
-            String result = oracleSessionQueryFactory.create(property, value);
-            assertEquals(expectedResult, result);
-        }
+        OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+        String result = oracleSessionQueryFactory.create(property, value3);
+        assertEquals(expectedResult, result);
     }
 
     @Test
     @SuppressWarnings("try")
     void createParallelSessionQueryWithDisable() {
-        String value = "disable.dml";
         String expectedResult = "ALTER SESSION DISABLE PARALLEL DML";
 
-        OracleParallelSessionParam param = new OracleParallelSessionParam();
-        param.setClause(OracleParallelSessionParam.Clause.DISABLE);
-        param.setStatementType(OracleParallelSessionParam.StatementType.DML);
-        param.setDegreeOfParallelism("");
-
-        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
-                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
-            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
-            String result = oracleSessionQueryFactory.create(property, value);
-            assertEquals(expectedResult, result);
-        }
+        OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+        String result = oracleSessionQueryFactory.create(property, value4);
+        assertEquals(expectedResult, result);
     }
 
     @Test
@@ -95,16 +79,43 @@ class OracleSessionQueryFactoryTest {
         String value = "TYPICAL";
         String expectedResult = "ALTER SESSION SET STATISTICS_LEVEL = TYPICAL";
 
-        OracleParallelSessionParam param = new OracleParallelSessionParam();
-        param.setClause(OracleParallelSessionParam.Clause.ENABLE);
-        param.setStatementType(OracleParallelSessionParam.StatementType.DDL);
-        param.setDegreeOfParallelism("2");
+        OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
+        String result = oracleSessionQueryFactory.create(property, value);
+        assertEquals(expectedResult, result);
+    }
 
-        try (MockedConstruction<OracleParallelSessionParamFactory> mocked = mockConstruction(OracleParallelSessionParamFactory.class,
-                (mock, context) -> when(mock.create(property, value, delimiter)).thenReturn(param))) {
-            OracleSessionQueryFactory oracleSessionQueryFactory = new OracleSessionQueryFactory();
-            String result = oracleSessionQueryFactory.create(property, value);
-            assertEquals(expectedResult, result);
-        }
+    @AfterAll
+    public static void endTest() {
+        mockedConstruction.close();
+    }
+
+    private static HashMap<String, OracleParallelSessionParam> createParams() {
+        HashMap<String, OracleParallelSessionParam> params = new HashMap<>();
+
+        OracleParallelSessionParam param1 = new OracleParallelSessionParam();
+        param1.setClause(OracleParallelSessionParam.Clause.FORCE);
+        param1.setStatementType(OracleParallelSessionParam.StatementType.QUERY);
+        param1.setDegreeOfParallelism("4");
+        params.put(value1, param1);
+
+        OracleParallelSessionParam param2 = new OracleParallelSessionParam();
+        param2.setClause(OracleParallelSessionParam.Clause.FORCE);
+        param2.setStatementType(OracleParallelSessionParam.StatementType.DML);
+        param2.setDegreeOfParallelism("");
+        params.put(value2, param2);
+
+        OracleParallelSessionParam param3 = new OracleParallelSessionParam();
+        param3.setClause(OracleParallelSessionParam.Clause.ENABLE);
+        param3.setStatementType(OracleParallelSessionParam.StatementType.DML);
+        param3.setDegreeOfParallelism("");
+        params.put(value3, param3);
+
+        OracleParallelSessionParam param4 = new OracleParallelSessionParam();
+        param4.setClause(OracleParallelSessionParam.Clause.DISABLE);
+        param4.setStatementType(OracleParallelSessionParam.StatementType.DML);
+        param4.setDegreeOfParallelism("");
+        params.put(value4, param4);
+
+        return params;
     }
 }


### PR DESCRIPTION
Some Oracle's session parameters can be used to control the parallelism of the query execution. These parameters can be set with the command: 
`ALTER SESSION { ENABLE | DISABLE | FORCE } PARALLEL { DML | DDL | QUERY } [ PARALLEL integer ];`

PXF allows to manage session variables with the following template command: `ALTER SESSION SET %key = %value`. But Oracle's parallel session parameters cannot be managed with this template. So, it is not possible to control the parallelism of query execution in Oracle using current template for session parameters.

This PR introduces an opportunity to set parallel session parameters for Oracle. The special session parameter `jdbc.session.property.alter_session_parallel` can be set in `jdbc-site.xml`. This parameter allows to use special template to set Oracle's parallel session parameters.

| Name  |        Value            | Description  |
| ------  |    -------------        | -------------- |
| name  | `jdbc.session.property.alter_session_parallel.<n>`         | Property name, where `<n>` is property ordinal because it's possible to specify a property several times with different values |
| value  | `<clause>.<statement_type>.<degree_of_parallelism>` | Combitnaftion of a clause, a statement type and  degree of parallelism for ALTER SESSION |

Possible values for a clause, statement type and degree_of_parallelism:
| Parameter  |    Value       |
| :-------------: | :-------------: |
| clause  | enable<br>disable<br>force |
| statement_type | query<br>ddl<br>dml |
| degree_of_parallelism | Optional. Number of parallel sessions that you can force |

If the name of the session parameter contains `alter_session_parallel` the value will be set with a special template for parallel session parameters. Otherwise  `ALTER SESSION SET %key = %value` will be used. It works only for Oracle.

The example of the jdbc-site.xml with Oracle's parallel session parameters:

```xml
<property>
    <name>jdbc.session.property.alter_session_parallel.1</name>
    <value>force.query.4</value>
</property>
<property>
    <name>jdbc.session.property.alter_session_parallel.2</name>
    <value>disable.ddl</value>
</property>
<property>
    <name>jdbc.session.property.alter_session_parallel.3</name>
    <value>enable.dml</value>
</property>
```

The example above means that before start the query the following session commands will be executed:
```
ALTER SESSION FORCE PARALLEL QUERY PARALLEL 4;
ALTER SESSION DISABLE PARALLEL DDL;
ALTER SESSION ENABLE PARALLEL DML
```