### PR TITLE
Refactor Makefiles to reduce complexity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,31 +41,30 @@ default: all
 .PHONY: all extensions external-table fdw cli server install install-server stage tar rpm rpm-tar deb deb-tar clean test it help
 
 all: extensions cli server
+	@echo "===> PXF compilation is complete <==="
 
 extensions: external-table fdw
 
-external-table:
-	make -C external-table
+external-table cli server:
+	@echo "===> Compiling [$@] module <==="
+	make -C $@
 
 fdw:
 ifeq ($(SKIP_FDW_BUILD_REASON),)
+	@echo "===> Compiling [$@] module <==="
 	make -C fdw
 else
 	@echo "Skipping building FDW extension because $(SKIP_FDW_BUILD_REASON)"
 endif
 
-cli:
-	make -C cli
-
-server:
-	make -C server
-
 clean:
 	rm -rf build
-	make -C external-table clean-all
-	make -C fdw clean-all
-	make -C cli clean
-	make -C server clean
+	set -e ;\
+	for module in $${PXF_MODULES[@]}; do \
+		echo "===> Cleaning [$${module}] module <===" ;\
+		make -C $${module} clean-all ;\
+	done ;\
+	echo "===> PXF cleaning is complete <==="
 
 test:
 ifeq ($(SKIP_FDW_BUILD_REASON),)
@@ -80,14 +79,16 @@ it:
 	make -C automation TEST=$(TEST)
 
 install:
-	make -C external-table install
-ifeq ($(SKIP_FDW_BUILD_REASON),)
-	make -C fdw install
-else
-	@echo "Skipping installing FDW extension because $(SKIP_FDW_BUILD_REASON)"
+ifneq ($(SKIP_FDW_PACKAGE_REASON),)
+	@echo "Skipping installing FDW extension because $(SKIP_FDW_PACKAGE_REASON)"
+	$(eval PXF_MODULES := $(filter-out fdw,$(PXF_MODULES)))
 endif
-	make -C cli install
-	make -C server install
+	set -e ;\
+	for module in $${PXF_MODULES[@]}; do \
+		echo "===> Installing [$${module}] module <===" ;\
+		make -C $${module} install ;\
+	done ;\
+	echo "===> PXF installation is complete <==="
 
 install-server:
 	make -C server install-server
