### PR TITLE
Additional gp7 release support

### DIFF
--- a/concourse/scripts/get_pxf_release_artifacts.bash
+++ b/concourse/scripts/get_pxf_release_artifacts.bash
@@ -44,6 +44,7 @@ artifacts=(
   "${GCS_RELEASES_PATH}/gp6/pxf-gp6-${version}-1.el7.x86_64.rpm"
   "${GCS_RELEASES_PATH}/gp6/pxf-gp6-${version}-1.el8.x86_64.rpm"
   "${GCS_RELEASES_PATH}/gp6/pxf-gp6-${version}-1-ubuntu18.04-amd64.deb"
+  "${GCS_RELEASES_PATH}/gp7/pxf-gp7-${version}-1.el8.x86_64.rpm"
   "${GCS_OSL_PATH}/open_source_license_VMware_Tanzu_Greenplum_Platform_Extension_Framework_${version}_GA.txt"
   "${GCS_ODP_PATH}/VMware-greenplum-pxf-${version}-ODP.tar.gz"
 )

--- a/concourse/scripts/get_pxf_release_artifacts.bash
+++ b/concourse/scripts/get_pxf_release_artifacts.bash
@@ -45,7 +45,7 @@ artifacts=(
   "${GCS_RELEASES_PATH}/gp6/pxf-gp6-${version}-1.el8.x86_64.rpm"
   "${GCS_RELEASES_PATH}/gp6/pxf-gp6-${version}-1-ubuntu18.04-amd64.deb"
   "${GCS_RELEASES_PATH}/gp7/pxf-gp7-${version}-1.el8.x86_64.rpm"
-  "${GCS_OSL_PATH}/open_source_license_VMware_Tanzu_Greenplum_Platform_Extension_Framework_${version}_GA.txt"
+  "${GCS_OSL_PATH}/open_source_license_VMware_Greenplum_Platform_Extension_Framework_${version}_GA.txt"
   "${GCS_ODP_PATH}/VMware-greenplum-pxf-${version}-ODP.tar.gz"
 )
 


### PR DESCRIPTION
Upon reviewing the `pxf-build (pipeline) --> Publish_PXF-GP5_and_PXF-GP6_Artifacts_to_GP-RelEng (job) --> Get PXF-GP5 and PXF-GP6 Artifacts from Releases Directory (task)`, I noticed the need for the changes in this PR.

Outstanding question: In `Publish_PXF-GP5_and_PXF-GP6_Artifacts_to_GP-RelEng`, I notice the creation of pxf_gp5 and pxf_gp6 tarballs. Is there a need for a gp7 variant?

There are also a few occurrences of jobs and tasks referencing PXF-GP5 and PXF-GP6 and not PXF-GP7 even though it is also part of the workflow. At some point, we should change that to be inclusive in terminology or generic in nature (my preference).  This should happen after the release. If the names are changed now, the previous build job logs will not be available for review. I'm expecting the previous run output to be helpful to diagnose any issues with the new PXF GP7 support.
