### PR TITLE
Adding Install and installcheck for the fdw test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,15 @@ default: all
 
 .PHONY: all external-table fdw cli server install install-server stage tar rpm rpm-tar deb deb-tar clean test it help
 
-all: external-table cli server
+all: external-table cli server fdw
 
 external-table:
 	make -C external-table
 
 fdw:
+ifneq ($(FDW_SUPPORT),)
 	make -C fdw
+endif
 
 cli:
 	make -C cli/go/src/pxf-cli
@@ -44,7 +46,7 @@ clean:
 
 test:
 ifneq ($(FDW_SUPPORT),)
-	make -C fdw installcheck
+	make -C fdw test
 endif
 	make -C cli/go/src/pxf-cli test
 	make -C server test

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ default: all
 
 .PHONY: all external-table fdw cli server install install-server stage tar rpm rpm-tar deb deb-tar clean test it help
 
-all: external-table cli server fdw
+all: fdw external-table cli server
 
 external-table:
 	make -C external-table
@@ -30,6 +30,8 @@ external-table:
 fdw:
 ifneq ($(FDW_SUPPORT),)
 	make -C fdw
+else
+	@echo "The variable FDW_SUPPORT was empty; skipping building the fdw/ directory"
 endif
 
 cli:
@@ -47,6 +49,8 @@ clean:
 test:
 ifneq ($(FDW_SUPPORT),)
 	make -C fdw test
+else
+	@echo "The variable FDW_SUPPORT was empty; skipping fdw tests"
 endif
 	make -C cli/go/src/pxf-cli test
 	make -C server test

--- a/fdw/Makefile
+++ b/fdw/Makefile
@@ -36,4 +36,5 @@ stage: pxf_fdw.so
 clean-all: clean
 	rm -rf build
 
+.PHONY: test
 test: install installcheck

--- a/fdw/Makefile
+++ b/fdw/Makefile
@@ -35,3 +35,5 @@ stage: pxf_fdw.so
 .PHONY: clean-all
 clean-all: clean
 	rm -rf build
+
+test: install installcheck


### PR DESCRIPTION
Currently, for GP7, if we run the `make test` it runs only `fdw -C make installcheck` and not `make install` due to which `fdw` doesn't gets installed properly and fails the fdw tests. This PR adds `install and installcheck` for the `test` target. 