### PR TITLE
Update table options names to not include dash character

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ExternalTable.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ExternalTable.java
@@ -136,6 +136,8 @@ public abstract class ExternalTable extends Table {
         }
 
         if (getDataSchema() != null) {
+            // even though the new option name is DATA_SCHEMA, we can still use DATA-SCHEMA for an external table
+            // to test backward compatibility
             appendParameter(sb, "DATA-SCHEMA=" + getDataSchema());
         }
 

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
@@ -98,7 +98,7 @@ public class ForeignTable extends WritableExternalTable {
         // combined in a single set, so the net result is the same, other than testing option precedence rules
 
         if (getDataSchema() != null) {
-            appendOption(joiner, "DATA-SCHEMA", getDataSchema());
+            appendOption(joiner, "DATA_SCHEMA", getDataSchema()); // new option name is DATA_SCHEMA
         }
 
         if (getExternalDataSchema() != null) {

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hdfs/HdfsAnalyzeTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hdfs/HdfsAnalyzeTest.java
@@ -1,5 +1,6 @@
 package org.greenplum.pxf.automation.features.hdfs;
 
+import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.components.cluster.PhdCluster;
 import org.greenplum.pxf.automation.datapreparer.CustomSequencePreparer;
 import org.greenplum.pxf.automation.datapreparer.CustomTextPreparer;
@@ -44,6 +45,7 @@ import java.sql.SQLWarning;
  * <li>performance 10TB.</li>
  * </ul>
  */
+@WorksWithFDW
 public class HdfsAnalyzeTest extends BaseFeature {
 
     private String resourcePath;
@@ -647,7 +649,7 @@ public class HdfsAnalyzeTest extends BaseFeature {
     }
 
     /**
-     * Create a table with STATS-MAX-FRAGMENTS parameter, and check that the
+     * Create a table with STATS_MAX_FRAGMENTS parameter, and check that the
      * number of returned fragments does not exceed this number when querying
      * the table.
      *
@@ -679,15 +681,15 @@ public class HdfsAnalyzeTest extends BaseFeature {
         exTable.setPath(protocol.getExternalTablePath(hdfs.getBasePath(), csvPathAll));
 
         exTable.setUserParameters(new String[] {
-                "STATS-MAX-FRAGMENTS=2",
-                "STATS-SAMPLE-RATIO=1.00" });
+                "STATS_MAX_FRAGMENTS=2",
+                "STATS_SAMPLE_RATIO=1.00" });
 
         gpdb.createTableAndVerify(exTable);
 
         ReportUtils.report(
                 null,
                 getClass(),
-                "Query table to check STATS-MAX-FRAGMENTS parameter - only 2 fragments should be returned.");
+                "Query table to check STATS_MAX_FRAGMENTS parameter - only 2 fragments should be returned.");
         gpdb.queryResults(exTable, "SELECT * FROM " + exTable.getName()
                 + " ORDER BY n1");
 
@@ -697,7 +699,7 @@ public class HdfsAnalyzeTest extends BaseFeature {
     }
 
     /**
-     * Create a table with STATS-SAMPLE-RATIO parameter, and check that the
+     * Create a table with STATS_SAMPLE_RATIO parameter, and check that the
      * number of returned records matches the ratio.
      *
      * @throws Exception if test failed to run
@@ -720,15 +722,15 @@ public class HdfsAnalyzeTest extends BaseFeature {
         exTable.setPath(protocol.getExternalTablePath(hdfs.getBasePath(), csvPath));
 
         exTable.setUserParameters(new String[] {
-                "STATS-MAX-FRAGMENTS=100",
-                "STATS-SAMPLE-RATIO=0.0010" });
+                "STATS_MAX_FRAGMENTS=100",
+                "STATS_SAMPLE_RATIO=0.0010" });
 
         gpdb.createTableAndVerify(exTable);
 
         ReportUtils.startLevel(
                 null,
                 getClass(),
-                "Query table to check STATS-SAMPLE-RATIO parameter - only 1 record should be returned.");
+                "Query table to check STATS_SAMPLE_RATIO parameter - only 1 record should be returned.");
         gpdb.queryResults(exTable, "SELECT COUNT(*) FROM " + exTable.getName());
 
         int countResult = Integer.parseInt(exTable.getData().get(0).get(0));
@@ -736,15 +738,15 @@ public class HdfsAnalyzeTest extends BaseFeature {
         ReportUtils.stopLevel(null);
 
         exTable.setUserParameters(new String[] {
-                "STATS-MAX-FRAGMENTS=100",
-                "STATS-SAMPLE-RATIO=0.05" });
+                "STATS_MAX_FRAGMENTS=100",
+                "STATS_SAMPLE_RATIO=0.05" });
 
         gpdb.createTableAndVerify(exTable);
 
         ReportUtils.startLevel(
                 null,
                 getClass(),
-                "Query table to check STATS-SAMPLE-RATIO parameter - only 50 records should be returned.");
+                "Query table to check STATS_SAMPLE_RATIO parameter - only 50 records should be returned.");
         gpdb.queryResults(exTable, "SELECT COUNT(*) FROM " + exTable.getName());
 
         countResult = Integer.parseInt(exTable.getData().get(0).get(0));
@@ -752,15 +754,15 @@ public class HdfsAnalyzeTest extends BaseFeature {
         ReportUtils.stopLevel(null);
 
         exTable.setUserParameters(new String[] {
-                "STATS-MAX-FRAGMENTS=100",
-                "STATS-SAMPLE-RATIO=0.935" });
+                "STATS_MAX_FRAGMENTS=100",
+                "STATS_SAMPLE_RATIO=0.935" });
 
         gpdb.createTableAndVerify(exTable);
 
         ReportUtils.startLevel(
                 null,
                 getClass(),
-                "Query table to check STATS-SAMPLE-RATIO parameter - only 935 record should be returned.");
+                "Query table to check STATS_SAMPLE_RATIO parameter - only 935 record should be returned.");
         gpdb.queryResults(exTable, "SELECT COUNT(*) FROM " + exTable.getName());
 
         countResult = Integer.parseInt(exTable.getData().get(0).get(0));

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -1,6 +1,5 @@
 package org.greenplum.pxf.automation.features.writable;
 
-import annotations.WorksWithFDW;
 import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.automation.datapreparer.writable.WritableDataPreparer;
 import org.greenplum.pxf.automation.enums.EnumCompressionTypes;

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -27,7 +27,6 @@ import static java.lang.Thread.sleep;
 /**
  * Testing cases for PXF Writable feature for Text formats (Text, CSV) and compressions.
  */
-@WorksWithFDW
 public class HdfsWritableTextTest extends BaseWritableFeature {
 
     private static final String COMPRESSION_CODEC = "org.apache.hadoop.io.compress.DefaultCodec";

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -84,44 +84,6 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
     }
 
     /**
-     * Insert data using "THREAD-SAFE=FALSE" option literally
-     *
-     * @throws Exception if test fails to run
-     */
-    @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    public void textFormatInsertThreadSafeFalse() throws Exception {
-
-        String hdfsPath = hdfsWritePath + "/text_format_thread_safe_false";
-        writableExTable = prepareWritableTable("pxf_text_format_thread_safe_false", hdfsPath, null, null, new String[]{"THREAD-SAFE=FALSE"});
-
-        insertData(dataTable, writableExTable, InsertionMethod.INSERT);
-        verifyResult(hdfsPath, dataTable);
-    }
-
-    /**
-     * Insert data using 2 Writable tables using "THREAD-SAFE=FALSE" and the
-     * other "THREAD-SAFE=TRUE"
-     *
-     * @throws Exception if test fails to run
-     */
-    @Test(groups = {"features", "gpdb", "hcfs", "security"})
-    public void textFormatInsertDifferentThreadSafeStates() throws Exception {
-
-        String hdfsPath = hdfsWritePath + "/text_format_insert_different_thread_safe_states";
-        writableExTable =
-                prepareWritableTable("pxf_text_format_insert_thread_safe_true", hdfsPath, null);
-        WritableExternalTable writableExTableFalseThreadSafe =
-                prepareWritableTable("pxf_text_format_insert_thread_safe_false", hdfsPath, null, null, new String[]{"THREAD-SAFE=FALSE"});
-
-        insertData(dataTable, writableExTable, InsertionMethod.INSERT);
-        insertData(dataTable, writableExTableFalseThreadSafe, InsertionMethod.INSERT);
-        Table pumpedDataTable = new Table("pumped_data_table", null);
-        pumpedDataTable.setData(dataTable.getData());
-        pumpedDataTable.pumpUpTableData(2);
-        verifyResult(hdfsPath, pumpedDataTable);
-    }
-
-    /**
      * Insert data using "org.apache.hadoop.io.compress.DefaultCodec" codec.
      *
      * @throws Exception if test fails to run
@@ -378,7 +340,7 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
     public void textFormatBZip2Insert() throws Exception {
 
         String hdfsPath = hdfsWritePath + "/bzip2_format_using_insert";
-        writableExTable = prepareWritableBZip2Table("pxf_bzip2_format_using_insert", hdfsPath, null);
+        writableExTable = prepareWritableBZip2Table("pxf_bzip2_format_using_insert", hdfsPath);
 
         insertData(dataTable, writableExTable, InsertionMethod.INSERT);
         verifyResult(hdfsPath, dataTable, EnumCompressionTypes.BZip2);
@@ -393,7 +355,7 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
     public void textFormatBZip2CopyFromStdin() throws Exception {
 
         String hdfsPath = hdfsWritePath + "/copy_from_stdin_bzip2";
-        writableExTable = prepareWritableBZip2Table("pxf_copy_from_stdin_bzip2", hdfsPath, null);
+        writableExTable = prepareWritableBZip2Table("pxf_copy_from_stdin_bzip2", hdfsPath);
 
         insertData(dataTable, writableExTable, InsertionMethod.COPY);
         verifyResult(hdfsPath, dataTable, EnumCompressionTypes.BZip2);
@@ -475,7 +437,7 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
         readableExTable = prepareReadableTable("pxf_insert_bzip2_from_table_r", sourcePath);
 
         String hdfsPath = hdfsWritePath + "/insert_bzip2_from_table";
-        writableExTable = prepareWritableBZip2Table("pxf_insert_bzip2_from_table_w", hdfsPath, null);
+        writableExTable = prepareWritableBZip2Table("pxf_insert_bzip2_from_table_w", hdfsPath);
 
         insertData(readableExTable, writableExTable, InsertionMethod.INSERT_FROM_TABLE);
         verifyResult(hdfsPath, dataTable, EnumCompressionTypes.BZip2);
@@ -555,7 +517,7 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
         FileFormatsUtils.prepareDataFile(data, 15000, multiBlockedLocalFilePath);
 
         String hdfsPath = hdfsWritePath + "/copy_from_file_multi_block_bzip2";
-        writableExTable = prepareWritableBZip2Table("pxf_text_multi_block_bzip2_w", hdfsPath, new String[]{"THREAD-SAFE=FALSE"});
+        writableExTable = prepareWritableBZip2Table("pxf_text_multi_block_bzip2_w", hdfsPath);
 
         gpdb.copyFromFile(writableExTable, new File(multiBlockedLocalFilePath), ",", false);
 
@@ -722,12 +684,9 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
         return table;
     }
 
-    private WritableExternalTable prepareWritableBZip2Table(String name, String path, String[] userParameters) throws Exception {
+    private WritableExternalTable prepareWritableBZip2Table(String name, String path) throws Exception {
         WritableExternalTable table = TableFactory.getPxfWritableBZip2Table(name, gpdbTableFields,
                 protocol.getExternalTablePath(hdfs.getBasePath(), path), ",");
-        if (userParameters != null) {
-            table.setUserParameters(userParameters);
-        }
         createTable(table);
         return table;
     }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -1,5 +1,6 @@
 package org.greenplum.pxf.automation.features.writable;
 
+import annotations.WorksWithFDW;
 import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.automation.datapreparer.writable.WritableDataPreparer;
 import org.greenplum.pxf.automation.enums.EnumCompressionTypes;
@@ -26,6 +27,7 @@ import static java.lang.Thread.sleep;
 /**
  * Testing cases for PXF Writable feature for Text formats (Text, CSV) and compressions.
  */
+@WorksWithFDW
 public class HdfsWritableTextTest extends BaseWritableFeature {
 
     private static final String COMPRESSION_CODEC = "org.apache.hadoop.io.compress.DefaultCodec";

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/model/RequestContext.java
@@ -521,7 +521,7 @@ public class RequestContext {
         this.statsMaxFragments = statsMaxFragments;
         if (statsMaxFragments <= 0) {
             throw new IllegalArgumentException(String
-                    .format("Wrong value '%d'. STATS-MAX-FRAGMENTS must be a positive integer",
+                    .format("Wrong value '%d'. STATS_MAX_FRAGMENTS must be a positive integer",
                             statsMaxFragments));
         }
     }
@@ -533,13 +533,13 @@ public class RequestContext {
                     "Wrong value '"
                             + statsSampleRatio
                             + "'. "
-                            + "STATS-SAMPLE-RATIO must be a value between 0.0001 and 1.0");
+                            + "STATS_SAMPLE_RATIO must be a value between 0.0001 and 1.0");
         }
     }
 
     public void validate() {
         if ((statsSampleRatio > 0) != (statsMaxFragments > 0)) {
-            fail("Missing parameter: STATS-SAMPLE-RATIO and STATS-MAX-FRAGMENTS must be set together");
+            fail("Missing parameter: STATS_SAMPLE_RATIO and STATS_MAX_FRAGMENTS must be set together");
         }
 
         if (requestType == RequestType.READ_BRIDGE) {

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/RequestContextTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/model/RequestContextTest.java
@@ -43,35 +43,35 @@ public class RequestContextTest {
     public void testStatsMaxFragmentsFailsOnZero() {
         Exception e = assertThrows(IllegalArgumentException.class,
                 () -> context.setStatsMaxFragments(0));
-        assertEquals("Wrong value '0'. STATS-MAX-FRAGMENTS must be a positive integer", e.getMessage());
+        assertEquals("Wrong value '0'. STATS_MAX_FRAGMENTS must be a positive integer", e.getMessage());
     }
 
     @Test
     public void testStatsMaxFragmentsFailsOnNegative() {
         Exception e = assertThrows(IllegalArgumentException.class,
                 () -> context.setStatsMaxFragments(-1));
-        assertEquals("Wrong value '-1'. STATS-MAX-FRAGMENTS must be a positive integer", e.getMessage());
+        assertEquals("Wrong value '-1'. STATS_MAX_FRAGMENTS must be a positive integer", e.getMessage());
     }
 
     @Test
     public void testStatsSampleRatioFailsOnOver1() {
         Exception e = assertThrows(IllegalArgumentException.class,
                 () -> context.setStatsSampleRatio(1.1f));
-        assertEquals("Wrong value '1.1'. STATS-SAMPLE-RATIO must be a value between 0.0001 and 1.0", e.getMessage());
+        assertEquals("Wrong value '1.1'. STATS_SAMPLE_RATIO must be a value between 0.0001 and 1.0", e.getMessage());
     }
 
     @Test
     public void testStatsSampleRatioFailsOnZero() {
         Exception e = assertThrows(IllegalArgumentException.class,
                 () -> context.setStatsSampleRatio(0));
-        assertEquals("Wrong value '0.0'. STATS-SAMPLE-RATIO must be a value between 0.0001 and 1.0", e.getMessage());
+        assertEquals("Wrong value '0.0'. STATS_SAMPLE_RATIO must be a value between 0.0001 and 1.0", e.getMessage());
     }
 
     @Test
     public void testStatsSampleRatioFailsOnLessThanOneTenThousand() {
         Exception e = assertThrows(IllegalArgumentException.class,
                 () -> context.setStatsSampleRatio(0.00005f));
-        assertEquals("Wrong value '5.0E-5'. STATS-SAMPLE-RATIO must be a value between 0.0001 and 1.0", e.getMessage());
+        assertEquals("Wrong value '5.0E-5'. STATS_SAMPLE_RATIO must be a value between 0.0001 and 1.0", e.getMessage());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class RequestContextTest {
         context.setStatsMaxFragments(5);
         Exception e = assertThrows(IllegalArgumentException.class,
                 () -> context.validate());
-        assertEquals("Missing parameter: STATS-SAMPLE-RATIO and STATS-MAX-FRAGMENTS must be set together", e.getMessage());
+        assertEquals("Missing parameter: STATS_SAMPLE_RATIO and STATS_MAX_FRAGMENTS must be set together", e.getMessage());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class RequestContextTest {
         context.setStatsSampleRatio(0.1f);
         Exception e = assertThrows(IllegalArgumentException.class,
                 () -> context.validate());
-        assertEquals("Missing parameter: STATS-SAMPLE-RATIO and STATS-MAX-FRAGMENTS must be set together", e.getMessage());
+        assertEquals("Missing parameter: STATS_SAMPLE_RATIO and STATS_MAX_FRAGMENTS must be set together", e.getMessage());
     }
 
     @Test

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/WritableResolver.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/WritableResolver.java
@@ -19,6 +19,7 @@ package org.greenplum.pxf.plugins.hdfs;
  * under the License.
  */
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.io.Writable;
@@ -60,7 +61,8 @@ public class WritableResolver extends BasePlugin implements Resolver {
      */
     @Override
     public void afterPropertiesSet() {
-        String schemaName = this.context.getOption("DATA-SCHEMA");
+        // DATA-SCHEMA option is deprecated in favor of DATA_SCHEMA to support FDW foreign table definitions
+        String schemaName = StringUtils.defaultString(context.getOption("DATA_SCHEMA"), context.getOption("DATA-SCHEMA"));
 
         /* Testing that the schema name was supplied by the user - schema is an optional property. */
         if (schemaName == null) {

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/DataSchemaException.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/utilities/DataSchemaException.java
@@ -30,7 +30,7 @@ public class DataSchemaException extends RuntimeException {
     public static enum MessageFmt {
 		SCHEMA_NOT_INDICATED("%s requires a data schema to be specified in the "+
 							 "pxf uri, but none was found. Please supply it" +
-							 "using the DATA-SCHEMA option "),
+							 "using the DATA_SCHEMA option "),
 		SCHEMA_NOT_ON_CLASSPATH("schema resource \"%s\" is not located on the classpath"),
 		SCHEMA_NOT_FOUND("schema resource \"%s\" is not located on the classpath nor is it a full path to a file");
 

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/HttpRequestParser.java
@@ -152,12 +152,18 @@ public class HttpRequestParser implements RequestParser<MultiValueMap<String, St
         String config = params.removeUserProperty("CONFIG");
         context.setConfig(StringUtils.isNotBlank(config) ? config : context.getServerName());
 
-        String maxFrags = params.removeUserProperty("STATS-MAX-FRAGMENTS");
+        // STATS-MAX-FRAGMENTS is deprecated in favor of STATS_MAX_FRAGMENTS for FDW options support
+        String maxFrags = StringUtils.defaultString(
+                params.removeUserProperty("STATS_MAX_FRAGMENTS"),
+                params.removeUserProperty("STATS-MAX-FRAGMENTS"));
         if (!StringUtils.isBlank(maxFrags)) {
             context.setStatsMaxFragments(Integer.parseInt(maxFrags));
         }
 
-        String sampleRatioStr = params.removeUserProperty("STATS-SAMPLE-RATIO");
+        // STATS-SAMPLE-RATIO is deprecated in favor of STATS_SAMPLE_RATIO for FDW options support
+        String sampleRatioStr = StringUtils.defaultString(
+                params.removeUserProperty("STATS_SAMPLE_RATIO"),
+                params.removeUserProperty("STATS-SAMPLE-RATIO"));
         if (!StringUtils.isBlank(sampleRatioStr)) {
             context.setStatsSampleRatio(Float.parseFloat(sampleRatioStr));
         }

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/HttpRequestParserTest.java
@@ -304,6 +304,17 @@ public class HttpRequestParserTest {
 
     @Test
     public void statsParams() {
+        parameters.add("X-GP-OPTIONS-STATS_MAX_FRAGMENTS", "10101");
+        parameters.add("X-GP-OPTIONS-STATS_SAMPLE_RATIO", "0.039");
+
+        RequestContext context = parser.parseRequest(parameters, RequestType.READ_BRIDGE);
+
+        assertEquals(10101, context.getStatsMaxFragments());
+        assertEquals(0.039, context.getStatsSampleRatio(), 0.01);
+    }
+
+    @Test
+    public void statsParamsDeprecated() {
         parameters.add("X-GP-OPTIONS-STATS-MAX-FRAGMENTS", "10101");
         parameters.add("X-GP-OPTIONS-STATS-SAMPLE-RATIO", "0.039");
 
@@ -315,7 +326,7 @@ public class HttpRequestParserTest {
 
     @Test
     public void testInvalidStatsSampleRatioValue() {
-        parameters.add("X-GP-OPTIONS-STATS-SAMPLE-RATIO", "a");
+        parameters.add("X-GP-OPTIONS-STATS_SAMPLE_RATIO", "a");
         Exception e = assertThrows(IllegalArgumentException.class,
                 () -> parser.parseRequest(parameters, RequestType.READ_BRIDGE));
         assertEquals("For input string: \"a\"", e.getMessage());
@@ -323,6 +334,22 @@ public class HttpRequestParserTest {
 
     @Test
     public void testInvalidStatsMaxFragmentsValue() {
+        parameters.add("X-GP-OPTIONS-STATS_MAX_FRAGMENTS", "10.101");
+        Exception e = assertThrows(IllegalArgumentException.class,
+                () -> parser.parseRequest(parameters, RequestType.READ_BRIDGE));
+        assertEquals("For input string: \"10.101\"", e.getMessage());
+    }
+
+    @Test
+    public void testInvalidStatsSampleRatioValueDeprecated() {
+        parameters.add("X-GP-OPTIONS-STATS-SAMPLE-RATIO", "a");
+        Exception e = assertThrows(IllegalArgumentException.class,
+                () -> parser.parseRequest(parameters, RequestType.READ_BRIDGE));
+        assertEquals("For input string: \"a\"", e.getMessage());
+    }
+
+    @Test
+    public void testInvalidStatsMaxFragmentsValueDeprecated() {
         parameters.add("X-GP-OPTIONS-STATS-MAX-FRAGMENTS", "10.101");
         Exception e = assertThrows(IllegalArgumentException.class,
                 () -> parser.parseRequest(parameters, RequestType.READ_BRIDGE));


### PR DESCRIPTION
Existing PXF table options that have "-" character in their names cannot be used with FDW where foreign table options do not allow dashes in the names. Currently, 4 options have been identified:

DATA-SCHEMA
THREAD-SAFE
STATS-SAMPLE-RATIO
STATS-MAX-FRAGMENTS

The THREAD-SAFE option is not used anywhere anymore. The other 3 options have been renamed to:
DATA_SCHEMA
STATS_SAMPLE_RATIO
STATS_MAX_FRAGMENTS

The new names should be used now, but the old ones will still work. If both the new and the old options are defined, the new option's value will take effect.