### PR TITLE
Improve PXF CLI reliability

### DIFF
--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -2,10 +2,10 @@
 # 1. health: returns the status of the application {"status":"UP"}
 # 2. info: returns information about the build {"build":{"version":"X.X.X","artifact":"pxf-service","name":"pxf-service","group":"org.greenplum.pxf","time":"timestamp"}}
 # 3. shutdown: allows shutting down the application
-# 4. metrics: shows ‘metrics’ information for the application
+# 4. metrics: shows 'metrics' information for the application
 # 5. prometheus: exposes metrics in a format that can be scraped by a Prometheus server
-management.endpoints.web.exposure.include=health,info,shutdown,metrics,prometheus
-management.endpoint.shutdown.enabled=true
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.shutdown.enabled=false
 management.endpoint.health.probes.enabled=true
 
 # common tags applied to all metrics

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -53,6 +53,10 @@ export JAVA_HOME=${JAVA_HOME:=/usr/java/default}
 # Path to Log directory
 export PXF_LOGDIR=${PXF_LOGDIR:=${PXF_BASE}/logs}
 
+export PXF_CLI_LOGDIR="${PXF_LOGDIR}/admin"
+PXF_CLI_LOGFILE="${PXF_CLI_LOGDIR}/pxf-cli-$(date +%Y-%m).log"
+export PXF_CLI_LOGFILE
+
 # Path to Run directory
 export PXF_RUNDIR=${PXF_RUNDIR:=${PXF_BASE}/run}
 
@@ -118,13 +122,19 @@ function failWithHint() {
     exit 1
 }
 
