### PR TITLE
Minor fixes for IPA dev cluster provision script and templates

### DIFF
--- a/concourse/terraform/ipa-multinode-hadoop/.terraform.lock.hcl
+++ b/concourse/terraform/ipa-multinode-hadoop/.terraform.lock.hcl
@@ -1,24 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/external" {
-  version = "2.1.0"
-  hashes = [
-    "h1:wbtDfLeawmv6xVT1W0w0fctRCb4ABlaD3JTxwb1jXag=",
-    "zh:0d83ffb72fbd08986378204a7373d8c43b127049096eaf2765bfdd6b00ad9853",
-    "zh:7577d6edc67b1e8c2cf62fe6501192df1231d74125d90e51d570d586d95269c5",
-    "zh:9c669ded5d5affa4b2544952c4b6588dfed55260147d24ced02dca3a2829f328",
-    "zh:a404d46f2831f90633947ab5d57e19dbfe35b3704104ba6ec80bcf50b058acfd",
-    "zh:ae1caea1c936d459ceadf287bb5c5bd67b5e2a7819df6f5c4114b7305df7f822",
-    "zh:afb4f805477694a4b9dde86b268d2c0821711c8aab1c6088f5f992228c4c06fb",
-    "zh:b993b4a1de8a462643e78f4786789e44ce5064b332fee1cb0d6250ed085561b8",
-    "zh:c84b2c13fa3ea2c0aa7291243006d560ce480a5591294b9001ce3742fc9c5791",
-    "zh:c8966f69b7eccccb771704fd5335923692eccc9e0e90cb95d14538fe2e92a3b8",
-    "zh:d5fe68850d449b811e633a300b114d0617df6d450305e8251643b4d143dc855b",
-    "zh:ddebfd1e674ba336df09b1f27bbaa0e036c25b7a7087dc8081443f6e5954028b",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/google" {
   version = "3.85.0"
   hashes = [

--- a/concourse/terraform/ipa-multinode-hadoop/outputs.tf
+++ b/concourse/terraform/ipa-multinode-hadoop/outputs.tf
@@ -5,7 +5,7 @@ output "ssh_config" {
     namenode = google_compute_instance.namenode
     datanode = google_compute_instance.datanode
   })
-
+  sensitive = true
 }
 output "ansible_inventory" {
   value = templatefile("${path.module}/templates/inventory.ini.tpl", {
@@ -13,6 +13,7 @@ output "ansible_inventory" {
     namenode = google_compute_instance.namenode
     datanode = google_compute_instance.datanode
   })
+  sensitive = true
 }
 
 output "etc_hosts" {
@@ -22,6 +23,7 @@ output "etc_hosts" {
     namenode = google_compute_instance.namenode
     datanode = google_compute_instance.datanode
   })
+  sensitive = true
 }
 
 output "ansible_variables" {

--- a/concourse/terraform/ipa-multinode-hadoop/outputs.tf
+++ b/concourse/terraform/ipa-multinode-hadoop/outputs.tf
@@ -7,6 +7,7 @@ output "ssh_config" {
   })
   sensitive = true
 }
