### PR TITLE
docs - pxf supports reading parquet lists of certain types

### DIFF
--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -49,6 +49,8 @@ PXF uses the following data type mapping when reading Parquet data:
 |-------------------|---------------|--------------------------|
 | boolean | -- | Boolean |
 | binary \(byte\_array\) | -- | Bytea |
+| binary \(byte\_array\) | Date | Date |
+| binary \(byte\_array\) | Timestamp_millis | Timestamp |
 | binary \(byte\_array\) | UTF8 | Text |
 | double | -- | Float8 |
 | fixed\_len\_byte\_array | Decimal | Numeric |
@@ -69,6 +71,8 @@ PXF can read a Parquet `LIST` nested type when it represents a one dimensional a
 |-------------------|-------------------------|
 | list of \<boolean> | Boolean[] |
 | list of \<binary>  | Bytea[] |
+| list of \<binary> (Date) | Date[] |
+| list of \<binary> (Timestamp_millis) | Timestamp |
 | list of \<binary> (UTF8) | Text[] |
 | list of \<double> | Float8[] |
 | list of \<fixed\_len\_byte\_array> (Decimal) | Numeric[] |

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -49,9 +49,8 @@ PXF uses the following data type mapping when reading Parquet data:
 |-------------------|---------------|--------------------------|
 | boolean | -- | Boolean |
 | byte\_array | -- | Bytea |
-| byte\_array | Date | Date |
-| byte\_array | Timestamp\_millis | Timestamp |
-| byte\_array | all others | Text |
+| byte\_array | UTF8 | Date |
+| byte\_array | String | Text |
 | double | -- | Float8 |
 | fixed\_len\_byte\_array | Decimal | Numeric |
 | float | -- | Real |
@@ -72,8 +71,8 @@ PXF can read a Parquet `LIST` nested type when it represents a one dimensional a
 |-------------------|-------------------------|
 | list of \<boolean> | Boolean[] |
 | list of \<byte\_array> | Bytea[] |
-| list of \<byte\_array> (Date) | Date[] |
-| list of \<byte\_array> (others) | Text[] |
+| list of \<byte\_array> (UTF8) | Date[] |
+| list of \<byte\_array> (String) | Text[] |
 | list of \<double> | Float8[] |
 | list of \<fixed\_len\_byte\_array> (Decimal) | Numeric[] |
 | list of \<float> | Real[] |

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -65,7 +65,7 @@ PXF uses the following data type mapping when reading Parquet data:
 
 **Note**: PXF supports filter predicate pushdown on all parquet data types listed above, *except* the `fixed_len_byte_array` and `int96` types.
 
-PXF can read a Parquet `LIST` nested type when it represents a one dimensional array of certain Parquet types. The supported mappings follow:
+PXF can read a Parquet `LIST` nested type when it represents a one-dimensional array of certain Parquet types. The supported mappings follow:
 
 | Parquet Data Type | PXF/Greenplum Data Type |
 |-------------------|-------------------------|

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -54,7 +54,6 @@ PXF uses the following data type mapping when reading Parquet data:
 | fixed\_len\_byte\_array | Decimal | Numeric |
 | float | -- | Real |
 | int32 | int_8 | Smallint |
-| int32 | int_16, signed | Smallint |
 | int32 | Date | Date |
 | int32 | Decimal | Numeric |
 | int32 | -- | Integer |
@@ -76,7 +75,6 @@ PXF can read a Parquet `LIST` nested type when it represents a one dimensional a
 | list of \<fixed\_len\_byte\_array> (Decimal) | Numeric[] |
 | list of \<float> | Real[] |
 | list of \<int32> (int_8) | Smallint[] |
-| list of \<int32> (int_16, signed) | Smallint[] |
 | list of \<int32> (Date) | Date[] |
 | list of \<int32> (Decimal) | Numeric[] |
 | list of \<int32> | Integer[] |

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -164,7 +164,7 @@ Parquet files that you write to HDFS with PXF have the following naming format: 
 
 ## <a id="parquet_write"></a> Example
 
