### PR TITLE
Update PXF CI code to replace mdw with cdw

### DIFF
--- a/automation/src/test/resources/sut/MultiHadoopIPAMultiNodesCluster.xml
+++ b/automation/src/test/resources/sut/MultiHadoopIPAMultiNodesCluster.xml
@@ -10,7 +10,7 @@
             <class>
                 org.greenplum.pxf.automation.components.cluster.installer.nodes.MasterNode
             </class>
-            <host>mdw</host>
+            <host>cdw</host>
             <userName>gpadmin</userName>
             <password></password>
             <services>gpdb,pxf</services>
@@ -38,7 +38,7 @@
     <gpdb>
         <class>org.greenplum.pxf.automation.components.gpdb.Gpdb</class>
         <host>localhost</host>
-        <masterHost>mdw</masterHost>
+        <masterHost>cdw</masterHost>
         <userName>gpadmin</userName>
         <db>pxfautomation</db>
     </gpdb>
@@ -46,7 +46,7 @@
     <gpdb2>
         <class>org.greenplum.pxf.automation.components.gpdb.Gpdb</class>
         <host>localhost</host>
-        <masterHost>mdw</masterHost>
+        <masterHost>cdw</masterHost>
         <userName>gpadmin</userName>
         <db>pxfautomation_encoding</db>
         <encoding>WIN1251</encoding>

--- a/automation/src/test/resources/sut/MultiHadoopMultiNodesCluster.xml
+++ b/automation/src/test/resources/sut/MultiHadoopMultiNodesCluster.xml
@@ -10,7 +10,7 @@
             <class>
                 org.greenplum.pxf.automation.components.cluster.installer.nodes.MasterNode
             </class>
-            <host>mdw</host>
+            <host>cdw</host>
             <userName>gpadmin</userName>
             <password></password>
             <services>gpdb,pxf</services>
@@ -38,7 +38,7 @@
     <gpdb>
         <class>org.greenplum.pxf.automation.components.gpdb.Gpdb</class>
         <host>localhost</host>
-        <masterHost>mdw</masterHost>
+        <masterHost>cdw</masterHost>
         <userName>gpadmin</userName>
         <db>pxfautomation</db>
     </gpdb>
@@ -46,7 +46,7 @@
     <gpdb2>
         <class>org.greenplum.pxf.automation.components.gpdb.Gpdb</class>
         <host>localhost</host>
-        <masterHost>mdw</masterHost>
+        <masterHost>cdw</masterHost>
         <userName>gpadmin</userName>
         <db>pxfautomation_encoding</db>
         <encoding>WIN1251</encoding>

--- a/automation/src/test/resources/sut/MultiNodesCluster.xml
+++ b/automation/src/test/resources/sut/MultiNodesCluster.xml
@@ -6,7 +6,7 @@
 		<hiveBaseHdfsDirectory>/hive/warehouse/</hiveBaseHdfsDirectory>
 		<nodes index="0">
 			<class>org.greenplum.pxf.automation.components.cluster.installer.nodes.MasterNode</class>
-			<host>mdw</host>
+			<host>cdw</host>
 			<userName>gpadmin</userName>
 			<password></password>
 			<services>gpdb,pxf</services>
@@ -30,7 +30,7 @@
 	<gpdb>
 		<class>org.greenplum.pxf.automation.components.gpdb.Gpdb</class>
 		<host>localhost</host>
-		<masterHost>mdw</masterHost>
+		<masterHost>cdw</masterHost>
 		<userName>gpadmin</userName>
 		<db>pxfautomation</db>
 	</gpdb>
@@ -38,7 +38,7 @@
 	<gpdb2>
 		<class>org.greenplum.pxf.automation.components.gpdb.Gpdb</class>
 		<host>localhost</host>
-		<masterHost>mdw</masterHost>
+		<masterHost>cdw</masterHost>
 		<userName>gpadmin</userName>
 		<db>pxfautomation_encoding</db>
 		<encoding>WIN1251</encoding>

--- a/concourse/scripts/cli/common.sh
+++ b/concourse/scripts/cli/common.sh
@@ -138,13 +138,13 @@ list_remote_pxf_running_pid() {
   ssh "${1}" "ps -aef | grep pxf | grep -v grep | tr -s ' ' | cut -d ' ' -f 2"
 }
 
