### PR TITLE
Update default value for FLY_CMD in concourse Makefile

### DIFF
--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -17,7 +17,7 @@ PIVNET_PIPELINE_NAME        ?= pivnet_artifacts
 NUM_GPDB5_VERSIONS          ?= 10
 NUM_GPDB6_VERSIONS          ?=  9
 REDHAT_MAJOR_VERSION        ?= 7
-FLY_CMD                      = /usr/local/bin/fly
+FLY_CMD                     ?= fly
 TEMPLATE_CMD                 = ./template_tool
 FLY_OPTION_NON-INTERACTIVE   =
 EMAIL                       ?= true
@@ -211,7 +211,7 @@ set-pivnet-pipeline:
 
 .PHONY: singlecluster
 singlecluster:
-	fly -t ud set-pipeline \
+	$(FLY_CMD) -t ud set-pipeline \
 		-c ~/workspace/pxf/concourse/pipelines/singlecluster-pipeline.yml \
 		-v pxf-git-branch=master -p pxf-singlecluster
 


### PR DESCRIPTION
The concourse Makefile expects the fly CLI to be installed in /usr/local/bin but it doesn't need to be -- it can anywhere on the user's path. This commit changes the defualt to just fly but allows this to be overriden when running make, for example:

make FLY_CMD=fly-7.6.0 dev

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>