### PR TITLE
Added error handling for FDW read flow

### DIFF
--- a/automation/src/main/java/annotations/FailsWithFDW.java
+++ b/automation/src/main/java/annotations/FailsWithFDW.java
@@ -1,9 +1,11 @@
 package annotations;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 
 /**
  * Annotation for marking Test cases that fail when run against PXF FDW.
@@ -12,6 +14,6 @@ import static java.lang.annotation.ElementType.METHOD;
  * (e.g. those exericisng features of external tables that are not supported wth FDW).
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@Target({ METHOD })
+@Target({ METHOD, TYPE })
 public @interface FailsWithFDW {
 }

--- a/automation/src/main/java/annotations/FailsWithFDW.java
+++ b/automation/src/main/java/annotations/FailsWithFDW.java
@@ -1,6 +1,5 @@
 package annotations;
 
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 

--- a/automation/src/main/java/annotations/FailsWithFDW.java
+++ b/automation/src/main/java/annotations/FailsWithFDW.java
@@ -11,7 +11,7 @@ import static java.lang.annotation.ElementType.TYPE;
  * Annotation for marking Test cases that fail when run against PXF FDW.
  *
  * This is a marker interface for now but can be used later to skip tests that cannot be run against FDW
- * (e.g. those exericisng features of external tables that are not supported wth FDW).
+ * (e.g. those exercising features of external tables that are not supported wth FDW).
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ METHOD, TYPE })

--- a/automation/src/main/java/annotations/SkipForFDW.java
+++ b/automation/src/main/java/annotations/SkipForFDW.java
@@ -1,0 +1,18 @@
+package annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * Annotation for marking Test cases that should be skipped when run against PXF FDW.
+ *
+ * This is a marker interface for tests that cannot be run against FDW because they
+ * exercise features of external tables that are not supported wth FDW.
+ */
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({ METHOD, TYPE })
+public @interface SkipForFDW {
+}

