### PR TITLE
Support for GP7 rhel8 & rocky8 distro identifier (el8) change.

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -523,7 +523,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/greenplum-db-(7.*)-rocky8-x86_64.rpm
+    regexp: server/published/main/greenplum-db-(7.*)-el8-x86_64.rpm
 
 ## ---------- PXF 5 (for GPDB 6) Artifact ---------------
 - name: pxf5_gp6_rhel7_released

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -301,7 +301,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/greenplum-db-(7.*)-rocky8-x86_64.rpm
+    regexp: server/published/main/greenplum-db-(7.*)-el8-x86_64.rpm
 
 ## ---------- PXF 5 Artifact ---------------
 {% if multinode %}

--- a/concourse/pipelines/templates/pr_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/pr_pipeline-tpl.yml
@@ -131,7 +131,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/greenplum-db-(7.*)-rocky8-x86_64.rpm
+    regexp: server/published/main/greenplum-db-(7.*)-el8-x86_64.rpm
 
 ## ======================================================================
 ## JOBS

--- a/concourse/scripts/build.bash
+++ b/concourse/scripts/build.bash
@@ -11,7 +11,15 @@ GPDB_VERSION=$(<"${GPDB_PKG_DIR}/version")
 function install_gpdb() {
     local pkg_file
     if command -v rpm; then
-        pkg_file=$(find "${GPDB_PKG_DIR}" -name "greenplum-db-${GPDB_VERSION}-r*-x86_64.rpm")
+        # For GP7 and above, a new rhel8 & rocky8 distro identifier
+        # (el8) has been introduced.
+        if [[ ${GPDB_VERSION%%.*} -ge 7 ]]; then
+            DISTRO_MATCHING_PATTERN="el"
+        else
+            DISTRO_MATCHING_PATTERN="r"
+        fi
+        pkg_file=$(find "${GPDB_PKG_DIR}" -name "greenplum-db-${GPDB_VERSION}-${DISTRO_MATCHING_PATTERN}*-x86_64.rpm")
+
         echo "Installing RPM ${pkg_file}..."
         rpm --quiet -ivh "${pkg_file}" >/dev/null
     elif command -v apt-get; then


### PR DESCRIPTION
For GP7 and above, a new rhel8 & rocky8 distro identifier (el8) has been introduced.

I have validated tests with dev release and build pipelines flexing the build job change in GP5, GP6, & GP7 configurations across all supported platforms.

Once this change is merged, I will be updating the `pxf-build` and `pxf_pr_pipeilne` pipelines.
The PR pipeline (`concourse-ci/Build and Test PXF-GP7 on RHEL8` job) catches this build issue this addresses.