### PR TITLE
remove RESOURCE QUEUE from test SQL

### DIFF
--- a/automation/tinc/main/tinctest/lib/global_init_file
+++ b/automation/tinc/main/tinctest/lib/global_init_file
@@ -71,4 +71,8 @@ s/, record/, line/
 m/invalid input syntax for type/
 s/invalid input syntax for type/invalid input syntax for/
 
+# ignore resource queue notice for GP6
+m/NOTICE: resource queue required – using default resource queue.*/
+s/.*//g
+
 -- end_matchsubs

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_1_pre_failover/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_1_pre_failover/expected/query02.ans
@@ -10,7 +10,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_1_pre_failover/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_1_pre_failover/expected/query04.ans
@@ -11,7 +11,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_1_pre_failover/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_1_pre_failover/sql/query02.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_hdfsha_hdfs_ipa TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_1_pre_failover/sql/query04.sql
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_1_pre_failover/sql/query04.sql
@@ -12,7 +12,7 @@ GRANT ALL ON TABLE pxf_hdfsha_hdfs_ipa TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_2_after_failover/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_2_after_failover/expected/query02.ans
@@ -10,7 +10,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_2_after_failover/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_2_after_failover/expected/query04.ans
@@ -11,7 +11,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_2_after_failover/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_2_after_failover/sql/query02.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_hdfsha_hdfs_ipa TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_2_after_failover/sql/query04.sql
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_2_after_failover/sql/query04.sql
@@ -12,7 +12,7 @@ GRANT ALL ON TABLE pxf_hdfsha_hdfs_ipa TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_3_after_failover_back/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_3_after_failover_back/expected/query02.ans
@@ -10,7 +10,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_3_after_failover_back/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_3_after_failover_back/expected/query04.ans
@@ -11,7 +11,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_3_after_failover_back/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_3_after_failover_back/sql/query02.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_hdfsha_hdfs_ipa TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/hdfsha/step_3_after_failover_back/sql/query04.sql
+++ b/automation/tincrepo/main/pxf/features/hdfsha/step_3_after_failover_back/sql/query04.sql
@@ -12,7 +12,7 @@ GRANT ALL ON TABLE pxf_hdfsha_hdfs_ipa TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_hdfsha_hdfs_ipa ORDER BY name;

--- a/automation/tincrepo/main/pxf/features/multi_user/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/multi_user/expected/query01.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 SELECT t1, t2, num1, dub1, dec1, tm, r, bg, b, tn, sml, dt, vc1, c1, encode(bin, 'escape') FROM pxf_jdbc_readable ORDER BY t1;
           t1          |  t2  | num1 | dub1 |      dec1      |         tm          |  r   |    bg    | b | tn | sml  |     dt     |  vc1  | c1  | bin

--- a/automation/tincrepo/main/pxf/features/multi_user/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/features/multi_user/expected/query02.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 You are now connected to database "pxfautomation" as user "testuser".

--- a/automation/tincrepo/main/pxf/features/multi_user/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/multi_user/sql/query01.sql
@@ -10,7 +10,7 @@
 GRANT ALL ON TABLE pxf_jdbc_readable TO PUBLIC;
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 SELECT t1, t2, num1, dub1, dec1, tm, r, bg, b, tn, sml, dt, vc1, c1, encode(bin, 'escape') FROM pxf_jdbc_readable ORDER BY t1;
 

--- a/automation/tincrepo/main/pxf/features/multi_user/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/features/multi_user/sql/query02.sql
@@ -9,7 +9,7 @@
 GRANT ALL ON TABLE pxf_jdbc_readable_overrideddl TO PUBLIC;
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT t1, t2, num1, dub1, dec1, tm, r, bg, b, tn, sml, dt, vc1, c1, encode(bin, 'escape') FROM pxf_jdbc_readable_overrideddl ORDER BY t1;