+
 output "ansible_inventory" {
   value = templatefile("${path.module}/templates/inventory.ini.tpl", {
     ipa = google_compute_instance.ipa

--- a/dev/IPA.md
+++ b/dev/IPA.md
@@ -38,7 +38,9 @@ The script will:
  * spin up GCP instances for the Hadoop cluster
  * apply ansible configuration steps to configure the Hadoop cluster
  * add a private key to access GCP VMs as `~/.ssh/[username]`
- * add SSH configurations to `~/.ssh/config` file
+ * create SSH ~/.ssh/config.d config directory
+ * add SSH `Include config.d/*` wild card include directive as first line in `~/.ssh/config` file
+ * add SSH configurations to `~/.ssh/config.d/ipa_config` file
  * create a PXF configuration server `$PXF_BASE/servers/hdfs-ipa`
  * print out messages instructing the user to:
    * enable constrained delegation property in their `$PXF_BASE/servers/hdfs-ipa/pxf-site.xml`

--- a/dev/ipa-cluster.bash
+++ b/dev/ipa-cluster.bash
@@ -135,9 +135,9 @@ function terraform_destroy() {
 
 # cleanup ansible artifacts that might exist from previous runs
 function cleanup_existing_artifacts() {
-    rm "${ansible_play_path}"/*.p12
-    rm "${ansible_play_path}"/inventory.ini
-    rm "${ansible_play_path}"/config.yml
+    rm -f "${ansible_play_path}"/*.p12
+    rm -f "${ansible_play_path}"/inventory.ini
+    rm -f "${ansible_play_path}"/config.yml
 }
 
 function generate_keystores() {

--- a/dev/ipa-cluster.bash
+++ b/dev/ipa-cluster.bash
@@ -73,7 +73,7 @@ function check_pre_requisites() {
 }
 
 function create_firewall_resource() {
-    local my_ip=$(curl ifconfig.co)
+    local my_ip=$(curl -s ifconfig.co)
     cat << EOF > "${terraform_dir}"/local-firewall.tf
 resource "google_compute_firewall" "$USER-access" {
   name    = "$USER-access"

--- a/dev/ipa-cluster.bash
+++ b/dev/ipa-cluster.bash
@@ -242,8 +242,8 @@ function setup_pxf_server() {
     cp ipa_env_files/conf/*.xml "${PXF_BASE}"/servers/hdfs-ipa/
     cp ipa_env_files/*.keytab "${PXF_BASE}"/servers/hdfs-ipa/
     cp "${parent_script_dir}"/server/pxf-service/src/templates/templates/pxf-site.xml "${PXF_BASE}"/servers/hdfs-ipa/
-    sed -i '' -e "s|>gpadmin/_HOST@EXAMPLE.COM<|>porter@${domain_name_upper}<|g" "${PXF_BASE}"/servers/hdfs-ipa/pxf-site.xml
-    sed -i '' -e 's|/keytabs/|/servers/hdfs-ipa/|g' "${PXF_BASE}"/servers/hdfs-ipa/pxf-site.xml
+    sed -e "s|>gpadmin/_HOST@EXAMPLE.COM<|>porter@${domain_name_upper}<|g" "${PXF_BASE}"/servers/hdfs-ipa/pxf-site.xml > /tmp/pxf-site.xml.$$ && mv /tmp/pxf-site.xml.$$ "${PXF_BASE}"/servers/hdfs-ipa/pxf-site.xml
+    sed -e 's|/keytabs/|/servers/hdfs-ipa/|g' "${PXF_BASE}"/servers/hdfs-ipa/pxf-site.xml > /tmp/pxf-site.xml.$$ && mv /tmp/pxf-site.xml.$$ "${PXF_BASE}"/servers/hdfs-ipa/pxf-site.xml
     # set Hadoop client to use hostnames for datanodes instead of IP addresses (which are internal in GCP network)
     xmlstarlet ed --inplace --pf --append '/configuration/property[last()]' --type elem -n property -v "" \
      --subnode '/configuration/property[last()]' --type elem -n name -v "dfs.client.use.datanode.hostname" \
@@ -253,7 +253,7 @@ function setup_pxf_server() {
 
     rm -rf "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation
     cp -R "${PXF_BASE}"/servers/hdfs-ipa "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation
-    sed -i '' -e 's|hdfs-ipa|hdfs-ipa-no-impersonation|g' "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation/pxf-site.xml
+    sed -e 's|hdfs-ipa|hdfs-ipa-no-impersonation|g' "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation/pxf-site.xml > /tmp/pxf-site.xml.$$ && mv /tmp/pxf-site.xml.$$ "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation/pxf-site.xml
     # set impersonation property to false for the PXF server
     xmlstarlet ed --inplace --pf --update "/configuration/property[name = 'pxf.service.user.impersonation']/value" -v false "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation/pxf-site.xml
     # set service user to foobar
@@ -263,7 +263,7 @@ function setup_pxf_server() {
 
     rm -rf "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation-no-svcuser
     cp -R "${PXF_BASE}"/servers/hdfs-ipa "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation-no-svcuser
-    sed -i '' -e 's|hdfs-ipa|hdfs-ipa-no-impersonation-no-svcuser|g' "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation-no-svcuser/pxf-site.xml
+    sed -e 's|hdfs-ipa|hdfs-ipa-no-impersonation-no-svcuser|g' "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation-no-svcuser/pxf-site.xml > /tmp/pxf-site.xml.$$ && mv /tmp/pxf-site.xml.$$ "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation-no-svcuser/pxf-site.xml
     # set impersonation property to false for the PXF server
     xmlstarlet ed --inplace --pf --update "/configuration/property[name = 'pxf.service.user.impersonation']/value" -v false "${PXF_BASE}"/servers/hdfs-ipa-no-impersonation-no-svcuser/pxf-site.xml
 }

--- a/dev/ipa-cluster.bash
+++ b/dev/ipa-cluster.bash
@@ -164,16 +164,26 @@ function generate_keystores() {
     done
 }
 
+# Add ssh "Include config.d/*" wild card directive at beginning of
+# ~/.ssh/config file.
+function update_ssh_config(){
+    cat <<EOF > /tmp/ssh-config.$$
+Include config.d/*
+
+EOF
+    cat ~/.ssh/config >> /tmp/ssh-config.$$
+    mv /tmp/ssh-config.$$ ~/.ssh/config
+}
+
 # setup ssh ipa_config with host alias, users, and identity files
 function setup_ssh_config() {
-    mkdir -p ~/.ssh
-
+    mkdir -p ~/.ssh/config.d
     [ ! -f ~/.ssh/config ] && touch ~/.ssh/config
 
     # If necessary, update ~/.ssh/config file with Include directive
-    grep -qxF 'Include "ipa_config"' ~/.ssh/config || echo 'Include "ipa_config"' >> ~/.ssh/config
+    grep -qxF 'Include config.d/*' ~/.ssh/config || update_ssh_config
 
-    jq <"${metadata_path}" -r '.ssh_config.value'  >~/.ssh/ipa_config
+    jq <"${metadata_path}" -r '.ssh_config.value'  >~/.ssh/config.d/ipa_config
     jq <"${metadata_path}" -r '.private_key.value' >~/.ssh/ipa_"${cluster_name}"_rsa
 
     chmod 0600 ~/.ssh/ipa_"${cluster_name}"_rsa

--- a/dev/ipa-cluster.bash
+++ b/dev/ipa-cluster.bash
@@ -75,8 +75,8 @@ function check_pre_requisites() {
 function create_firewall_resource() {
     local my_ip=$(curl -s ifconfig.co)
     cat << EOF > "${terraform_dir}"/local-firewall.tf
-resource "google_compute_firewall" "$USER-access" {
-  name    = "$USER-access"
+resource "google_compute_firewall" "${TF_VAR_env_name}-access" {
+  name    = "${TF_VAR_env_name}-access"
   network = var.network
   direction = "INGRESS"
   allow {
@@ -270,7 +270,7 @@ function setup_pxf_server() {
 
 # print instructions for the manual steps the user must perform
 function print_user_instructions() {
-    echo "Cluster $USER has been created, now do the following:"
+    echo "Cluster ${TF_VAR_env_name} has been created, now do the following:"
     echo "1. --- copy the following to your /etc/hosts :"
     cat ipa_env_files/etc_hostfile
     echo "2. --- add the following to your /etc/krb5.conf :"
@@ -283,8 +283,8 @@ function print_user_instructions() {
 
 [realms]
  C.DATA-GPDB-UD-IPA.INTERNAL = {
-  kdc = ccp-$USER-ipa.c.data-gpdb-ud-ipa.internal
-  admin_server = ccp-$USER-ipa.c.data-gpdb-ud-ipa.internal
+  kdc = ccp-${TF_VAR_env_name}-ipa.c.data-gpdb-ud-ipa.internal
+  admin_server = ccp-${TF_VAR_env_name}-ipa.c.data-gpdb-ud-ipa.internal
  }
 
 [domain_realm]

--- a/dev/ipa-cluster.bash
+++ b/dev/ipa-cluster.bash
@@ -164,11 +164,18 @@ function generate_keystores() {
     done
 }
 
-# setup ssh_config with host alias, users, and identity files
+# setup ssh ipa_config with host alias, users, and identity files
 function setup_ssh_config() {
     mkdir -p ~/.ssh
-    jq <"${metadata_path}" -r '.ssh_config.value' >>~/.ssh/config
+
+    [ ! -f ~/.ssh/config ] && touch ~/.ssh/config
+
+    # If necessary, update ~/.ssh/config file with Include directive
+    grep -qxF 'Include "ipa_config"' ~/.ssh/config || echo 'Include "ipa_config"' >> ~/.ssh/config
+
+    jq <"${metadata_path}" -r '.ssh_config.value'  >~/.ssh/ipa_config
     jq <"${metadata_path}" -r '.private_key.value' >~/.ssh/ipa_"${cluster_name}"_rsa
+
     chmod 0600 ~/.ssh/ipa_"${cluster_name}"_rsa
     ssh-keygen -y -f ~/.ssh/ipa_"${cluster_name}"_rsa >~/.ssh/ipa_"${cluster_name}"_rsa.pub
 }


### PR DESCRIPTION
I have the following updates to allow `ipa-install-bash` to run in an Ubuntu 18.04 dev environment.

Here is an overview of the change:
-     SSH Config file - non-append approach
-     Terraform v1.3.4 - Sensitive = true
-     Removal of files errors (if they do not exist)
-     Portable Sed command alternative
-     Curl noise (-s)
-     For consistency use, expand TF_VAR_env_name use within the script.