--- a/automation/src/main/java/annotations/WorksWithFDW.java
+++ b/automation/src/main/java/annotations/WorksWithFDW.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 
 /**
  * Annotation for marking Test cases that can be run against PXF FDW.
@@ -12,6 +13,6 @@ import static java.lang.annotation.ElementType.METHOD;
  * to run against FDW as later most tests will be able to and there will be no need for this annotation.
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@Target({ METHOD })
+@Target({ METHOD, TYPE })
 public @interface WorksWithFDW {
 }

--- a/automation/src/main/java/listeners/FDWSkipTestAnalyzer.java
+++ b/automation/src/main/java/listeners/FDWSkipTestAnalyzer.java
@@ -1,6 +1,7 @@
 package listeners;
 
 import annotations.FailsWithFDW;
+import annotations.SkipForFDW;
 import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.utils.system.FDWUtils;
 import org.testng.IInvokedMethod;
@@ -27,7 +28,11 @@ public class FDWSkipTestAnalyzer implements IInvokedMethodListener {
             Class clazz = method.getDeclaringClass();
             // check if the method should not be skipped
             if (method.isAnnotationPresent(WorksWithFDW.class) ||
-                    (clazz.isAnnotationPresent(WorksWithFDW.class) && !method.isAnnotationPresent(FailsWithFDW.class))) {
+                    (clazz.isAnnotationPresent(WorksWithFDW.class) &&
+                     !method.isAnnotationPresent(FailsWithFDW.class) &&
+                     !method.isAnnotationPresent(SkipForFDW.class)
+                    )
+            ) {
                 return;
             }
             // in all other cases skip the test

--- a/automation/src/main/java/listeners/FDWSkipTestAnalyzer.java
+++ b/automation/src/main/java/listeners/FDWSkipTestAnalyzer.java
@@ -1,5 +1,6 @@
 package listeners;
 
+import annotations.FailsWithFDW;
 import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.utils.system.FDWUtils;
 import org.testng.IInvokedMethod;
@@ -22,7 +23,14 @@ public class FDWSkipTestAnalyzer implements IInvokedMethodListener {
             return;
         }
         // check only @Test annotated method, not @Before.. and @After.. ones
-        if (FDWUtils.useFDW && method.isAnnotationPresent(Test.class) && !method.isAnnotationPresent(WorksWithFDW.class)) {
+        if (FDWUtils.useFDW && method.isAnnotationPresent(Test.class)) {
+            Class clazz = method.getDeclaringClass();
+            // check if the method should not be skipped
+            if (method.isAnnotationPresent(WorksWithFDW.class) ||
+                    (clazz.isAnnotationPresent(WorksWithFDW.class) && !method.isAnnotationPresent(FailsWithFDW.class))) {
+                return;
+            }
+            // in all other cases skip the test
             throw new SkipException("The test is not supported in FDW mode");
         }
     }

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -176,7 +176,7 @@ public class Gpdb extends DbSystemObject {
 		"default_test");
 
 		// version below GP7 do not have IF EXISTS / IF NOT EXISTS command options
-		String option = (version >= 7) ? IF_NOT_EXISTS_OPTION : "";
+		String option = (version < 7) ? "" : IF_NOT_EXISTS_OPTION;
 		for (String server : servers) {
 			String foreignServerName = server.replace("-", "_");
 			if (version < 7 && serverExists(foreignServerName)) {

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -473,7 +473,7 @@ public class Gpdb extends DbSystemObject {
 		ResultSet res = stmt.executeQuery(query);
 		res.next();
 		int count = res.getInt(1);
-		ReportUtils.report(report, getClass(), "Retrieved from Greenplum: [" + count + "]");
+		ReportUtils.report(report, getClass(), "Retrieved from Greenplum: [" + count + "] servers");
 		return count > 0;
 	}
 

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -175,7 +175,7 @@ public class Gpdb extends DbSystemObject {
 		"hdfs-ipa_hdfs",
 		"default_test");
 
-		// version below GP7 do not have IF EXISTS / IF NOT EXISTS command options
+		// version below GP7 do not have IF EXISTS / IF NOT EXISTS command options for foreign SERVER creation
 		String option = (version < 7) ? "" : IF_NOT_EXISTS_OPTION;
 		for (String server : servers) {
 			String foreignServerName = server.replace("-", "_");
@@ -467,6 +467,13 @@ public class Gpdb extends DbSystemObject {
 	}
 
 	private boolean serverExists(String name) throws SQLException {
+		/* If in the future we want to check the existence of both the foreign server and the user mapping
+		we can use the following query
+		SELECT COUNT(*) FROM pg_catalog.pg_user_mapping um
+		LEFT JOIN pg_catalog.pg_foreign_server fs ON um.umserver = fs.oid
+		LEFT JOIN pg_catalog.pg_roles r ON um.umuser = r.oid
+		WHERE r.rolname = session_user::text AND fs.srvname = '%s';
+		 */
 		String query = String.format("SELECT COUNT(*) FROM pg_catalog.pg_foreign_server WHERE srvname = '%s'", name);
 		ReportUtils.report(report, getClass(), "Determining if foreign server exists - query: " + query);
 

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -80,6 +80,7 @@ public class Gpdb extends DbSystemObject {
 		createExtension(extensionName, true);
 
 		if (FDWUtils.useFDW) {
+			createTestFDW(true);
 			createForeignServers(true);
 		}
 
@@ -148,6 +149,13 @@ public class Gpdb extends DbSystemObject {
 		runQuery("CREATE EXTENSION IF NOT EXISTS " + extensionName, ignoreFail, false);
 	}
 
+	private void createTestFDW(boolean ignoreFail) throws Exception {
+		runQuery("DROP FOREIGN DATA WRAPPER IF EXISTS test_pxf_fdw CASCADE", ignoreFail, false);
+		runQuery("CREATE FOREIGN DATA WRAPPER test_pxf_fdw HANDLER pxf_fdw_handler " +
+				 "VALIDATOR pxf_fdw_validator OPTIONS (protocol 'test', mpp_execute 'all segments')",
+				ignoreFail, false);
+	}
+
 	private void createForeignServers(boolean ignoreFail) throws Exception {
 		List<String> servers = Lists.newArrayList(
 		"default_hdfs",
@@ -162,7 +170,8 @@ public class Gpdb extends DbSystemObject {
 		"s3_s3",
 		"hdfs-non-secure_hdfs",
 		"hdfs-secure_hdfs",
-		"hdfs-ipa_hdfs");
+		"hdfs-ipa_hdfs",
+		"default_test");
 
 		for (String server : servers) {
 			String foreignServerName = server.replace("-", "_");

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
@@ -83,19 +83,14 @@ public class ForeignTable extends WritableExternalTable {
             appendOption(builder, "encoding", getEncoding());
         }
 
-        // TODO: are these really "copy options" ? copy.c does not have to seem to have them
-        /*
         if (getErrorTable() != null) {
-            appendOption(builder, "log errors", getEncoding());
-            createStatment += " LOG ERRORS";
+            appendOption(builder, "log_errors", "true");
         }
 
         if (getSegmentRejectLimit() > 0) {
-            createStatment += " SEGMENT REJECT LIMIT "
-                    + getSegmentRejectLimit() + " "
-                    + getSegmentRejectLimitType();
+            appendOption(builder, "reject_limit", String.valueOf(getSegmentRejectLimit()));
+            appendOption(builder, "reject_limit_type", getSegmentRejectLimitType().toLowerCase());
         }
-        */
 
         // process user options, some might actually belong to Foreign Server, but eventually they all will be
         // combined in a single set, so the net result is the same, other than testing option precedence rules

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
@@ -120,10 +120,6 @@ public class ForeignTable extends WritableExternalTable {
         appendOption(builder, optionName, optionValue, false, true);
     }
 
-    private void appendQuotedOption(StringBuilder builder, String optionName, String optionValue) {
-        appendOption(builder, optionName, optionValue, false, false);
-    }
-
     private void appendOption(StringBuilder builder, String optionName, String optionValue, boolean first, boolean needQuoting) {
         if (!first) {
             builder.append(", ");

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
@@ -2,6 +2,8 @@ package org.greenplum.pxf.automation.structures.tables.pxf;
 
 import org.apache.commons.lang.StringUtils;
 
+import java.util.StringJoiner;
+
 public class ForeignTable extends WritableExternalTable {
 
     public ForeignTable(String name, String[] fields, String path, String format) {
@@ -43,64 +45,64 @@ public class ForeignTable extends WritableExternalTable {
     protected String createOptions() {
         // foreign tables do not have locations, parameters go into options
         // path (resource option for FDW) should always be present
-        StringBuilder builder = new StringBuilder(" OPTIONS (");
-        appendOption(builder,"resource", getPath(), true, true);
+        StringJoiner joiner = new StringJoiner(",", " OPTIONS (", ")");
+        appendOption(joiner,"resource", getPath(), true);
 
         String formatOption = getFormatOption();
         if (formatOption != null) {
-            appendOption(builder, "format", formatOption);
+            appendOption(joiner, "format", formatOption);
         }
 
         // process F/A/R as options, they are used in tests to test column projection / predicate pushdown
         if (getFragmenter() != null) {
-            appendOption(builder, "fragmenter", getFragmenter());
+            appendOption(joiner, "fragmenter", getFragmenter());
         }
         if (getAccessor() != null) {
-            appendOption(builder, "accessor", getAccessor());
+            appendOption(joiner, "accessor", getAccessor());
         }
         if (getResolver() != null) {
-            appendOption(builder, "resolver", getResolver());
+            appendOption(joiner, "resolver", getResolver());
         }
 
         // process copy options
         if (getDelimiter() != null) {
             // if Escape character, no need for "'"
-            appendOption(builder,"delimiter", getDelimiter(), false, !getDelimiter().startsWith("E"));
+            appendOption(joiner,"delimiter", getDelimiter(), !getDelimiter().startsWith("E"));
         }
 
         if (getEscape() != null) {
             // if Escape character, no need for "'"
-            appendOption(builder,"delimiter", getEscape(), false, !getEscape().startsWith("E"));
+            appendOption(joiner,"delimiter", getEscape(), !getEscape().startsWith("E"));
         }
 
         if (getNewLine() != null) {
-            appendOption(builder, "newline", getNewLine());
+            appendOption(joiner, "newline", getNewLine());
         }
 
         // TODO: encoding might only be properly supported in refactor branch
         // https://github.com/greenplum-db/pxf/commit/6be3ca67e1a2748205fcaf9ac96e124925593e11#diff-495fb626f562922c4333130eb7334b9766a18f1968e577549bff0384890e0d05
         if (getEncoding() != null) {
-            appendOption(builder, "encoding", getEncoding());
+            appendOption(joiner, "encoding", getEncoding());
         }
 
         if (getErrorTable() != null) {
-            appendOption(builder, "log_errors", "true");
+            appendOption(joiner, "log_errors", "true");
         }
 
         if (getSegmentRejectLimit() > 0) {
-            appendOption(builder, "reject_limit", String.valueOf(getSegmentRejectLimit()));
-            appendOption(builder, "reject_limit_type", getSegmentRejectLimitType().toLowerCase());
+            appendOption(joiner, "reject_limit", String.valueOf(getSegmentRejectLimit()));
+            appendOption(joiner, "reject_limit_type", getSegmentRejectLimitType().toLowerCase());
         }
 
         // process user options, some might actually belong to Foreign Server, but eventually they all will be
         // combined in a single set, so the net result is the same, other than testing option precedence rules
 
         if (getDataSchema() != null) {
-            appendOption(builder, "DATA-SCHEMA", getDataSchema());
+            appendOption(joiner, "DATA-SCHEMA", getDataSchema());
         }
 
         if (getExternalDataSchema() != null) {
-            appendOption(builder, "SCHEMA", getExternalDataSchema());
+            appendOption(joiner, "SCHEMA", getExternalDataSchema());
         }
 
         String[] params = getUserParameters();
@@ -108,27 +110,18 @@ public class ForeignTable extends WritableExternalTable {
             for (String param : params) {
                 // parse parameter, each one is KEY=VALUE
                 String[] paramPair = param.split("=");
-                appendOption(builder, paramPair[0], paramPair[1]);
+                appendOption(joiner, paramPair[0], paramPair[1]);
             }
         }
-
-        builder.append(")");
-        return builder.toString();
+        return joiner.toString();
     }
 
-    private void appendOption(StringBuilder builder, String optionName, String optionValue) {
-        appendOption(builder, optionName, optionValue, false, true);
+    private void appendOption(StringJoiner joiner, String optionName, String optionValue) {
+        appendOption(joiner, optionName, optionValue, true);
     }
 
-    private void appendOption(StringBuilder builder, String optionName, String optionValue, boolean first, boolean needQuoting) {
-        if (!first) {
-            builder.append(", ");
-        }
-        builder.append(optionName)
-               .append(" ")
-               .append(needQuoting ? "'" : "")
-               .append(optionValue)
-               .append(needQuoting ? "'" : "");
+    private void appendOption(StringJoiner joiner, String optionName, String optionValue, boolean needQuoting) {
+        joiner.add(String.format("%s %s", optionName, needQuoting ? "'" + optionValue + "'" : optionValue));
     }
 
     private String getFormatOption() {

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -228,6 +228,27 @@ public abstract class TableFactory {
     }
 
     /**
+     * Prepares PXF Readable External Table for CSV data, using
+     * "HdfsTextSimple" profile
+     *
+     * @param name
+     * @param fields
+     * @param path
+     * @param delimiter
+     * @return PXF Readable External Table using "HdfsTextSimple" profile and
+     *         "CSV" format.
+     */
+    public static ReadableExternalTable getPxfReadableCSVTable(String name,
+                                                               String[] fields,
+                                                               String path,
+                                                               String delimiter) {
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name, fields, path, "CSV");
+        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":csv");
+        exTable.setDelimiter(delimiter);
+        return exTable;
+    }
+
+    /**
      * Prepares PXF Writable External Table for Simple Text data, using
      * "HdfsTextSimple" profile
      *

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -196,6 +196,16 @@ public abstract class TableFactory {
         return exTable;
     }
 
+    public static ReadableExternalTable getPxfReadableTestTextTable(String name,
+                                                                    String[] fields,
+                                                                    String path,
+                                                                    String delimiter) {
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name, fields, path, "Text");
+        exTable.setProfile("test:text");
+        exTable.setDelimiter(delimiter);
+        return exTable;
+    }
+
     /**
      * Prepares PXF Readable External Table for Simple Text data, using
      * "HdfsTextSimple" profile
@@ -211,7 +221,6 @@ public abstract class TableFactory {
                                                                 String[] fields,
                                                                 String path,
                                                                 String delimiter) {
-
         ReadableExternalTable exTable = getReadableExternalOrForeignTable(name, fields, path, "Text");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":text");
         exTable.setDelimiter(delimiter);

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -22,21 +22,21 @@ import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 public abstract class TableFactory {
 
     /**
-     * Prepares PXF Readable External Table for Hive data
+     * Prepares PXF Readable External or Foreign Table for Hive data, using CUSTOM format and either
+     * "hive" profile or Hive fragmenter, accessor and resolver.
      *
-     * @param tableName
-     * @param fields
-     * @param hiveTable
-     * @param useProfile true to use Profile or false to use Fragmenter Accessor
-     *            Resolver
-     * @return PXF Readable External Table using "Hive" profile
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param hiveTable Hive table object
+     * @param useProfile true to use Profile or false to use Fragmenter, Accessor and Resolver
+     * @return PXF Readable External or Foreign table
      */
-    public static ReadableExternalTable getPxfHiveReadableTable(String tableName,
+    public static ReadableExternalTable getPxfHiveReadableTable(String name,
                                                                 String[] fields,
                                                                 HiveTable hiveTable,
                                                                 boolean useProfile) {
 
-        ReadableExternalTable exTable = getReadableExternalOrForeignTable(tableName,
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name,
                 fields, hiveTable.getName(), "CUSTOM");
 
         if (useProfile) {
@@ -53,21 +53,21 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Readable External Table for Hive RC data
+     * Prepares PXF Readable External or Foreign Table for Hive RC data, using TEXT format and either
+     * "HiveRC" profile or Hive fragmenter, accessor and resolver.
      *
-     * @param tableName external table name
-     * @param fields for external table
-     * @param hiveTable to direct to
-     * @param useProfile true to use Profile or false to use Fragmenter Accessor
-     *            Resolver
-     * @return PXF Readable External Table using "HiveRC" profile
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param hiveTable Hive table object
+     * @param useProfile true to use Profile or false to use Fragmenter, Accessor and Resolver
+     * @return PXF Readable External or Foreign table
      */
-    public static ReadableExternalTable getPxfHiveRcReadableTable(String tableName,
+    public static ReadableExternalTable getPxfHiveRcReadableTable(String name,
                                                                   String[] fields,
                                                                   HiveTable hiveTable,
                                                                   boolean useProfile) {
 
-        ReadableExternalTable exTable = getReadableExternalOrForeignTable(tableName,
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name,
                 fields, hiveTable.getName(), "TEXT");
 
         if (useProfile) {
@@ -83,21 +83,21 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Readable External Table for Hive ORC data
+     * Prepares PXF Readable External or Foreign Table for Hive ORC data, using CUSTOM format and either
+     * "HiveORC" profile or Hive fragmenter, accessor and resolver.
      *
-     * @param tableName external table name
-     * @param fields for external table
-     * @param hiveTable to direct to
-     * @param useProfile true to use Profile or false to use Fragmenter Accessor
-     *            Resolver
-     * @return PXF Readable External Table using "HiveORC" profile
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param hiveTable Hive table object
+     * @param useProfile true to use Profile or false to use Fragmenter, Accessor and Resolver
+     * @return PXF Readable External or Foreign table
      */
-    public static ReadableExternalTable getPxfHiveOrcReadableTable(String tableName,
-                                                                  String[] fields,
-                                                                  HiveTable hiveTable,
-                                                                  boolean useProfile) {
+    public static ReadableExternalTable getPxfHiveOrcReadableTable(String name,
+                                                                   String[] fields,
+                                                                   HiveTable hiveTable,
+                                                                   boolean useProfile) {
 
-        ReadableExternalTable exTable = getReadableExternalOrForeignTable(tableName,
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name,
                 fields, hiveTable.getName(), "CUSTOM");
 
         if (useProfile) {
@@ -113,21 +113,21 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Readable External Table for Hive ORC data using vectorized profile
+     * Prepares PXF Readable External or Foreign Table for Hive data, using CUSTOM format and either
+     * "HiveVectorizedORC" profile or Hive fragmenter, accessor and resolver.
      *
-     * @param tableName external table name
-     * @param fields for external table
-     * @param hiveTable to direct to
-     * @param useProfile true to use Profile or false to use Fragmenter Accessor
-     *            Resolver
-     * @return PXF Readable External Table using "HiveVectorizedORC" profile
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param hiveTable Hive table object
+     * @param useProfile true to use Profile or false to use Fragmenter, Accessor and Resolver
+     * @return PXF Readable External or Foreign table
      */
-    public static ReadableExternalTable getPxfHiveVectorizedOrcReadableTable(String tableName,
-                                                                   String[] fields,
-                                                                   HiveTable hiveTable,
-                                                                   boolean useProfile) {
+    public static ReadableExternalTable getPxfHiveVectorizedOrcReadableTable(String name,
+                                                                             String[] fields,
+                                                                             HiveTable hiveTable,
+                                                                             boolean useProfile) {
 
-        ReadableExternalTable exTable = getReadableExternalOrForeignTable(tableName,
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name,
                 fields, hiveTable.getName(), "CUSTOM");
 
         if (useProfile) {
@@ -142,29 +142,21 @@ public abstract class TableFactory {
         return exTable;
     }
 
-    public static void main(String[] args) {
-        HiveTable t = new HiveTable("bin_data", null);
-        ReadableExternalTable a = getPxfHiveRcReadableTable("hive_bin",
-                new String[] { "bin BYTEA" }, t, true);
-
-        System.out.println(a.constructCreateStmt());
-    }
-
     /**
-     * Prepares PXF Readable External Table for Hive Text data
+     * Prepares PXF Readable External or Foreign Table for Hive data, using TEXT format and either "hive:text" profile
+     * or Hive fragmenter, accessor and resolver.
      *
-     * @param tableName external table name
-     * @param fields for external table
-     * @param hiveTable to direct to
-     * @param useProfile true to use Profile or false to use Fragmenter Accessor
-     *            Resolver
-     * @return PXF Readable External Table using "HiveText" profile
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param hiveTable Hive table object
+     * @param useProfile true to use Profile or false to use Fragmenter, Accessor and Resolver
+     * @return PXF Readable External or Foreign table
      */
-    public static ReadableExternalTable getPxfHiveTextReadableTable(String tableName,
+    public static ReadableExternalTable getPxfHiveTextReadableTable(String name,
                                                                     String[] fields,
                                                                     HiveTable hiveTable,
                                                                     boolean useProfile) {
-        ReadableExternalTable exTable = getReadableExternalOrForeignTable(tableName,
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name,
                 fields, hiveTable.getName(), "TEXT");
         if (useProfile) {
             exTable.setProfile(EnumPxfDefaultProfiles.HiveText.toString());
@@ -179,23 +171,33 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Readable External Table for HBase data
+     * Prepares PXF Readable External or Foreign Table for HBase data, using CUSTOM format and "hbase" profile.
      *
-     * @param tableName
-     * @param fields
-     * @param hbaseTable for external table path
-     * @return PXF Readable external table using HBase Profile
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param hbaseTable HBase table object
+     * @return PXF Readable External or Foreign table
      */
-    public static ReadableExternalTable getPxfHBaseReadableTable(String tableName,
+    public static ReadableExternalTable getPxfHBaseReadableTable(String name,
                                                                  String[] fields,
                                                                  HBaseTable hbaseTable) {
-        ReadableExternalTable exTable = getReadableExternalOrForeignTable(tableName,
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name,
                 fields, hbaseTable.getName(), "CUSTOM");
         exTable.setProfile("hbase");
         exTable.setFormatter("pxfwritable_import");
         return exTable;
     }
 
+    /**
+     * Prepares PXF Readable External or Foreign Table for test data, using TEXT format and "test:text" profile.
+     * Since "test:*" profiles are ephemeral, it should be used when testing with custom Fragmenter, Accessor or Resolver.
+     *
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
+     * @param delimiter delimiter used in the external data
+     * @return PXF Readable External or Foreign table
+     */
     public static ReadableExternalTable getPxfReadableTestTextTable(String name,
                                                                     String[] fields,
                                                                     String path,
@@ -207,15 +209,13 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Readable External Table for Simple Text data, using
-     * "HdfsTextSimple" profile
+     * Prepares PXF Readable External or Foreign Table for TEXT data, using TEXT format and "<protocol>:text" profile.
      *
-     * @param name
-     * @param fields
-     * @param path
-     * @param delimiter
-     * @return PXF Readable External Table using "HdfsTextSimple" profile and
-     *         "Text" format.
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
+     * @param delimiter delimiter used in the external data
+     * @return PXF Readable External or Foreign table
      */
     public static ReadableExternalTable getPxfReadableTextTable(String name,
                                                                 String[] fields,
@@ -228,15 +228,13 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Readable External Table for CSV data, using
-     * "HdfsTextSimple" profile
+     * Prepares PXF Readable External or Foreign Table for CSV data, using CSV format and "<protocol>:csv" profile.
      *
-     * @param name
-     * @param fields
-     * @param path
-     * @param delimiter
-     * @return PXF Readable External Table using "HdfsTextSimple" profile and
-     *         "CSV" format.
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
+     * @param delimiter delimiter used in the external data
+     * @return PXF Readable External or Foreign table
      */
     public static ReadableExternalTable getPxfReadableCSVTable(String name,
                                                                String[] fields,
@@ -249,15 +247,13 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Writable External Table for Simple Text data, using
-     * "HdfsTextSimple" profile
+     * Prepares PXF Writable External or Foreign Table for TEXT data, using TEXT format and "<protocol>:text" profile.
      *
-     * @param name
-     * @param fields
-     * @param path
-     * @param delimiter
-     * @return PXF Writable External Table using "HdfsTextSimple" profile and
-     *         "Text" format.
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
+     * @param delimiter delimiter used in the external data
+     * @return PXF Writable External or Foreign table
      */
     public static WritableExternalTable getPxfWritableTextTable(String name,
                                                                 String[] fields,
@@ -269,39 +265,61 @@ public abstract class TableFactory {
         return exTable;
     }
 
+    /**
+     * Prepares PXF Readable External or Foreign Table for HCFS-compatible file systems with a given file format
+     * using CUSTOM table format and "<protocol>:<fileFormat>" profile.
+     *
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
+     * @param hcfsBasePath base path on HCFS file system
+     * @param fileFormat format of the file being read
+     * @return PXF Readable External or Foreign table
+     */
     public static ReadableExternalTable getPxfHcfsReadableTable(String name,
                                                                 String[] fields,
                                                                 String path,
-                                                                String hdfsBasePath,
-                                                                String profileFormat) {
-        String effectivePath = ProtocolUtils.getProtocol().getExternalTablePath(hdfsBasePath, path);
+                                                                String hcfsBasePath,
+                                                                String fileFormat) {
+        String effectivePath = ProtocolUtils.getProtocol().getExternalTablePath(hcfsBasePath, path);
         ReadableExternalTable exTable = getReadableExternalOrForeignTable(name, fields, effectivePath, "custom");
-        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":" + profileFormat);
+        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":" + fileFormat);
         exTable.setFormatter("pxfwritable_import");
         return exTable;
     }
 
+    /**
+     * Prepares PXF Writable External or Foreign Table for HCFS-compatible file systems with a given file format
+     * using CUSTOM table format and "<protocol>:<fileFormat>" profile.
+     *
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
+     * @param hcfsBasePath base path on HCFS file system
+     * @param fileFormat format of the file being written
+     * @return PXF Writable External or Foreign table
+     */
     public static ReadableExternalTable getPxfHcfsWritableTable(String name,
                                                                 String[] fields,
                                                                 String path,
-                                                                String hdfsBasePath,
-                                                                String profileFormat) {
-        String effectivePath = ProtocolUtils.getProtocol().getExternalTablePath(hdfsBasePath, path);
+                                                                String hcfsBasePath,
+                                                                String fileFormat) {
+        String effectivePath = ProtocolUtils.getProtocol().getExternalTablePath(hcfsBasePath, path);
         ReadableExternalTable exTable = getWritableExternalOrForeignTable(name, fields, effectivePath, "custom");
-        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":" + profileFormat);
+        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":" + fileFormat);
         exTable.setFormatter("pxfwritable_export");
         return exTable;
     }
 
     /**
-     * Prepares PXF Writable External Table for Simple Text data, using
-     * "HdfsTextSimple" profile and Gzip Codec
+     * Prepares PXF Writable External or Foreign Table for TEXT data, using TEXT format and "<protocol>:text" profile
+     * with Gzip compression codec.
      *
-     * @param name
-     * @param fields
-     * @param path
-     * @return PXF Writable External Table using "HdfsTextSimple" profile and
-     *         "GZipCodec" compression.
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
+     * @param delimiter delimiter used in the external data
+     * @return PXF Writable External or Foreign table
      */
     public static WritableExternalTable getPxfWritableGzipTable(String name,
                                                                 String[] fields,
@@ -315,14 +333,14 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Writable External Table for Simple Text data, using
-     * "HdfsTextSimple" profile and BZip2 Codec
+     * Prepares PXF Writable External or Foreign Table for TEXT data, using TEXT format and "<protocol>:text" profile
+     * with BZip2 compression codec.
      *
-     * @param name
-     * @param fields
-     * @param path
-     * @return PXF Writable External Table using "HdfsTextSimple" profile and
-     *         "BZip2" compression.
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
+     * @param delimiter delimiter used in the external data
+     * @return PXF Writable External or Foreign table
      */
     public static WritableExternalTable getPxfWritableBZip2Table(String name,
                                                                  String[] fields,
@@ -336,16 +354,13 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Readable External Table using "SequenceWritable" profile,
-     * CUSTOM format with "pxfwritable_export" formatter and data schema.
+     * Prepares PXF Readable External or Foreign Table for SEQUENCE data, using CUSTOM format and "<protocol>:SequenceFile" profile.
      *
-     * @param name
-     * @param fields
-     * @param path
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
      * @param schema data schema
-     * @return PXF Readable External Table using "SequenceWritable" profile,
-     *         CUSTOM format with "pxfwritable_export" formatter and data
-     *         schema.
+     * @return PXF Readable External or Foreign table
      */
     public static ReadableExternalTable getPxfReadableSequenceTable(String name,
                                                                     String[] fields,
@@ -363,16 +378,13 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Writable External Table using "SequenceWritable" profile,
-     * CUSTOM format with "pxfwritable_export" formatter and data schema.
+     * Prepares PXF Writable External or Foreign Table for SEQUENCE data, using CUSTOM format and "<protocol>:SequenceFile" profile.
      *
-     * @param name
-     * @param fields
-     * @param path
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
      * @param schema data schema
-     * @return PXF Writable External Table using "SequenceWritable" profile,
-     *         CUSTOM format with "pxfwritable_export" formatter and data
-     *         schema.
+     * @return PXF Writable External or Foreign table
      */
     public static WritableExternalTable getPxfWritableSequenceTable(String name,
                                                                     String[] fields,
@@ -428,8 +440,8 @@ public abstract class TableFactory {
     /**
      * Generates Hive External Table using row format and comma delimiter
      *
-     * @param name
-     * @param fields
+     * @param name table name
+     * @param fields table fields
      * @return {@link HiveExternalTable} with "row" format and comma Delimiter.
      */
     public static HiveExternalTable getHiveByRowCommaExternalTable(String name,
@@ -443,13 +455,24 @@ public abstract class TableFactory {
         return table;
     }
 
-    private static ExternalTable getPxfJdbcReadableTable(String tableName,
+    /**
+     * Generates a PXF External Readable or Foreign Table using JDBC profile.
+     *
+     * @param name name of the external table which will be generated
+     * @param fields fields of the external table
+     * @param dataSourcePath path to the target table to be written to i.e. schema_name.table_name
+     * @param driver full class name of the JDBC driver
+     * @param dbUrl JDBC URL
+     * @param user database user
+     * @return PXF Writable External or Foreign table
+     */
+    private static ExternalTable getPxfJdbcReadableTable(String name,
                                                          String[] fields, String dataSourcePath, String driver,
                                                          String dbUrl, boolean isPartitioned,
                                                          Integer partitionByColumnIndex, String rangeExpression,
                                                          String interval, String user, EnumPartitionType partitionType,
                                                          String server, String customParameters) {
-        ExternalTable exTable = getReadableExternalOrForeignTable(tableName, fields,
+        ExternalTable exTable = getReadableExternalOrForeignTable(name, fields,
                 dataSourcePath, "CUSTOM");
         List<String> userParameters = new ArrayList<String>();
         if (driver != null) {
@@ -487,21 +510,21 @@ public abstract class TableFactory {
     }
 
     /**
-     * Generates an External Writable Table using JDBC profile.
+     * Generates a PXF External Writable or Foreign Table using JDBC profile.
      *
-     * @param tableName name of the external table which will be generated
+     * @param name name of the external table which will be generated
      * @param fields fields of the external table
      * @param dataSourcePath path to the target table to be written to i.e. schema_name.table_name
      * @param driver full class name of the JDBC driver
      * @param dbUrl JDBC URL
      * @param user database user
-     * @return External Writable Table
+     * @return PXF Writable External or Foreign table
      */
-    public static ExternalTable getPxfJdbcWritableTable(String tableName,
+    public static ExternalTable getPxfJdbcWritableTable(String name,
             String[] fields, String dataSourcePath, String driver,
             String dbUrl, String user, String customParameters) {
 
-        ExternalTable exTable = getWritableExternalOrForeignTable(tableName, fields, dataSourcePath, "CUSTOM");
+        ExternalTable exTable = getWritableExternalOrForeignTable(name, fields, dataSourcePath, "CUSTOM");
         List<String> userParameters = new ArrayList<String>();
         if (driver != null) {
             userParameters.add("JDBC_DRIVER=" + driver);
@@ -523,11 +546,11 @@ public abstract class TableFactory {
     }
 
     /**
-     * Generates an External Readable Table using JDBC profile, partitioned by given column
+     * Generates a PXF External Readable or Foreign Table using JDBC profile, partitioned by given column
      * on a given range with a given interval.
      * Recommended to use for large tables.
      *
-     * @param tableName name of the external table which will be generated
+     * @param name name of the external table which will be generated
      * @param fields fields of the external table
      * @param dataSourcePath path to the data object i.e. schema_name.table_name
      * @param driver full class name of the JDBC driver
@@ -537,107 +560,106 @@ public abstract class TableFactory {
      * @param interval interval expression
      * @param user database user
      * @param partitionType partition type used to get fragments
-     * @return External Readable Table
+     * @return PXF Readable External or Foreign table
      */
     public static ExternalTable getPxfJdbcReadablePartitionedTable(
-            String tableName,
+            String name,
             String[] fields, String dataSourcePath, String driver,
             String dbUrl, Integer partitionByColumnIndex,
             String rangeExpression, String interval, String user, EnumPartitionType partitionType, String server) {
 
-        return getPxfJdbcReadableTable(tableName, fields, dataSourcePath, driver,
+        return getPxfJdbcReadableTable(name, fields, dataSourcePath, driver,
             dbUrl, true, partitionByColumnIndex, rangeExpression,
             interval, user, partitionType, server, null);
     }
 
     /**
-     * Generates an External Readable Table using JDBC profile.
+     * Generates a PXF External Readable or Foreign Table using JDBC profile.
      * It's not recommended for large tables.
      *
-     * @param tableName name of the external table which will be generated
+     * @param name name of the external table which will be generated
      * @param fields fields of the external table
      * @param dataSourcePath path to the data object i.e. schema_name.table_name
      * @param driver full class name of the JDBC driver
      * @param dbUrl JDBC url
      * @param user databases user name
-     * @return External Readable Table
+     * @return PXF Readable External or Foreign table
      */
-    public static ExternalTable getPxfJdbcReadableTable(String tableName,
+    public static ExternalTable getPxfJdbcReadableTable(String name,
             String[] fields, String dataSourcePath, String driver, String dbUrl, String user) {
 
-        return getPxfJdbcReadableTable(tableName, fields, dataSourcePath, driver,
+        return getPxfJdbcReadableTable(name, fields, dataSourcePath, driver,
             dbUrl, false, null, null, null, user, null, null, null);
     }
 
     /**
-     * Generates an External Readable Table using JDBC profile.
+     * Generates a PXF External Readable or Foreign Table using JDBC profile.
      * It's not recommended for large tables.
      *
-     * @param tableName name of the external table which will be generated
+     * @param name name of the external table which will be generated
      * @param fields fields of the external table
      * @param dataSourcePath path to the data object i.e. schema_name.table_name
      * @param driver full class name of the JDBC driver
      * @param dbUrl JDBC url
      * @param user databases user name
      * @param customParameters additional user parameters
-     * @param
-     * @return External Readable Table
+     * @return PXF Readable External or Foreign table
      */
-    public static ExternalTable getPxfJdbcReadableTable(String tableName,
+    public static ExternalTable getPxfJdbcReadableTable(String name,
             String[] fields, String dataSourcePath, String driver, String dbUrl, String user, String customParameters) {
 
-        return getPxfJdbcReadableTable(tableName, fields, dataSourcePath, driver,
+        return getPxfJdbcReadableTable(name, fields, dataSourcePath, driver,
                 dbUrl, false, null, null, null, user, null, null, customParameters);
     }
 
     /**
-     * Generates an External Readable Table using JDBC profile.
+     * Generates a PXF External Readable or Foreign Table using JDBC profile.
      *
-     * @param tableName name of the external table which will be generated
+     * @param name name of the external table which will be generated
      * @param fields fields of the external table
      * @param dataSourcePath path to the data object i.e. schema_name.table_name
      * @param server name of configuration server
-     * @return External Readable Table
+     * @return PXF Readable External or Foreign table
      */
-    public static ExternalTable getPxfJdbcReadableTable(String tableName, String[] fields, String dataSourcePath, String server) {
-        return getPxfJdbcReadableTable(tableName, fields, dataSourcePath, null,
+    public static ExternalTable getPxfJdbcReadableTable(String name, String[] fields, String dataSourcePath, String server) {
+        return getPxfJdbcReadableTable(name, fields, dataSourcePath, null,
                 null, false, null, null, null, null, null, server, null);
     }
 
     /**
-     * Generates an External Readable Table using JDBC profile.
+     * Generates a PXF External Readable or Foreign Table using JDBC profile.
      *
-     * @param tableName name of the external table which will be generated
+     * @param name name of the external table which will be generated
      * @param fields fields of the external table
      * @param dataSourcePath path to the data object i.e. schema_name.table_name
      * @param dbUrl JDBC url
      * @param server name of configuration server
-     * @return External Readable Table
+     * @return PXF Readable External or Foreign table
      */
-    public static ExternalTable getPxfJdbcReadableTable(String tableName, String[] fields, String dataSourcePath, String dbUrl, String server) {
-        return getPxfJdbcReadableTable(tableName, fields, dataSourcePath, null,
+    public static ExternalTable getPxfJdbcReadableTable(String name, String[] fields, String dataSourcePath, String dbUrl, String server) {
+        return getPxfJdbcReadableTable(name, fields, dataSourcePath, null,
                 dbUrl, false, null, null, null, null, null, server, null);
     }
 
     /**
-     * Generate an External Writable Table using JDBC profile.
+     * Generate a PXF External Writable or Foreign Table using JDBC profile.
      *
-     * @param tableName name of the external table which will be generated
+     * @param name name of the external table which will be generated
      * @param fields fields of the external table
      * @param dataSourcePath path to the data object i.e. schema_name.table_name
      * @param server name of configuration server
-     * @return External Writable Table
+     * @return PXF Writable External or Foreign table
      */
-    public static ExternalTable getPxfJdbcWritableTable(String tableName, String[] fields, String dataSourcePath, String server) {
+    public static ExternalTable getPxfJdbcWritableTable(String name, String[] fields, String dataSourcePath, String server) {
         String customParameter = server != null ? "SERVER=" + server : null;
-        return getPxfJdbcWritableTable(tableName, fields, dataSourcePath, null, null, null, customParameter);
+        return getPxfJdbcWritableTable(name, fields, dataSourcePath, null, null, null, customParameter);
     }
 
     // ============ FDW Adapter ============
     private static ReadableExternalTable getReadableExternalOrForeignTable (String name, String[] fields, String path, String format) {
         return FDWUtils.useFDW ?
-               new ForeignTable(name, fields, path, format) :
-               new ReadableExternalTable(name, fields, path, format);
+                new ForeignTable(name, fields, path, format) :
+                new ReadableExternalTable(name, fields, path, format);
     }
 
     private static WritableExternalTable getWritableExternalOrForeignTable (String name, String[] fields, String path, String format) {

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/avro/HdfsReadableAvroTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/avro/HdfsReadableAvroTest.java
@@ -22,6 +22,7 @@ import java.io.File;
  * See <a href="https://testrail.greenplum.com/index.php?/suites/view/1099">HDFS
  * Readable - Avro</a>
  */
+@WorksWithFDW
 public class HdfsReadableAvroTest extends BaseFeature {
 
     private String hdfsPath;
@@ -148,7 +149,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroSimple() throws Exception {
         prepareReadableTable("avrotest_simple", new String[]{"name text", "age int"}, hdfsPath + avroSimpleFileName + SUFFIX_AVRO);
         gpdb.createTableAndVerify(exTable);
@@ -163,7 +163,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroSupportedPrimitives() throws Exception {
         prepareReadableTable("avrotest_supported_primitive_types", new String[]{
                 "type_int      int",
@@ -184,7 +183,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroArrays() throws Exception {
         prepareReadableTable("avrotest_arrays", AVRO_ARRAYS_AS_TEXT_FIELDS, hdfsPath + avroArrayFileName + SUFFIX_AVRO);
         gpdb.createTableAndVerify(exTable);
@@ -202,7 +200,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroComplex() throws Exception {
         prepareReadableTable("avrotest_complex", AVRO_ALL_TYPES_FIELDS, hdfsPath + avroComplexFileName + SUFFIX_AVRO);
         gpdb.createTableAndVerify(exTable);
@@ -211,7 +208,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
     }
 
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroComplexTextFormat() throws Exception {
         prepareReadableTable("avrotest_complex_text", AVRO_ALL_TYPES_FIELDS, hdfsPath + avroComplexFileName + SUFFIX_AVRO);
         exTable.setFormatter(null);
@@ -222,7 +218,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
     }
 
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroComplexCsvFormat() throws Exception {
         prepareReadableTable("avrotest_complex_csv", AVRO_ALL_TYPES_FIELDS, hdfsPath + avroComplexFileName + SUFFIX_AVRO);
         exTable.setFormatter(null);
@@ -233,7 +228,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
     }
 
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroLogicalTypes() throws Exception {
         prepareReadableTable("avro_logical_types", new String[]{
                 "uid                    uuid",
@@ -252,7 +246,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
     }
 
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroLogicalDecimalTypes() throws Exception {
         prepareReadableTable("avro_logical_decimal_types", new String[]{
               "decNum1   decimal",
@@ -268,7 +261,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
     }
 
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void arrayOfLogicalTypes() throws Exception {
         prepareReadableTable("array_of_logical_types", new String[]{
             "type_uid                    uuid[]",
@@ -287,7 +279,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
     }
 
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @FailsWithFDW
     public void logicalIncorrectSchemaTest() throws Exception {
         prepareReadableTable("logical_incorrect_schema_test", new String[]{
             "dob    date " },
@@ -306,7 +297,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroComplexReadSchemaFromHcfs() throws Exception {
         hdfs.copyFromLocal(resourcePath + complexAvroFile, hdfsPath + "schema/" + complexAvroFile);
         prepareReadableTable("avrotest_complex", AVRO_ALL_TYPES_FIELDS, hdfsPath + avroComplexFileName + SUFFIX_AVRO);
@@ -323,7 +313,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroComplexReadSchemaFromSegmentHosts() throws Exception {
         prepareReadableTable("avrotest_complex", AVRO_ALL_TYPES_FIELDS, hdfsPath + avroComplexFileName + SUFFIX_AVRO);
         String schemaPath = remotePublicStage + "/" + complexAvroFile;
@@ -339,7 +328,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroNull() throws Exception {
         prepareReadableTable("avrotest_null", AVRO_ALL_TYPES_FIELDS, hdfsPath + avroComplexFileName + SUFFIX_AVRO);
         gpdb.createTableAndVerify(exTable);
@@ -353,7 +341,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroComplexNull() throws Exception {
         prepareReadableTable("avrotest_complex_null", new String[]{
                 "sourcetimestamp              bigint",
@@ -393,7 +380,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroInSequenceFileArrays() throws Exception {
         prepareReadableTable("avro_in_seq_arrays", AVRO_SEQUENCE_FILE_FIELDS, hdfsPath + avroInSequenceArraysFileName);
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":AvroSequenceFile");
@@ -409,7 +395,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroFileNameWithSpaces() throws Exception {
         prepareReadableTable("avro_in_seq_arrays", AVRO_SEQUENCE_FILE_FIELDS, hdfsPath + avroInSequenceArraysFileName);
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":AvroSequenceFile");
@@ -427,7 +412,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroFileNameWithSpacesOnHcfs() throws Exception {
         hdfs.copyFromLocal(resourcePath + avroInSequenceArraysSchemaFileWithSpaces, hdfsPath + avroInSequenceArraysSchemaFileWithSpaces);
         prepareReadableTable("avro_in_seq_arrays", AVRO_SEQUENCE_FILE_FIELDS, hdfsPath + avroInSequenceArraysFileName);
@@ -445,7 +429,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroMultiFiles() throws Exception {
         String schemaName = resourcePath + avroInSequenceArraysSchemaFile;
 
@@ -476,7 +459,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @WorksWithFDW
     public void avroCodecs() throws Exception {
         String schemaName = resourcePath + avroInSequenceArraysSchemaFile;
         Table dataTable = new Table("dataTable", null);
@@ -503,7 +485,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @FailsWithFDW
     public void extraField() throws Exception {
         prepareReadableTable("avro_extra_field", new String[]{
                 "name text",
@@ -521,7 +502,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @FailsWithFDW
     public void missingField() throws Exception {
         prepareReadableTable("avro_missing_field",
                 new String[]{"name text"},
@@ -537,7 +517,6 @@ public class HdfsReadableAvroTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    @FailsWithFDW
     public void noSchemaFile() throws Exception {
         prepareReadableTable("avro_in_seq_no_schema", AVRO_SEQUENCE_FILE_FIELDS, hdfsPath + avroInSequenceArraysFileName);
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/avro/HdfsWritableAvroTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/avro/HdfsWritableAvroTest.java
@@ -1,10 +1,12 @@
 package org.greenplum.pxf.automation.features.avro;
 
+import annotations.FailsWithFDW;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.greenplum.pxf.automation.features.BaseFeature;
 import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;
 import org.greenplum.pxf.automation.structures.tables.pxf.WritableExternalTable;
+import org.greenplum.pxf.automation.structures.tables.utils.TableFactory;
 import org.greenplum.pxf.automation.utils.jsystem.report.ReportUtils;
 import org.greenplum.pxf.automation.utils.system.ProtocolEnum;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
@@ -22,6 +24,7 @@ import java.util.Objects;
 import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertEquals;
 
+@FailsWithFDW
 public class HdfsWritableAvroTest extends BaseFeature {
 
     private ReadableExternalTable readableExternalTable;
@@ -478,24 +481,12 @@ public class HdfsWritableAvroTest extends BaseFeature {
     }
 
     private void prepareWritableExternalTable(String name, String[] fields, String path) {
-        exTable = new WritableExternalTable(name + "_writable",
-                fields,
-                protocol.getExternalTablePath(hdfs.getBasePath(), path),
-                "custom");
-        exTable.setHost(pxfHost);
-        exTable.setPort(pxfPort);
-        exTable.setFormatter("pxfwritable_export");
-        exTable.setProfile(protocol.value() + ":avro");
+        exTable = TableFactory.getPxfHcfsWritableTable(name + "_writable",
+                fields, path, hdfs.getBasePath(), "avro");
     }
 
     private void prepareReadableExternalTable(String name, String[] fields, String path) {
-        readableExternalTable = new ReadableExternalTable(name + "_readable",
-                fields,
-                protocol.getExternalTablePath(hdfs.getBasePath(), path),
-                "custom");
-        readableExternalTable.setHost(pxfHost);
-        readableExternalTable.setPort(pxfPort);
-        readableExternalTable.setFormatter("pxfwritable_import");
-        readableExternalTable.setProfile(protocol.value() + ":avro");
+        readableExternalTable = TableFactory.getPxfHcfsReadableTable(name + "_readable",
+                fields, path, hdfs.getBasePath(),"avro");
     }
 }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/cloud/CloudAccessTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/cloud/CloudAccessTest.java
@@ -62,8 +62,10 @@ public class CloudAccessTest extends BaseFeature {
     @Override
     protected void afterMethod() throws Exception {
         super.afterMethod();
-        s3Server.removeDirectory(PROTOCOL_S3 + s3PathRead);
-        s3Server.removeDirectory(PROTOCOL_S3 + s3PathWrite);
+        if (s3Server != null) {
+            s3Server.removeDirectory(PROTOCOL_S3 + s3PathRead);
+            s3Server.removeDirectory(PROTOCOL_S3 + s3PathWrite);
+        }
     }
 
     protected void prepareData() throws Exception {

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -1,7 +1,6 @@
 package org.greenplum.pxf.automation.features.columnprojection;
 
 import annotations.FailsWithFDW;
-import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.components.cluster.PhdCluster;
 import org.greenplum.pxf.automation.features.BaseFeature;
 import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -1,13 +1,17 @@
 package org.greenplum.pxf.automation.features.columnprojection;
 
+import annotations.FailsWithFDW;
+import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.components.cluster.PhdCluster;
 import org.greenplum.pxf.automation.features.BaseFeature;
 import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;
+import org.greenplum.pxf.automation.structures.tables.utils.TableFactory;
 import org.testng.annotations.Test;
 
 import java.io.File;
 
 /** Functional PXF column projection cases */
+@WorksWithFDW
 public class ColumnProjectionTest extends BaseFeature {
 
     String testPackageLocation = "/org/greenplum/pxf/automation/testplugin/";
@@ -35,20 +39,16 @@ public class ColumnProjectionTest extends BaseFeature {
     public void checkColumnProjection() throws Exception {
 
         // Create PXF external table for column projection testing
-        ReadableExternalTable pxfExternalTable = new ReadableExternalTable("test_column_projection", new String[] {
+        ReadableExternalTable pxfExternalTable = TableFactory.getPxfReadableTestTextTable("test_column_projection", new String[] {
                 "t0    text",
                 "a1    integer",
                 "b2    boolean",
                 "colprojValue  text"
-        }, "dummy_path","TEXT");
+        }, "dummy_path",",");
 
         pxfExternalTable.setFragmenter(testPackage + "ColumnProjectionVerifyFragmenter");
         pxfExternalTable.setAccessor(testPackage + "ColumnProjectionVerifyAccessor");
         pxfExternalTable.setResolver("org.greenplum.pxf.plugins.hdfs.StringPassResolver");
-        pxfExternalTable.setDelimiter(",");
-        pxfExternalTable.setHost(pxfHost);
-        pxfExternalTable.setPort(pxfPort);
-
         gpdb.createTableAndVerify(pxfExternalTable);
 
         runTincTest("pxf.features.columnprojection.checkColumnProjection.runTest");

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 
 /** Functional PXF column projection cases */
-@WorksWithFDW
+@FailsWithFDW
 public class ColumnProjectionTest extends BaseFeature {
 
     String testPackageLocation = "/org/greenplum/pxf/automation/testplugin/";

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/filterpushdown/FilterPushDownTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/filterpushdown/FilterPushDownTest.java
@@ -1,8 +1,11 @@
 package org.greenplum.pxf.automation.features.filterpushdown;
 
+import annotations.FailsWithFDW;
+import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.components.cluster.PhdCluster;
 import org.greenplum.pxf.automation.features.BaseFeature;
 import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;
+import org.greenplum.pxf.automation.structures.tables.utils.TableFactory;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -10,6 +13,7 @@ import java.io.File;
 /**
  * Functional PXF filter pushdown cases
  */
+@WorksWithFDW
 public class FilterPushDownTest extends BaseFeature {
 
     String testPackageLocation = "/org/greenplum/pxf/automation/testplugin/";
@@ -42,39 +46,32 @@ public class FilterPushDownTest extends BaseFeature {
     public void checkFilterPushDown() throws Exception {
 
         // Create PXF external table for filter testing
-        ReadableExternalTable pxfExternalTable = new ReadableExternalTable("test_filter", new String[]{
+        ReadableExternalTable pxfExternalTable = TableFactory.getPxfReadableTestTextTable(
+                "test_filter", new String[]{
                 "t0    text",
                 "a1    integer",
                 "b2    boolean",
                 "filterValue  text"
-        }, "dummy_path", "TEXT");
+        }, "dummy_path", ",");
 
         pxfExternalTable.setFragmenter(testPackage + "FilterVerifyFragmenter");
         pxfExternalTable.setAccessor(testPackage + "UserDataVerifyAccessor");
         pxfExternalTable.setResolver("org.greenplum.pxf.plugins.hdfs.StringPassResolver");
-        pxfExternalTable.setDelimiter(",");
-        pxfExternalTable.setHost(pxfHost);
-        pxfExternalTable.setPort(pxfPort);
-
         gpdb.createTableAndVerify(pxfExternalTable);
 
         runTincTest("pxf.features.filterpushdown.checkFilterPushDown.runTest");
 
         // Recreate the table with the first column as varchar instead of text
-        pxfExternalTable = new ReadableExternalTable("test_filter", new String[]{
+        pxfExternalTable = TableFactory.getPxfReadableTestTextTable("test_filter", new String[]{
                 "t0    varchar(1)",
                 "a1    integer",
                 "b2    boolean",
                 "filterValue  text"
-        }, "dummy_path", "TEXT");
+        }, "dummy_path", ",");
 
         pxfExternalTable.setFragmenter(testPackage + "FilterVerifyFragmenter");
         pxfExternalTable.setAccessor(testPackage + "UserDataVerifyAccessor");
         pxfExternalTable.setResolver("org.greenplum.pxf.plugins.hdfs.StringPassResolver");
-        pxfExternalTable.setDelimiter(",");
-        pxfExternalTable.setHost(pxfHost);
-        pxfExternalTable.setPort(pxfPort);
-
         gpdb.createTableAndVerify(pxfExternalTable);
 
         runTincTest("pxf.features.filterpushdown.checkFilterPushDown.runTest");
@@ -87,23 +84,20 @@ public class FilterPushDownTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "security"})
+    @FailsWithFDW // the guc used in the test is not applicable to FDW and has no effect
     public void checkFilterPushDownDisabled() throws Exception {
 
         // Create PXF external table for filter testing
-        ReadableExternalTable pxfExternalTable = new ReadableExternalTable("test_filter", new String[]{
+        ReadableExternalTable pxfExternalTable = TableFactory.getPxfReadableTestTextTable("test_filter", new String[]{
                 "t0    text",
                 "a1    integer",
                 "b2    boolean",
                 "filterValue  text"
-        }, "dummy_path", "TEXT");
+        }, "dummy_path", ",");
 
         pxfExternalTable.setFragmenter(testPackage + "FilterVerifyFragmenter");
         pxfExternalTable.setAccessor(testPackage + "UserDataVerifyAccessor");
         pxfExternalTable.setResolver("org.greenplum.pxf.plugins.hdfs.StringPassResolver");
-        pxfExternalTable.setDelimiter(",");
-        pxfExternalTable.setHost(pxfHost);
-        pxfExternalTable.setPort(pxfPort);
-
         gpdb.createTableAndVerify(pxfExternalTable);
 
         runTincTest("pxf.features.filterpushdown.checkFilterPushDownDisabled.runTest");
@@ -119,39 +113,31 @@ public class FilterPushDownTest extends BaseFeature {
     public void checkFilterStringHexDelimiter() throws Exception {
 
         // Create PXF external table for filter testing
-        ReadableExternalTable pxfExternalTable = new ReadableExternalTable("test_filter", new String[]{
+        ReadableExternalTable pxfExternalTable = TableFactory.getPxfReadableTestTextTable("test_filter", new String[]{
                 "t0    text",
                 "a1    integer",
                 "b2    boolean",
                 "filterValue  text"
-        }, "dummy_path", "TEXT");
+        }, "dummy_path", "E'\\x01'");
 
         pxfExternalTable.setFragmenter(testPackage + "FilterVerifyFragmenter");
         pxfExternalTable.setAccessor(testPackage + "UserDataVerifyAccessor");
         pxfExternalTable.setResolver("org.greenplum.pxf.plugins.hdfs.StringPassResolver");
-        pxfExternalTable.setDelimiter("E'\\x01'");
-        pxfExternalTable.setHost(pxfHost);
-        pxfExternalTable.setPort(pxfPort);
-
         gpdb.createTableAndVerify(pxfExternalTable);
 
         // Recreate the table with the first column as varchar instead of text
         runTincTest("pxf.features.filterpushdown.checkFilterPushDownHexDelimiter.runTest");
 
-        pxfExternalTable = new ReadableExternalTable("test_filter", new String[]{
+        pxfExternalTable = TableFactory.getPxfReadableTestTextTable("test_filter", new String[]{
                 "t0    varchar(1)",
                 "a1    integer",
                 "b2    boolean",
                 "filterValue  text"
-        }, "dummy_path", "TEXT");
+        }, "dummy_path", "E'\\x01'");
 
         pxfExternalTable.setFragmenter(testPackage + "FilterVerifyFragmenter");
         pxfExternalTable.setAccessor(testPackage + "UserDataVerifyAccessor");
         pxfExternalTable.setResolver("org.greenplum.pxf.plugins.hdfs.StringPassResolver");
-        pxfExternalTable.setDelimiter("E'\\x01'");
-        pxfExternalTable.setHost(pxfHost);
-        pxfExternalTable.setPort(pxfPort);
-
         gpdb.createTableAndVerify(pxfExternalTable);
 
         runTincTest("pxf.features.filterpushdown.checkFilterPushDownHexDelimiter.runTest");

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/filterpushdown/FilterPushDownTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/filterpushdown/FilterPushDownTest.java
@@ -1,6 +1,6 @@
 package org.greenplum.pxf.automation.features.filterpushdown;
 
-import annotations.FailsWithFDW;
+import annotations.SkipForFDW;
 import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.components.cluster.PhdCluster;
 import org.greenplum.pxf.automation.features.BaseFeature;
@@ -84,7 +84,7 @@ public class FilterPushDownTest extends BaseFeature {
      * @throws Exception
      */
     @Test(groups = {"features", "gpdb", "security"})
-    @FailsWithFDW // the guc used in the test is not applicable to FDW and has no effect
+    @SkipForFDW // the guc used in the test is not applicable to FDW and has no effect
     public void checkFilterPushDownDisabled() throws Exception {
 
         // Create PXF external table for filter testing

--- a/automation/tinc/main/tinctest/lib/global_init_file
+++ b/automation/tinc/main/tinctest/lib/global_init_file
@@ -61,8 +61,12 @@ s/DETAIL/CONTEXT/
 m/Foreign table.*/
 s/Foreign table/External table/
 
-# ignore new context information about record number and FDW resource
-m/.*, record \d+ of.*/
-s/, record \d+ of.*//
+# rename record (FDW) to line (exttable)
+m/, record \d+ of/
+s/, record/, line/
+
+# syntax mismatch error is different between exttable with GP6 and fdw with GP7
+m/invalid input syntax for type/
+s/invalid input syntax for type/invalid input syntax for/
 
 -- end_matchsubs

--- a/automation/tinc/main/tinctest/lib/global_init_file
+++ b/automation/tinc/main/tinctest/lib/global_init_file
@@ -53,4 +53,16 @@ s/Check the PXF logs located in the.*/Check the PXF logs located in the 'logs-di
 m/HINT:  .*/
 s/.*//g
 
+# rename DETAIL (from GP5) to CONTEXT (in GP6+)
+m/DETAIL/
+s/DETAIL/CONTEXT/
+
+# treat foreign table error messages as if they were from external table
+m/Foreign table.*/
+s/Foreign table/External table/
+
+# ignore new context information about record number and FDW resource
+m/.*, record \d+ of.*/
+s/, record \d+ of.*//
+
 -- end_matchsubs

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/expected/query01.ans
@@ -73,21 +73,21 @@ SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = fa
  D  |  3 | t0|a1|b2|colprojvalue
 (2 rows)
 
-SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
-       sqrt       |     colprojvalue
-------------------+-----------------------
-                1 | t0|a1|b2|colprojvalue
- 1.73205080756888 | t0|a1|b2|colprojvalue
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+  round  |     colprojvalue
+---------+-----------------------
+ 1.00000 | t0|a1|b2|colprojvalue
+ 1.73205 | t0|a1|b2|colprojvalue
 (2 rows)
 
-SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
-       sqrt       |     colprojvalue
-------------------+-----------------------
-                1 | t0|a1|b2|colprojvalue
- 1.73205080756888 | t0|a1|b2|colprojvalue
- 2.23606797749979 | t0|a1|b2|colprojvalue
- 2.64575131106459 | t0|a1|b2|colprojvalue
-                3 | t0|a1|b2|colprojvalue
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+  round  |     colprojvalue
+---------+-----------------------
+ 1.00000 | t0|a1|b2|colprojvalue
+ 1.73205 | t0|a1|b2|colprojvalue
+ 2.23607 | t0|a1|b2|colprojvalue
+ 2.64575 | t0|a1|b2|colprojvalue
+ 3.00000 | t0|a1|b2|colprojvalue
 (5 rows)
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
@@ -149,19 +149,19 @@ SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY 
  J  | t0|a1|colprojvalue
 (8 rows)
 
-SELECT t0, colprojvalue, sqrt(a1) FROM test_column_projection ORDER BY t0;
- t0 |    colprojvalue    |       sqrt
-----+--------------------+------------------
- A  | t0|a1|colprojvalue |                0
- B  | t0|a1|colprojvalue |                1
- C  | t0|a1|colprojvalue |  1.4142135623731
- D  | t0|a1|colprojvalue | 1.73205080756888
- E  | t0|a1|colprojvalue |                2
- F  | t0|a1|colprojvalue | 2.23606797749979
- G  | t0|a1|colprojvalue | 2.44948974278318
- H  | t0|a1|colprojvalue | 2.64575131106459
- I  | t0|a1|colprojvalue | 2.82842712474619
- J  | t0|a1|colprojvalue |                3
+SELECT t0, colprojvalue, round(sqrt(a1)::numeric, 5) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    |  round
+----+--------------------+---------
+ A  | t0|a1|colprojvalue | 0.00000
+ B  | t0|a1|colprojvalue | 1.00000
+ C  | t0|a1|colprojvalue | 1.41421
+ D  | t0|a1|colprojvalue | 1.73205
+ E  | t0|a1|colprojvalue | 2.00000
+ F  | t0|a1|colprojvalue | 2.23607
+ G  | t0|a1|colprojvalue | 2.44949
+ H  | t0|a1|colprojvalue | 2.64575
+ I  | t0|a1|colprojvalue | 2.82843
+ J  | t0|a1|colprojvalue | 3.00000
 (10 rows)
 
 -- Casting boolean column to int
@@ -244,21 +244,21 @@ SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = fa
  D  |  3 | t0|a1|b2|colprojvalue
 (2 rows)
 
-SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
-       sqrt       |     colprojvalue
-------------------+-----------------------
-                1 | t0|a1|b2|colprojvalue
- 1.73205080756888 | t0|a1|b2|colprojvalue
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+  round  |     colprojvalue
+---------+-----------------------
+ 1.00000 | t0|a1|b2|colprojvalue
+ 1.73205 | t0|a1|b2|colprojvalue
 (2 rows)
 
-SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
-       sqrt       |     colprojvalue
-------------------+-----------------------
-                1 | t0|a1|b2|colprojvalue
- 1.73205080756888 | t0|a1|b2|colprojvalue
- 2.23606797749979 | t0|a1|b2|colprojvalue
- 2.64575131106459 | t0|a1|b2|colprojvalue
-                3 | t0|a1|b2|colprojvalue
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+  round  |     colprojvalue
+---------+-----------------------
+ 1.00000 | t0|a1|b2|colprojvalue
+ 1.73205 | t0|a1|b2|colprojvalue
+ 2.23607 | t0|a1|b2|colprojvalue
+ 2.64575 | t0|a1|b2|colprojvalue
+ 3.00000 | t0|a1|b2|colprojvalue
 (5 rows)
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
@@ -320,19 +320,19 @@ SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY 
  J  | t0|a1|colprojvalue
 (8 rows)
 
-SELECT t0, colprojvalue, sqrt(a1) FROM test_column_projection ORDER BY t0;
- t0 |    colprojvalue    |       sqrt
-----+--------------------+------------------
- A  | t0|a1|colprojvalue |                0
- B  | t0|a1|colprojvalue |                1
- C  | t0|a1|colprojvalue |  1.4142135623731
- D  | t0|a1|colprojvalue | 1.73205080756888
- E  | t0|a1|colprojvalue |                2
- F  | t0|a1|colprojvalue | 2.23606797749979
- G  | t0|a1|colprojvalue | 2.44948974278318
- H  | t0|a1|colprojvalue | 2.64575131106459
- I  | t0|a1|colprojvalue | 2.82842712474619
- J  | t0|a1|colprojvalue |                3
+SELECT t0, colprojvalue, round(sqrt(a1)::numeric, 5) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    |  round
+----+--------------------+---------
+ A  | t0|a1|colprojvalue | 0.00000
+ B  | t0|a1|colprojvalue | 1.00000
+ C  | t0|a1|colprojvalue | 1.41421
+ D  | t0|a1|colprojvalue | 1.73205
+ E  | t0|a1|colprojvalue | 2.00000
+ F  | t0|a1|colprojvalue | 2.23607
+ G  | t0|a1|colprojvalue | 2.44949
+ H  | t0|a1|colprojvalue | 2.64575
+ I  | t0|a1|colprojvalue | 2.82843
+ J  | t0|a1|colprojvalue | 3.00000
 (10 rows)
 
 -- Casting boolean column to int

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection/sql/query01.sql
@@ -17,9 +17,9 @@ SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
 
 SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
 
-SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
 
-SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
 
@@ -33,7 +33,7 @@ SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDE
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
 
-SELECT t0, colprojvalue, sqrt(a1) FROM test_column_projection ORDER BY t0;
+SELECT t0, colprojvalue, round(sqrt(a1)::numeric, 5) FROM test_column_projection ORDER BY t0;
 
 -- Casting boolean column to int
 SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;
@@ -50,9 +50,9 @@ SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
 
 SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
 
-SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
 
-SELECT sqrt(a1), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
 
@@ -66,7 +66,7 @@ SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDE
 
 SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
 
-SELECT t0, colprojvalue, sqrt(a1) FROM test_column_projection ORDER BY t0;
+SELECT t0, colprojvalue, round(sqrt(a1)::numeric, 5) FROM test_column_projection ORDER BY t0;
 
 -- Casting boolean column to int
 SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;

--- a/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/expected/query01.ans
@@ -1,6 +1,25 @@
 -- start_ignore
 -- end_ignore
 -- @description query01 for PXF Hive filter pushdown case
+--
+-- start_matchsubs
+--
+-- # filter values that are equivalent but have different operand order
+--
+-- m/a1c23s1d1o5a1c23s2d10o5l1a0c25s1dBo5l0/
+-- s/a1c23s1d1o5a1c23s2d10o5l1a0c25s1dBo5l0/a0c25s1dBo5a1c23s1d1o5a1c23s2d10o5l1l0/
+--
+-- m/a1c23s1d5o1a2c16s4dtrueo0l2l0/
+-- s/a1c23s1d5o1a2c16s4dtrueo0l2l0/a2c16s4dtrueo0l2a1c23s1d5o1l0/
+--
+-- m/a1c23s1d1o3a0c25s1dBo5l0/
+-- s/a1c23s1d1o3a0c25s1dBo5l0/a0c25s1dBo5a1c23s1d1o3l0/
+--
+-- m/a1c23s1d1o5a1c23s2d10o5l1a0c25s1dBo5l0/
+-- s/a1c23s1d1o5a1c23s2d10o5l1a0c25s1dBo5l0/a0c25s1dBo5a1c23s1d1o5a1c23s2d10o5l1l0/
+--
+-- end_matchsubs
+
 SET gp_external_enable_filter_pushdown = true;
 SET
 SET optimizer = off;
@@ -48,21 +67,21 @@ SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY
  D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
 (2 rows)
 
-SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
-       sqrt       |          filtervalue
-------------------+-------------------------------
-                1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
- 1.73205080756888 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+   sqrt    |          filtervalue
+-----------+-------------------------------
+         1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+ 1.7320508 | a2c16s4dtrueo0l2a1c23s1d5o1l0
 (2 rows)
 
-SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
-       sqrt       |   filtervalue
-------------------+------------------
-                1 | a2c16s4dtrueo0l2
- 1.73205080756888 | a2c16s4dtrueo0l2
- 2.23606797749979 | a2c16s4dtrueo0l2
- 2.64575131106459 | a2c16s4dtrueo0l2
-                3 | a2c16s4dtrueo0l2
+SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+   sqrt    |   filtervalue
+-----------+------------------
+         1 | a2c16s4dtrueo0l2
+ 1.7320508 | a2c16s4dtrueo0l2
+  2.236068 | a2c16s4dtrueo0l2
+ 2.6457512 | a2c16s4dtrueo0l2
+         3 | a2c16s4dtrueo0l2
 (5 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
@@ -128,21 +147,21 @@ SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY
  D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
 (2 rows)
 
-SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
-       sqrt       |          filtervalue
-------------------+-------------------------------
-                1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
- 1.73205080756888 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+   sqrt    |          filtervalue
+-----------+-------------------------------
+         1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ 1.7320508 | a1c23s1d5o1a2c16s4dtrueo0l2l0
 (2 rows)
 
-SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
-       sqrt       |   filtervalue
-------------------+------------------
-                1 | a2c16s4dtrueo0l2
- 1.73205080756888 | a2c16s4dtrueo0l2
- 2.23606797749979 | a2c16s4dtrueo0l2
- 2.64575131106459 | a2c16s4dtrueo0l2
-                3 | a2c16s4dtrueo0l2
+SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+   sqrt    |   filtervalue
+-----------+------------------
+         1 | a2c16s4dtrueo0l2
+ 1.7320508 | a2c16s4dtrueo0l2
+  2.236068 | a2c16s4dtrueo0l2
+ 2.6457512 | a2c16s4dtrueo0l2
+         3 | a2c16s4dtrueo0l2
 (5 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;

--- a/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/expected/query01.ans
@@ -67,21 +67,21 @@ SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY
  D  |  3 | a2c16s4dtrueo0l2a1c23s1d5o1l0
 (2 rows)
 
-SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
-   sqrt    |          filtervalue
------------+-------------------------------
-         1 | a2c16s4dtrueo0l2a1c23s1d5o1l0
- 1.7320508 | a2c16s4dtrueo0l2a1c23s1d5o1l0
+SELECT round(sqrt(a1)::numeric,5), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+  round  |          filtervalue
+---------+-------------------------------
+ 1.00000 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ 1.73205 | a1c23s1d5o1a2c16s4dtrueo0l2l0
 (2 rows)
 
-SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
-   sqrt    |   filtervalue
------------+------------------
-         1 | a2c16s4dtrueo0l2
- 1.7320508 | a2c16s4dtrueo0l2
-  2.236068 | a2c16s4dtrueo0l2
- 2.6457512 | a2c16s4dtrueo0l2
-         3 | a2c16s4dtrueo0l2
+SELECT round(sqrt(a1)::numeric,5), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+  round  |   filtervalue
+---------+------------------
+ 1.00000 | a2c16s4dtrueo0l2
+ 1.73205 | a2c16s4dtrueo0l2
+ 2.23607 | a2c16s4dtrueo0l2
+ 2.64575 | a2c16s4dtrueo0l2
+ 3.00000 | a2c16s4dtrueo0l2
 (5 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
@@ -147,21 +147,21 @@ SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY
  D  |  3 | a1c23s1d5o1a2c16s4dtrueo0l2l0
 (2 rows)
 
-SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
-   sqrt    |          filtervalue
------------+-------------------------------
-         1 | a1c23s1d5o1a2c16s4dtrueo0l2l0
- 1.7320508 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+SELECT round(sqrt(a1)::numeric,5), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+  round  |          filtervalue
+---------+-------------------------------
+ 1.00000 | a1c23s1d5o1a2c16s4dtrueo0l2l0
+ 1.73205 | a1c23s1d5o1a2c16s4dtrueo0l2l0
 (2 rows)
 
-SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
-   sqrt    |   filtervalue
------------+------------------
-         1 | a2c16s4dtrueo0l2
- 1.7320508 | a2c16s4dtrueo0l2
-  2.236068 | a2c16s4dtrueo0l2
- 2.6457512 | a2c16s4dtrueo0l2
-         3 | a2c16s4dtrueo0l2
+SELECT round(sqrt(a1)::numeric,5), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+  round  |   filtervalue
+---------+------------------
+ 1.00000 | a2c16s4dtrueo0l2
+ 1.73205 | a2c16s4dtrueo0l2
+ 2.23607 | a2c16s4dtrueo0l2
+ 2.64575 | a2c16s4dtrueo0l2
+ 3.00000 | a2c16s4dtrueo0l2
 (5 rows)
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;

--- a/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/sql/query01.sql
@@ -34,9 +34,9 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
 SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
-SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+SELECT round(sqrt(a1)::numeric,5), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
-SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+SELECT round(sqrt(a1)::numeric,5), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
@@ -56,9 +56,9 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
 SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
-SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+SELECT round(sqrt(a1)::numeric,5), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
-SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+SELECT round(sqrt(a1)::numeric,5), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 

--- a/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/filterpushdown/checkFilterPushDown/sql/query01.sql
@@ -1,4 +1,23 @@
 -- @description query01 for PXF Hive filter pushdown case
+--
+-- start_matchsubs
+--
+-- # filter values that are equivalent but have different operand order
+--
+-- m/a1c23s1d1o5a1c23s2d10o5l1a0c25s1dBo5l0/
+-- s/a1c23s1d1o5a1c23s2d10o5l1a0c25s1dBo5l0/a0c25s1dBo5a1c23s1d1o5a1c23s2d10o5l1l0/
+--
+-- m/a1c23s1d5o1a2c16s4dtrueo0l2l0/
+-- s/a1c23s1d5o1a2c16s4dtrueo0l2l0/a2c16s4dtrueo0l2a1c23s1d5o1l0/
+--
+-- m/a1c23s1d1o3a0c25s1dBo5l0/
+-- s/a1c23s1d1o3a0c25s1dBo5l0/a0c25s1dBo5a1c23s1d1o3l0/
+--
+-- m/a1c23s1d1o5a1c23s2d10o5l1a0c25s1dBo5l0/
+-- s/a1c23s1d1o5a1c23s2d10o5l1a0c25s1dBo5l0/a0c25s1dBo5a1c23s1d1o5a1c23s2d10o5l1l0/
+--
+-- end_matchsubs
+
 SET gp_external_enable_filter_pushdown = true;
 
 SET optimizer = off;
@@ -15,9 +34,9 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
 SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
-SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
-SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 
@@ -37,9 +56,9 @@ SELECT * FROM test_filter WHERE  b2 = false ORDER BY t0, a1;
 
 SELECT t0, a1, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
-SELECT sqrt(a1), filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
+SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE a1 < 5 AND b2 = false ORDER BY t0, a1;
 
-SELECT sqrt(a1), filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
+SELECT sqrt(a1)::real, filtervalue FROM test_filter WHERE b2 = false ORDER BY t0;
 
 SELECT * FROM test_filter WHERE  b2 = false AND (a1 = 1 OR a1 = 10) ORDER BY t0, a1;
 

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/extra_field/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/extra_field/expected/query01.ans
@@ -1,13 +1,5 @@
 -- @description query01 for PXF HDFS Readable Avro with extra field test cases
 
--- start_matchsubs
---
--- # create a match/subs
---
--- m/DETAIL/
--- s/DETAIL/CONTEXT/
---
--- end_matchsubs
 SELECT * from avro_extra_field ORDER BY age;
 ERROR:  Avro record has 2 fields but GPDB table has 3 columns.
-DETAIL:  External table avro_extra_field
+CONTEXT:  External table avro_extra_field

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/extra_field/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/extra_field/expected/query01.ans
@@ -1,4 +1,10 @@
 -- @description query01 for PXF HDFS Readable Avro with extra field test cases
+-- start_matchsubs
+--
+-- m/, line \d+ of/
+-- s/, line \d+ of .*//
+--
+-- end_matchsubs
 
 SELECT * from avro_extra_field ORDER BY age;
 ERROR:  Avro record has 2 fields but GPDB table has 3 columns.

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/extra_field/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/extra_field/sql/query01.sql
@@ -1,3 +1,9 @@
 -- @description query01 for PXF HDFS Readable Avro with extra field test cases
+-- start_matchsubs
+--
+-- m/, line \d+ of/
+-- s/, line \d+ of .*//
+--
+-- end_matchsubs
 
 SELECT * from avro_extra_field ORDER BY age;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/extra_field/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/extra_field/sql/query01.sql
@@ -1,11 +1,3 @@
 -- @description query01 for PXF HDFS Readable Avro with extra field test cases
 
--- start_matchsubs
---
--- # create a match/subs
---
--- m/DETAIL/
--- s/DETAIL/CONTEXT/
---
--- end_matchsubs
 SELECT * from avro_extra_field ORDER BY age;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/expected/query01.ans
@@ -4,9 +4,12 @@
 --
 -- # create a match/subs
 --
+-- m/, line \d+ of/
+-- s/, line \d+ of .*//
+--
 -- # FDW in CSV mode will fail during parsing on C side twith the below error
--- m/invalid input syntax for type date: .*/
--- s/invalid input syntax for type date: .*/For field dob schema requires type DATE but input record has type INTEGER/
+-- m/invalid input syntax for date: .*/
+-- s/invalid input syntax for date: .*/For field dob schema requires type DATE but input record has type INTEGER/
 --
 -- end_matchsubs
 

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/expected/query01.ans
@@ -7,7 +7,7 @@
 -- m/, line \d+ of/
 -- s/, line \d+ of .*//
 --
--- # FDW in CSV mode will fail during parsing on C side twith the below error
+-- # FDW in CSV mode will fail during parsing on C side with the below error
 -- m/invalid input syntax for date: .*/
 -- s/invalid input syntax for date: .*/For field dob schema requires type DATE but input record has type INTEGER/
 --

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/expected/query01.ans
@@ -4,11 +4,12 @@
 --
 -- # create a match/subs
 --
--- m/DETAIL/
--- s/DETAIL/CONTEXT/
+-- # FDW in CSV mode will fail during parsing on C side twith the below error
+-- m/invalid input syntax for type date: .*/
+-- s/invalid input syntax for type date: .*/For field dob schema requires type DATE but input record has type INTEGER/
 --
 -- end_matchsubs
 
 select * from logical_incorrect_schema_test;
 ERROR:  For field dob schema requires type DATE but input record has type INTEGER
-DETAIL:  External table logical_incorrect_schema_test
+CONTEXT:  External table logical_incorrect_schema_test

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/sql/query01.sql
@@ -7,7 +7,7 @@
 -- m/, line \d+ of/
 -- s/, line \d+ of .*//
 --
--- # FDW in CSV mode will fail during parsing on C side twith the below error
+-- # FDW in CSV mode will fail during parsing on C side with the below error
 -- m/invalid input syntax for date: .*/
 -- s/invalid input syntax for date: .*/For field dob schema requires type DATE but input record has type INTEGER/
 --

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/sql/query01.sql
@@ -4,8 +4,9 @@
 --
 -- # create a match/subs
 --
--- m/DETAIL/
--- s/DETAIL/CONTEXT/
+-- # FDW in CSV mode will fail during parsing on C side twith the below error
+-- m/invalid input syntax for type date: .*/
+-- s/invalid input syntax for type date: .*/For field dob schema requires type DATE but input record has type INTEGER/
 --
 -- end_matchsubs
 select * from logical_incorrect_schema_test;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/logical_incorrect_schema_test/sql/query01.sql
@@ -4,9 +4,12 @@
 --
 -- # create a match/subs
 --
+-- m/, line \d+ of/
+-- s/, line \d+ of .*//
+--
 -- # FDW in CSV mode will fail during parsing on C side twith the below error
--- m/invalid input syntax for type date: .*/
--- s/invalid input syntax for type date: .*/For field dob schema requires type DATE but input record has type INTEGER/
+-- m/invalid input syntax for date: .*/
+-- s/invalid input syntax for date: .*/For field dob schema requires type DATE but input record has type INTEGER/
 --
 -- end_matchsubs
 select * from logical_incorrect_schema_test;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/missing_field/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/missing_field/expected/query01.ans
@@ -1,13 +1,5 @@
 -- @description query01 for PXF HDFS Readable Avro with missing field test cases
 
--- start_matchsubs
---
--- # create a match/subs
---
--- m/DETAIL/
--- s/DETAIL/CONTEXT/
---
--- end_matchsubs
 SELECT * from avro_missing_field;
 ERROR:  Avro record has 2 fields but GPDB table has 1 columns.
-DETAIL:  External table avro_missing_field
+CONTEXT:  External table avro_missing_field

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/missing_field/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/missing_field/expected/query01.ans
@@ -1,4 +1,10 @@
 -- @description query01 for PXF HDFS Readable Avro with missing field test cases
+-- start_matchsubs
+--
+-- m/, line \d+ of/
+-- s/, line \d+ of .*//
+--
+-- end_matchsubs
 
 SELECT * from avro_missing_field;
 ERROR:  Avro record has 2 fields but GPDB table has 1 columns.

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/missing_field/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/missing_field/sql/query01.sql
@@ -1,3 +1,9 @@
 -- @description query01 for PXF HDFS Readable Avro with missing field test cases
+-- start_matchsubs
+--
+-- m/, line \d+ of/
+-- s/, line \d+ of .*//
+--
+-- end_matchsubs
 
 SELECT * from avro_missing_field;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/missing_field/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/missing_field/sql/query01.sql
@@ -1,11 +1,3 @@
 -- @description query01 for PXF HDFS Readable Avro with missing field test cases
 
--- start_matchsubs
---
--- # create a match/subs
---
--- m/DETAIL/
--- s/DETAIL/CONTEXT/
---
--- end_matchsubs
 SELECT * from avro_missing_field;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/no_schema_file/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/no_schema_file/expected/query01.ans
@@ -16,10 +16,13 @@
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/
 --
+-- m/Foreign table/
+-- s/Foreign table/External table/
+--
 -- end_matchsubs
 SELECT * from avro_in_seq_no_schema;
 ERROR:  PXF server error : Failed to obtain Avro schema from 'i_do_not_exist'
 -- start_ignore
 HINT:  Check the PXF logs located in the 'logs-dir' directory on host 'mdw' or 'set client_min_messages=LOG' for additional details.
 -- end_ignore
-DETAIL:  External table avro_in_seq_no_schema
+CONTEXT:  External table avro_in_seq_no_schema

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/no_schema_file/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/no_schema_file/expected/query01.ans
@@ -13,12 +13,6 @@
 -- m/(E|e)xception (r|R)eport +(m|M)essage/
 -- s/(E|e)xception (r|R)eport +(m|M)essage/exception report message/
 --
--- m/DETAIL/
--- s/DETAIL/CONTEXT/
---
--- m/Foreign table/
--- s/Foreign table/External table/
---
 -- end_matchsubs
 SELECT * from avro_in_seq_no_schema;
 ERROR:  PXF server error : Failed to obtain Avro schema from 'i_do_not_exist'

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/no_schema_file/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/no_schema_file/sql/query01.sql
@@ -13,11 +13,5 @@
 -- m/(E|e)xception (r|R)eport +(m|M)essage/
 -- s/(E|e)xception (r|R)eport +(m|M)essage/exception report message/
 --
--- m/DETAIL/
--- s/DETAIL/CONTEXT/
---
--- m/Foreign table/
--- s/Foreign table/External table/
---
 -- end_matchsubs
 SELECT * from avro_in_seq_no_schema;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/no_schema_file/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/avro/errors/no_schema_file/sql/query01.sql
@@ -16,5 +16,8 @@
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/
 --
+-- m/Foreign table/
+-- s/Foreign table/External table/
+--
 -- end_matchsubs
 SELECT * from avro_in_seq_no_schema;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_csv/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_csv/expected/query01.ans
@@ -18,7 +18,7 @@ SELECT *
 FROM jsontest_malformed_record
 ORDER BY id;
 ERROR:  extra data after last expected column
-CONTEXT:  External table jsontest_malformed_record, pxf://pxf_automation_data/tweets-broken.json?PROFILE=json&IDENTIFIER=created_at: ",,,,,,,"PXFERRMSG> error while parsing json record 'Unexpected character (':' (code 58)): was expecting comma t..."
+CONTEXT:  External table jsontest_malformed_record, pxf://pxf_automation_data/tweets-broken.json?PROFILE=json&IDENTIFIER=created_at: ",,,,,,,"PXFERRMSG> error while parsing json record 'Unexpected character (':' (code 58)): was expect..."
 
 SELECT *
 FROM jsontest_malformed_record_filefrag

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_csv/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_csv/expected/query01.ans
@@ -18,10 +18,10 @@ SELECT *
 FROM jsontest_malformed_record
 ORDER BY id;
 ERROR:  extra data after last expected column
-CONTEXT:  External table jsontest_malformed_record, pxf://pxf_automation_data/tweets-broken.json?PROFILE=json&IDENTIFIER=created_at: ",,,,,,,"error while parsing json record 'Unexpected character (':' (code 58)): was expecting comma t..."
+CONTEXT:  External table jsontest_malformed_record, pxf://pxf_automation_data/tweets-broken.json?PROFILE=json&IDENTIFIER=created_at: ",,,,,,,"PXFERRMSG> error while parsing json record 'Unexpected character (':' (code 58)): was expecting comma t..."
 
 SELECT *
 FROM jsontest_malformed_record_filefrag
 ORDER BY id;
 ERROR:  extra data after last expected column
-CONTEXT:  External table jsontest_malformed_record_filefrag, pxf://pxf_automation_data/tweets-broken.json?PROFILE=json&IDENTIFIER=created_at&SPLIT_BY_FILE=true: ",,,,,,,"error while parsing json record 'Unexpected character (':' (code 58)): was expecting comma t..."
+CONTEXT:  External table jsontest_malformed_record_filefrag, pxf://pxf_automation_data/tweets-broken.json?PROFILE=json&IDENTIFIER=created_at&SPLIT_BY_FILE=true: ",,,,,,,"PXFERRMSG> error while parsing json record 'Unexpected character (':' (code 58)): was expecting comma t..."

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_csv/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/json/malformed_record_csv/expected/query01.ans
@@ -24,4 +24,4 @@ SELECT *
 FROM jsontest_malformed_record_filefrag
 ORDER BY id;
 ERROR:  extra data after last expected column
-CONTEXT:  External table jsontest_malformed_record_filefrag, pxf://pxf_automation_data/tweets-broken.json?PROFILE=json&IDENTIFIER=created_at&SPLIT_BY_FILE=true: ",,,,,,,"PXFERRMSG> error while parsing json record 'Unexpected character (':' (code 58)): was expecting comma t..."
+CONTEXT:  External table jsontest_malformed_record_filefrag, pxf://pxf_automation_data/tweets-broken.json?PROFILE=json&IDENTIFIER=created_at&SPLIT_BY_FILE=true: ",,,,,,,"PXFERRMSG> error while parsing json record 'Unexpected character (':' (code 58)): was expect..."

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
@@ -3,6 +3,8 @@
 -- start_matchsubs
 --
 -- # create a match/subs
+--
+-- replace PXF URL with "pxf-location" string
 -- m/pxf:\/\/(.*)\|/
 -- s/pxf:\/\/.*data\?PROFILE=hdfs:text/pxf-location/
 --

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
@@ -4,7 +4,10 @@
 --
 -- # create a match/subs
 -- m/pxf:\/\/(.*)\|/
--- s/pxf:\/\/.*\|/pxf:\/\/location |/
+-- s/pxf:\/\/.*\/data/pxf-location/
+--
+-- m/\|.*\/data/
+-- s/\|.*\/data/\|pxf-location/
 --
 -- end_matchsubs
 
@@ -27,8 +30,8 @@ NOTICE:  Found 4 data formatting errors (4 or more input rows). Rejected related
 SELECT relname, filename, linenum, errmsg, rawdata FROM  gp_read_error_log('err_table_test') ORDER BY linenum ASC;
     relname     |                               filename                                | linenum |                              errmsg                              |           rawdata
 ----------------+-----------------------------------------------------------------------+---------+------------------------------------------------------------------+------------------------------
- err_table_test | pxf://location |       1 | invalid input syntax for integer: "All Together Now", column num | All Together Now,The Beatles
- err_table_test | pxf://location |       6 | invalid input syntax for integer: "can", column num              | can,I
- err_table_test | pxf://location |       7 | invalid input syntax for integer: "have", column num             | have,a
- err_table_test | pxf://location |       8 | invalid input syntax for integer: "little", column num           | little,more
+ err_table_test | pxf-location |       1 | invalid input syntax for integer: "All Together Now", column num | All Together Now,The Beatles
+ err_table_test | pxf-location |       6 | invalid input syntax for integer: "can", column num              | can,I
+ err_table_test | pxf-location |       7 | invalid input syntax for integer: "have", column num             | have,a
+ err_table_test | pxf-location |       8 | invalid input syntax for integer: "little", column num           | little,more
 (4 rows)

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
@@ -4,7 +4,7 @@
 --
 -- # create a match/subs
 -- m/pxf:\/\/(.*)\|/
--- s/pxf:\/\/.*\/data/pxf-location/
+-- s/pxf:\/\/.*data\?PROFILE=hdfs:text/pxf-location/
 --
 -- m/\|.*\/data/
 -- s/\|.*\/data/\|pxf-location/

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
@@ -4,7 +4,7 @@
 --
 -- # create a match/subs
 --
--- replace PXF URL with "pxf-location" string
+-- # replace PXF URL with "pxf-location" string
 -- m/pxf:\/\/(.*)\|/
 -- s/pxf:\/\/.*data\?PROFILE=hdfs:text/pxf-location/
 --

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
@@ -6,7 +6,7 @@
 --
 -- # replace PXF URL with "pxf-location" string
 -- m/pxf:\/\/(.*)\|/
--- s/pxf:\/\/.*data\?PROFILE=hdfs:text/pxf-location/
+-- s/pxf:\/\/.*data\?PROFILE=.*/pxf-location/
 --
 -- m/\|.*\/data/
 -- s/\|.*\/data/\|pxf-location/

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/expected/query01.ans
@@ -6,7 +6,7 @@
 --
 -- # replace PXF URL with "pxf-location" string
 -- m/pxf:\/\/(.*)\|/
--- s/pxf:\/\/.*data\?PROFILE=.*/pxf-location/
+-- s/pxf:\/\/.*data\?PROFILE=.+?\|/pxf-location\|/
 --
 -- m/\|.*\/data/
 -- s/\|.*\/data/\|pxf-location/

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
@@ -3,6 +3,8 @@
 -- start_matchsubs
 --
 -- # create a match/subs
+--
+-- replace PXF URL with "pxf-location" string
 -- m/pxf:\/\/(.*)\|/
 -- s/pxf:\/\/.*data\?PROFILE=hdfs:text/pxf-location/
 --

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
@@ -4,7 +4,10 @@
 --
 -- # create a match/subs
 -- m/pxf:\/\/(.*)\|/
--- s/pxf:\/\/.*\|/pxf:\/\/location |/
+-- s/pxf:\/\/.*\/data/pxf-location/
+--
+-- m/\|.*\/data/
+-- s/\|.*\/data/\|pxf-location/
 --
 -- end_matchsubs
 

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
@@ -4,7 +4,7 @@
 --
 -- # create a match/subs
 -- m/pxf:\/\/(.*)\|/
--- s/pxf:\/\/.*\/data/pxf-location/
+-- s/pxf:\/\/.*data\?PROFILE=hdfs:text/pxf-location/
 --
 -- m/\|.*\/data/
 -- s/\|.*\/data/\|pxf-location/

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
@@ -4,7 +4,7 @@
 --
 -- # create a match/subs
 --
--- replace PXF URL with "pxf-location" string
+-- # replace PXF URL with "pxf-location" string
 -- m/pxf:\/\/(.*)\|/
 -- s/pxf:\/\/.*data\?PROFILE=hdfs:text/pxf-location/
 --

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
@@ -6,7 +6,7 @@
 --
 -- # replace PXF URL with "pxf-location" string
 -- m/pxf:\/\/(.*)\|/
--- s/pxf:\/\/.*data\?PROFILE=hdfs:text/pxf-location/
+-- s/pxf:\/\/.*data\?PROFILE=.*/pxf-location/
 --
 -- m/\|.*\/data/
 -- s/\|.*\/data/\|pxf-location/

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/error_table_gpdb/sql/query01.sql
@@ -6,7 +6,7 @@
 --
 -- # replace PXF URL with "pxf-location" string
 -- m/pxf:\/\/(.*)\|/
--- s/pxf:\/\/.*data\?PROFILE=.*/pxf-location/
+-- s/pxf:\/\/.*data\?PROFILE=.+?\|/pxf-location\|/
 --
 -- m/\|.*\/data/
 -- s/\|.*\/data/\|pxf-location/

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/error_table_breached/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/error_table_breached/expected/query01.ans
@@ -12,7 +12,13 @@
 -- s/CONTEXT:\s*Last error was/GP_IGNORE:/
 --
 -- m/pxf:\/\/(.*),/
--- s/pxf:\/\/.*,/pxf:\/\/location,/
+-- s/pxf:\/\/.*,/pxf-location,/
+--
+-- m/pxf_automation_data/
+-- s/of .*,/of pxf-location,/
+--
+-- m/column num:/
+-- s/column num:.*/column num/
 --
 -- end_matchsubs
 

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/error_table_breached/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/error_table_breached/sql/query01.sql
@@ -12,7 +12,13 @@
 -- s/CONTEXT:\s*Last error was/GP_IGNORE:/
 --
 -- m/pxf:\/\/(.*),/
--- s/pxf:\/\/.*,/pxf:\/\/location,/
+-- s/pxf:\/\/.*,/pxf-location,/
+--
+-- m/pxf_automation_data/
+-- s/of .*,/of pxf-location,/
+--
+-- m/column num:/
+-- s/column num:.*/column num/
 --
 -- end_matchsubs
 

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/middle_of_stream/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/middle_of_stream/expected/query01.ans
@@ -5,8 +5,8 @@
 -- m/(ERROR|WARNING):.*'\d+\.\d+\.\d+\.\d+:\d+'.*/
 -- s/'\d+\.\d+\.\d+\.\d+:\d+'/'SOME_IP:SOME_PORT'/
 --
--- m/DETAIL:  \n/
--- s/DETAIL:  \n/DETAIL:  /
+-- m/CONTEXT:  \n/
+-- s/CONTEXT:  \n/CONTEXT:  /
 --
 -- m/External table error_on_10000/
 -- s/.*External table error_on_10000.*/CONTEXT:  External table error_on_10000/

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/middle_of_stream/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/middle_of_stream/sql/query01.sql
@@ -5,8 +5,8 @@
 -- m/(ERROR|WARNING):.*'\d+\.\d+\.\d+\.\d+:\d+'.*/
 -- s/'\d+\.\d+\.\d+\.\d+:\d+'/'SOME_IP:SOME_PORT'/
 --
--- m/DETAIL:  \n/
--- s/DETAIL:  \n/DETAIL:  /
+-- m/CONTEXT:  \n/
+-- s/CONTEXT:  \n/CONTEXT:  /
 --
 -- m/External table error_on_10000/
 -- s/.*External table error_on_10000.*/CONTEXT:  External table error_on_10000/

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/wrong_type/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/wrong_type/expected/query01.ans
@@ -8,6 +8,9 @@
 -- m/pxf:\/\/(.*),/
 -- s/pxf:\/\/.*,/pxf:\/\/location,/
 --
+-- m/, line 51 of/
+-- s/, line 51 of.*//
+--
 -- end_matchsubs
 
 SELECT * FROM bad_text ORDER BY num ASC;

--- a/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/wrong_type/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/hdfs/readable/text/errors/wrong_type/sql/query01.sql
@@ -8,6 +8,9 @@
 -- m/pxf:\/\/(.*),/
 -- s/pxf:\/\/.*,/pxf:\/\/location,/
 --
+-- m/, line 51 of/
+-- s/, line 51 of.*//
+--
 -- end_matchsubs
 
 SELECT * FROM bad_text ORDER BY num ASC;

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -330,6 +330,14 @@ resources:
     bucket: ((ud/pxf/common/build-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf6/pxf-gp[[gp_ver]]-ubuntu18.04.tar.gz
+
+- name: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: ((ud/pxf/common/build-bucket-name))
+    json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
+    versioned_file: dev/[[user]]-[[branch]]/snapshots/pxf6/pxf-fdw-gp[[gp_ver]].el8.tar.gz
 {% set gp_ver = None %}
 
 {% for gp_ver in range(6, 8) %}
@@ -534,6 +542,11 @@ jobs:
   - put: pxf_gp[[gp_ver]]_tarball_rhel8
     params:
       file: dist/pxf-gp[[gp_ver]]-*.el8.tar.gz
+{% if gp_ver == 6 %}
+  - put: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
+    params:
+      file: dist/pxf-fdw-gp[[gp_ver]]-*.el8.tar.gz
+{% endif %}
 
 - name: Test PXF-GP[[gp_ver]]-HDP2 on RHEL8
   plan:
@@ -544,6 +557,11 @@ jobs:
       - get: pxf_tarball
         resource: pxf_gp[[gp_ver]]_tarball_rhel8
         passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+{% if gp_ver == 6 %}
+      - get: pxf_fdw_tarball
+        resource: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
+        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+{% endif %}
       - get: gpdb_package
         resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
         passed: [Build PXF-GP[[gp_ver]] on RHEL8]
@@ -570,7 +588,7 @@ jobs:
 {% set gp_ver = None %}
 
 ## ---------- FDW RHEL 8 Swimlane ----------
-{% set gp_ver = 7 %}
+{% for gp_ver in range(6, 8) %}
 - name: Test PXF-FDW-GP[[gp_ver]]-HDP2 on RHEL8
   plan:
   - in_parallel:
@@ -583,7 +601,9 @@ jobs:
       - get: gpdb_package
         resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
         passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+{% if gp_ver == 7 %}
       - get: gp6-python-libs
+{% endif %}
       - get: gpdb[[gp_ver]]-pxf-dev-rhel8-image
         passed: [Build PXF-GP[[gp_ver]] on RHEL8]
       - get: pxf-automation-dependencies
@@ -598,6 +618,7 @@ jobs:
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
       USE_FDW: true
+{% endfor %}
 {% set gp_ver = None %}
 
 ## ---------- Extended Tests ----------

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -557,11 +557,6 @@ jobs:
       - get: pxf_tarball
         resource: pxf_gp[[gp_ver]]_tarball_rhel8
         passed: [Build PXF-GP[[gp_ver]] on RHEL8]
-{% if gp_ver == 6 %}
-      - get: pxf_fdw_tarball
-        resource: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
-{% endif %}
       - get: gpdb_package
         resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
         passed: [Build PXF-GP[[gp_ver]] on RHEL8]
@@ -598,6 +593,11 @@ jobs:
       - get: pxf_tarball
         resource: pxf_gp[[gp_ver]]_tarball_rhel8
         passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+{% if gp_ver == 6 %}
+      - get: pxf_fdw_tarball
+        resource: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
+        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+{% endif %}
       - get: gpdb_package
         resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
         passed: [Build PXF-GP[[gp_ver]] on RHEL8]

--- a/concourse/scripts/build.bash
+++ b/concourse/scripts/build.bash
@@ -77,9 +77,8 @@ function package_pxf_fdw() {
         make -C '${PWD}/pxf_src/fdw' stage
     "
     # get the filename of previously built main PXF tarball to use its full name as a suffix
-    local pxf_main_tarball, pxf_fdw_tarball
-    pxf_tarball="$(ls pxf_src/build/${DIST_DIR}/pxf-*.tar.gz | xargs -n 1 basename)"
-    pxf_fdw_tarball="pxf_src/build/${DIST_DIR}/pxf-fdw${pxf_tarball#pxf}"
+    local pxf_tarball=$(ls pxf_src/build/${DIST_DIR}/pxf-*.tar.gz | xargs -n 1 basename)
+    local pxf_fdw_tarball="pxf_src/build/${DIST_DIR}/pxf-fdw${pxf_tarball#pxf}"
 
     # build the tarball and copy it to the output directory
     ls -al pxf_src/fdw/build/stage

--- a/concourse/scripts/initialize_gpdb.bash
+++ b/concourse/scripts/initialize_gpdb.bash
@@ -22,7 +22,6 @@ sed -e "s/MASTER_HOSTNAME=mdw/MASTER_HOSTNAME=\$(hostname -f)/g" \
 chmod +w ~gpadmin/gpconfigs/gpinitsystem_config
 
 #Script to start segments and create directories.
-ls -al /tmp
 hostname -f >/tmp/hosts.txt
 
 # gpinitsystem fails in concourse environment without this "ping" workaround. "[FATAL]:-Unknown host..."

--- a/concourse/scripts/initialize_gpdb.bash
+++ b/concourse/scripts/initialize_gpdb.bash
@@ -22,6 +22,7 @@ sed -e "s/MASTER_HOSTNAME=mdw/MASTER_HOSTNAME=\$(hostname -f)/g" \
 chmod +w ~gpadmin/gpconfigs/gpinitsystem_config
 
 #Script to start segments and create directories.
+ls -al /tmp
 hostname -f >/tmp/hosts.txt
 
 # gpinitsystem fails in concourse environment without this "ping" workaround. "[FATAL]:-Unknown host..."

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -308,9 +308,9 @@ function install_pxf_tarball() {
 		tar -xzf pxf_fdw_tarball/pxf-fdw-*.tar.gz -C /tmp
 		chmod 777 /tmp
 		ls -al /tmp
-		/usr/bin/install -c -m 755 /tmp/pxf_fdw.so "${GPHOME}/lib/postgresql/pxf_fdw.so"
-		/usr/bin/install -c -m 644 /tmp/pxf_fdw.control "${GPHOME}/share/postgresql/extension/"
-		/usr/bin/install -c -m 644 /tmp/pxf_fdw*.sql "${GPHOME}/share/postgresql/extension/"
+		/usr/bin/install -c -m 755 /tmp/pxf_fdw.so "$("${GPHOME}/bin/pg_config" --pkglibdir)"
+		/usr/bin/install -c -m 644 /tmp/pxf_fdw.control "$("${GPHOME}/bin/pg_config" --sharedir)"
+		/usr/bin/install -c -m 644 /tmp/pxf_fdw*.sql "$("${GPHOME}/bin/pg_config" --sharedir)"
 	fi
 }
 

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -305,7 +305,9 @@ function install_pxf_tarball() {
 
 	# install separately built PXF FDW extension if it is available on the inputs
 	if [[ -d pxf_fdw_tarball ]]; then
+		ls -al /tmp
 		tar -xzf pxf_fdw_tarball/pxf-fdw-*.tar.gz -C /tmp
+		ls -al /tmp
 		/usr/bin/install -c -m 755 /tmp/pxf_fdw.so "${GPHOME}/lib/postgresql/pxf_fdw.so"
 		/usr/bin/install -c -m 644 /tmp/pxf_fdw.control "${GPHOME}/share/postgresql/extension/"
 		/usr/bin/install -c -m 644 /tmp/pxf_fdw*.sql "${GPHOME}/share/postgresql/extension/"
@@ -510,6 +512,9 @@ function configure_pxf_server() {
 		echo 'JDK 11 requested for runtime, setting PXF JAVA_HOME=/usr/lib/jvm/jdk-11 in pxf-env.sh'
 		su gpadmin -c "echo 'export JAVA_HOME=/usr/lib/jvm/jdk-11' >> ${BASE_DIR}/conf/pxf-env.sh"
 	fi
+
+	# add property to allow dynamic test: profiles that are used when testing against FDW
+	echo "pxf.profile.dynamic.regex=test:.*" >> "${BASE_DIR}/conf/pxf-application.properties"
 }
 
 function configure_hdfs_client_for_s3() {

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -306,7 +306,7 @@ function install_pxf_tarball() {
 	# install separately built PXF FDW extension if it is available on the inputs
 	if [[ -d pxf_fdw_tarball ]]; then
 		tar -xzf pxf_fdw_tarball/pxf-fdw-*.tar.gz -C /tmp
-		chmod 755 /tmp
+		chmod 777 /tmp
 		ls -al /tmp
 		/usr/bin/install -c -m 755 /tmp/pxf_fdw.so "${GPHOME}/lib/postgresql/pxf_fdw.so"
 		/usr/bin/install -c -m 644 /tmp/pxf_fdw.control "${GPHOME}/share/postgresql/extension/"

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -299,13 +299,14 @@ function install_pxf_server() {
 
 function install_pxf_tarball() {
 	local tarball_dir=${PXF_PKG_DIR:-pxf_tarball}
-	tar -xzf "${tarball_dir}/"pxf-*.tar.gz -C /tmp
+	tar -xzf "${tarball_dir}/"pxf-gp*.tar.gz -C /tmp
 	/tmp/pxf*/install_component
 	chown -R gpadmin:gpadmin "${PXF_HOME}"
 
 	# install separately built PXF FDW extension if it is available on the inputs
-	if [[ -d pxf_fdw_tarball ]]; then
-		tar -xzf pxf_fdw_tarball/pxf-fdw-*.tar.gz -C /tmp
+	local fdw_tarball_dir=${PXF_PKG_DIR:-pxf_fdw_tarball}
+	if compgen -G "${fdw_tarball_dir}/pxf-fdw-*.tar.gz" > /dev/null; then
+		tar -xzf "${fdw_tarball_dir}/"pxf-fdw-*.tar.gz -C /tmp
 		chmod 777 /tmp
 		ls -al /tmp
 		/usr/bin/install -c -m 755 /tmp/pxf_fdw.so "$("${GPHOME}/bin/pg_config" --pkglibdir)"

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -309,8 +309,8 @@ function install_pxf_tarball() {
 		chmod 777 /tmp
 		ls -al /tmp
 		/usr/bin/install -c -m 755 /tmp/pxf_fdw.so "$("${GPHOME}/bin/pg_config" --pkglibdir)"
-		/usr/bin/install -c -m 644 /tmp/pxf_fdw.control "$("${GPHOME}/bin/pg_config" --sharedir)"
-		/usr/bin/install -c -m 644 /tmp/pxf_fdw*.sql "$("${GPHOME}/bin/pg_config" --sharedir)"
+		/usr/bin/install -c -m 644 /tmp/pxf_fdw.control "$("${GPHOME}/bin/pg_config" --sharedir)/extension/"
+		/usr/bin/install -c -m 644 /tmp/pxf_fdw*.sql "$("${GPHOME}/bin/pg_config" --sharedir)/extension/"
 	fi
 }
 

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -302,6 +302,14 @@ function install_pxf_tarball() {
 	tar -xzf "${tarball_dir}/"pxf-*.tar.gz -C /tmp
 	/tmp/pxf*/install_component
 	chown -R gpadmin:gpadmin "${PXF_HOME}"
+
+	# install separately built PXF FDW extension if it is available on the inputs
+	if [[ -d pxf_fdw_tarball ]]; then
+		tar -xzf pxf_fdw_tarball/pxf-fdw-*.tar.gz -C /tmp
+		/usr/bin/install -c -m 755 /tmp/pxf_fdw.so "${GPHOME}/lib/postgresql/pxf_fdw.so"
+		/usr/bin/install -c -m 644 /tmp/pxf_fdw.control "${GPHOME}/share/postgresql/extension/"
+		/usr/bin/install -c -m 644 /tmp/pxf_fdw*.sql "${GPHOME}/share/postgresql/extension/"
+	fi
 }
 
 function install_pxf_package() {

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -305,8 +305,8 @@ function install_pxf_tarball() {
 
 	# install separately built PXF FDW extension if it is available on the inputs
 	if [[ -d pxf_fdw_tarball ]]; then
-		ls -al /tmp
 		tar -xzf pxf_fdw_tarball/pxf-fdw-*.tar.gz -C /tmp
+		chmod 755 /tmp
 		ls -al /tmp
 		/usr/bin/install -c -m 755 /tmp/pxf_fdw.so "${GPHOME}/lib/postgresql/pxf_fdw.so"
 		/usr/bin/install -c -m 644 /tmp/pxf_fdw.control "${GPHOME}/share/postgresql/extension/"
@@ -514,7 +514,7 @@ function configure_pxf_server() {
 	fi
 
 	# add property to allow dynamic test: profiles that are used when testing against FDW
-	echo "pxf.profile.dynamic.regex=test:.*" >> "${BASE_DIR}/conf/pxf-application.properties"
+	echo -e "\npxf.profile.dynamic.regex=test:.*" >> "${BASE_DIR}/conf/pxf-application.properties"
 }
 
 function configure_hdfs_client_for_s3() {

--- a/concourse/scripts/test.bash
+++ b/concourse/scripts/test.bash
@@ -224,6 +224,7 @@ function _main() {
 
 	# Ping is called by gpinitsystem, which must be run by gpadmin
 	chmod u+s /bin/ping
+	chmod a+rwx /tmp
 
 	if [[ ${HADOOP_CLIENT} == MAPR ]]; then
 		# start mapr services before installing GPDB

--- a/concourse/scripts/test.bash
+++ b/concourse/scripts/test.bash
@@ -263,9 +263,6 @@ function _main() {
 		fi
 	fi
 
-	ls -al /tmp
-	chmod a+rwx /tmp
-	ls -al /tmp
 	# initialize GPDB as gpadmin user
 	su gpadmin -c "${CWDIR}/initialize_gpdb.bash"
 

--- a/concourse/scripts/test.bash
+++ b/concourse/scripts/test.bash
@@ -224,7 +224,6 @@ function _main() {
 
 	# Ping is called by gpinitsystem, which must be run by gpadmin
 	chmod u+s /bin/ping
-	chmod a+rwx /tmp
 
 	if [[ ${HADOOP_CLIENT} == MAPR ]]; then
 		# start mapr services before installing GPDB
@@ -264,6 +263,9 @@ function _main() {
 		fi
 	fi
 
+	ls -al /tmp
+	chmod a+rwx /tmp
+	ls -al /tmp
 	# initialize GPDB as gpadmin user
 	su gpadmin -c "${CWDIR}/initialize_gpdb.bash"
 

--- a/concourse/scripts/test_pxf_multinode.bash
+++ b/concourse/scripts/test_pxf_multinode.bash
@@ -183,6 +183,7 @@ EOF
 			${BASE_DIR}/servers/default-no-impersonation/pxf-site.xml
 		fi &&
 		echo 'export PXF_LOADER_PATH=file:/tmp/publicstage/pxf' >> ${BASE_DIR}/conf/pxf-env.sh && \
+		echo -e '\npxf.profile.dynamic.regex=test:.*' >> ${BASE_DIR}/conf/pxf-application.properties && \
 		PXF_BASE=${BASE_DIR} ${PXF_HOME}/bin/pxf cluster sync
 	"
 }

--- a/concourse/tasks/test.yml
+++ b/concourse/tasks/test.yml
@@ -15,6 +15,8 @@ inputs:
   optional: true
 - name: gp6-python-libs
   optional: true
+- name: pxf_fdw_tarball
+  optional: true
 
 params:
   ACCESS_KEY_ID:

--- a/fdw/libchurl.h
+++ b/fdw/libchurl.h
@@ -138,11 +138,6 @@ void		churl_read_check_connectivity(CHURL_HANDLE handle);
  */
 void		churl_cleanup(CHURL_HANDLE handle, bool after_error);
 
-/*
- * Debug function - print the http headers
- */
-void		print_http_headers(CHURL_HEADERS headers);
-
 #define LOCAL_HOST_RESOLVE_STRING_FORMAT "localhost:%d:127.0.0.1"
 /* PORT can be at most five digits giving a total length for the resolve string
  * of 25 plus one for the trailing '\0'

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -42,6 +42,12 @@ PG_MODULE_MAGIC;
 
 #define DEFAULT_PXF_FDW_STARTUP_COST   50000
 
+/*
+ * Error token embedded in the data sent by PXF as part of an error row
+ */
+#define PXF_ERROR_TOKEN "PXFERRMSG> "
+#define PXF_ERROR_TOKEN_SIZE strlen(PXF_ERROR_TOKEN)
+
 extern Datum pxf_fdw_handler(PG_FUNCTION_ARGS);
 
 /*
@@ -181,12 +187,6 @@ enum FdwScanPrivateIndex
 	/* Integer list of attribute numbers retrieved by the SELECT */
 	FdwScanPrivateRetrievedAttrs
 };
-
-/*
- * Error token embedded in the data sent by PXF as part of an error row
- */
-static char *const PXF_ERROR_TOKEN = "PXFERRMSG> ";
-static size_t PXF_ERROR_TOKEN_SIZE = strlen(PXF_ERROR_TOKEN);
 
 /*
  * GetForeignRelSize
@@ -953,7 +953,7 @@ PxfCopyFromErrorCallback(void *arg)
              * "extra data after last expected column" that we want to change to
              * contain the actual error message reported by PXF
              */
-            char *token_index = strnstr(cstate->line_buf.data, PXF_ERROR_TOKEN, cstate->line_buf.len);
+            char *token_index = strstr(cstate->line_buf.data, PXF_ERROR_TOKEN);
             if (token_index != NULL) {
                 /* token was found, get the actual message and set it as the main error message */
                 errmsg("%s", token_index + PXF_ERROR_TOKEN_SIZE);

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenter.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveDataFragmenter.java
@@ -302,11 +302,12 @@ public class HiveDataFragmenter extends HdfsDataFragmenter {
             // if user passed accessor+fragmenter+resolver - use them
             profile = ProfileFactory.get(fformat, hasComplexTypes, userProfile);
         }
-        String fragmenterForProfile;
+        String fragmenterForProfile = context.getFragmenter();
         if (profile != null) {
-            fragmenterForProfile = context.getPluginConf().getPlugins(profile).get("FRAGMENTER");
-        } else {
-            fragmenterForProfile = context.getFragmenter();
+            Map<String, String> plugins = context.getPluginConf().getPlugins(profile);
+            if (plugins != null) {
+                fragmenterForProfile = plugins.get("FRAGMENTER");
+            }
         }
 
         FileInputFormat.setInputPaths(jobConf, new Path(tablePartition.storageDesc.getLocation()));

--- a/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveMetadataFetcher.java
+++ b/server/pxf-hive/src/main/java/org/greenplum/pxf/plugins/hive/HiveMetadataFetcher.java
@@ -144,7 +144,8 @@ public class HiveMetadataFetcher extends BasePlugin implements MetadataFetcher {
     private OutputFormat getOutputFormat(String inputFormat, boolean hasComplexTypes) throws Exception {
         InputFormat<?, ?> fformat = hiveUtilities.makeInputFormat(inputFormat, jobConf);
         String profile = ProfileFactory.get(fformat, hasComplexTypes);
-        String outputFormatClassName = context.getPluginConf().getPlugins(profile).get("OUTPUTFORMAT");
+        Map<String, String> plugins = context.getPluginConf().getPlugins(profile);
+        String outputFormatClassName = plugins != null ? plugins.get("OUTPUTFORMAT") : null;
         return OutputFormat.getOutputFormat(outputFormatClassName);
     }
 

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/BridgeOutputBuilder.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/BridgeOutputBuilder.java
@@ -62,6 +62,7 @@ public class BridgeOutputBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(BridgeOutputBuilder.class);
 
     private static final byte DELIM = 10; /* (byte)'\n'; */
+    public static final String PXF_ERROR_TOKEN = "PXFERRMSG> ";
     private final Charset databaseEncoding;
     private final String newLine;
     private final byte[] newLineBytes;
@@ -131,11 +132,11 @@ public class BridgeOutputBuilder {
             return errorRecord;
         } else {
             // Serialize error text into CSV
-            // We create a row with an extra column containing the error information
+            // We create a row with an extra column containing the error token (used by FDW) and error information
             LOG.error(ex.getMessage(), ex);
             return new Text(
                     StringUtils.repeat(String.valueOf(greenplumCSV.getDelimiter()), columnDescriptors.size()) +
-                            greenplumCSV.toCsvField(ex.getMessage(), true, true, true) +
+                            greenplumCSV.toCsvField(PXF_ERROR_TOKEN + ex.getMessage(), true, true, true) +
                             newLine);
         }
     }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
@@ -40,7 +40,6 @@ public class HttpRequestParser implements RequestParser<MultiValueMap<String, St
     private static final String TRUE_LCASE = "true";
     private static final String PROFILE_SCHEME = "PROFILE-SCHEME";
     private static final String PXF_API_VERSION = "pxfApiVersion";
-    private static final String TEST_PROFILE_PREFIX = "test:";
 
     private final CharsetUtils charsetUtils;
     private final PluginConf pluginConf;
@@ -105,11 +104,8 @@ public class HttpRequestParser implements RequestParser<MultiValueMap<String, St
         // first of all, set profile and enrich parameters with information from specified profile
         String profileUserValue = params.removeUserProperty("PROFILE");
         String profile = profileUserValue == null ? null : profileUserValue.toLowerCase();
-        // test: profile is pseudo-profile used for testing only, there should be no corresponding mappings
-        if (!isTestProfile(profile)) {
-            context.setProfile(profile);
-            addProfilePlugins(profile, params);
-        }
+        context.setProfile(profile);
+        addProfilePlugins(profile, params);
 
         // Ext table uses system property FORMAT for wire serialization format
         String wireFormat = params.removeProperty("FORMAT");
@@ -250,15 +246,6 @@ public class HttpRequestParser implements RequestParser<MultiValueMap<String, St
 
     String getServerApiVersion() {
         return buildProperties.get(PXF_API_VERSION);
-    }
-
-    /**
-     * Checks whether a profile provided in the request is a test profile
-     * @param profile name of the profile
-     * @return true if the profile is a test profile, false otherwise
-     */
-    private boolean isTestProfile(String profile) {
-        return StringUtils.startsWith(profile, TEST_PROFILE_PREFIX);
     }
 
     private void parseGreenplumCSV(RequestMap params, RequestContext context) {

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/ReadServiceImpl.java
@@ -190,13 +190,22 @@ public class ReadServiceImpl extends BaseServiceImpl<OperationStats> implements 
     private void updateProfile(RequestContext context, String profile) {
         context.setProfile(profile);
         PluginConf pluginConf = context.getPluginConf();
+
         Map<String, String> pluginMap = pluginConf.getPlugins(profile);
-        context.setAccessor(pluginMap.get("ACCESSOR"));
-        context.setResolver(pluginMap.get("RESOLVER"));
+        if (pluginMap != null) {
+            context.setAccessor(pluginMap.get("ACCESSOR"));
+            context.setResolver(pluginMap.get("RESOLVER"));
+        }
 
         String handlerClassName = pluginConf.getHandler(profile);
-        Utilities.updatePlugins(context, handlerClassName);
-        context.setProfileScheme(pluginConf.getProtocol(profile));
+        if (handlerClassName != null) {
+            Utilities.updatePlugins(context, handlerClassName);
+        }
+
+        String profileProtocol = pluginConf.getProtocol(profile);
+        if (profileProtocol != null) {
+            context.setProfileScheme(profileProtocol);
+        }
     }
 
 }

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -58,3 +58,7 @@ pxf.features.kerberos.expand-user-principal=true
 pxf.log.level=info
 logging.file.name=${pxf.logdir:/tmp}/pxf-service.log
 logging.file.path=${pxf.logdir:/tmp}
+
+# regex for profile names that makes profiles dynamic, i.e. allows for the profile names to be
+# missing from the profile configuration file and have user specify F/A/R directly as query options
+pxf.profile.dynamic.regex=

--- a/server/pxf-service/src/main/resources/application.properties
+++ b/server/pxf-service/src/main/resources/application.properties
@@ -60,5 +60,7 @@ logging.file.name=${pxf.logdir:/tmp}/pxf-service.log
 logging.file.path=${pxf.logdir:/tmp}
 
 # regex for profile names that makes profiles dynamic, i.e. allows for the profile names to be
-# missing from the profile configuration file and have user specify F/A/R directly as query options
+# missing from the profile configuration file and have user specify Fragmenter / Accessor / Resolver directly
+# as query options. The default value is empty.
+# Used by FDW test cases that setup this property for test:* profiles and custom test Fragmenters / Accessors / Resolvers
 pxf.profile.dynamic.regex=

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/profile/ProfilesConfTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/profile/ProfilesConfTest.java
@@ -58,6 +58,16 @@ public class ProfilesConfTest {
     }
 
     @Test
+    public void undefinedDynamicProfile() {
+        String profileName = "test:foo";
+        ProfilesConf profilesConf = getProfilesConfWithTestDynamicRegex("undefinedProfile");
+        assertNull(profilesConf.getHandler(profileName));
+        assertNull(profilesConf.getOptionMappings(profileName));
+        assertNull(profilesConf.getPlugins(profileName));
+        assertNull(profilesConf.getProtocol(profileName));
+    }
+
+    @Test
     public void testUndefinedProfileWhenGettingProtocol() {
         ProfilesConf profilesConf = getProfilesConf("undefinedProfile");
 
@@ -194,6 +204,12 @@ public class ProfilesConfTest {
 
     private ProfilesConf getProfilesConf(String testCase) {
         return new ProfilesConf(String.format("profile/%s/pxf-profiles-default.xml", testCase),
-                String.format("profile/%s/pxf-profiles.xml", testCase));
+                String.format("profile/%s/pxf-profiles.xml", testCase), null);
     }
+
+    private ProfilesConf getProfilesConfWithTestDynamicRegex(String testCase) {
+        return new ProfilesConf(String.format("profile/%s/pxf-profiles-default.xml", testCase),
+                String.format("profile/%s/pxf-profiles.xml", testCase), "test:.*");
+    }
+
 }


### PR DESCRIPTION
This PR brings in a number of functional changes:

1. ported JSON parsing for error handling for PXF FDW read use cases
2. ported curl debugging from `exttable` extension
3. changed the way PXF CSV wire format reports the error by introducing `PXFERRMSG>` token
4. enabled additional test cases to run against FDW
5. expanded @WorksWithFDW and @FailsWithFDW annotations to class scope
6. introduced `pxf.profile.dynamic.regex` property to be used by tests to work with custom accessors
7. introduced a new build PXF FDW extension build artifact for DEV pipeline only (for now)
8. introduced a test job for GP6 with PXF FDW for DEV pipeline only (for now)