### PR TITLE
Pass `ENVIRONMENT` var to `Promote PXF-GP5 and PXF-GP6 Artifacts` task.

### DIFF
--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -83,6 +83,7 @@ set-dev-release-pipeline:
 		--pipeline=$(DEV_BUILD_PIPELINE_NAME) \
 		--config "$${PIPELINE_FILE}" \
 		--load-vars-from=$(HOME)/workspace/pxf/concourse/settings/pxf-multinode-params.yml \
+		--var=ud/pxf/dev/git-remote-ssh-url=noop \
 		--var=pxf-git-branch=${BRANCH} \
 		--var=pxf-build-bucket-prefix=dev/$(USER)-$(BRANCH) \
 		--var=pxf-releases-bucket-prefix=dev/$(USER)-$(BRANCH) \

--- a/concourse/README.md
+++ b/concourse/README.md
@@ -75,6 +75,16 @@ By default, these pipelines run perf on RHEL7.
 If you would like to run pipelines using RHEL8, please include `REDHAT_MAJOR_VERSION=8` to the command.
 Ex: `make SCALE=10 REDHAT_MAJOR_VERSION=8 -C "${HOME}/workspace/pxf/concourse" perf`
 
+# Deploy development PXF release pipelines
+
+The dev release pipeline performs most functions of the `pxf-build` release pipeline except for the tagging and bumping of the build version.
+
+To deploy dev release pipeline, use:
+
+```shell
+make -C "${HOME}/workspace/pxf/concourse" dev-release
+```
+
 # Deploy development PXF pipelines
 
 The dev pipeline is an abbreviated version of the `pxf-build` pipeline.

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -1691,6 +1691,7 @@ jobs:
     image: google-cloud-sdk-slim-image
     file: pxf_src/concourse/tasks/promote_pxf_artifacts.yml
     params:
+      ENVIRONMENT: [[ environment ]]
       GCS_RELEASES_BUCKET: ((ud/pxf/common/releases-bucket-name))
       GCS_RELEASES_PATH: [[ environment ]]/releases
       GIT_BRANCH: ((pxf-git-branch))

--- a/concourse/tasks/promote_pxf_artifacts.yml
+++ b/concourse/tasks/promote_pxf_artifacts.yml
@@ -11,6 +11,7 @@ inputs:
 - name: pxf_gp6_tarball_ubuntu18
 
 params:
+  ENVIRONMENT:
   GCS_RELEASES_BUCKET:
   GCS_RELEASES_PATH:
   GIT_BRANCH:


### PR DESCRIPTION
Making it easier to work on the release pipeline in a development environment, the `Promote PXF-GP5 and PXF-GP6 Artifacts` release pipeline task and underlying `promote_pxf_artifacts` task yml and corresponding bash script will be passed the `ENVIRONMENT` variable containing `prod` (production release) or `dev` (development release).

This change was specifically introduced to control the Tagging and Bumping Version Number operations.

Setting the `ENVIRONMENT` variable to `prod` will perform the Tagging and Bumping Version Number operations. Otherwise, these operations are skipped.

Additionally, for dev release pipelines set via the Makefile, set the pipeline variable `ud/pxf/dev/git-remote-ssh-url` to `noop`. This value is assigned to `GIT_REMOTE_URL`. It is unused in the development release pipeline environment. This assignment remains in the Makefile to allow the possibility for developers to perform tagging operations on an alternate non-production git repo.

Update README.md to include reference to the Makefile target `dev-release` to depkloy a developer version of the release pipeline.