-has_standby_master() {
-  grep -q smdw hostfile_all
+has_standby_coordinator() {
+  grep -q scdw hostfile_all
 }
 
 get_cluster_description() {
   local cluster_description="master host"
-  if has_standby_master; then
+  if has_standby_coordinator; then
     cluster_description+=", standby master host,"
   fi
   local num_segment_hosts
@@ -156,7 +156,7 @@ get_cluster_description() {
 
 get_cluster_sync_description() {
   local cluster_sync_description="master host to "
-  if has_standby_master; then
+  if has_standby_coordinator; then
     cluster_sync_description+="standby master host and "
   fi
   local num_segment_hosts

--- a/concourse/scripts/cli/test_stop_start_restart_status.sh
+++ b/concourse/scripts/cli/test_stop_start_restart_status.sh
@@ -107,11 +107,11 @@ run_test test_stop_succeeds_none_running "pxf cluster stop (none running) should
 expected_status_message=\
 "Checking status of PXF servers on ${cluster_description}\n\
 ERROR: PXF is not running on ${num_hosts} out of ${num_hosts} hosts\n\
-mdw ==> ${yellow}Checking if PXF is up and running...${reset}\n\
+cdw ==> ${yellow}Checking if PXF is up and running...${reset}\n\
 ${red}ERROR: PXF is down - the application is not running${reset}...\n"
 
-if has_standby_master; then
-  expected_status_message+="smdw ==> ${yellow}Checking if PXF is up and running...${reset}\n${red}ERROR: PXF is down - the application is not running${reset}...\n"
+if has_standby_coordinator; then
+  expected_status_message+="scdw ==> ${yellow}Checking if PXF is up and running...${reset}\n${red}ERROR: PXF is down - the application is not running${reset}...\n"
 fi
 
 expected_status_message+=\
@@ -305,7 +305,7 @@ expected_restart_message=\
 "Restarting PXF on ${cluster_description}
 PXF restarted successfully on ${num_hosts} out of ${num_hosts} hosts"
 test_restart_succeeds_one_running() {
-  # given: PXF is not running on master, standby master or segment host 2
+  # given: PXF is not running on coordinator, standby coordinator or segment host 2
   for host in "${all_cluster_hosts[@]}"; do
     [[ $host == sdw1 ]] && continue
 
@@ -345,7 +345,7 @@ test_start_succeeds_one_running() {
   # given: PXF is running on segment host 1
   local sdw1_pid="$(list_remote_pxf_running_pid sdw1)"
   assert_not_empty "${sdw1_pid}" "PXF should be running on host sdw1"
-  #      : AND PXF is not running on master, standby master or segment host 2
+  #      : AND PXF is not running on coordinator, standby coordinator or segment host 2
   for host in "${all_cluster_hosts[@]}"; do
     [[ $host == sdw1 ]] && continue
 
@@ -378,11 +378,11 @@ run_test test_start_succeeds_one_running "pxf cluster start (one running) should
 expected_status_message=\
 "Checking status of PXF servers on ${cluster_description}\n\
 ERROR: PXF is not running on $((num_hosts-1)) out of ${num_hosts} hosts\n\
-mdw ==> ${yellow}Checking if PXF is up and running...${reset}\n\
+cdw ==> ${yellow}Checking if PXF is up and running...${reset}\n\
 ${red}ERROR: PXF is down - the application is not running${reset}...\n"
 
-if has_standby_master; then
-  expected_status_message+="smdw ==> ${yellow}Checking if PXF is up and running...${reset}\n${red}ERROR: PXF is down - the application is not running${reset}...\n"
+if has_standby_coordinator; then
+  expected_status_message+="scdw ==> ${yellow}Checking if PXF is up and running...${reset}\n${red}ERROR: PXF is down - the application is not running${reset}...\n"
 fi
 
 expected_status_message+=\
@@ -412,7 +412,7 @@ expected_stop_message=\
 "Stopping PXF on ${cluster_description}
 PXF stopped successfully on ${num_hosts} out of ${num_hosts} hosts"
 test_stop_succeeds_one_running() {
-  # given: PXF is not running on master, standby master or segment host 2
+  # given: PXF is not running on coordinator, standby coordinator or segment host 2
   for host in "${all_cluster_hosts[@]}"; do
     [[ ${host} == sdw1 ]] && continue
 

--- a/concourse/scripts/cli/test_sync.sh
+++ b/concourse/scripts/cli/test_sync.sh
@@ -22,7 +22,7 @@ expected_sync_message=\
 PXF configs synced successfully on $((num_hosts-1)) out of $((num_hosts-1)) hosts"
 
 expected_cluster_configs=\
-"mdw:
+"cdw:
 1
 2
 3
@@ -38,19 +38,19 @@ sdw2:
 3
 ${PXF_BASE_DIR}/conf/foo.jar"
 
-if has_standby_master; then
-  printf -v expected_cluster_configs "%s\nsmdw:\n1\n2\n3\n${PXF_BASE_DIR}/conf/foo.jar" "${expected_cluster_configs}"
+if has_standby_coordinator; then
+  printf -v expected_cluster_configs "%s\nscdw:\n1\n2\n3\n${PXF_BASE_DIR}/conf/foo.jar" "${expected_cluster_configs}"
 fi
 
 test_sync_succeeds() {
   # given:
   for host in "${all_cluster_hosts[@]}"; do
-    [[ $host == mdw ]] && continue
+    [[ $host == cdw ]] && continue
     #    : files do not exist on remote hosts
     remove_remote_configs "${host}"
     assert_empty "$(list_remote_configs ${host})" "config files should not exist on host ${host}"
   done
-  #      : AND new files are created on master host
+  #      : AND new files are created on coordinator host
   rm -rf "${PXF_BASE_DIR}/servers/foo"
   rm -f  "${PXF_BASE_DIR}/conf/foo.jar"
   mkdir -p "${PXF_BASE_DIR}/servers/foo"
@@ -71,7 +71,7 @@ expected_sync_message=\
 PXF configs synced successfully on $((num_hosts-1)) out of $((num_hosts-1)) hosts"
 
 expected_cluster_configs=\
-"mdw:
+"cdw:
 1
 2
 3
@@ -86,32 +86,32 @@ sdw2:
 3
 ${PXF_BASE_DIR}/conf/foo.jar"
 
-if has_standby_master; then
-  printf -v expected_cluster_configs "%s\nsmdw:\n1\n2\n3\n${PXF_BASE_DIR}/conf/foo.jar" "${expected_cluster_configs}"
+if has_standby_coordinator; then
+  printf -v expected_cluster_configs "%s\nscdw:\n1\n2\n3\n${PXF_BASE_DIR}/conf/foo.jar" "${expected_cluster_configs}"
 fi
 
 test_sync_succeeds_no_delete() {
   # given:
   for host in "${all_cluster_hosts[@]}"; do
-    [[ $host == mdw ]] && continue
+    [[ $host == cdw ]] && continue
     #    : files exist on remote hosts
     assert_equals "${PXF_BASE_DIR}/conf/foo.jar" "$(list_remote_file ${host} "${PXF_BASE_DIR}/conf/foo.jar")" "foo.jar should exist on host ${host}"
   done
-  #      : AND the file is removed from the master host
+  #      : AND the file is removed from the coordinator host
   rm -f "${PXF_BASE_DIR}/conf/foo.jar"
   # when : "pxf cluster sync" command is run
   local result="$(pxf cluster sync)"
   # then : it succeeds and prints the expected message
   assert_equals "${expected_sync_message}" "${result}" "pxf cluster sync should succeed"
   #      : AND foo.jar should still exist on remote hosts
-  assert_equals "${expected_cluster_configs}" "$(list_cluster_configs)" "foo.jar should be missing from mdw"
+  assert_equals "${expected_cluster_configs}" "$(list_cluster_configs)" "foo.jar should be missing from cdw"
 }
 run_test test_sync_succeeds_no_delete "pxf cluster sync (no delete) should succeed"
 # ============================================================================================================
 
 # === Test "pxf cluster sync (delete one host)" ==============================================================
 expected_cluster_configs=\
-"mdw:
+"cdw:
 1
 2
 3
@@ -125,18 +125,18 @@ sdw2:
 3
 ${PXF_BASE_DIR}/conf/foo.jar"
 
-if has_standby_master; then
-  printf -v expected_cluster_configs "%s\nsmdw:\n1\n2\n3\n${PXF_BASE_DIR}/conf/foo.jar" "${expected_cluster_configs}"
+if has_standby_coordinator; then
+  printf -v expected_cluster_configs "%s\nscdw:\n1\n2\n3\n${PXF_BASE_DIR}/conf/foo.jar" "${expected_cluster_configs}"
 fi
 
 test_sync_succeeds_delete_one_host() {
   # given:
   for host in "${all_cluster_hosts[@]}"; do
-    [[ $host == mdw ]] && continue
+    [[ $host == cdw ]] && continue
     #    : files exist on remote hosts
     assert_equals "${PXF_BASE_DIR}/conf/foo.jar" "$(list_remote_file ${host} "${PXF_BASE_DIR}/conf/foo.jar")" "foo.jar should exist on host ${host}"
   done
-  #      : AND the file is removed from the master host
+  #      : AND the file is removed from the coordinator host
   rm -f "${PXF_BASE_DIR}/conf/foo.jar"
   # when : "pxf sync --delete" command is run for one host
   local result1="$(pxf sync --delete sdw1)"
@@ -146,7 +146,7 @@ test_sync_succeeds_delete_one_host() {
   assert_empty "${result1}" "pxf sync --delete sdw1 should succeed"
   assert_empty "${result2}" "pxf sync sdw2 should succeed"
   #      : AND foo.jar should be removed from sdw1 only
-  assert_equals "${expected_cluster_configs}" "$(list_cluster_configs)" "foo.jar should be missing from mdw and sdw1"
+  assert_equals "${expected_cluster_configs}" "$(list_cluster_configs)" "foo.jar should be missing from cdw and sdw1"
 }
 run_test test_sync_succeeds_delete_one_host "pxf cluster sync (delete one host) should succeed"
 # ============================================================================================================
@@ -156,7 +156,7 @@ expected_sync_message=\
 "Syncing PXF configuration files from ${cluster_sync_description}
 PXF configs synced successfully on $((num_hosts-1)) out of $((num_hosts-1)) hosts"
 expected_cluster_configs=\
-"mdw:
+"cdw:
 2
 3
 sdw1:
@@ -169,25 +169,25 @@ sdw2:
 3
 ${PXF_BASE_DIR}/conf/foo.jar"
 
-if has_standby_master; then
-  printf -v expected_cluster_configs "%s\nsmdw:\n1\n2\n3\n${PXF_BASE_DIR}/conf/foo.jar" "${expected_cluster_configs}"
+if has_standby_coordinator; then
+  printf -v expected_cluster_configs "%s\nscdw:\n1\n2\n3\n${PXF_BASE_DIR}/conf/foo.jar" "${expected_cluster_configs}"
 fi
 
 test_sync_succeeds_no_delete_server_conf() {
   # given:
   for host in "${all_cluster_hosts[@]}"; do
-    [[ $host == mdw ]] && continue
+    [[ $host == cdw ]] && continue
     #    : files exist on remote hosts
     assert_equals "${PXF_BASE_DIR}/servers/foo/1" "$(list_remote_file ${host} "${PXF_BASE_DIR}/servers/foo/1")" "servers/foo/1 should exist on host ${host}"
   done
-  #      : AND the file is removed from the master host
+  #      : AND the file is removed from the coordinator host
   rm -f "${PXF_BASE_DIR}/servers/foo/1"
   # when : "pxf cluster sync" command is run
   local result="$(pxf cluster sync)"
   # then : it succeeds and prints the expected message
   assert_equals "${expected_sync_message}" "${result}" "pxf cluster sync should succeed"
   #      : AND servers/foo/1 should still exist on remote hosts
-  assert_equals "${expected_cluster_configs}" "$(list_cluster_configs)" "servers/foo/1 should be missing from mdw"
+  assert_equals "${expected_cluster_configs}" "$(list_cluster_configs)" "servers/foo/1 should be missing from cdw"
 }
 run_test test_sync_succeeds_no_delete_server_conf "pxf cluster sync (no delete server conf) should succeed"
 # ============================================================================================================
@@ -197,7 +197,7 @@ expected_sync_message=\
 "Syncing PXF configuration files from ${cluster_sync_description}
 PXF configs synced successfully on $((num_hosts-1)) out of $((num_hosts-1)) hosts"
 expected_cluster_configs=\
-"mdw:
+"cdw:
 2
 3
 sdw1:
@@ -207,18 +207,18 @@ sdw2:
 2
 3"
 
-if has_standby_master; then
-  printf -v expected_cluster_configs "%s\nsmdw:\n2\n3" "${expected_cluster_configs}"
+if has_standby_coordinator; then
+  printf -v expected_cluster_configs "%s\nscdw:\n2\n3" "${expected_cluster_configs}"
 fi
 
 test_sync_succeeds_delete_server_conf() {
   # given:
   for host in "${all_cluster_hosts[@]}"; do
-    [[ $host == mdw ]] && continue
+    [[ $host == cdw ]] && continue
     #    : files exist on remote hosts
     assert_equals "${PXF_BASE_DIR}/servers/foo/1" "$(list_remote_file ${host} "${PXF_BASE_DIR}/servers/foo/1")" "servers/foo/1 should exist on host ${host}"
   done
-  #      : AND the file is removed from the master host
+  #      : AND the file is removed from the coordinator host
   rm -f "${PXF_BASE_DIR}/servers/foo/1"
   # when : "pxf cluster sync --delete" command is run
   local result="$(pxf cluster sync --delete)"
@@ -235,22 +235,22 @@ expected_sync_message=\
 "Syncing PXF configuration files from ${cluster_sync_description}
 PXF configs synced successfully on $((num_hosts-1)) out of $((num_hosts-1)) hosts"
 expected_cluster_configs=\
-"mdw:
+"cdw:
 sdw1:
 sdw2:"
 
-if has_standby_master; then
-  printf -v expected_cluster_configs "%s\nsmdw:" "${expected_cluster_configs}"
+if has_standby_coordinator; then
+  printf -v expected_cluster_configs "%s\nscdw:" "${expected_cluster_configs}"
 fi
 
 test_sync_succeeds_delete_server() {
   # given:
   for host in "${all_cluster_hosts[@]}"; do
-    [[ $host == mdw ]] && continue
+    [[ $host == cdw ]] && continue
     #    : server directory exists on remote hosts
     assert_equals "${PXF_BASE_DIR}/servers/foo" "$(echo_remote_dir ${host} "${PXF_BASE_DIR}/servers/foo")" "servers/foo should exist on host ${host}"
   done
-  #      : AND the server directory is removed from the master host
+  #      : AND the server directory is removed from the coordinator host
   rm -rf "${PXF_BASE_DIR}/servers/foo"
   # when : "pxf cluster sync --delete" command is run
   local result="$(pxf cluster sync --delete)"
@@ -267,30 +267,30 @@ expected_sync_message=\
 "Syncing PXF configuration files from master host to 2 segment hosts...
 PXF configs synced successfully on 2 out of 2 hosts"
 expected_cluster_configs=\
-"mdw:
+"cdw:
 ${PXF_BASE_DIR}/conf/foo.jar
 sdw1:
 ${PXF_BASE_DIR}/conf/foo.jar
 sdw2:
 ${PXF_BASE_DIR}/conf/foo.jar"
 
-if has_standby_master; then
-  printf -v expected_cluster_configs "%s\nsmdw:" "${expected_cluster_configs}"
+if has_standby_coordinator; then
+  printf -v expected_cluster_configs "%s\nscdw:" "${expected_cluster_configs}"
 fi
 
 test_sync_succeeds_no_standby() {
   # given:
   for host in "${all_cluster_hosts[@]}"; do
-    [[ $host == mdw ]] && continue
+    [[ $host == cdw ]] && continue
     #    : files do not exist on remote hosts
     remove_remote_configs "${host}"
     assert_empty "$(list_remote_configs ${host})" "config files should not exist on host ${host}"
   done
-  #      : AND new file is created on master host
+  #      : AND new file is created on coordinator host
   touch "${PXF_BASE_DIR}/conf/foo.jar"
-  #      : AND the standby master is no longer on smdw
+  #      : AND the standby coordinator is no longer on scdw
   source "${GPHOME}/greenplum_path.sh"
-  if has_standby_master; then
+  if has_standby_coordinator; then
     gpinitstandby -ar >/dev/null
   fi
   # when : "pxf cluster sync" command is run
@@ -298,14 +298,14 @@ test_sync_succeeds_no_standby() {
   # then : it succeeds and prints the expected message
   assert_equals "${expected_sync_message}" "${result}" "pxf cluster sync should succeed"
   #      : AND the files appear on segment hosts, but not on the former standby host
-  assert_equals "${expected_cluster_configs}" "$(list_cluster_configs)" "foo.jar should be missing from smdw"
+  assert_equals "${expected_cluster_configs}" "$(list_cluster_configs)" "foo.jar should be missing from scdw"
 }
 run_test test_sync_succeeds_no_standby "pxf cluster sync (no standby) should succeed"
 # ============================================================================================================
 
-# put standby master back on smdw
-if has_standby_master; then
-  gpinitstandby -as smdw >/dev/null
+# put standby coordinator back on scdw
+if has_standby_coordinator; then
+  gpinitstandby -as scdw >/dev/null
 fi
 
 exit_with_err "${BASH_SOURCE[0]}"

--- a/concourse/scripts/pxf-perf-multi-node.bash
+++ b/concourse/scripts/pxf-perf-multi-node.bash
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-export PGHOST=mdw
+export PGHOST=cdw
 export PGUSER=gpadmin
 export PGDATABASE=tpch
 GPHOME="/usr/local/greenplum-db-devel"
@@ -98,7 +98,7 @@ function read_and_validate_table_count() {
 }
 
 function sync_configuration() {
-    gpssh -u gpadmin -h mdw -v -s -e "${PXF_HOME}/bin/pxf cluster sync"
+    gpssh -u gpadmin -h cdw -v -s -e "${PXF_HOME}/bin/pxf cluster sync"
 }
 
 function create_database_and_schema() {
@@ -189,10 +189,10 @@ function validate_write_to_external() {
 function configure_adl_server() {
     ADL_SERVER_DIR="${PXF_SERVER_DIR}/adlbenchmark"
     # Create the ADL Benchmark server and copy core-site.xml
-    gpssh -u gpadmin -h mdw -v -s -e "mkdir -p $ADL_SERVER_DIR && cp ${PXF_HOME}/templates/adl-site.xml $ADL_SERVER_DIR"
-    gpssh -u gpadmin -h mdw -v -s -e "sed -i \"s|YOUR_ADL_REFRESH_URL|${ADL_REFRESH_URL}|\" ${ADL_SERVER_DIR}/adl-site.xml"
-    gpssh -u gpadmin -h mdw -v -s -e "sed -i \"s|YOUR_ADL_CLIENT_ID|${ADL_CLIENT_ID}|\" ${ADL_SERVER_DIR}/adl-site.xml"
-    gpssh -u gpadmin -h mdw -v -s -e "sed -i \"s|YOUR_ADL_CREDENTIAL|${ADL_CREDENTIAL}|\" ${ADL_SERVER_DIR}/adl-site.xml"
+    gpssh -u gpadmin -h cdw -v -s -e "mkdir -p $ADL_SERVER_DIR && cp ${PXF_HOME}/templates/adl-site.xml $ADL_SERVER_DIR"
+    gpssh -u gpadmin -h cdw -v -s -e "sed -i \"s|YOUR_ADL_REFRESH_URL|${ADL_REFRESH_URL}|\" ${ADL_SERVER_DIR}/adl-site.xml"
+    gpssh -u gpadmin -h cdw -v -s -e "sed -i \"s|YOUR_ADL_CLIENT_ID|${ADL_CLIENT_ID}|\" ${ADL_SERVER_DIR}/adl-site.xml"
+    gpssh -u gpadmin -h cdw -v -s -e "sed -i \"s|YOUR_ADL_CREDENTIAL|${ADL_CREDENTIAL}|\" ${ADL_SERVER_DIR}/adl-site.xml"
     sync_configuration
 }
 
@@ -208,9 +208,9 @@ ${GOOGLE_CREDENTIALS}
 EOF
 
     GS_SERVER_DIR="${PXF_SERVER_DIR}/gsbenchmark"
-    gpssh -u gpadmin -h mdw -v -s -e "mkdir -p $GS_SERVER_DIR && cp ${PXF_HOME}/templates/gs-site.xml $GS_SERVER_DIR"
-    gpscp -u gpadmin -h mdw /tmp/gsc-ci-service-account.key.json =:${GS_SERVER_DIR}/
-    gpssh -u gpadmin -h mdw -v -s -e "sed -i \"s|YOUR_GOOGLE_STORAGE_KEYFILE|${GS_SERVER_DIR}/gsc-ci-service-account.key.json|\" ${GS_SERVER_DIR}/gs-site.xml"
+    gpssh -u gpadmin -h cdw -v -s -e "mkdir -p $GS_SERVER_DIR && cp ${PXF_HOME}/templates/gs-site.xml $GS_SERVER_DIR"
+    gpscp -u gpadmin -h cdw /tmp/gsc-ci-service-account.key.json =:${GS_SERVER_DIR}/
+    gpssh -u gpadmin -h cdw -v -s -e "sed -i \"s|YOUR_GOOGLE_STORAGE_KEYFILE|${GS_SERVER_DIR}/gsc-ci-service-account.key.json|\" ${GS_SERVER_DIR}/gs-site.xml"
     sync_configuration
 }
 
@@ -292,13 +292,13 @@ function configure_s3_server() {
     # Special configuration for reading parquet files
     S3_SERVER_DIR_PARQUET="${PXF_SERVER_DIR}/s3benchmarkparquet"
     # Make a backup of core-site and update it with the S3 core-site
-    gpssh -u gpadmin -h mdw -v -s -e "mkdir -p $S3_SERVER_DIR && cp ${PXF_HOME}/templates/s3-site.xml $S3_SERVER_DIR"
-    gpssh -u gpadmin -h mdw -v -s -e "sed -i \"s|YOUR_AWS_ACCESS_KEY_ID|${AWS_ACCESS_KEY_ID}|\" $S3_SERVER_DIR/s3-site.xml"
-    gpssh -u gpadmin -h mdw -v -s -e "sed -i \"s|YOUR_AWS_SECRET_ACCESS_KEY|${AWS_SECRET_ACCESS_KEY}|\" $S3_SERVER_DIR/s3-site.xml"
+    gpssh -u gpadmin -h cdw -v -s -e "mkdir -p $S3_SERVER_DIR && cp ${PXF_HOME}/templates/s3-site.xml $S3_SERVER_DIR"
+    gpssh -u gpadmin -h cdw -v -s -e "sed -i \"s|YOUR_AWS_ACCESS_KEY_ID|${AWS_ACCESS_KEY_ID}|\" $S3_SERVER_DIR/s3-site.xml"
+    gpssh -u gpadmin -h cdw -v -s -e "sed -i \"s|YOUR_AWS_SECRET_ACCESS_KEY|${AWS_SECRET_ACCESS_KEY}|\" $S3_SERVER_DIR/s3-site.xml"
 
-    gpssh -u gpadmin -h mdw -v -s -e "cp -R $S3_SERVER_DIR $S3_SERVER_DIR_PARQUET"
+    gpssh -u gpadmin -h cdw -v -s -e "cp -R $S3_SERVER_DIR $S3_SERVER_DIR_PARQUET"
     # Improves reading from parquet files for S3
-    gpssh -u gpadmin -h mdw -v -s -e "sed -i \"s|</configuration>|<property><name>fs.s3a.experimental.input.fadvise</name><value>random</value></property></configuration>|\" $S3_SERVER_DIR_PARQUET/s3-site.xml"
+    gpssh -u gpadmin -h cdw -v -s -e "sed -i \"s|</configuration>|<property><name>fs.s3a.experimental.input.fadvise</name><value>random</value></property></configuration>|\" $S3_SERVER_DIR_PARQUET/s3-site.xml"
     sync_configuration
 }
 
@@ -321,9 +321,9 @@ function create_s3_parquet_tables() {
 function configure_wasb_server() {
     WASB_SERVER_DIR="${PXF_SERVER_DIR}/wasbbenchmark"
     # Create the WASB Benchmark server and copy core-site.xml
-    gpssh -u gpadmin -h mdw -v -s -e "mkdir -p $WASB_SERVER_DIR && cp ${PXF_HOME}/templates/wasbs-site.xml $WASB_SERVER_DIR"
-    gpssh -u gpadmin -h mdw -v -s -e "sed -i \"s|YOUR_AZURE_BLOB_STORAGE_ACCOUNT_NAME|${WASB_ACCOUNT_NAME}|\" ${WASB_SERVER_DIR}/wasbs-site.xml"
-    gpssh -u gpadmin -h mdw -v -s -e "sed -i \"s|YOUR_AZURE_BLOB_STORAGE_ACCOUNT_KEY|${WASB_ACCOUNT_KEY}|\" ${WASB_SERVER_DIR}/wasbs-site.xml"
+    gpssh -u gpadmin -h cdw -v -s -e "mkdir -p $WASB_SERVER_DIR && cp ${PXF_HOME}/templates/wasbs-site.xml $WASB_SERVER_DIR"
+    gpssh -u gpadmin -h cdw -v -s -e "sed -i \"s|YOUR_AZURE_BLOB_STORAGE_ACCOUNT_NAME|${WASB_ACCOUNT_NAME}|\" ${WASB_SERVER_DIR}/wasbs-site.xml"
+    gpssh -u gpadmin -h cdw -v -s -e "sed -i \"s|YOUR_AZURE_BLOB_STORAGE_ACCOUNT_KEY|${WASB_ACCOUNT_KEY}|\" ${WASB_SERVER_DIR}/wasbs-site.xml"
     sync_configuration
 }
 

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -2,7 +2,7 @@
 
 GPHOME=${GPHOME:=/usr/local/greenplum-db-devel}
 PXF_HOME=${PXF_HOME:=${GPHOME}/pxf}
-MDD_VALUE=/data/gpdata/master/gpseg-1
+CDD_VALUE=/data/gpdata/coordinator/gpseg-1
 PXF_COMMON_SRC_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PXF_VERSION=${PXF_VERSION:=6}
 PROXY_USER=${PROXY_USER:-pxfuser}
@@ -208,10 +208,10 @@ function remote_access_to_gpdb() {
 	cp cluster_env_files/.ssh/*.pem /home/gpadmin/.ssh/id_rsa
 	cp cluster_env_files/public_key.openssh /home/gpadmin/.ssh/authorized_keys
 	{ ssh-keyscan localhost; ssh-keyscan 0.0.0.0; } >> /home/gpadmin/.ssh/known_hosts
-	ssh "${SSH_OPTS[@]}" gpadmin@mdw "
+	ssh "${SSH_OPTS[@]}" gpadmin@cdw "
 		source ${GPHOME}/greenplum_path.sh &&
-		export MASTER_DATA_DIRECTORY=${MDD_VALUE} &&
-		echo 'host all all 10.0.0.0/16 trust' >> ${MDD_VALUE}/pg_hba.conf &&
+		export MASTER_DATA_DIRECTORY=${CDD_VALUE} &&
+		echo 'host all all 10.0.0.0/16 trust' >> ${CDD_VALUE}/pg_hba.conf &&
 		psql -d template1 <<-EOF && gpstop -u
 			CREATE EXTENSION pxf;
 			CREATE DATABASE gpadmin;

--- a/concourse/scripts/test_pxf_cli.bash
+++ b/concourse/scripts/test_pxf_cli.bash
@@ -6,13 +6,13 @@ cluster_env_files=$( cd "${SCRIPT_DIR}/../../../cluster_env_files" && pwd )
 
 cp -r "${cluster_env_files}/.ssh" "${HOME}"
 
-scp "${SCRIPT_DIR}/cli/common.sh" mdw:
+scp "${SCRIPT_DIR}/cli/common.sh" cdw:
 
 err_cnt=0
 for script in "${SCRIPT_DIR}/cli/"test_*.sh; do
-	scp "${script}" mdw:
+	scp "${script}" cdw:
 	script_short_name=${script##*/} # chop off path to script
-	ssh mdw "~gpadmin/${script_short_name}"
+	ssh cdw "~gpadmin/${script_short_name}"
 	((err_cnt+=$?))
 done
 

--- a/concourse/scripts/test_pxf_multinode.bash
+++ b/concourse/scripts/test_pxf_multinode.bash
@@ -49,7 +49,7 @@ function run_multinode_smoke_test() {
 	echo "Found $("${LOCAL_GPHD_ROOT}/bin/hdfs" dfs -ls /tmp/pxf_test | grep -c pxf_test) items in /tmp/pxf_test"
 	expected_output=$((3 * NO_OF_FILES))
 
-	time ssh "${SSH_OPTS[@]}" gpadmin@mdw "
+	time ssh "${SSH_OPTS[@]}" gpadmin@cdw "
 		source ${GPHOME}/greenplum_path.sh
 		psql -d template1 -c \"
 			CREATE EXTERNAL TABLE pxf_multifile_test (b TEXT)
@@ -70,25 +70,25 @@ function update_pghba_conf() {
 	local sdw_ips=("$@")
 	for ip in "${sdw_ips[@]}"; do
 		echo "host	all	gpadmin		$ip/32	trust"
-	done | ssh "${SSH_OPTS[@]}" gpadmin@mdw "
-		cat >> /data/gpdata/master/gpseg-1/pg_hba.conf &&
-		cat /data/gpdata/master/gpseg-1/pg_hba.conf
+	done | ssh "${SSH_OPTS[@]}" gpadmin@cdw "
+		cat >> /data/gpdata/coordinator/gpseg-1/pg_hba.conf &&
+		cat /data/gpdata/coordinator/gpseg-1/pg_hba.conf
 	"
 }
 
 function add_testing_encoding() {
 	# install new encoding and restart Greenplum so that the new encoding is picked up by Greenplum
-	ssh "${SSH_OPTS[@]}" gpadmin@mdw "
+	ssh "${SSH_OPTS[@]}" gpadmin@cdw "
 		source ${GPHOME}/greenplum_path.sh &&
 		gpssh -f ~gpadmin/hostfile_all -v -u centos -s -e 'sudo localedef -c -i ru_RU -f CP1251 ru_RU.CP1251' &&
-		export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1 &&
+		export MASTER_DATA_DIRECTORY=/data/gpdata/coordinator/gpseg-1 &&
 		gpstop -air
 	"
 }
 
 function setup_pxf_on_cluster() {
-	# drop named query file for JDBC test to gpadmin's home on mdw
-	scp "${SSH_OPTS[@]}" pxf_src/automation/src/test/resources/{,hive-}report.sql gpadmin@mdw:
+	# drop named query file for JDBC test to gpadmin's home on cdw
+	scp "${SSH_OPTS[@]}" pxf_src/automation/src/test/resources/{,hive-}report.sql gpadmin@cdw:
 
 	if [[ "${PROTOCOL}" == "file" ]]; then
 		# drop pxf-profiles.xml file with sequence file profiles for file protocol
@@ -114,11 +114,11 @@ function setup_pxf_on_cluster() {
 </profiles>
 EOF
 
-		scp "${SSH_OPTS[@]}" /tmp/pxf-profiles.xml "gpadmin@mdw:${BASE_DIR}/conf/pxf-profiles.xml"
+		scp "${SSH_OPTS[@]}" /tmp/pxf-profiles.xml "gpadmin@cdw:${BASE_DIR}/conf/pxf-profiles.xml"
 	fi
 
-	# configure PXF on master, sync configs and start pxf
-	ssh "${SSH_OPTS[@]}" gpadmin@mdw "
+	# configure PXF on coordinator, sync configs and start pxf
+	ssh "${SSH_OPTS[@]}" gpadmin@cdw "
 		source ${GPHOME}/greenplum_path.sh &&
 		${PXF_HOME}/bin/pxf cluster register
 		if [[ ! -d ${BASE_DIR} ]]; then
@@ -139,7 +139,7 @@ EOF
 		mkdir -p ${BASE_DIR}/servers/database &&
 		cp ${TEMPLATES_DIR}/templates/jdbc-site.xml ${BASE_DIR}/servers/database/ &&
 		sed -i  -e 's|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.postgresql.Driver|' \
-			-e 's|YOUR_DATABASE_JDBC_URL|jdbc:postgresql://mdw:5432/pxfautomation|' \
+			-e 's|YOUR_DATABASE_JDBC_URL|jdbc:postgresql://cdw:5432/pxfautomation|' \
 			-e 's|YOUR_DATABASE_JDBC_USER|gpadmin|' \
 			-e 's|YOUR_DATABASE_JDBC_PASSWORD||' \
 			${BASE_DIR}/servers/database/jdbc-site.xml &&
@@ -149,7 +149,7 @@ EOF
 		mkdir -p ${BASE_DIR}/servers/db-session-params &&
 		cp ${TEMPLATES_DIR}/templates/jdbc-site.xml ${BASE_DIR}/servers/db-session-params &&
 		sed -i  -e 's|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.postgresql.Driver|' \
-			-e 's|YOUR_DATABASE_JDBC_URL|jdbc:postgresql://mdw:5432/pxfautomation|' \
+			-e 's|YOUR_DATABASE_JDBC_URL|jdbc:postgresql://cdw:5432/pxfautomation|' \
 			-e 's|YOUR_DATABASE_JDBC_USER||' \
 			-e 's|YOUR_DATABASE_JDBC_PASSWORD||' \
 			-e 's|</configuration>|<property><name>jdbc.session.property.client_min_messages</name><value>debug1</value></property></configuration>|' \
@@ -197,7 +197,7 @@ function setup_pxf_kerberos_on_cluster() {
 		-e "s|</cluster>|<testKerberosPrincipal>gpadmin@${REALM}</testKerberosPrincipal></cluster>|g" \
 		-e "s|</hive>|<kerberosPrincipal>${KERBERIZED_HADOOP_URI}</kerberosPrincipal><userName>gpadmin</userName></hive>|g" \
 		"$multiNodesCluster"
-	ssh gpadmin@mdw "
+	ssh gpadmin@cdw "
 		cp ${TEMPLATES_DIR}/templates/pxf-site.xml ${BASE_DIR}/servers/db-hive/pxf-site.xml &&
 		sed -i 's|gpadmin/_HOST@EXAMPLE.COM|gpadmin@${REALM}|g' ${BASE_DIR}/servers/db-hive/pxf-site.xml &&
 		sed -i 's|</configuration>|<property><name>hadoop.security.authentication</name><value>kerberos</value></property></configuration>|g' \
@@ -209,7 +209,7 @@ function setup_pxf_kerberos_on_cluster() {
 	sudo mkdir -p /etc/security/keytabs
 	sudo cp "${DATAPROC_DIR}/pxf.service.keytab" /etc/security/keytabs/gpadmin.headless.keytab
 	sudo chown gpadmin:gpadmin /etc/security/keytabs/gpadmin.headless.keytab
-	scp centos@mdw:/etc/krb5.conf /tmp/krb5.conf
+	scp centos@cdw:/etc/krb5.conf /tmp/krb5.conf
 	sudo cp /tmp/krb5.conf /etc/krb5.conf
 
 	# Add foreign dataproc hostfile to /etc/hosts
@@ -225,21 +225,21 @@ function setup_pxf_kerberos_on_cluster() {
 		REALM2=$(< "${DATAPROC_2_DIR}/REALM")
 		REALM2=${REALM2^^} # make sure REALM2 is up-cased, down-case below for hive principal
 		KERBERIZED_HADOOP_2_URI="hive/${HADOOP_2_HOSTNAME}.${REALM2,,}@${REALM2};saslQop=auth-conf" # quoted because of semicolon
-		ssh gpadmin@mdw "
+		ssh gpadmin@cdw "
 			mkdir -p ${BASE_DIR}/servers/hdfs-secure &&
 			cp ${TEMPLATES_DIR}/templates/pxf-site.xml ${BASE_DIR}/servers/hdfs-secure &&
 			sed -i -e \"s|>gpadmin/_HOST@EXAMPLE.COM<|>${HADOOP_2_USER}/_HOST@${REALM2}<|g\" ${BASE_DIR}/servers/hdfs-secure/pxf-site.xml &&
 			sed -i -e 's|/pxf.service.keytab<|/pxf.service.2.keytab<|g' ${BASE_DIR}/servers/hdfs-secure/pxf-site.xml
 		"
-		scp dataproc_2_env_files/conf/*-site.xml "gpadmin@mdw:${BASE_DIR}/servers/hdfs-secure"
-		ssh gpadmin@mdw "PXF_BASE=${BASE_DIR} ${PXF_HOME}/bin/pxf cluster sync"
+		scp dataproc_2_env_files/conf/*-site.xml "gpadmin@cdw:${BASE_DIR}/servers/hdfs-secure"
+		ssh gpadmin@cdw "PXF_BASE=${BASE_DIR} ${PXF_HOME}/bin/pxf cluster sync"
 
 		sed -i  -e "s|</hdfs2>|<hadoopRoot>$DATAPROC_2_DIR</hadoopRoot><testKerberosPrincipal>${HADOOP_2_USER}@${REALM2}</testKerberosPrincipal></hdfs2>|g" \
 			-e "s|</hive2>|<kerberosPrincipal>${KERBERIZED_HADOOP_2_URI}</kerberosPrincipal><userName>${HADOOP_2_USER}</userName></hive2>|g" \
 			"$multiNodesCluster"
 
 		# Create the db-hive-kerberos server configuration
-		ssh "${SSH_OPTS[@]}" gpadmin@mdw "
+		ssh "${SSH_OPTS[@]}" gpadmin@cdw "
 			mkdir -p ${BASE_DIR}/servers/db-hive-kerberos &&
 			cp ${TEMPLATES_DIR}/templates/jdbc-site.xml ${BASE_DIR}/servers/db-hive-kerberos &&
 			sed -i -e 's|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.apache.hive.jdbc.HiveDriver|' \
@@ -269,24 +269,24 @@ function setup_pxf_kerberos_on_cluster() {
 			sudo kadmin.local -q 'addprinc -pw pxf ${HADOOP_2_USER}/${GPDB_CLUSTER_NAME_BASE}-0.c.${GOOGLE_PROJECT_ID}.internal'
 			sudo kadmin.local -q 'addprinc -pw pxf ${HADOOP_2_USER}/${GPDB_CLUSTER_NAME_BASE}-1.c.${GOOGLE_PROJECT_ID}.internal'
 			sudo kadmin.local -q 'addprinc -pw pxf ${HADOOP_2_USER}/${GPDB_CLUSTER_NAME_BASE}-2.c.${GOOGLE_PROJECT_ID}.internal'
-			sudo kadmin.local -q \"xst -k \${HOME}/pxf.service-mdw.keytab ${HADOOP_2_USER}/${GPDB_CLUSTER_NAME_BASE}-0.c.${GOOGLE_PROJECT_ID}.internal\"
+			sudo kadmin.local -q \"xst -k \${HOME}/pxf.service-cdw.keytab ${HADOOP_2_USER}/${GPDB_CLUSTER_NAME_BASE}-0.c.${GOOGLE_PROJECT_ID}.internal\"
 			sudo kadmin.local -q \"xst -k \${HOME}/pxf.service-sdw1.keytab ${HADOOP_2_USER}/${GPDB_CLUSTER_NAME_BASE}-1.c.${GOOGLE_PROJECT_ID}.internal\"
 			sudo kadmin.local -q \"xst -k \${HOME}/pxf.service-sdw2.keytab ${HADOOP_2_USER}/${GPDB_CLUSTER_NAME_BASE}-2.c.${GOOGLE_PROJECT_ID}.internal\"
-			sudo chown ${HADOOP_2_USER} \"\${HOME}/pxf.service-mdw.keytab\"
+			sudo chown ${HADOOP_2_USER} \"\${HOME}/pxf.service-cdw.keytab\"
 			sudo chown ${HADOOP_2_USER} \"\${HOME}/pxf.service-sdw1.keytab\"
 			sudo chown ${HADOOP_2_USER} \"\${HOME}/pxf.service-sdw2.keytab\"
 			"
 		scp "${HADOOP_2_SSH_OPTS[@]}" "${HADOOP_2_USER}@${HADOOP_2_HOSTNAME}":~/pxf.service-*.keytab \
 			/tmp/
 
-		scp /tmp/pxf.service-*.keytab gpadmin@mdw:~/dataproc_2_env_files/
+		scp /tmp/pxf.service-*.keytab gpadmin@cdw:~/dataproc_2_env_files/
 
 		# Add foreign dataproc hostfile to /etc/hosts on all nodes and copy keytab
-		ssh gpadmin@mdw "
+		ssh gpadmin@cdw "
 			source ${GPHOME}/greenplum_path.sh &&
 			gpscp -f ~gpadmin/hostfile_all -v -r -u centos ~/dataproc_2_env_files/etc_hostfile =:/tmp/etc_hostfile &&
 			gpssh -f ~gpadmin/hostfile_all -v -u centos -s -e 'sudo tee --append /etc/hosts < /tmp/etc_hostfile' &&
-			gpscp -h mdw -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-mdw.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab &&
+			gpscp -h cdw -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-cdw.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab &&
 			gpscp -h sdw1 -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-sdw1.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab &&
 			gpscp -h sdw2 -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-sdw2.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab
 		"
@@ -307,7 +307,7 @@ function setup_pxf_kerberos_on_cluster() {
 		DOMAIN3="$(< "${HADOOP_3_DIR}/domain")"
 		REALM3="$(< "${HADOOP_3_DIR}/REALM")"
 		REALM3="${REALM3^^}" # make sure REALM3 is upper-case
-		ssh gpadmin@mdw "
+		ssh gpadmin@cdw "
 			mkdir -p ${BASE_DIR}/servers/hdfs-ipa &&
 			cp ${TEMPLATES_DIR}/templates/pxf-site.xml ${BASE_DIR}/servers/hdfs-ipa &&
 			sed -i \
@@ -316,10 +316,10 @@ function setup_pxf_kerberos_on_cluster() {
 				-e '/pxf.service.kerberos.constrained-delegation/{n;s|<value>.*</value>|<value>true</value>|}' ${BASE_DIR}/servers/hdfs-ipa/pxf-site.xml
 		"
 
-		scp ipa_env_files/conf/*-site.xml "gpadmin@mdw:${BASE_DIR}/servers/hdfs-ipa"
+		scp ipa_env_files/conf/*-site.xml "gpadmin@cdw:${BASE_DIR}/servers/hdfs-ipa"
 
 		# optionally create a non-impersonation configuration servers with/without a service user for the IPA cluster for the proxy test
-		ssh gpadmin@mdw "
+		ssh gpadmin@cdw "
 			if [[ ${IMPERSONATION} == true ]]; then
 				cp -r ${BASE_DIR}/servers/hdfs-ipa ${BASE_DIR}/servers/hdfs-ipa-no-impersonation
 				sed -i \
@@ -336,7 +336,7 @@ function setup_pxf_kerberos_on_cluster() {
 		"
 
 		# sync up PXF server configuration
-		ssh gpadmin@mdw "PXF_BASE=${BASE_DIR} ${PXF_HOME}/bin/pxf cluster sync"
+		ssh gpadmin@cdw "PXF_BASE=${BASE_DIR} ${PXF_HOME}/bin/pxf cluster sync"
 
 		# add configuration information to the SUT file for the automation suite
 		sed -i \
@@ -353,7 +353,7 @@ function setup_pxf_kerberos_on_cluster() {
 		sudo tee --append /etc/hosts < ipa_env_files/etc_hostfile
 
 		# add foreign Hadoop and IPA KDC hostfile to /etc/hosts on all nodes
-		ssh gpadmin@mdw "
+		ssh gpadmin@cdw "
 			source ${GPHOME}/greenplum_path.sh &&
 			gpscp -f ~gpadmin/hostfile_all -v -r -u centos ~/ipa_env_files/etc_hostfile =:/tmp/etc_hostfile &&
 			gpssh -f ~gpadmin/hostfile_all -v -u centos -s -e 'sudo tee --append /etc/hosts < /tmp/etc_hostfile' &&
@@ -371,7 +371,7 @@ function setup_pxf_kerberos_on_cluster() {
 
 	# Create the non-secure cluster configuration
 	NON_SECURE_HADOOP_IP=$(grep < cluster_env_files/etc_hostfile edw0 | awk '{print $1}')
-	ssh gpadmin@mdw "
+	ssh gpadmin@cdw "
 		mkdir -p ${BASE_DIR}/servers/db-hive-non-secure &&
 		cp ${TEMPLATES_DIR}/templates/jdbc-site.xml ${BASE_DIR}/servers/db-hive-non-secure &&
 		sed -i -e 's|YOUR_DATABASE_JDBC_DRIVER_CLASS_NAME|org.apache.hive.jdbc.HiveDriver|' \
@@ -389,7 +389,7 @@ function setup_pxf_kerberos_on_cluster() {
 	sed -i "s/>non-secure-hadoop</>${NON_SECURE_HADOOP_IP}</g" "$multiNodesCluster"
 
 	# Create a secured server configuration with invalid principal name
-	ssh gpadmin@mdw "
+	ssh gpadmin@cdw "
 		mkdir -p ${BASE_DIR}/servers/secure-hdfs-invalid-principal &&
 		cp ${BASE_DIR}/servers/default/*-site.xml ${BASE_DIR}/servers/secure-hdfs-invalid-principal &&
 		cp ${TEMPLATES_DIR}/templates/pxf-site.xml ${BASE_DIR}/servers/secure-hdfs-invalid-principal &&
@@ -398,7 +398,7 @@ function setup_pxf_kerberos_on_cluster() {
 	"
 
 	# Create a secured server configuration with invalid keytab
-	ssh gpadmin@mdw "
+	ssh gpadmin@cdw "
 		mkdir -p ${BASE_DIR}/servers/secure-hdfs-invalid-keytab &&
 		cp ${BASE_DIR}/servers/default/*-site.xml ${BASE_DIR}/servers/secure-hdfs-invalid-keytab &&
 		cp ${TEMPLATES_DIR}/templates/pxf-site.xml ${BASE_DIR}/servers/secure-hdfs-invalid-keytab &&
@@ -407,7 +407,7 @@ function setup_pxf_kerberos_on_cluster() {
 	"
 
 	# Configure the principal for the default-no-impersonation server
-	ssh gpadmin@mdw "
+	ssh gpadmin@cdw "
 	if [[ ${IMPERSONATION} == true ]]; then
 		sed -i -e 's|gpadmin/_HOST@EXAMPLE.COM|gpadmin@${REALM}|g' ${BASE_DIR}/servers/default-no-impersonation/pxf-site.xml &&
 		PXF_BASE=${BASE_DIR} ${PXF_HOME}/bin/pxf cluster sync
@@ -419,12 +419,12 @@ function configure_nfs() {
 	echo "install the NFS client"
 	yum install -y -q -e 0 nfs-utils
 
-	echo "check available NFS shares in mdw"
-	showmount -e mdw
+	echo "check available NFS shares in cdw"
+	showmount -e cdw
 
 	echo "create mount point and mount it"
 	mkdir -p "${BASE_PATH}"
-	mount -o nolock -t nfs mdw:/var/nfs "${BASE_PATH}"
+	mount -o nolock -t nfs cdw:/var/nfs "${BASE_PATH}"
 	chown -R gpadmin:gpadmin "${BASE_PATH}"
 	chmod -R 755 "${BASE_PATH}"
 
@@ -462,7 +462,7 @@ function run_pxf_automation() {
 
 	# point the tests at remote Hadoop and GPDB
 	sed -i "s/>hadoop</>${HADOOP_HOSTNAME}</g" "$multiNodesCluster"
-	sed -i "/<class>org.greenplum.pxf.automation.components.gpdb.Gpdb<\/class>/ {n; s/localhost/mdw/}" \
+	sed -i "/<class>org.greenplum.pxf.automation.components.gpdb.Gpdb<\/class>/ {n; s/localhost/cdw/}" \
 		"$multiNodesCluster"
 
 	if [[ $KERBEROS == true ]]; then
@@ -481,7 +481,7 @@ function run_pxf_automation() {
 		# set explicit GPHOME here for consistency across container / CCP
 		export GPHOME=${GPHOME}
 		export PXF_HOME=${PXF_HOME}
-		export PGHOST=mdw
+		export PGHOST=cdw
 		export PGPORT=5432
 
 		export ACCESS_KEY_ID='${ACCESS_KEY_ID}' SECRET_ACCESS_KEY='${SECRET_ACCESS_KEY}'
@@ -511,8 +511,8 @@ function _main() {
 	if [[ "${PROTOCOL}" == "file" ]]; then
 		# ensure user id and group id match the VM id on the container to be able
 		# to read and write files
-		usermod -u  "$(ssh mdw 'id -u gpadmin')" gpadmin
-		groupmod -g "$(ssh mdw 'id -g gpadmin')" gpadmin
+		usermod -u  "$(ssh cdw 'id -u gpadmin')" gpadmin
+		groupmod -g "$(ssh cdw 'id -g gpadmin')" gpadmin
 	fi
 
 	cp -R cluster_env_files/.ssh/* /root/.ssh
@@ -556,7 +556,7 @@ function _main() {
 	inflate_singlecluster
 	configure_local_hdfs
 
-	# widen access to mdw to all nodes in the cluster for JDBC test
+	# widen access to cdw to all nodes in the cluster for JDBC test
 	update_pghba_conf "${gpdb_segments[@]}"
 
 	# Add the ru_RU.CP1251 encoding for testing

--- a/concourse/scripts/upgrade_pxf.bash
+++ b/concourse/scripts/upgrade_pxf.bash
@@ -13,8 +13,8 @@ else
 	PXF5_HOME=${GPHOME}/pxf
 fi
 
-# we need word boundary in case of standby master (smdw)
-MASTER_HOSTNAME=$(grep < cluster_env_files/etc_hostfile '\bmdw' | awk '{print $2}')
+# we need word boundary in case of standby coordinator (scdw)
+COORDINATOR_HOSTNAME="cdw"
 PXF_HOME=/usr/local/pxf-gp${GP_VER}
 PXF_BASE_DIR=${PXF_BASE_DIR:-$PXF_HOME}
 
@@ -22,10 +22,10 @@ echoGreen() { echo $'\e[0;32m'"$1"$'\e[0m'; }
 
 function upgrade_pxf() {
 	echoGreen "Stopping PXF 5"
-	ssh "${MASTER_HOSTNAME}" "${PXF5_HOME}/bin/pxf version && ${PXF5_HOME}/bin/pxf cluster stop"
+	ssh "${COORDINATOR_HOSTNAME}" "${PXF5_HOME}/bin/pxf version && ${PXF5_HOME}/bin/pxf cluster stop"
 
 	echoGreen "Installing PXF 6"
-	ssh "${MASTER_HOSTNAME}" "
+	ssh "${COORDINATOR_HOSTNAME}" "
 		source ${GPHOME}/greenplum_path.sh &&
 		export JAVA_HOME=/usr/lib/jvm/jre &&
 		gpscp -f ~gpadmin/hostfile_all -v -u centos -r ~/pxf_tarball centos@=: &&
@@ -34,34 +34,34 @@ function upgrade_pxf() {
 	"
 
 	echoGreen "Change ownership of PXF 6 directory to gpadmin"
-	ssh "${MASTER_HOSTNAME}" "source ${GPHOME}/greenplum_path.sh && gpssh -f ~gpadmin/hostfile_all -v -u centos -s -e 'sudo chown -R gpadmin:gpadmin ${PXF_HOME}'"
+	ssh "${COORDINATOR_HOSTNAME}" "source ${GPHOME}/greenplum_path.sh && gpssh -f ~gpadmin/hostfile_all -v -u centos -s -e 'sudo chown -R gpadmin:gpadmin ${PXF_HOME}'"
 
 	echoGreen "Check the PXF 6 version"
-	ssh "${MASTER_HOSTNAME}" "${PXF_HOME}/bin/pxf version"
+	ssh "${COORDINATOR_HOSTNAME}" "${PXF_HOME}/bin/pxf version"
 
 	echoGreen "Register the PXF extension into Greenplum"
-	ssh "${MASTER_HOSTNAME}" "GPHOME=${GPHOME} ${PXF_HOME}/bin/pxf cluster register"
+	ssh "${COORDINATOR_HOSTNAME}" "GPHOME=${GPHOME} ${PXF_HOME}/bin/pxf cluster register"
 
 	if [[ "${PXF_BASE_DIR}" != "${PXF_HOME}" ]]; then
 		echoGreen "Prepare PXF in ${PXF_BASE_DIR}"
-		ssh "${MASTER_HOSTNAME}" "
+		ssh "${COORDINATOR_HOSTNAME}" "
 			PXF_BASE=${PXF_BASE_DIR} ${PXF_HOME}/bin/pxf cluster prepare
 			echo \"export PXF_BASE=${PXF_BASE_DIR}\" >> ~gpadmin/.bashrc
 		"
 	fi
 
 	echoGreen "Perform PXF migrate from PXF_CONF=~gpadmin/pxf to PXF_BASE_DIR=${PXF_BASE_DIR}"
-	ssh "${MASTER_HOSTNAME}" "PXF_BASE=${PXF_BASE_DIR} PXF_CONF=~gpadmin/pxf ${PXF_HOME}/bin/pxf cluster migrate"
+	ssh "${COORDINATOR_HOSTNAME}" "PXF_BASE=${PXF_BASE_DIR} PXF_CONF=~gpadmin/pxf ${PXF_HOME}/bin/pxf cluster migrate"
 
 	echoGreen "Starting PXF 6"
-	ssh "${MASTER_HOSTNAME}" "PXF_BASE=${PXF_BASE_DIR} ${PXF_HOME}/bin/pxf cluster start"
+	ssh "${COORDINATOR_HOSTNAME}" "PXF_BASE=${PXF_BASE_DIR} ${PXF_HOME}/bin/pxf cluster start"
 
 	echoGreen "ALTER EXTENSION pxf UPDATE - for testupgrade database"
-	ssh "${MASTER_HOSTNAME}" "source ${GPHOME}/greenplum_path.sh && psql -d testupgrade -c 'ALTER EXTENSION pxf UPDATE'"
+	ssh "${COORDINATOR_HOSTNAME}" "source ${GPHOME}/greenplum_path.sh && psql -d testupgrade -c 'ALTER EXTENSION pxf UPDATE'"
 }
 
 function _main() {
-	scp -r pxf_tarball "${MASTER_HOSTNAME}:~gpadmin"
+	scp -r pxf_tarball "${COORDINATOR_HOSTNAME}:~gpadmin"
 	upgrade_pxf
 }
 


### PR DESCRIPTION
The tool we use for provisiong GPDB clusters (i.e., CCP) is being updated to replace `mdw` hostname with `cdw` and `/data/master` directory with `/data/coordinator`. This change is being applied regardless of the version of GPDB being used on the provisioned cluster.