@@ -107,36 +108,22 @@ endif
 		cp -a "$${module}"/build/stage/* "build/stage/$${PXF_PACKAGE_NAME}/pxf" ;\
 	done ;\
 	echo $$(git rev-parse --verify HEAD) > build/stage/$${PXF_PACKAGE_NAME}/pxf/commit.sha ;\
-	cp package/install_binary build/stage/$${PXF_PACKAGE_NAME}/install_component
+	cp package/install_binary build/stage/$${PXF_PACKAGE_NAME}/install_component ;\
+	echo "===> PXF staging is complete <==="
 
 tar: stage
 	rm -rf build/dist
 	mkdir -p build/dist
 	tar -czf build/dist/$(shell ls build/stage).tar.gz -C build/stage $(shell ls build/stage)
+	echo "===> PXF TAR file with binaries creation is complete <==="
 
-rpm:
-	make -C external-table stage
-ifeq ($(SKIP_FDW_PACKAGE_REASON),)
-	make -C fdw stage
-else
-	@echo "Skipping packaging FDW extension because $(SKIP_FDW_PACKAGE_REASON)"
-endif
-	make -C cli stage
-	make -C server stage
+rpm: stage
+	rm -rf build/rpmbuild
 	set -e ;\
 	PXF_MAIN_VERSION=$${PXF_VERSION//-SNAPSHOT/} ;\
 	if [[ $${PXF_VERSION} == *"-SNAPSHOT" ]]; then PXF_RELEASE=SNAPSHOT; else PXF_RELEASE=1; fi ;\
-	rm -rf build/rpmbuild ;\
 	mkdir -p build/rpmbuild/{BUILD,RPMS,SOURCES,SPECS} ;\
-	mkdir -p build/rpmbuild/SOURCES/gpextable ;\
-	cp -a external-table/build/stage/* build/rpmbuild/SOURCES/gpextable ;\
-	if [[ -z $${SKIP_FDW_PACKAGE_REASON} ]]; then \
-	mkdir -p build/rpmbuild/SOURCES/fdw ;\
-	cp -a fdw/build/stage/* build/rpmbuild/SOURCES/fdw ;\
-	fi;\
-	cp -a cli/build/stage/pxf/* build/rpmbuild/SOURCES ;\
-	cp -a server/build/stage/pxf/* build/rpmbuild/SOURCES ;\
-	echo $$(git rev-parse --verify HEAD) > build/rpmbuild/SOURCES/commit.sha ;\
+	cp -a /build/stage/pxf/* build/rpmbuild/SOURCES ;\
 	cp package/*.spec build/rpmbuild/SPECS/ ;\
 	rpmbuild \
 	--define "_topdir $${PWD}/build/rpmbuild" \
@@ -144,7 +131,8 @@ endif
 	--define "pxf_release $${PXF_RELEASE}" \
 	--define "license ${LICENSE}" \
 	--define "vendor ${VENDOR}" \
-	-bb $${PWD}/build/rpmbuild/SPECS/pxf-gp$${GP_MAJORVERSION}.spec
+	-bb $${PWD}/build/rpmbuild/SPECS/pxf-gp$${GP_MAJORVERSION}.spec ;\
+	echo "===> PXF RPM package creation is complete <==="
 
 rpm-tar: rpm
 	rm -rf build/{stagerpm,distrpm}
@@ -156,35 +144,23 @@ rpm-tar: rpm
 	mkdir -p build/stagerpm/$${PXF_PACKAGE_NAME} ;\
 	cp $${PXF_RPM_FILE} build/stagerpm/$${PXF_PACKAGE_NAME} ;\
 	cp package/install_rpm build/stagerpm/$${PXF_PACKAGE_NAME}/install_component ;\
-	tar -czf build/distrpm/$${PXF_PACKAGE_NAME}.tar.gz -C build/stagerpm $${PXF_PACKAGE_NAME}
+	tar -czf build/distrpm/$${PXF_PACKAGE_NAME}.tar.gz -C build/stagerpm $${PXF_PACKAGE_NAME} ;\
+	echo "===> PXF TAR file with RPM package creation is complete <==="
 
-deb:
-	make -C external-table stage
-ifeq ($(SKIP_FDW_PACKAGE_REASON),)
-	make -C fdw stage
-else
-	@echo "Skipping packaging FDW extension because $(SKIP_FDW_PACKAGE_REASON)"
-endif
-	make -C cli stage
-	make -C server stage
+deb: stage
+	rm -rf build/debbuild
 	set -e ;\
 	PXF_MAIN_VERSION=$${PXF_VERSION//-SNAPSHOT/} ;\
 	if [[ $${PXF_VERSION} == *"-SNAPSHOT" ]]; then PXF_RELEASE=SNAPSHOT; else PXF_RELEASE=1; fi ;\
-	rm -rf build/debbuild ;\
-	mkdir -p build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION}/gpextable ;\
-	cp -a external-table/build/stage/* build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION}/gpextable ;\
-	if [[ -z $${SKIP_FDW_PACKAGE_REASON} ]]; then \
-	mkdir -p build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION}/fdw ;\
-	cp -a fdw/build/stage/* build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION}/fdw ;\
-	fi;\
-	cp -a cli/build/stage/pxf/* build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION} ;\
-	cp -a server/build/stage/pxf/* build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION} ;\
-	echo $$(git rev-parse --verify HEAD) > build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION}/commit.sha ;\
+	mkdir -p build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION} ;\
+	cp -a build/stage/pxf/* build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION} ;\
 	mkdir build/debbuild/DEBIAN ;\
 	cp -a package/DEBIAN/* build/debbuild/DEBIAN/ ;\
 	sed -i -e "s/%VERSION%/$${PXF_MAIN_VERSION}-$${PXF_RELEASE}/" -e "s/%MAINTAINER%/${VENDOR}/" build/debbuild/DEBIAN/control ;\
 	dpkg-deb --build build/debbuild ;\
-	mv build/debbuild.deb build/pxf-gp$${GP_MAJORVERSION}-$${PXF_MAIN_VERSION}-$${PXF_RELEASE}-ubuntu18.04-amd64.deb
+	mv build/debbuild.deb build/pxf-gp$${GP_MAJORVERSION}-$${PXF_MAIN_VERSION}-$${PXF_RELEASE}-ubuntu18.04-amd64.deb ;\
+	echo "===> PXF DEB package creation is complete <==="
+
 
 deb-tar: deb
 	rm -rf build/{stagedeb,distdeb}
@@ -195,23 +171,25 @@ deb-tar: deb
 	mkdir -p build/stagedeb/$${PXF_PACKAGE_NAME} ;\
 	cp $${PXF_DEB_FILE} build/stagedeb/$${PXF_PACKAGE_NAME} ;\
 	cp package/install_deb build/stagedeb/$${PXF_PACKAGE_NAME}/install_component ;\
-	tar -czf build/distdeb/$${PXF_PACKAGE_NAME}.tar.gz -C build/stagedeb $${PXF_PACKAGE_NAME}
+	tar -czf build/distdeb/$${PXF_PACKAGE_NAME}.tar.gz -C build/stagedeb $${PXF_PACKAGE_NAME} ;\
+	echo "===> PXF TAR file with DEB package creation is complete <==="
 
 
 help:
 	@echo
 	@echo 'Possible targets'
-	@echo	'  - all (extensions, cli, server)'
-	@echo	'  - extensions - build external table, fdw extensions'
+	@echo	'  - all - build extensions, cli, and server modules'
+	@echo	'  - extensions - build Greenplum external table and foreign data wrapper extensions'
 	@echo	'  - external-table - build Greenplum external table extension'
-	@echo	'  - fdw - build PXF Foreign-Data Wrapper Greenplum extension'
+	@echo	'  - fdw - build Greenplum foreign data wrapper extension'
 	@echo	'  - cli - install Go CLI dependencies and build Go CLI'
-	@echo	'  - server - install PXF server dependencies and build PXF server'
+	@echo	'  - server - install server dependencies and build server module'
 	@echo	'  - clean - clean up external-table, fdw, CLI and server binaries'
-	@echo	'  - test - runs tests for PXF Go CLI and server'
-	@echo	'  - install - install PXF external table extension, CLI and server'
-	@echo	'  - install-server - install PXF server without running tests'
-	@echo	'  - tar - bundle PXF external table extension, CLI, server and tomcat into a single tarball'
+	@echo	'  - test - runs tests for Go CLI and server'
+	@echo	'  - install - install external table and foreign data wrapper extensions, CLI and server binaries'
+	@echo	'  - install-server - install server binaries only without running tests'
+	@echo	'  - stage - install external table and foreign data wrapper extensions, CLI, and server binaries into build/stage/pxf directory'
+	@echo	'  - tar - bundle external table and foreign data wrapper extensions, CLI, and server into a single tarball'
 	@echo	'  - rpm - create PXF RPM package'
 	@echo	'  - rpm-tar - bundle PXF RPM package along with helper scripts into a single tarball'
 	@echo	'  - deb - create PXF DEB package'

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ rpm: stage
 	PXF_MAIN_VERSION=$${PXF_VERSION//-SNAPSHOT/} ;\
 	if [[ $${PXF_VERSION} == *"-SNAPSHOT" ]]; then PXF_RELEASE=SNAPSHOT; else PXF_RELEASE=1; fi ;\
 	mkdir -p build/rpmbuild/{BUILD,RPMS,SOURCES,SPECS} ;\
-	cp -a /build/stage/pxf/* build/rpmbuild/SOURCES ;\
+	cp -a build/stage/pxf/* build/rpmbuild/SOURCES ;\
 	cp package/*.spec build/rpmbuild/SPECS/ ;\
 	rpmbuild \
 	--define "_topdir $${PWD}/build/rpmbuild" \

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ export SKIP_FDW_PACKAGE_REASON
 export GP_MAJORVERSION
 export GP_BUILD_ARCH
 
+PXF_PACKAGE_NAME := pxf-gpdb$(GP_MAJORVERSION)-$(PXF_VERSION)-$(GP_BUILD_ARCH)
+export PXF_PACKAGE_NAME
+
 LICENSE ?= ASL 2.0
 VENDOR ?= Open Source
 
@@ -100,7 +103,6 @@ ifneq ($(SKIP_FDW_PACKAGE_REASON),)
 	$(eval PXF_MODULES := $(filter-out fdw,$(PXF_MODULES)))
 endif
 	set -e ;\
-	PXF_PACKAGE_NAME=pxf-gpdb$${GP_MAJORVERSION}-$${PXF_VERSION}-$${GP_BUILD_ARCH} ;\
 	mkdir -p build/stage/$${PXF_PACKAGE_NAME}/pxf ;\
 	for module in $${PXF_MODULES[@]}; do \
 		echo "===> Staging [$${module}] module <===" ;\
@@ -114,7 +116,7 @@ endif
 tar: stage
 	rm -rf build/dist
 	mkdir -p build/dist
-	tar -czf build/dist/$(shell ls build/stage).tar.gz -C build/stage $(shell ls build/stage)
+	tar -czf build/dist/$(PXF_PACKAGE_NAME).tar.gz -C build/stage $(PXF_PACKAGE_NAME)
 	echo "===> PXF TAR file with binaries creation is complete <==="
 
 rpm: stage
@@ -123,7 +125,7 @@ rpm: stage
 	PXF_MAIN_VERSION=$${PXF_VERSION//-SNAPSHOT/} ;\
 	if [[ $${PXF_VERSION} == *"-SNAPSHOT" ]]; then PXF_RELEASE=SNAPSHOT; else PXF_RELEASE=1; fi ;\
 	mkdir -p build/rpmbuild/{BUILD,RPMS,SOURCES,SPECS} ;\
-	cp -a build/stage/pxf/* build/rpmbuild/SOURCES ;\
+	cp -a build/stage/$${PXF_PACKAGE_NAME}/pxf/* build/rpmbuild/SOURCES ;\
 	cp package/*.spec build/rpmbuild/SPECS/ ;\
 	rpmbuild \
 	--define "_topdir $${PWD}/build/rpmbuild" \
@@ -153,7 +155,7 @@ deb: stage
 	PXF_MAIN_VERSION=$${PXF_VERSION//-SNAPSHOT/} ;\
 	if [[ $${PXF_VERSION} == *"-SNAPSHOT" ]]; then PXF_RELEASE=SNAPSHOT; else PXF_RELEASE=1; fi ;\
 	mkdir -p build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION} ;\
-	cp -a build/stage/pxf/* build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION} ;\
+	cp -a build/stage/$${PXF_PACKAGE_NAME}/pxf/* build/debbuild/usr/local/pxf-gp$${GP_MAJORVERSION} ;\
 	mkdir build/debbuild/DEBIAN ;\
 	cp -a package/DEBIAN/* build/debbuild/DEBIAN/ ;\
 	sed -i -e "s/%VERSION%/$${PXF_MAIN_VERSION}-$${PXF_RELEASE}/" -e "s/%MAINTAINER%/${VENDOR}/" build/debbuild/DEBIAN/control ;\

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -21,7 +21,7 @@ help:
 	@echo	"  - all (build, test, stage, install)"
 	@echo	"  - build - build pxf-cli binary"
 	@echo	"  - test - runs tests for pxf-cli binary"
-	@echo	"  - stage - install pxf-cli binary into build/stage/pxf/bin directory"
+	@echo	"  - stage - install pxf-cli binary into build/stage/bin directory"
 	@echo	"  - install - install pxf-cli binary into $PXF_HOME/bin/"
 	@echo	"  - clean - remove pxf-cli binary"
 
@@ -35,8 +35,8 @@ build:
 	go build -v $(LDFLAGS) -o build/$(TARGET) $(MODULE_NAME)
 
 stage: test
-	mkdir -p $(PXF_CLI_DIR)/build/stage/pxf/bin
-	cp build/$(TARGET) build/stage/pxf/bin
+	mkdir -p $(PXF_CLI_DIR)/build/stage/bin
+	cp build/$(TARGET) build/stage/bin
 
 install: build
 	@if [ -z "$(PXF_HOME)" ]; then \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,6 +1,6 @@
 include ../common.mk
 
-.PHONY: all build stage install test clean help
+.PHONY: all build stage install test clean clean-all help
 .DEFAULT_GOAL := build
 
 MODULE_NAME    := $(shell go list -m)
@@ -29,7 +29,7 @@ all: test stage install
 
 build:
 	@if [ -d ${HOME}/.go-mod-cached-sources ] && [ ! -d $(GOMODCACHE) ]; then \
-		mkdir -p $(GO_MOD_CACHE); \
+		mkdir -p $(GOMODCACHE); \
 		ln -s ${HOME}/.go-mod-cached-sources $(GOMODCACHE); \
 	fi
 	go build -v $(LDFLAGS) -o build/$(TARGET) $(MODULE_NAME)
@@ -56,3 +56,5 @@ install-tools:
 clean:
 	rm -rf $(PXF_CLI_DIR)/build
 	go clean -i
+
+clean-all: clean

--- a/concourse/scripts/build.bash
+++ b/concourse/scripts/build.bash
@@ -81,8 +81,8 @@ function package_pxf_fdw() {
     local pxf_fdw_tarball="pxf_src/build/${DIST_DIR}/pxf-fdw${pxf_tarball#pxf}"
 
     # build the tarball and copy it to the output directory
-    ls -al pxf_src/fdw/build/stage
-    tar -cvzf "${pxf_fdw_tarball}" -C pxf_src/fdw/build/stage .
+    ls -al pxf_src/fdw/build/stage/fdw
+    tar -cvzf "${pxf_fdw_tarball}" -C pxf_src/fdw/build/stage/fdw .
     cp pxf_src/build/${DIST_DIR}/pxf-fdw-*.tar.gz dist
 }
 

--- a/external-table/Makefile
+++ b/external-table/Makefile
@@ -17,14 +17,14 @@ include $(PGXS)
 
 .PHONY: stage
 stage: pxf.so
-	mkdir -p build/stage
-	install -c -m 755 pxf.so build/stage/pxf.so
-	install -c -m 644 pxf.control build/stage/
-	install -c -m 644 pxf--1.0.sql build/stage/
-	install -c -m 644 pxf--2.0.sql build/stage/
-	install -c -m 644 pxf--1.0--2.0.sql build/stage/
-	@echo "gpdb.version=$(GP_VERSION)" > build/stage/metadata
-	@echo "gpdb.major-version=$(GP_MAJORVERSION)" >> build/stage/metadata
+	mkdir -p build/stage/gpextable
+	install -c -m 755 pxf.so build/stage/gpextable/pxf.so
+	install -c -m 644 pxf.control build/stage/gpextable/
+	install -c -m 644 pxf--1.0.sql build/stage/gpextable/
+	install -c -m 644 pxf--2.0.sql build/stage/gpextable/
+	install -c -m 644 pxf--1.0--2.0.sql build/stage/gpextable/
+	@echo "gpdb.version=$(GP_VERSION)" > build/stage/gpextable/metadata
+	@echo "gpdb.major-version=$(GP_MAJORVERSION)" >> build/stage/gpextable/metadata
 
 .PHONY: clean-all
 clean-all: clean

--- a/fdw/Makefile
+++ b/fdw/Makefile
@@ -18,12 +18,12 @@ include $(PGXS)
 
 .PHONY: stage
 stage: pxf_fdw.so
-	mkdir -p build/stage
-	install -c -m 755 pxf_fdw.so build/stage/pxf_fdw.so
-	install -c -m 644 pxf_fdw.control build/stage/
-	install -c -m 644 pxf_fdw--1.0.sql build/stage/
-	@echo "gpdb.version=$(GP_VERSION)" > build/stage/metadata
-	@echo "gpdb.major-version=$(GP_MAJORVERSION)" >> build/stage/metadata
+	mkdir -p build/stage/fdw
+	install -c -m 755 pxf_fdw.so build/stage/fdw/pxf_fdw.so
+	install -c -m 644 pxf_fdw.control build/stage/fdw/
+	install -c -m 644 pxf_fdw--1.0.sql build/stage/fdw/
+	@echo "gpdb.version=$(GP_VERSION)" > build/stage/fdw/metadata
+	@echo "gpdb.major-version=$(GP_MAJORVERSION)" >> build/stage/fdw/metadata
 
 .PHONY: clean-all
 clean-all: clean

--- a/server/Makefile
+++ b/server/Makefile
@@ -72,24 +72,24 @@ coverage:
 .PHONY: stage
 stage:
 	./gradlew $(PXF_GRADLE_PROPERTIES) test stage
-	install -m 744 -d "build/stage/pxf/lib"
-	install -m 744 -d "build/stage/pxf/lib/native"
-	install -m 744 -d "build/stage/pxf/servers"
-	install -m 744 -d "build/stage/pxf/servers/default"
-	install -m 700 -d "build/stage/pxf/logs"
-	install -m 700 -d "build/stage/pxf/run"
-	install -m 700 -d "build/stage/pxf/keytabs"
+	install -m 744 -d "build/stage/lib"
+	install -m 744 -d "build/stage/lib/native"
+	install -m 744 -d "build/stage/servers"
+	install -m 744 -d "build/stage/servers/default"
+	install -m 700 -d "build/stage/logs"
+	install -m 700 -d "build/stage/run"
+	install -m 700 -d "build/stage/keytabs"
 
 .PHONY: stage-notest
 stage-notest:
 	./gradlew $(PXF_GRADLE_PROPERTIES) stage -x test
-	install -m 744 -d "build/stage/pxf/lib"
-	install -m 744 -d "build/stage/pxf/lib/native"
-	install -m 744 -d "build/stage/pxf/servers"
-	install -m 744 -d "build/stage/pxf/servers/default"
-	install -m 700 -d "build/stage/pxf/logs"
-	install -m 700 -d "build/stage/pxf/run"
-	install -m 700 -d "build/stage/pxf/keytabs"
+	install -m 744 -d "build/stage/lib"
+	install -m 744 -d "build/stage/lib/native"
+	install -m 744 -d "build/stage/servers"
+	install -m 744 -d "build/stage/servers/default"
+	install -m 700 -d "build/stage/logs"
+	install -m 700 -d "build/stage/run"
+	install -m 700 -d "build/stage/keytabs"
 
 clean:
 	./gradlew clean
@@ -106,7 +106,7 @@ install: stage
 		echo "ERROR: PXF_HOME is not set"; exit 2; \
 	fi
 	mkdir -p "$(PXF_HOME)"
-	cp -R build/stage/pxf/* "$(PXF_HOME)"
+	cp -R build/stage/* "$(PXF_HOME)"
 
 .PHONY: install-server
 install-server: stage-notest
@@ -114,7 +114,7 @@ install-server: stage-notest
 		echo "ERROR: PXF_HOME is not set"; exit 2; \
 	fi
 	mkdir -p "$(PXF_HOME)"
-	cp -R build/stage/pxf/* "$(PXF_HOME)"
+	cp -R build/stage/* "$(PXF_HOME)"
 
 .PHONY: version
 version:

--- a/server/Makefile
+++ b/server/Makefile
@@ -95,6 +95,9 @@ clean:
 	./gradlew clean
 	rm -rf build
 
+.PHONY: clean-all
+clean-all: clean
+
 distclean maintainer-clean: clean
 
 doc:

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -268,7 +268,7 @@ task stage(type: Copy) {
         filter { line -> line.replaceAll('_PXF_VERSION_', "${version}") }
     }
     from('pxf-service/src/templates')
-    into "$buildDir/stage/pxf"
+    into "$buildDir/stage"
 
-    doLast { new File("${buildDir}/stage/pxf/version").text = "${version}\n" }
+    doLast { new File("${buildDir}/stage/version").text = "${version}\n" }
 }


### PR DESCRIPTION
A few changes introduced here to streamline the main Makefile:
- each individual module's stage target copies its artifacts into `build/stage/<dirs>` where `<dirs>` are directories inside a PXF_HOME, so for example any files that will go into PXF_HOME/bin would be staged by individual modules into their own respective build/stage/bin directories
- top Makefile stage target now just copies artifacts from sub-modules' build/stage directory since submodules take responsibility of laying out directories and artifacts according to their place in PXF_HOME
- rpm and deb targets now depend on the stage target
- more echoing to the user what is happening and the overall success message at the end of multi-module targets such as stage / install / rpm etc. 