### PR TITLE
PXF Cloud Build Trigger: pxf-5-build-base is failing due to missing ginkgo version

### DIFF
--- a/concourse/docker/pxf-build-base/Dockerfile
+++ b/concourse/docker/pxf-build-base/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 RUN cd /tmp && \
     wget -O go.tgz -q https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go.tgz && rm go.tgz && \
-    GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo
+    GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo@latest
 
 ADD . /tmp/pxf_src
 


### PR DESCRIPTION
The PXF Cloud Build Trigger pxf-5-build-base is failing due to missing ginkgo version at installation time.

Here is the ginkgo installation error:

```
Step #1 - "pxf-build-dependencies": Step 3/5 : RUN cd /tmp && wget -O go.tgz -q https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz && tar -C /usr/local -xzf go.tgz && rm go.tgz && GOPATH=/opt/go /usr/local/go/bin/go install github.com/onsi/ginkgo/ginkgo
Step #1 - "pxf-build-dependencies": ---> Running in 7f7fdec5bc25
Step #1 - "pxf-build-dependencies": go install: version is required when current directory is not in a module
Step #1 - "pxf-build-dependencies": Try 'go install github.com/onsi/ginkgo/ginkgo@latest' to install the latest version
```
The error recommendation (go install github.com/onsi/ginkgo/ginkgo@latest) to specify the ginkgo version corrects this issue.