### PR TITLE
Replace shell parameter expansions with Make functions

### DIFF
--- a/cli/go/src/pxf-cli/Makefile
+++ b/cli/go/src/pxf-cli/Makefile
@@ -3,7 +3,7 @@ include ../../../../common.mk
 .PHONY: all build stage install test clean help
 .DEFAULT_GOAL := build
 
-TARGET := $(shell echo $${PWD\#\#*/})
+TARGET := $(notdir $(CURDIR))
 PXF_ROOT_DIR := $(shell cd ../../../.. && pwd)
 PXF_SERVER_DIR := ${PXF_ROOT_DIR}/server
 PXF_CLI_DIR := ${PXF_ROOT_DIR}/cli

--- a/server/Makefile
+++ b/server/Makefile
@@ -48,11 +48,11 @@ compile:
 GRADLEW_TEST_PARAMS = test
 ifneq "$(TEST)" ""
 	# find test file, remove leading "./" and trailing ".java"
-	TEST_FILE = $(shell : "$$(find . -name $(TEST).java)"; : "$${_%.java}"; echo "$${_\#./}")
+	TEST_FILE = $(subst ./,,$(subst .java,,$(shell find . -name $(TEST).java)))
 	# parse out the gradle project by grabbing top-level dir name
-	PROJECT   = $(shell : '${TEST_FILE}'; echo "$${_%%/*}")
+	PROJECT = $(word 1,$(subst /, ,$(TEST_FILE)))
 	# get java-style path with dots, starting at "org"
-	TEST_PATH = $(shell : '${TEST_FILE}'; : "$${_\#${PROJECT}/src/test/java/}"; echo "$${_//\//.}")
+	TEST_PATH = $(subst /,.,$(subst $(PROJECT)/src/test/java/,,$(TEST_FILE)))
 	GRADLEW_TEST_PARAMS = :$(PROJECT):test --rerun-tasks --tests $(TEST_PATH)
 endif
 


### PR DESCRIPTION
The various Makefiles used to build PXF contain a number of shell parameter expansions that either work or cause Make to fail with a syntax error, depending on the version of bash and Make that are installed. This commit replaces these parameter expansions witl Make text functions that are more portable.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>