+function log() {
+    printf "%s\t[%d]\t%s\n" "$(date '+%Y-%m-%d %H:%M:%S.%3N %Z')" "${BASHPID}" "$*" >>"${PXF_CLI_LOGFILE}"
+}
+
 # determines whether the application is running
 function isRunning() {
+    log "Checking if PXF process with PID=$1 exists"
     ps -o pid,command -p "$1" | grep 'pxf-app' &> /dev/null
 }
 
 # creates the runtime directory structure inside $PXF_BASE
 function createPxfBaseDirectories() {
+    log "Creating PXF runtime directory structure in ${PXF_BASE}"
     install -m 744 -d "${PXF_BASE}/conf"
     install -m 744 -d "${PXF_BASE}/lib"
     install -m 744 -d "${PXF_BASE}/lib/native"
@@ -137,6 +147,7 @@ function createPxfBaseDirectories() {
 
 # copies configuration files inside $PXF_BASE
 function copyConfigurationFilesToPxfBase() {
+    log "Copying PXF configuration files from ${PXF_HOME} to ${PXF_BASE}"
     cp -Lv "${PXF_HOME}/conf/pxf-application.properties" "${PXF_BASE}/conf"
     cp -Lv "${PXF_HOME}/conf/pxf-env.sh"                 "${PXF_BASE}/conf"
     cp -Lv "${PXF_HOME}/conf/pxf-log4j2.xml"             "${PXF_BASE}/conf"
@@ -322,6 +333,7 @@ function doStart() {
 }
 
 function do_start() {
+    log "Starting PXF service..."
     if [[ -f "$pid_file" ]]; then
         pid=$(cat "$pid_file")
         isRunning "$pid" && { echoYellow "PXF is already running [pid=$pid]"; return 0; }
@@ -354,6 +366,8 @@ function do_start() {
     disown $pid
     echo "$pid" > "$pid_file"
 
+    log "Started PXF service on port ${PXF_PORT} - PID=${pid}"
+
     [[ -z $pid ]] && fail "Failed to start PXF"
     echoGreen "PXF started [pid=$pid]. Listening on port $PXF_PORT";
 }
@@ -369,11 +383,21 @@ function doStop() {
     checkJavaHome
     warnUserEnvScript
 
+    log "Stopping PXF service..."
     working_dir=$(dirname "$jarfile")
     pushd "$working_dir" > /dev/null
-    [[ -f $pid_file ]] || { echoYellow "Not running (pidfile not found). Is PXF running? Stop aborted."; return 0; }
+    if [[ ! -f $pid_file ]]; then
+        log "No pidfile=${pid_file} for PXF found"
+        echoYellow "Not running (pidfile not found). Is PXF running? Stop aborted."
+        return 0
+    fi
     pid=$(cat "$pid_file")
-    isRunning "$pid" || { echoYellow "Not running (process ${pid}). Removing stale pid file '$pid_file'."; rm -f "$pid_file"; return 0; }
+    if ! isRunning "$pid"; then
+        log "No running PXF process with PID=${pid} found; removing stale pidfile"
+        echoYellow "Not running (process ${pid}). Removing stale pid file '$pid_file'."
+        rm -f "$pid_file"
+        return 0
+    fi
 
     echoYellow "Stopping PXF [pid=$pid]..."
     do_stop "$pid" "$pid_file" || do_stop "$pid" "$pid_file" "-f"
@@ -384,12 +408,18 @@ function do_stop() {
     local killcmd=(kill)
     [[ $3 == -f ]] && killcmd+=(-9)
     killcmd+=("$1")
+    log "Attempting to stop PXF with '${killcmd[*]}'"
     "${killcmd[@]}" &> /dev/null || { echoRed "Unable to terminate process $1"; return 1; }
     for i in $(seq 1 $STOP_WAIT_TIME); do
         isRunning "$1" || { echoGreen "PXF stopped [$1]"; rm -f "$2"; return 0; }
-        [[ $i -eq STOP_WAIT_TIME/2 ]] && "${killcmd[@]}" &> /dev/null
+        log "PXF process with PID=$1 is still running..."
+        if [[ $i -eq STOP_WAIT_TIME/2 ]]; then
+            log "Attempting to stop PXF again with '${killcmd[*]}'"
+            "${killcmd[@]}" &> /dev/null
+        fi
         sleep 1
     done
+    log "Unable to stop process PID=$1 with '${killcmd[*]}'"
     echoRed "Unable to terminate process $1"
     return 1
 }
@@ -402,7 +432,11 @@ function doStatus() {
 
     working_dir="$(dirname "${jarfile}")"
     pushd "${working_dir}" >/dev/null
-    [[ -s "${pid_file}" ]] || { echoRed 'ERROR: PXF is down - the application is not running'; return 3; }
+    if [[ ! -s "${pid_file}" ]]; then
+        log "PXF pidfile '${pid_file}' does not exist"
+        echoRed 'ERROR: PXF is down - the application is not running'
+        return 3
+    fi
     pid="$(cat "${pid_file}")"
     isRunning "${pid}" || { echoRed "ERROR: PXF is down - process ${pid} not found"; return 1; }
     echoGreen "PXF is listening on port $PXF_PORT"
@@ -416,6 +450,7 @@ function doSync() {
         fail 'A destination hostname must be provided'
     fi
     warnUserEnvScript
+    log "Synchronizing PXF configuration to ${target_host}"
     rsync -az${DELETE:+ --delete} -e "ssh -o StrictHostKeyChecking=no" "$PXF_BASE"/{conf,lib,servers} "${target_host}:$PXF_BASE"
 }
 
@@ -425,6 +460,7 @@ function doCluster() {
     if [[ ${cmd} != init ]] && [[ ${cmd} != prepare ]]; then
         warnUserEnvScript
     fi
+    log "Running command '${cmd}' on PXF cluster"
     "${parent_script_dir}/bin/pxf-cli" "$@"
 }
 
@@ -436,6 +472,8 @@ function warnUserEnvScript() {
 pxf_script_command=$1
 
 silent=false
+
+[[ -d "${PXF_CLI_LOGDIR}" ]] || mkdir "${PXF_CLI_LOGDIR}"
 
 validate_user
 

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -118,45 +118,6 @@ function failWithHint() {
     exit 1
 }
 
-#
-# waitForSpringBoot waits for spring boot to finish loading
-# for given attempts number.
-#
-function waitForSpringBoot() {
-    attempts=0
-    max_attempts=$1 # number of attempts to connect
-    echo_after_attempts=$2 # only start echoing after this number of attempts
-    sleep_time=1 # sleep 1 second between attempts
-
-    # wait until spring boot is up:
-    echoYellow 'Checking if PXF is up and running...'
-    until $curl --silent --connect-timeout 1 -I "http://localhost:$PXF_PORT" | grep 'PXF Server' > /dev/null; do
-        if (( ++attempts == max_attempts )); then
-            echoRed 'ERROR: PXF is down - the application is not running'
-            return 1
-        fi
-        if (( attempts >= echo_after_attempts )); then
-            echoYellow "PXF not responding, re-trying after $sleep_time second (attempt number ${attempts})"
-        fi
-        sleep $sleep_time
-    done
-
-    return 0
-}
-
-#
-# checkWebapp checks if PXF is up for $1 attempts and then
-# verifies PXF webapp is functional
-#
-function checkWebapp() {
-    waitForSpringBoot "$1" "$2" || return 1
-
-    curlResponse=$($curl -s "http://localhost:${PXF_PORT}/actuator/health")
-
-    [[ $curlResponse == {\"status\":\"UP\"* ]] || fail "PXF is inaccessible. Check logs ($PXF_LOGDIR) for more information"
-    return 0
-}
-
 # determines whether the application is running
 function isRunning() {
     ps -o pid,command -p "$1" | grep 'pxf-app' &> /dev/null
@@ -180,13 +141,6 @@ function copyConfigurationFilesToPxfBase() {
     cp -Lv "${PXF_HOME}/conf/pxf-env.sh"                 "${PXF_BASE}/conf"
     cp -Lv "${PXF_HOME}/conf/pxf-log4j2.xml"             "${PXF_BASE}/conf"
     cp -Lv "${PXF_HOME}/conf/pxf-profiles.xml"           "${PXF_BASE}/conf"
-}
-
-function validate_system() {
-    # validate curl
-    if ! curl=$(command -v curl); then
-        fail 'curl is not installed, please install'
-    fi
 }
 
 function printUsage() {
@@ -359,7 +313,6 @@ function doMigrate() {
 # doStart handles start commands
 # command is executed as the current user
 #
-# after start, uses checkWebapp to verify the PXF webapp was loaded
 # successfully
 #
 function doStart() {
@@ -402,7 +355,6 @@ function do_start() {
     echo "$pid" > "$pid_file"
 
     [[ -z $pid ]] && fail "Failed to start PXF"
-    checkWebapp 300 10 || return 1
     echoGreen "PXF started [pid=$pid]. Listening on port $PXF_PORT";
 }
 
@@ -424,21 +376,6 @@ function doStop() {
     isRunning "$pid" || { echoYellow "Not running (process ${pid}). Removing stale pid file '$pid_file'."; rm -f "$pid_file"; return 0; }
 
     echoYellow "Stopping PXF [pid=$pid]..."
-
-    # first try endpoint (assume it might be disabled)
-    if $curl --max-time 5 --silent -X POST "localhost:$PXF_PORT/actuator/shutdown" | grep "Shutting down, bye..." > /dev/null; then
-        for i in $(seq 1 $STOP_WAIT_TIME); do
-            if isRunning "$pid"; then
-                sleep 1
-            else
-                echoGreen "PXF stopped [pid=$pid]"
-                rm -f $pid_file
-                return 0
-            fi
-        done
-    fi
-
-    # second try a nice kill and if that doesn't work force kill
     do_stop "$pid" "$pid_file" || do_stop "$pid" "$pid_file" "-f"
     rm -f $pid_file
 }
@@ -460,8 +397,16 @@ function do_stop() {
 function doStatus() {
     checkJavaHome
     warnUserEnvScript
-    checkWebapp 1 0 || return 1
+
+    echoYellow 'Checking if PXF is up and running...'
+
+    working_dir="$(dirname "${jarfile}")"
+    pushd "${working_dir}" >/dev/null
+    [[ -s "${pid_file}" ]] || { echoRed 'ERROR: PXF is down - the application is not running'; return 3; }
+    pid="$(cat "${pid_file}")"
+    isRunning "${pid}" || { echoRed "ERROR: PXF is down - process ${pid} not found"; return 1; }
     echoGreen "PXF is listening on port $PXF_PORT"
+
     return 0
 }
 
@@ -493,7 +438,6 @@ pxf_script_command=$1
 silent=false
 
 validate_user
-validate_system
 
 case $pxf_script_command in
     'init')

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -53,9 +53,9 @@ export JAVA_HOME=${JAVA_HOME:=/usr/java/default}
 # Path to Log directory
 export PXF_LOGDIR=${PXF_LOGDIR:=${PXF_BASE}/logs}
 
-export PXF_CLI_LOGDIR="${PXF_LOGDIR}/admin"
-PXF_CLI_LOGFILE="${PXF_CLI_LOGDIR}/pxf-cli-$(date +%Y-%m).log"
-export PXF_CLI_LOGFILE
+export PXF_ADMIN_LOGDIR="${PXF_LOGDIR}/admin"
+PXF_COMMANDS_LOGFILE="${PXF_ADMIN_LOGDIR}/pxf-commands-$(date +%Y-%m).log"
+export PXF_COMMANDS_LOGFILE
 
 # Path to Run directory
 export PXF_RUNDIR=${PXF_RUNDIR:=${PXF_BASE}/run}
@@ -122,8 +122,17 @@ function failWithHint() {
     exit 1
 }
 
+# Writes all function arguments as a string to PXF commands log
+# Before the function args are written to the log file, they are prefixed with
+# the current timestamp and this process' PID to allow grouping log messages
+# from the same invocation of the launcher
+#
+# Example
+#    log "Checking if PXF process exists"
+#
+#     2022-10-20 17:23:55.554 PDT	[27717]	Checking if PXF process exists
 function log() {
-    printf "%s\t[%d]\t%s\n" "$(date '+%Y-%m-%d %H:%M:%S.%3N %Z')" "${BASHPID}" "$*" >>"${PXF_CLI_LOGFILE}"
+    printf "%s\t[%d]\t%s\n" "$(date '+%Y-%m-%d %H:%M:%S.%3N %Z')" "${BASHPID}" "$*" >>"${PXF_COMMANDS_LOGFILE}"
 }
 
 # determines whether the application is running
@@ -132,26 +141,50 @@ function isRunning() {
     ps -o pid,command -p "$1" | grep 'pxf-app' &> /dev/null
 }
 
+# Creates the PXF admin log directory if it doesn't exist
+function ensureAdminLogDirectory() {
+    if [[ ! -d "${PXF_ADMIN_LOGDIR}" ]]; then
+        install -m 700 -d "${PXF_ADMIN_LOGDIR}"
+    fi
+}
+
+# Creates a directory under $PXF_BASE with the given mode
+function createPxfBaseDirectory() {
+    local mode="$1"
+    local directory="$2"
+
+    log "Creating directory ${directory} in ${PXF_BASE} with mode ${mode}"
+    install -m "${mode}" -d "${PXF_BASE}/${directory}"
+}
+
 # creates the runtime directory structure inside $PXF_BASE
 function createPxfBaseDirectories() {
     log "Creating PXF runtime directory structure in ${PXF_BASE}"
-    install -m 744 -d "${PXF_BASE}/conf"
-    install -m 744 -d "${PXF_BASE}/lib"
-    install -m 744 -d "${PXF_BASE}/lib/native"
-    install -m 744 -d "${PXF_BASE}/servers"
-    install -m 744 -d "${PXF_BASE}/servers/default"
-    install -m 700 -d "${PXF_BASE}/logs"
-    install -m 700 -d "${PXF_BASE}/run"
-    install -m 700 -d "${PXF_BASE}/keytabs"
+    createPxfBaseDirectory 744 "conf"
+    createPxfBaseDirectory 744 "lib"
+    createPxfBaseDirectory 744 "lib/native"
+    createPxfBaseDirectory 744 "servers"
+    createPxfBaseDirectory 744 "servers/default"
+    createPxfBaseDirectory 700 "logs"
+    createPxfBaseDirectory 700 "logs/admin"
+    createPxfBaseDirectory 700 "run"
+    createPxfBaseDirectory 700 "keytabs"
+}
+
+function copyFile() {
+    local config_file="$1"
+
+    log "Copying ${PXF_HOME}/conf/${config_file} to ${PXF_BASE}/conf"
+    cp -Lv "${PXF_HOME}/conf/${config_file}" "${PXF_BASE}/conf"
 }
 
 # copies configuration files inside $PXF_BASE
 function copyConfigurationFilesToPxfBase() {
     log "Copying PXF configuration files from ${PXF_HOME} to ${PXF_BASE}"
-    cp -Lv "${PXF_HOME}/conf/pxf-application.properties" "${PXF_BASE}/conf"
-    cp -Lv "${PXF_HOME}/conf/pxf-env.sh"                 "${PXF_BASE}/conf"
-    cp -Lv "${PXF_HOME}/conf/pxf-log4j2.xml"             "${PXF_BASE}/conf"
-    cp -Lv "${PXF_HOME}/conf/pxf-profiles.xml"           "${PXF_BASE}/conf"
+    copyFile pxf-application.properties
+    copyFile pxf-env.sh
+    copyFile pxf-log4j2.xml
+    copyFile pxf-profiles.xml
 }
 
 function printUsage() {
@@ -411,9 +444,14 @@ function do_stop() {
     log "Attempting to stop PXF with '${killcmd[*]}'"
     "${killcmd[@]}" &> /dev/null || { echoRed "Unable to terminate process $1"; return 1; }
     for i in $(seq 1 $STOP_WAIT_TIME); do
-        isRunning "$1" || { echoGreen "PXF stopped [$1]"; rm -f "$2"; return 0; }
+        if ! isRunning "$1"; then
+            log "PXF stopped [$1]"
+            echoGreen "PXF stopped [$1]"
+            rm -f "$2"
+            return 0
+        fi
         log "PXF process with PID=$1 is still running..."
-        if [[ $i -eq STOP_WAIT_TIME/2 ]]; then
+        if ((i == STOP_WAIT_TIME/2)); then
             log "Attempting to stop PXF again with '${killcmd[*]}'"
             "${killcmd[@]}" &> /dev/null
         fi
@@ -425,13 +463,12 @@ function do_stop() {
 }
 
 function doStatus() {
+    log "Checking if PXF is up and running..."
     checkJavaHome
     warnUserEnvScript
 
     echoYellow 'Checking if PXF is up and running...'
 
-    working_dir="$(dirname "${jarfile}")"
-    pushd "${working_dir}" >/dev/null
     if [[ ! -s "${pid_file}" ]]; then
         log "PXF pidfile '${pid_file}' does not exist"
         echoRed 'ERROR: PXF is down - the application is not running'
@@ -469,11 +506,11 @@ function warnUserEnvScript() {
     [[ -f $user_env_script ]] || echoYellow "WARNING: failed to find ${user_env_script}, default parameters will be used"
 }
 
+ensureAdminLogDirectory
+
 pxf_script_command=$1
 
 silent=false
-
-[[ -d "${PXF_CLI_LOGDIR}" ]] || mkdir "${PXF_CLI_LOGDIR}"
 
 validate_user
 


### PR DESCRIPTION
1. Check the status of the PXF service by checking the status of the PXF JVM process and by checking the HTTP health endpoint; if the PXF webapp fails to load for some reason, the JVM exits.

2. Disable actuator shutdown endpoint
    * The recommended way for shutting down a Spring Boot application is to send the JVM SIGTERM. This commit disables the shutdown endpoint since we can always assume that PXF is being shutdown locally and not remotely.

3. Add logging function to PXF CLI
    * PXF CLI writes log messages to `$PXF_LOGDIR/admin/pxf-cli-YYYY-MM.log`
    * Log lines are prefixed with a timestamp and the PID of the shell script to help identify all log messages from a single invocation of the PXF CLI
  
4. Remove PXF CLI's dependency on `curl` command
    * the `curl` command was previously required because of its use in shutting down and checking the status of PXF