--- a/automation/tincrepo/main/pxf/proxy/hbase_small_data/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/proxy/hbase_small_data/expected/query01.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hbase_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hbase_small_data/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/proxy/hbase_small_data/expected/query02.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT name, num FROM pxf_proxy_hbase_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hbase_small_data/expected/query03.ans
+++ b/automation/tincrepo/main/pxf/proxy/hbase_small_data/expected/query03.ans
@@ -21,7 +21,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hbase_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hbase_small_data/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/proxy/hbase_small_data/sql/query01.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_hbase_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hbase_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hbase_small_data/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/proxy/hbase_small_data/sql/query02.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_hbase_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT name, num FROM pxf_proxy_hbase_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hbase_small_data/sql/query03.sql
+++ b/automation/tincrepo/main/pxf/proxy/hbase_small_data/sql/query03.sql
@@ -20,7 +20,7 @@ GRANT ALL ON TABLE pxf_proxy_hbase_small_data_prohibited TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hbase_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query01.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query02.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT name, num FROM pxf_proxy_hive_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query03.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query03.ans
@@ -21,7 +21,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query04.ans
@@ -33,7 +33,7 @@ DETAIL:  External table pxf_proxy_hive_small_data_allowed_no_impersonation
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_small_data_allowed_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query05.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/expected/query05.ans
@@ -33,7 +33,7 @@ DETAIL:  External table pxf_proxy_hive_small_data_prohibited_no_impersonation
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_small_data_prohibited_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query01.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_hive_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query02.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_hive_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT name, num FROM pxf_proxy_hive_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query03.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query03.sql
@@ -20,7 +20,7 @@ GRANT ALL ON TABLE pxf_proxy_hive_small_data_prohibited TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query04.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query04.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_hive_small_data_allowed_no_impersonation ORDER BY name;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_small_data_allowed_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query05.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data/sql/query05.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_hive_small_data_prohibited_no_impersonation ORDER BY nam
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_small_data_prohibited_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query01.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_ipa_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query02.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT name, num FROM pxf_proxy_hive_ipa_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query03.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query03.ans
@@ -21,7 +21,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_ipa_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query04.ans
@@ -33,7 +33,7 @@ DETAIL:  External table pxf_proxy_hive_ipa_small_data_allowed_no_impersonation
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_ipa_small_data_allowed_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query05.ans
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/expected/query05.ans
@@ -33,7 +33,7 @@ DETAIL:  External table pxf_proxy_hive_ipa_small_data_prohibited_no_impersonatio
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_ipa_small_data_prohibited_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query01.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_hive_ipa_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_ipa_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query02.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_hive_ipa_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT name, num FROM pxf_proxy_hive_ipa_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query03.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query03.sql
@@ -20,7 +20,7 @@ GRANT ALL ON TABLE pxf_proxy_hive_ipa_small_data_prohibited TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_ipa_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query04.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query04.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_hive_ipa_small_data_allowed_no_impersonation ORDER BY na
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_ipa_small_data_allowed_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query05.sql
+++ b/automation/tincrepo/main/pxf/proxy/hive_small_data_ipa/sql/query05.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_hive_ipa_small_data_prohibited_no_impersonation ORDER BY
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_hive_ipa_small_data_prohibited_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data/expected/query01.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data/expected/query02.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT name, num FROM pxf_proxy_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/expected/query03.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data/expected/query03.ans
@@ -24,7 +24,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data/expected/query04.ans
@@ -33,7 +33,7 @@ DETAIL:  External table pxf_proxy_small_data_allowed_no_impersonation, file pxf:
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_small_data_allowed_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/expected/query05.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data/expected/query05.ans
@@ -33,7 +33,7 @@ DETAIL:  External table pxf_proxy_small_data_prohibited_no_impersonation, file p
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_small_data_prohibited_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data/sql/query01.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data/sql/query02.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT name, num FROM pxf_proxy_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/sql/query03.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data/sql/query03.sql
@@ -23,7 +23,7 @@ GRANT ALL ON TABLE pxf_proxy_small_data_prohibited TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/sql/query04.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data/sql/query04.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_small_data_allowed_no_impersonation ORDER BY name;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_small_data_allowed_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data/sql/query05.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data/sql/query05.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_small_data_prohibited_no_impersonation ORDER BY name;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_small_data_prohibited_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query01.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query02.ans
@@ -12,7 +12,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT name, num FROM pxf_proxy_ipa_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query03.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query03.ans
@@ -24,7 +24,7 @@ GRANT
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query04.ans
@@ -33,7 +33,7 @@ DETAIL:  External table pxf_proxy_ipa_small_data_allowed_no_impersonation, file 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_allowed_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query05.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query05.ans
@@ -33,7 +33,7 @@ DETAIL:  External table pxf_proxy_ipa_small_data_prohibited_no_impersonation, fi
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_prohibited_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query06.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query06.ans
@@ -34,7 +34,7 @@ DETAIL:  External table pxf_proxy_ipa_small_data_allowed_no_impersonation_no_svc
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_allowed_no_impersonation_no_svcuser ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query07.ans
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/expected/query07.ans
@@ -133,7 +133,7 @@ SELECT * FROM pxf_proxy_ipa_small_data_prohibited_no_impersonation_no_svcuser OR
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
 DROP ROLE
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 CREATE ROLE
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_prohibited_no_impersonation_no_svcuser ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query01.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_ipa_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_allowed ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query02.sql
@@ -11,7 +11,7 @@ GRANT ALL ON TABLE pxf_proxy_ipa_small_data_allowed TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT name, num FROM pxf_proxy_ipa_small_data_allowed WHERE num > 50 ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query03.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query03.sql
@@ -23,7 +23,7 @@ GRANT ALL ON TABLE pxf_proxy_ipa_small_data_prohibited TO PUBLIC;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_prohibited ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query04.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query04.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_ipa_small_data_allowed_no_impersonation ORDER BY name;
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_allowed_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query05.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query05.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_ipa_small_data_prohibited_no_impersonation ORDER BY name
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_prohibited_no_impersonation ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query06.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query06.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_ipa_small_data_allowed_no_impersonation_no_svcuser ORDER
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_allowed_no_impersonation_no_svcuser ORDER BY name;

--- a/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query07.sql
+++ b/automation/tincrepo/main/pxf/proxy/small_data_ipa/sql/query07.sql
@@ -29,7 +29,7 @@ SELECT * FROM pxf_proxy_ipa_small_data_prohibited_no_impersonation_no_svcuser OR
 
 \set OLD_GP_USER :USER
 DROP ROLE IF EXISTS testuser;
-CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE testuser LOGIN;
 
 \connect - testuser
 SELECT * FROM pxf_proxy_ipa_small_data_prohibited_no_impersonation_no_svcuser ORDER BY name;


### PR DESCRIPTION
GP7 made a change related to `RESOURCE QUEUE` in this [commit](https://github.com/greenplum-db/gpdb/commit/82851a0b855c0c980422f3541d2f770470cbd8b9), which brings extra warning message when running `CREATE ROLE testuser LOGIN RESOURCE QUEUE pg_default` in GP7 automation tests. 
- Since PXF doesn't care about `RESOURCE QUEUE`. We decide to remove `RESOURCE QUEUE` from our automation testing sql. 
- At the meantime, `CREATE ROLE testuser LOGIN` will generate another `NOTICE` message when running GP6 automation tests, so a `matchsubs` is added in `global_init_file` to ignore all these `NOTICE` messages.