### PR TITLE
Upgrade gp-common-go-libs to 1.0.5

### DIFF
--- a/cli/go/src/pxf-cli/go.mod
+++ b/cli/go/src/pxf-cli/go.mod
@@ -3,7 +3,7 @@ module pxf-cli
 go 1.17
 
 require (
-	github.com/greenplum-db/gp-common-go-libs v1.0.5-0.20220119222931-572bf8fa8e9c
+	github.com/greenplum-db/gp-common-go-libs v1.0.5
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/pkg/errors v0.9.1

--- a/cli/go/src/pxf-cli/go.sum
+++ b/cli/go/src/pxf-cli/go.sum
@@ -70,8 +70,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/greenplum-db/gp-common-go-libs v1.0.5-0.20220119222931-572bf8fa8e9c h1:5RZfN5IUOK1kTzxVtelFTw4ciis5vVQ0/g9rHjF7x9Q=
-github.com/greenplum-db/gp-common-go-libs v1.0.5-0.20220119222931-572bf8fa8e9c/go.mod h1:GBxILDmnWXS56nlMUUiOEQNrTlFRtLPUwx/wpiOh50k=
+github.com/greenplum-db/gp-common-go-libs v1.0.5 h1:3GdGWoBbPEka7OSnMo655u0Yld31ofeFMkSBnaauFNo=
+github.com/greenplum-db/gp-common-go-libs v1.0.5/go.mod h1:GBxILDmnWXS56nlMUUiOEQNrTlFRtLPUwx/wpiOh50k=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=


### PR DESCRIPTION
go get github.com/greenplum-db/gp-common-go-libs@v1.0.5 go mod tidy

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>