### PR TITLE
Fix ProfilesConfTest to work with other locales

### DIFF
--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/profile/ProfilesConfTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/profile/ProfilesConfTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -193,7 +195,7 @@ public class ProfilesConfTest {
     public void testMalformedXmlFile() {
         Exception e = assertThrows(ProfileConfException.class,
                 () -> getProfilesConf("malformedXmlFile"));
-        assertTrue(e.getMessage().contains("Content is not allowed in prolog"));
+        assertThat(e.getMessage(), matchesPattern("^Profiles configuration .+ could not be loaded:.*"));
     }
 
     @Test


### PR DESCRIPTION
If a locale other than en_US is used to run PXF's unit tests, then ProfilesConfTest > testMalformedXmlFile may fail because the test is asserting that an exception message contains a particular substring. However this particular substring comes from the JDK itself and can change based on the user's locale. For example, if the locale is changed to German (export LC_ALL=de_DE.UTF-8) and the unit tests are run, ProfilesConfTest > testMalformedXmlFile fails because the message is localized to "Content ist nicht zulaessig in Prolog." instead of "Content is not allowed in prolog." Note, that not every locale results in translation of the message; looking at [openjdk/jdk8u][0], there is no localization for Russian.

This commit changes the tests assertion to look for expected message coming from PXF itself, which does not change based on locale.

Closes #927.

[0]: https://github.com/openjdk/jdk8u/tree/master/jaxp/src/com/sun/org/apache/xerces/internal/impl/msg

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>