### PR TITLE
Update jackson-databind to 2.13.4.1

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.6.1</version>
+            <version>2.13.4.1</version>
         </dependency>
 
         <dependency>

--- a/server/pxf-api/build.gradle
+++ b/server/pxf-api/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation("org.apache.hadoop:hadoop-auth")                  { transitive = false }
     implementation("org.codehaus.woodstox:stax2-api")                { transitive = false }
     implementation("com.fasterxml.woodstox:woodstox-core")           { transitive = false }
-    implementation("com.fasterxml.jackson.core:jackson-core")        { transitive = false }
     implementation("com.esotericsoftware:kryo")                      { transitive = false }
 
     /*******************************

--- a/server/pxf-api/build.gradle
+++ b/server/pxf-api/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     implementation("org.codehaus.woodstox:stax2-api")                { transitive = false }
     implementation("com.fasterxml.woodstox:woodstox-core")           { transitive = false }
     implementation("com.fasterxml.jackson.core:jackson-core")        { transitive = false }
-    implementation("com.fasterxml.jackson.core:jackson-databind")    { transitive = false }
     implementation("com.esotericsoftware:kryo")                      { transitive = false }
 
     /*******************************

--- a/server/pxf-hdfs/build.gradle
+++ b/server/pxf-hdfs/build.gradle
@@ -31,8 +31,6 @@ dependencies {
     implementation("org.slf4j:slf4j-api")
 
     implementation("org.apache.avro:avro-mapred")                    { transitive = false }
-    implementation("com.fasterxml.jackson.core:jackson-core")        { transitive = false }
-    implementation("com.fasterxml.jackson.core:jackson-annotations") { transitive = false }
     implementation("org.apache.hadoop:hadoop-yarn-api")              { transitive = false } // Kerberos dependency
     implementation("org.apache.hadoop:hadoop-yarn-client")           { transitive = false } // Kerberos dependency
     implementation("org.apache.hadoop:hadoop-common")                { transitive = false }

--- a/server/pxf-hdfs/build.gradle
+++ b/server/pxf-hdfs/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation("org.slf4j:slf4j-api")
 
     implementation("org.apache.avro:avro-mapred")                    { transitive = false }
-    implementation("com.fasterxml.jackson.core:jackson-databind")    { transitive = false }
     implementation("com.fasterxml.jackson.core:jackson-core")        { transitive = false }
     implementation("com.fasterxml.jackson.core:jackson-annotations") { transitive = false }
     implementation("org.apache.hadoop:hadoop-yarn-api")              { transitive = false } // Kerberos dependency


### PR DESCRIPTION
This commit updates the `jackson-databind` version to 2.13.4.1 in the automation framework as a precautionary measure to mitigate CVE-2022-42003. 

PXF pulls in `jackson-databind` through Springboot v2.5.12. The CVE in question is related to `UNWRAP_SINGLE_VALUE_ARRAYS` which is disabled by default in `jackson-databind` and stays disabled in Springboot v2.5.12. We remove explicit declarations of these dependencies in the subproject `build.gradle` files.