### PR TITLE
Add close connection if statementRead is null

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
@@ -22,7 +22,6 @@ package org.greenplum.pxf.plugins.jdbc;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.api.OneRow;
-import org.greenplum.pxf.api.error.PxfRuntimeException;
 import org.greenplum.pxf.api.model.Accessor;
 import org.greenplum.pxf.api.model.ConfigurationFactory;
 import org.greenplum.pxf.api.security.SecureLogin;
@@ -36,12 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLTimeoutException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -101,8 +95,18 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
         if (statementRead != null && !statementRead.isClosed()) {
             return true;
         }
-
         Connection connection = super.getConnection();
+        try {
+            return openForReadInner(connection);
+        } catch (Throwable e) {
+            if (statementRead == null) {
+                JdbcBasePlugin.closeConnection(connection);
+            }
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private boolean openForReadInner(Connection connection) throws SQLException {
         SQLQueryBuilder sqlQueryBuilder = new SQLQueryBuilder(context, connection.getMetaData(), getQueryText());
 
         // Build SELECT query
@@ -225,7 +229,7 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
         return true;
     }
 
-     /**
+    /**
      * writeNextObject() implementation
      * <p>
      * If batchSize is not 0 or 1, add a tuple to the batch of statementWrite

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessor.java
@@ -22,6 +22,7 @@ package org.greenplum.pxf.plugins.jdbc;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.api.OneRow;
+import org.greenplum.pxf.api.error.PxfRuntimeException;
 import org.greenplum.pxf.api.model.Accessor;
 import org.greenplum.pxf.api.model.ConfigurationFactory;
 import org.greenplum.pxf.api.security.SecureLogin;
@@ -35,7 +36,12 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
+import java.sql.Statement;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -95,14 +101,15 @@ public class JdbcAccessor extends JdbcBasePlugin implements Accessor {
         if (statementRead != null && !statementRead.isClosed()) {
             return true;
         }
+
         Connection connection = super.getConnection();
         try {
             return openForReadInner(connection);
         } catch (Throwable e) {
             if (statementRead == null) {
-                JdbcBasePlugin.closeConnection(connection);
+                closeConnection(connection);
             }
-            throw new RuntimeException(e.getMessage(), e);
+            throw new PxfRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -479,7 +479,7 @@ public class JdbcBasePlugin extends BasePlugin {
      * @param connection connection to close
      * @throws SQLException throws when a SQLException occurs
      */
-    private static void closeConnection(Connection connection) throws SQLException {
+    static void closeConnection(Connection connection) throws SQLException {
         if (connection == null) {
             LOG.warn("Call to close connection is ignored as connection provided was null");
             return;

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -479,7 +479,7 @@ public class JdbcBasePlugin extends BasePlugin {
      * @param connection connection to close
      * @throws SQLException throws when a SQLException occurs
      */
-    static void closeConnection(Connection connection) throws SQLException {
+    protected static void closeConnection(Connection connection) throws SQLException {
         if (connection == null) {
             LOG.warn("Call to close connection is ignored as connection provided was null");
             return;

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -82,7 +82,7 @@ public class JdbcAccessorTest {
         context.setDataSource("query:foo");
         accessor.setRequestContext(context);
         accessor.afterPropertiesSet();
-        Exception e = assertThrows(IllegalStateException.class,
+        Exception e = assertThrows(RuntimeException.class,
                 () -> accessor.openForRead());
         assertEquals("No server configuration directory found for server unknown", e.getMessage());
     }

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcAccessorTest.java
@@ -1,6 +1,7 @@
 package org.greenplum.pxf.plugins.jdbc;
 
 import org.apache.hadoop.conf.Configuration;
+import org.greenplum.pxf.api.error.PxfRuntimeException;
 import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.security.SecureLogin;
 import org.greenplum.pxf.plugins.jdbc.partitioning.IntPartition;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
@@ -27,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 public class JdbcAccessorTest {
@@ -77,51 +80,63 @@ public class JdbcAccessorTest {
 
     @Test
     public void testReadFromQueryFailsWhenServerDirectoryIsNotSpecified() throws SQLException {
-        wireMocksForRead();
-        context.setServerName("unknown");
-        context.setDataSource("query:foo");
-        accessor.setRequestContext(context);
-        accessor.afterPropertiesSet();
-        Exception e = assertThrows(RuntimeException.class,
-                () -> accessor.openForRead());
-        assertEquals("No server configuration directory found for server unknown", e.getMessage());
+        try (MockedStatic<JdbcBasePlugin> jdbcBasePluginMockedStatic = mockStatic(JdbcBasePlugin.class)) {
+            wireMocksForRead();
+            context.setServerName("unknown");
+            context.setDataSource("query:foo");
+            accessor.setRequestContext(context);
+            accessor.afterPropertiesSet();
+            Exception e = assertThrows(PxfRuntimeException.class,
+                    () -> accessor.openForRead());
+            assertEquals("No server configuration directory found for server unknown", e.getMessage());
+            jdbcBasePluginMockedStatic.verify(() -> JdbcBasePlugin.closeConnection(mockConnection));
+        }
     }
 
     @Test
     public void testReadFromQueryFailsWhenServerDirectoryDoesNotExist() throws SQLException {
-        wireMocksForRead();
-        configuration.set("pxf.config.server.directory", "/non-existing-directory");
-        context.setDataSource("query:foo");
-        accessor.setRequestContext(context);
-        accessor.afterPropertiesSet();
-        Exception e = assertThrows(RuntimeException.class,
-                () -> accessor.openForRead());
-        assertEquals("Failed to read text of query foo : File '/non-existing-directory/foo.sql' does not exist", e.getMessage());
+        try (MockedStatic<JdbcBasePlugin> jdbcBasePluginMockedStatic = mockStatic(JdbcBasePlugin.class)) {
+            wireMocksForRead();
+            configuration.set("pxf.config.server.directory", "/non-existing-directory");
+            context.setDataSource("query:foo");
+            accessor.setRequestContext(context);
+            accessor.afterPropertiesSet();
+            Exception e = assertThrows(RuntimeException.class,
+                    () -> accessor.openForRead());
+            assertEquals("Failed to read text of query foo : File '/non-existing-directory/foo.sql' does not exist", e.getMessage());
+            jdbcBasePluginMockedStatic.verify(() -> JdbcBasePlugin.closeConnection(mockConnection));
+        }
     }
 
     @Test
     public void testReadFromQueryFailsWhenQueryFileIsNotFoundInExistingDirectory() throws SQLException {
-        wireMocksForRead();
-        configuration.set("pxf.config.server.directory", "/tmp/");
-        context.setDataSource("query:foo");
-        accessor.setRequestContext(context);
-        accessor.afterPropertiesSet();
-        Exception e = assertThrows(RuntimeException.class,
-                () -> accessor.openForRead());
-        assertEquals("Failed to read text of query foo : File '/tmp/foo.sql' does not exist", e.getMessage());
+        try (MockedStatic<JdbcBasePlugin> jdbcBasePluginMockedStatic = mockStatic(JdbcBasePlugin.class)) {
+            wireMocksForRead();
+            configuration.set("pxf.config.server.directory", "/tmp/");
+            context.setDataSource("query:foo");
+            accessor.setRequestContext(context);
+            accessor.afterPropertiesSet();
+            Exception e = assertThrows(RuntimeException.class,
+                    () -> accessor.openForRead());
+            assertEquals("Failed to read text of query foo : File '/tmp/foo.sql' does not exist", e.getMessage());
+            jdbcBasePluginMockedStatic.verify(() -> JdbcBasePlugin.closeConnection(mockConnection));
+        }
     }
 
     @Test
     public void testReadFromQueryFailsWhenQueryFileIsEmpty() throws Exception {
-        wireMocksForRead();
-        String serversDirectory = new File(this.getClass().getClassLoader().getResource("servers").toURI()).getCanonicalPath();
-        configuration.set("pxf.config.server.directory", serversDirectory + File.separator + "test-server");
-        context.setDataSource("query:emptyquery");
-        accessor.setRequestContext(context);
-        accessor.afterPropertiesSet();
-        Exception e = assertThrows(RuntimeException.class,
-                () -> accessor.openForRead());
-        assertEquals("Query text file is empty for query emptyquery", e.getMessage());
+        try (MockedStatic<JdbcBasePlugin> jdbcBasePluginMockedStatic = mockStatic(JdbcBasePlugin.class)) {
+            wireMocksForRead();
+            String serversDirectory = new File(this.getClass().getClassLoader().getResource("servers").toURI()).getCanonicalPath();
+            configuration.set("pxf.config.server.directory", serversDirectory + File.separator + "test-server");
+            context.setDataSource("query:emptyquery");
+            accessor.setRequestContext(context);
+            accessor.afterPropertiesSet();
+            Exception e = assertThrows(RuntimeException.class,
+                    () -> accessor.openForRead());
+            assertEquals("Query text file is empty for query emptyquery", e.getMessage());
+            jdbcBasePluginMockedStatic.verify(() -> JdbcBasePlugin.closeConnection(mockConnection));
+        }
     }
 
     @Test


### PR DESCRIPTION
Sometimes the connection to the external data source is still open and doesn't close.
One of the examples is when the user runs named query with readable external table. If the file with query is not present on the segment, the query finishes with error but the session will not be closed.
Here is a simple logic of the issue:
1. The user runs query to the external readable table with named query;
2. The method `openForRead()` opens the connection to the external data source;
3. The method `getQueryText()` tries to read query from the file and receives the error that file doesn't exist. The field `statementRead` is still `null`
4. The method `closeForRead()` executes the `closeStatementAndConnection(statementRead)` method that checks whether the `statementRead` is `null` or not. If it is `null` we don't close neither statement nor connection.
5. The connection is still open in that case until the idle timeout.

This commit adds try-catch block to catch the error if some exceptions happen before the statement execution. The connection will be closed in case of the error. 