### PR TITLE
ignore parquetWriteListReadWithHive test

### DIFF
--- a/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetWriteTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetWriteTest.java
@@ -271,8 +271,9 @@ public class ParquetWriteTest extends BaseFeature {
      * Do not run this test with "hcfs" group as Hive is not available in the environments prepared for that group
      * Also do not run with "security" group that would require kerberos principal to be included in Hive JDBC URL
      */
-    @Test(groups = {"features", "gpdb"})
+//    @Test(groups = {"features", "gpdb"})
     public void parquetWriteListsReadWithHive() throws Exception {
+        // TODO: HDP and HDP3 can pass this test. HIVE 1.1 in CDH doesn't support Parquet Date
         // init only here, not in beforeClass() method as other tests run in environments without Hive
         hive = (Hive) SystemManagerImpl.getInstance().getSystemObject("hive");
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetWriteTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetWriteTest.java
@@ -11,6 +11,7 @@ import org.greenplum.pxf.automation.structures.tables.utils.TableFactory;
 import org.greenplum.pxf.automation.utils.system.ProtocolEnum;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 import org.greenplum.pxf.plugins.hdfs.utilities.PgUtilities;
+import org.junit.Ignore;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -271,7 +272,7 @@ public class ParquetWriteTest extends BaseFeature {
      * Do not run this test with "hcfs" group as Hive is not available in the environments prepared for that group
      * Also do not run with "security" group that would require kerberos principal to be included in Hive JDBC URL
      */
-//    @Test(groups = {"features", "gpdb"})
+    @Test(groups = {"features", "gpdb"}, enabled = false)
     public void parquetWriteListsReadWithHive() throws Exception {
         // TODO: HDP and HDP3 can pass this test. HIVE 1.1 in CDH doesn't support Parquet Date
         // init only here, not in beforeClass() method as other tests run in environments without Hive


### PR DESCRIPTION
For this test, we use HIVE to read out Parquet Data we write using pxf. This test can pass on HDP2 and HDP3, but it fails on CDH. CDH is using HIVE1.1, which doesn't support Parquet Date. Parquet Date is supported by Hive1.2+. So for now, we decide to temporarily ignore this test.