### PR TITLE
Fix pxf-dev-base build configration

### DIFF
--- a/concourse/docker/pxf-dev-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-dev-base/cloudbuild.yaml
@@ -228,7 +228,7 @@ steps:
     - gpdb7-ubuntu18.04-test-pxf-image-cache
 
 substitutions:
-  _GO_VERSION: 1.19 # default values
+  _GO_VERSION: '1.19' # default values
 
 # Push images to Cloud Build to Container Registry
 images:

--- a/concourse/docker/pxf-dev-base/gpdb7/rhel8/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/rhel8/Dockerfile
@@ -21,6 +21,7 @@ RUN curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERS
     && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
     && rm -f /tmp/apache-maven.tar.gz \
     && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
+    && dnf install -y -d1 python2 python2-pip \
     && /usr/bin/pip2 install paramiko --no-cache-dir
 
 # create rsa key for the root user


### PR DESCRIPTION
According to the Cloud Build documentation [1], the substitutions field is a map of string keys to string values. Unfortunately in YAML, an unquoted value of 1.19 is parsed as a number, causing the build to fail with

> json: cannot unmarshal number into Go value of type string

This commit quotes the substitution value of 1.19 to force it to be parsed as a string.

[1]: https://cloud.google.com/build/docs/build-config-file-schema

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>