### PR TITLE
Minor fixes for IPA dev cluster provision script and templates

### DIFF
--- a/concourse/terraform/ipa-multinode-hadoop/.terraform.lock.hcl
+++ b/concourse/terraform/ipa-multinode-hadoop/.terraform.lock.hcl
@@ -1,24 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/external" {
-  version = "2.1.0"
-  hashes = [
-    "h1:wbtDfLeawmv6xVT1W0w0fctRCb4ABlaD3JTxwb1jXag=",
-    "zh:0d83ffb72fbd08986378204a7373d8c43b127049096eaf2765bfdd6b00ad9853",
-    "zh:7577d6edc67b1e8c2cf62fe6501192df1231d74125d90e51d570d586d95269c5",
-    "zh:9c669ded5d5affa4b2544952c4b6588dfed55260147d24ced02dca3a2829f328",
-    "zh:a404d46f2831f90633947ab5d57e19dbfe35b3704104ba6ec80bcf50b058acfd",
-    "zh:ae1caea1c936d459ceadf287bb5c5bd67b5e2a7819df6f5c4114b7305df7f822",
-    "zh:afb4f805477694a4b9dde86b268d2c0821711c8aab1c6088f5f992228c4c06fb",
-    "zh:b993b4a1de8a462643e78f4786789e44ce5064b332fee1cb0d6250ed085561b8",
-    "zh:c84b2c13fa3ea2c0aa7291243006d560ce480a5591294b9001ce3742fc9c5791",
-    "zh:c8966f69b7eccccb771704fd5335923692eccc9e0e90cb95d14538fe2e92a3b8",
-    "zh:d5fe68850d449b811e633a300b114d0617df6d450305e8251643b4d143dc855b",
-    "zh:ddebfd1e674ba336df09b1f27bbaa0e036c25b7a7087dc8081443f6e5954028b",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/google" {
   version = "3.85.0"
   hashes = [

--- a/concourse/terraform/ipa-multinode-hadoop/outputs.tf
+++ b/concourse/terraform/ipa-multinode-hadoop/outputs.tf
@@ -5,14 +5,16 @@ output "ssh_config" {
     namenode = google_compute_instance.namenode
     datanode = google_compute_instance.datanode
   })
-
+  sensitive = true
 }
+
 output "ansible_inventory" {
   value = templatefile("${path.module}/templates/inventory.ini.tpl", {
     ipa = google_compute_instance.ipa
     namenode = google_compute_instance.namenode
     datanode = google_compute_instance.datanode
   })
+  sensitive = true
 }
 
 output "etc_hosts" {
@@ -22,6 +24,7 @@ output "etc_hosts" {
     namenode = google_compute_instance.namenode
     datanode = google_compute_instance.datanode
   })
+  sensitive = true
 }
 
 output "ansible_variables" {

--- a/dev/ipa-cluster.bash
+++ b/dev/ipa-cluster.bash
@@ -135,9 +135,9 @@ function terraform_destroy() {
 
 # cleanup ansible artifacts that might exist from previous runs
 function cleanup_existing_artifacts() {
-    rm "${ansible_play_path}"/*.p12
-    rm "${ansible_play_path}"/inventory.ini
-    rm "${ansible_play_path}"/config.yml
+    rm -f "${ansible_play_path}"/*.p12
+    rm -f "${ansible_play_path}"/inventory.ini
+    rm -f "${ansible_play_path}"/config.yml
 }
 
 function generate_keystores() {


### PR DESCRIPTION
- updated terraform template and added designation of some values as sensitive to make it work with the latest versions of terraform
- added a flag to not error out when cleanup tries to remove files that might not exist during the first run 