-This example utilizes the data schema introduced in [Example: Reading Text Data on HDFS](hdfs_text.html#profile_text_query) and adds a new column, `item_quantity_per_order`, an array of `number_of_orders` length that identifies the number of items in each order.
+This example utilizes the data schema introduced in [Example: Reading Text Data on HDFS](hdfs_text.html#profile_text_query) and adds a new column, `item_quantity_per_order`, an array with length equal to `number_of_orders`, that identifies the number of items in each order.
 
 | Column Name  | Data Type |
 |-------|-------------------------------------|

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -49,7 +49,6 @@ PXF uses the following data type mapping when reading Parquet data:
 |-------------------|---------------|--------------------------|
 | boolean | -- | Boolean |
 | byte\_array | -- | Bytea |
-| byte\_array | UTF8 | Date |
 | byte\_array | String | Text |
 | double | -- | Float8 |
 | fixed\_len\_byte\_array | Decimal | Numeric |

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -72,7 +72,7 @@ PXF can read a Parquet `LIST` nested type when it represents a one-dimensional a
 | list of \<boolean> | Boolean[] |
 | list of \<binary>  | Bytea[] |
 | list of \<binary> (Date) | Date[] |
-| list of \<binary> (Timestamp_millis) | Timestamp |
+| list of \<binary> (Timestamp_millis) | Timestamp[] |
 | list of \<binary> (UTF8) | Text[] |
 | list of \<double> | Float8[] |
 | list of \<fixed\_len\_byte\_array> (Decimal) | Numeric[] |

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -45,26 +45,47 @@ Parquet supports a small set of primitive data types, and uses metadata annotati
 
 PXF uses the following data type mapping when reading Parquet data:
 
-| Parquet Data Type | Original Type | PXF/Greenplum Data Type |
+| Parquet Physical Type | Parquet Logical Type | PXF/Greenplum Data Type |
 |-------------------|---------------|--------------------------|
-| binary (byte_array) | Date | Date |
-| binary (byte_array) | Timestamp_millis | Timestamp |
-| binary (byte_array) | all others | Text |
-| binary (byte_array) | -- | Bytea |
 | boolean | -- | Boolean |
+| byte\_array | -- | Bytea |
+| byte\_array | Date | Date |
+| byte\_array | Timestamp\_millis | Timestamp |
+| byte\_array | all others | Text |
 | double | -- | Float8 |
-| fixed\_len\_byte\_array | -- | Numeric |
+| fixed\_len\_byte\_array | Decimal | Numeric |
 | float | -- | Real |
+| int32 | int_8 | Smallint |
+| int32 | int_16, signed | Smallint |
 | int32 | Date | Date |
 | int32 | Decimal | Numeric |
-| int32 | int_8 | Smallint |
-| int32 | int_16 | Smallint |
 | int32 | -- | Integer |
 | int64 | Decimal | Numeric |
 | int64 | -- | Bigint |
-| int96 | -- | Timestamp |
+| int96 | Timestamp | Timestamp |
 
 **Note**: PXF supports filter predicate pushdown on all parquet data types listed above, *except* the `fixed_len_byte_array` and `int96` types.
+
+PXF can read a Parquet `LIST` nested type when it represents a one dimensional array of certain Parquet types. The supported mappings follow:
+
+| Parquet Data Type | PXF/Greenplum Data Type |
+|-------------------|-------------------------|
+| list of \<boolean> | Boolean[] |
+| list of \<byte\_array> | Bytea[] |
+| list of \<byte\_array> (Date) | Date[] |
+| list of \<byte\_array> (others) | Text[] |
+| list of \<double> | Float8[] |
+| list of \<fixed\_len\_byte\_array> (Decimal) | Numeric[] |
+| list of \<float> | Real[] |
+| list of \<int32> (int_8) | Smallint[] |
+| list of \<int32> (int_16, signed) | Smallint[] |
+| list of \<int32> (Date) | Date[] |
+| list of \<int32> (Decimal) | Numeric[] |
+| list of \<int32> | Integer[] |
+| list of \<int64> (Decimal) | Numeric[] |
+| list of \<int64> | Bigint[] |
+| list of \<int96> | Timestamp[] |
+
 
 ### <a id="datatype_map_Write "></a>Write Mapping
 
@@ -143,13 +164,14 @@ Parquet files that you write to HDFS with PXF have the following naming format: 
 
 ## <a id="parquet_write"></a> Example
 
-This example utilizes the data schema introduced in [Example: Reading Text Data on HDFS](hdfs_text.html#profile_text_query).
+This example utilizes the data schema introduced in [Example: Reading Text Data on HDFS](hdfs_text.html#profile_text_query) and adds a new column, `item_quantity_per_order`, an array of `number_of_orders` length that identifies the number of items in each order.
 
 | Column Name  | Data Type |
 |-------|-------------------------------------|
 | location | text |
 | month | text |
 | number\_of\_orders | int |
+| item\_quantity\_per\_order | int[] |
 | total\_sales | float8 |
 
 In this example, you create a Parquet-format writable external table that uses the default PXF server to reference Parquet-format data in HDFS, insert some data into the table, and then create a readable external table to read the data.
@@ -157,7 +179,7 @@ In this example, you create a Parquet-format writable external table that uses t
 1. Use the `hdfs:parquet` profile to create a writable external table. For example:
 
     ``` sql
-    postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_tbl_parquet (location text, month text, number_of_orders int, total_sales double precision)
+    postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_tbl_parquet (location text, month text, number_of_orders int, item_quantity_per_order int[], total_sales double precision)
         LOCATION ('pxf://data/pxf_examples/pxf_parquet?PROFILE=hdfs:parquet')
       FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
     ```
@@ -165,14 +187,14 @@ In this example, you create a Parquet-format writable external table that uses t
 2. Write a few records to the `pxf_parquet` HDFS directory by inserting directly into the `pxf_tbl_parquet` table. For example:
 
     ``` sql
-    postgres=# INSERT INTO pxf_tbl_parquet VALUES ( 'Frankfurt', 'Mar', 777, 3956.98 );
-    postgres=# INSERT INTO pxf_tbl_parquet VALUES ( 'Cleveland', 'Oct', 3812, 96645.37 );
+    postgres=# INSERT INTO pxf_tbl_parquet VALUES ( 'Frankfurt', 'Mar', 3, '{1,11,111}', 3956.98 );
+    postgres=# INSERT INTO pxf_tbl_parquet VALUES ( 'Cleveland', 'Oct', 2, '{3333,7777}', 96645.37 );
     ```
 
 3. Recall that Greenplum Database does not support directly querying a writable external table. To read the data in `pxf_parquet`, create a readable external Greenplum Database referencing this HDFS directory:
 
     ``` sql
-    postgres=# CREATE EXTERNAL TABLE read_pxf_parquet(location text, month text, number_of_orders int, total_sales double precision)
+    postgres=# CREATE EXTERNAL TABLE read_pxf_parquet(location text, month text, number_of_orders int, item_quantity_per_order int[], total_sales double precision)
         LOCATION ('pxf://data/pxf_examples/pxf_parquet?PROFILE=hdfs:parquet')
         FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
     ```
@@ -184,10 +206,10 @@ In this example, you create a Parquet-format writable external table that uses t
     ```
 
     ``` pre
-     location  | month | number_of_orders | total_sales
-    -----------+-------+------------------+-------------
-     Frankfurt | Mar   |              777 |     3956.98
-     Cleveland | Oct   |             3812 |     96645.4
+     location  | month | number_of_orders | item_quantity_per_order | total_sales
+    -----------+-------+------------------+-------------------------+-------------
+     Frankfurt | Mar   |              777 | {1,11,111}              |     3956.98
+     Cleveland | Oct   |             3812 | {3333,7777}             |    96645.4
     (2 rows)
     ```
 

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -59,7 +59,7 @@ PXF uses the following data type mapping when reading Parquet data:
 | int32 | -- | Integer |
 | int64 | Decimal | Numeric |
 | int64 | -- | Bigint |
-| int96 | Timestamp | Timestamp |
+| int96 | -- | Timestamp |
 
 **Note**: PXF supports filter predicate pushdown on all parquet data types listed above, *except* the `fixed_len_byte_array` and `int96` types.
 

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -49,7 +49,7 @@ PXF uses the following data type mapping when reading Parquet data:
 |-------------------|---------------|--------------------------|
 | boolean | -- | Boolean |
 | binary \(byte\_array\) | -- | Bytea |
-| binary \(byte\_array\) | String | Text |
+| binary \(byte\_array\) | UTF8 | Text |
 | double | -- | Float8 |
 | fixed\_len\_byte\_array | Decimal | Numeric |
 | float | -- | Real |

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -48,8 +48,8 @@ PXF uses the following data type mapping when reading Parquet data:
 | Parquet Physical Type | Parquet Logical Type | PXF/Greenplum Data Type |
 |-------------------|---------------|--------------------------|
 | boolean | -- | Boolean |
-| byte\_array | -- | Bytea |
-| byte\_array | String | Text |
+| binary \(byte\_array\) | -- | Bytea |
+| binary \(byte\_array\) | String | Text |
 | double | -- | Float8 |
 | fixed\_len\_byte\_array | Decimal | Numeric |
 | float | -- | Real |
@@ -68,9 +68,8 @@ PXF can read a Parquet `LIST` nested type when it represents a one dimensional a
 | Parquet Data Type | PXF/Greenplum Data Type |
 |-------------------|-------------------------|
 | list of \<boolean> | Boolean[] |
-| list of \<byte\_array> | Bytea[] |
-| list of \<byte\_array> (UTF8) | Date[] |
-| list of \<byte\_array> (String) | Text[] |
+| list of \<binary>  | Bytea[] |
+| list of \<binary> (UTF8) | Text[] |
 | list of \<double> | Float8[] |
 | list of \<fixed\_len\_byte\_array> (Decimal) | Numeric[] |
 | list of \<float> | Real[] |

--- a/docs/content/objstore_parquet.html.md.erb
+++ b/docs/content/objstore_parquet.html.md.erb
@@ -81,7 +81,7 @@ Refer to the [Example](hdfs_parquet.html#parquet_write) in the PXF HDFS Parquet 
 - Using the `CREATE WRITABLE EXTERNAL TABLE` syntax and `LOCATION` keywords and settings described above for the writable external table. For example, if your server name is `s3srvcfg`:
 
     ``` sql
-    CREATE WRITABLE EXTERNAL TABLE pxf_tbl_parquet_s3 (location text, month text, number_of_orders int, total_sales double precision)
+    CREATE WRITABLE EXTERNAL TABLE pxf_tbl_parquet_s3 (location text, month text, number_of_orders int, item_quantity_per_order int[], total_sales double precision)
       LOCATION ('pxf://BUCKET/pxf_examples/pxf_parquet?PROFILE=s3:parquet&SERVER=s3srvcfg')
     FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
     ```
@@ -89,7 +89,7 @@ Refer to the [Example](hdfs_parquet.html#parquet_write) in the PXF HDFS Parquet 
 - Using the `CREATE EXTERNAL TABLE` syntax and `LOCATION` keywords and settings described above for the readable external table. For example, if your server name is `s3srvcfg`:
 
     ``` sql
-    CREATE EXTERNAL TABLE read_pxf_parquet_s3(location text, month text, number_of_orders int, total_sales double precision)
+    CREATE EXTERNAL TABLE read_pxf_parquet_s3(location text, month text, number_of_orders int, item_quantity_per_order int[], total_sales double precision)
       LOCATION ('pxf://BUCKET/pxf_examples/pxf_parquet?PROFILE=s3:parquet&SERVER=s3srvcfg')
     FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
     ```


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/895.

update the data type mapping, and include a list/array column in the example.  i did not test out the example with pxf, it does work with a regular table.

i am not sure if i captured the data type mapping correctly.  please check that.

doc review site link (behind VPN):  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/pqlist/tanzu-greenplum-platform-extension-framework/GUID-hdfs_parquet.html#datatype_map