### PR TITLE
docs - add/update content for new pxf fixedwidth profiles

### DIFF
--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -107,7 +107,7 @@ The PXF Hadoop connectors expose the following profiles to read, and in many cas
 |-------------|------|---------|-----|-----|
 | HDFS | delimited single line [text](hdfs_text.html#profile_text) | hdfs:text | n/a | Read, Write |
 | HDFS | delimited single line comma-separated values of [text](hdfs_text.html#profile_text) | hdfs:csv | n/a | Read, Write |
-| HDFS | single line [fixed width text](hdfs_fixedwidth.html) | hdfs:fixedwidth | n/a | Read, Write |
+| HDFS | fixed width single line [text](hdfs_fixedwidth.html) | hdfs:fixedwidth | n/a | Read, Write |
 | HDFS | delimited [text with quoted linefeeds](hdfs_text.html#profile_textmulti) | hdfs:text:multi | n/a | Read |
 | HDFS | [Avro](hdfs_avro.html) | hdfs:avro | n/a | Read, Write |
 | HDFS | [JSON](hdfs_json.html) | hdfs:json | n/a | Read |

--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -107,6 +107,7 @@ The PXF Hadoop connectors expose the following profiles to read, and in many cas
 |-------------|------|---------|-----|-----|
 | HDFS | delimited single line [text](hdfs_text.html#profile_text) | hdfs:text | n/a | Read, Write |
 | HDFS | delimited single line comma-separated values of [text](hdfs_text.html#profile_text) | hdfs:csv | n/a | Read, Write |
+| HDFS | single line [fixed width text](hdfs_fixedwidth.html) | hdfs:fixedwidth | n/a | Read, Write |
 | HDFS | delimited [text with quoted linefeeds](hdfs_text.html#profile_textmulti) | hdfs:text:multi | n/a | Read |
 | HDFS | [Avro](hdfs_avro.html) | hdfs:avro | n/a | Read, Write |
 | HDFS | [JSON](hdfs_json.html) | hdfs:json | n/a | Read |

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -67,7 +67,7 @@ Similarly, the PXF connectors to Google Cloud Storage, and S3-compatible object 
 | delimited single line [plain text](objstore_text.html) | gs:text | s3:text | Read, Write |
 | delimited single line comma-separated values of [plain text](objstore_text.html) | gs:csv | s3:csv | Read, Write |
 | delimited [text with quoted linefeeds](objstore_text.html) | gs:text:multi | s3:text:multi | Read |
-| single line [fixed width text](objstore_fixedwidth.html) | gs:fixedwidth | s3:fixedwidth | Read, Write |
+| fixed width single line [text](objstore_fixedwidth.html) | gs:fixedwidth | s3:fixedwidth | Read, Write |
 | [Avro](objstore_avro.html) | gs:avro | s3:avro | Read, Write |
 | [JSON](objstore_json.html) | gs:json | s3:json | Read|
 | [ORC](objstore_orc.html) | gs:orc | s3:orc | Read, Write |

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -67,7 +67,7 @@ Similarly, the PXF connectors to Google Cloud Storage, and S3-compatible object 
 | delimited single line [plain text](objstore_text.html) | gs:text | s3:text | Read, Write |
 | delimited single line comma-separated values of [plain text](objstore_text.html) | gs:csv | s3:csv | Read, Write |
 | delimited [text with quoted linefeeds](objstore_text.html) | gs:text:multi | s3:text:multi | Read |
-| single line [fixed width text](objstore_fixedwidth.html) | gs:fixedwidth | aws:fixedwidth | Read, Write |
+| single line [fixed width text](objstore_fixedwidth.html) | gs:fixedwidth | s3:fixedwidth | Read, Write |
 | [Avro](objstore_avro.html) | gs:avro | s3:avro | Read, Write |
 | [JSON](objstore_json.html) | gs:json | s3:json | Read|
 | [ORC](objstore_orc.html) | gs:orc | s3:orc | Read, Write |

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -52,7 +52,7 @@ The PXF connectors to Azure expose the following profiles to read, and in many c
 | delimited single line [plain text](objstore_text.html) | wasbs:text | adl:text | Read, Write |
 | delimited single line comma-separated values of [plain text](objstore_text.html) | wasbs:csv | adl:csv | Read, Write |
 | delimited [text with quoted linefeeds](objstore_text.html) | wasbs:text:multi | adl:text:multi | Read |
-| single line [fixed width text](objstore_fixedwidth.html) | wasbs:fixedwidth | adl:fixedwidth | Read, Write |
+| fixed width single line [text](objstore_fixedwidth.html) | wasbs:fixedwidth | adl:fixedwidth | Read, Write |
 | [Avro](objstore_avro.html) | wasbs:avro | adl:avro | Read, Write |
 | [JSON](objstore_json.html) | wasbs:json | adl:json | Read |
 | [ORC](objstore_orc.html) | wasbs:orc | adl:orc | Read, Write |

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -52,6 +52,7 @@ The PXF connectors to Azure expose the following profiles to read, and in many c
 | delimited single line [plain text](objstore_text.html) | wasbs:text | adl:text | Read, Write |
 | delimited single line comma-separated values of [plain text](objstore_text.html) | wasbs:csv | adl:csv | Read, Write |
 | delimited [text with quoted linefeeds](objstore_text.html) | wasbs:text:multi | adl:text:multi | Read |
+| single line [fixed width text](objstore_fixedwidth.html) | wasbs:fixedwidth | adl:fixedwidth | Read, Write |
 | [Avro](objstore_avro.html) | wasbs:avro | adl:avro | Read, Write |
 | [JSON](objstore_json.html) | wasbs:json | adl:json | Read |
 | [ORC](objstore_orc.html) | wasbs:orc | adl:orc | Read, Write |
@@ -66,6 +67,7 @@ Similarly, the PXF connectors to Google Cloud Storage, and S3-compatible object 
 | delimited single line [plain text](objstore_text.html) | gs:text | s3:text | Read, Write |
 | delimited single line comma-separated values of [plain text](objstore_text.html) | gs:csv | s3:csv | Read, Write |
 | delimited [text with quoted linefeeds](objstore_text.html) | gs:text:multi | s3:text:multi | Read |
+| single line [fixed width text](objstore_fixedwidth.html) | gs:fixedwidth | aws:fixedwidth | Read, Write |
 | [Avro](objstore_avro.html) | gs:avro | s3:avro | Read, Write |
 | [JSON](objstore_json.html) | gs:json | s3:json | Read|
 | [ORC](objstore_orc.html) | gs:orc | s3:orc | Read, Write |

--- a/docs/content/filter_push.html.md.erb
+++ b/docs/content/filter_push.html.md.erb
@@ -62,7 +62,7 @@ The following PXF profiles support some aspects of filter pushdown as well as di
 </br><sup>3</sup>&nbsp;PXF filtering is based on file-level, stripe-level, and row-level ORC statistics.
 </br><sup>4</sup>&nbsp;The PXF `jdbc` profile supports the `LIKE` operator only for `TEXT` fields.
 
-PXF does not support filter pushdown for any profile not mentioned in the table above, including: *:avro, *:AvroSequenceFile, *:SequenceFile, *:json, *:text, *:csv, and *:text:multi.
+PXF does not support filter pushdown for any profile not mentioned in the table above, including: *:avro, *:AvroSequenceFile, *:SequenceFile, *:json, *:text, *:csv, `*:fixedwidth`, and *:text:multi.
 
 To summarize, all of the following criteria must be met for filter pushdown to occur:
 

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -28,7 +28,7 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | \<path&#8209;to&#8209;hdfs&#8209;file\>    | The path to the directory or file in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
 | PROFILE    | Use `PROFILE=hdfs:fixedwidth` when \<path-to-hdfs-file\> references fixed-width text data. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
-| NEWLINE=\<bytecode\>    | When `line_delim` contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
+| NEWLINE=\<bytecode\>    | When the `line_delim` formatter option contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
 | IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty dataset. |
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `FORMATTER='fixedwidth_in'` (read). |
 | \<field_name>='\<width>'    | The name and the width of the field. For example: `first_name='15'` specifies that the `first_name` field is `15` characters long. By default, when the field value is less than `<width>` size, Greenplum Database expects the field to be right-padded with spaces to that size. |
@@ -44,7 +44,7 @@ Refer to the Greenplum Database [fixed width custom formatter documentation](htt
 
 ## <a id="about_lineend"></a>About the line_delim and NEWLINE Formatter Options
 
-By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` formatter option, and set the value to `CR`, `CRLF` or the set of bytecode characters, respectively.
+By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` option in the external table `LOCATION` clause, and set the value to `CR`, `CRLF` or the set of bytecode characters, respectively.
 
 Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
 
@@ -137,7 +137,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://doc
 | \<path&#8209;to&#8209;hdfs&#8209;dir\>    | The path to the directory in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;dir\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;dir\> must not specify a relative path nor include the dollar sign (`$`) character. |
 | PROFILE    | Use `PROFILE=hdfs:fixedwidth` to write fixed-width data to \<path-to-hdfs-file\>. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
-| NEWLINE=\<bytecode\>    | When `line_delim` contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF` or the set of bytecode characters, respectively. |
+| NEWLINE=\<bytecode\>    | When the `line_delim` formatter option contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF` or the set of bytecode characters, respectively. |
 | \<write&#8209;option\>=\<value\>  | \<write-option\>s are described below.|
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `FORMATTER='fixedwidth_out'` (write). |
 | \<field_name>='\<width>'    | The name and the width of the field. For example: `first_name='15'` specifies that the `first_name` field is `15` characters long. By default, when writing to the external file and the field value is less than `<width>` size, Greenplum Database right-pads the field with spaces to `<width>` size. |

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -1,0 +1,231 @@
+---
+title: Reading and Writing Fixed-Width Text Data
+---
+
+The PXF HDFS Connector supports reading and writing fixed-width text using the Greenplum Database [fixed width custom formatter](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html). This section describes how to use PXF to access fixed-width text, including how to create, query, and insert data into an external table that references files in the HDFS data store.
+
+PXF supports reading or writing fixed-width text that is compressed with the `default`, `bzip2`, and `gzip` codecs.
+
+## <a id="prereq"></a>Prerequisites
+
+Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq) before you attempt to read fixed-width text from, or write fixed-width text to, HDFS.
+
+## <a id="profile_fixedwidth"></a>Reading Text Data with Fixed Widths
+
+Use the `hdfs:fixedwidth` profile when you read fixed-width text where each line is considered a single record. The following syntax creates a Greenplum Database readable external table that references such a text file on HDFS: 
+
+``` sql
+CREATE EXTERNAL TABLE <table_name> 
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:fixedwidth[&SERVER=<server_name>][&NEWLINE=<bytecode>][&IGNORE_MISSING_PATH=<boolean>]')
+FORMAT 'CUSTOM' (FORMATTER='fixedwidth_in', <field_name>='<width>' [, ...] [, line_delim[=|<space>][E]'<delim_value>']);
+```
+
+The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<path&#8209;to&#8209;hdfs&#8209;file\>    | The path to the directory or file in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
+| PROFILE    | Use `PROFILE=hdfs:fixedwidth` when \<path-to-hdfs-file\> references fixed-width text data. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
+| NEWLINE=\<bytecode\>    | When `line_delim` contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `FORMATTER='fixedwidth_in'` (read). |
+| \<field_name>='\<width>'    | The name and the width of the field. For example: `first_name='15'` specifies that the `first_name` field is `15` characters long. By default, when the field value is less than `<width>` size, Greenplum Database expects the field to be right-padded with spaces to that size. |
+| line_delim    | The line delimiter character in the data. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `line_delim=E'\n'`, `line_delim 'aaa'`. The default value is `'\n'`.|
+
+**Note**: PXF does not support the `(HEADER)` formatter option in the `CREATE EXTERNAL TABLE` command.
+
+## <a id="about_fields"></a>About Specifying field_name and width
+
+Greenplum Database loads all fields in a line of fixed-width data in their physical order. The `<field_name>`s that you specify in the `FORMAT` options must match the order that you define the columns in the `CREATE [WRITABLE] EXTERNAL TABLE` command. You specify the size of each field in the `<width>` value.
+
+Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
+
+## <a id="about_lineend"></a>About the line_delim and NEWLINE Formatter Options
+
+By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` formatter option, and set the value to `CR`, `CRLF` or the set of bytecode characters, respectively.
+
+Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
+
+## <a id="fixedwidth_read_example"></a>Example: Reading Fixed-Width Text Data on HDFS
+
+Perform the following procedure to create a sample text file, copy the file to HDFS, and use the `hdfs:fixedwidth` profile and the default PXF server to create a PXF external table to query the data:
+
+1. Create an HDFS directory for PXF example data files. For example:
+
+    ``` shell
+    $ hdfs dfs -mkdir -p /data/pxf_examples
+    ```
+
+2. Create a plain text data file named `pxf_hdfs_fixedwidth.txt`:
+
+    ``` shell
+    $ echo 'Prague         Jan 101   4875.33   
+    Rome           Mar 87    1557.39   
+    Bangalore      May 317   8936.99   
+    Beijing        Jul 411   11600.67  ' > /tmp/pxf_hdfs_fixedwidth.txt
+    ```
+
+    In this sample file, the first field is 15 characters long, the second is 4 characters, the third is 6 characters, and the last field is 10 characters long.
+
+    > **Note** Open the `/tmp/pxf_hdfs_fixedwidth.txt` file in the editor of your choice, and ensure that the last field is right-padded with spaces to 10 characters in size.
+
+4. Copy the data file to HDFS:
+
+    ``` shell
+    $ hdfs dfs -put /tmp/pxf_hdfs_fixedwidth.txt /data/pxf_examples/
+    ```
+
+5. Display the contents of the `pxf_hdfs_fixedwidth.txt` file stored in HDFS:
+
+    ``` shell
+    $ hdfs dfs -cat /data/pxf_examples/pxf_hdfs_fixedwidth.txt
+    ```
+
+4. Start the `psql` subsystem:
+
+    ``` shell
+    $ psql -d postgres
+    ```
+
+1. Use the PXF `hdfs:fixedwidth` profile to create a Greenplum Database external table that references the `pxf_hdfs_fixedwidth.txt` file that you just created and added to HDFS:
+
+    ``` sql
+    postgres=# CREATE EXTERNAL TABLE pxf_hdfs_fixedwidth_r(location text, month text, num_orders int, total_sales float8)
+                 LOCATION ('pxf://data/pxf_examples/pxf_hdfs_fixedwidth.txt?PROFILE=hdfs:fixedwidth')
+               FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\r\n');
+    ```
+              
+2. Query the external table:
+
+    ``` sql
+    postgres=# SELECT * FROM pxf_hdfs_fixedwidth_r;
+    ```
+
+    ``` pre
+       location    | month | num_orders | total_sales 
+    ---------------+-------+------------+-------------
+     Prague        | Jan   |        101 |     4875.33
+     Rome          | Mar   |         87 |     1557.39
+     Bangalore     | May   |        317 |     8936.99
+     Beijing       | Jul   |        411 |    11600.67
+    (4 rows)
+    ```
+
+## <a id="hdfswrite_text"></a>Writing Fixed-Width Text Data to HDFS
+
+The PXF HDFS connector `hdfs:fixedwidth` profile supports writing fixed-width text to HDFS. When you create a writable external table with the PXF HDFS connector, you specify the name of a directory on HDFS. When you insert records into a writable external table, the block(s) of data that you insert are written to one or more files in the directory that you specified.
+
+**Note**: External tables that you create with a writable profile can only be used for `INSERT` operations. If you want to query the data that you inserted, you must create a separate readable external table that references the HDFS directory.
+
+Use the following syntax to create a Greenplum Database writable external table that references an HDFS directory: 
+
+``` sql
+CREATE WRITABLE EXTERNAL TABLE <table_name> 
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<path-to-hdfs-dir>
+    ?PROFILE=hdfs:fixedwidth[&SERVER=<server_name>][&NEWLINE=<bytecode>][&<write-option>=<value>[...]]')
+FORMAT 'CUSTOM' (FORMATTER='fixedwidth_out' [, <field_name>='<width>'] [, ...] [, line_delim[=|<space>][E]'<delim_value>']);
+[DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
+```
+
+The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<path&#8209;to&#8209;hdfs&#8209;dir\>    | The path to the directory in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;dir\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;dir\> must not specify a relative path nor include the dollar sign (`$`) character. |
+| PROFILE    | Use `PROFILE=hdfs:fixedwidth` to write fixed-width data to \<path-to-hdfs-file\>. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
+| NEWLINE=\<bytecode\>    | When `line_delim` contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF` or the set of bytecode characters, respectively. |
+| \<write&#8209;option\>=\<value\>  | \<write-option\>s are described below.|
+| FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `FORMATTER='fixedwidth_out'` (write). |
+| \<field_name>='\<width>'    | The name and the width of the field. For example: `first_name='15'` specifies that the `first_name` field is `15` characters long. By default, when writing to the external file and the field value is less than `<width>` size, Greenplum Database right-pads the field with spaces to `<width>` size. |
+| line_delim    | The line delimiter character in the data. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `line_delim=E'\n'`, `line_delim 'aaa'`. The default value is `'\n'`. |
+| DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or `<column_name>` on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
+
+Writable external tables that you create using the `hdfs:fixedwidth` profile can optionally use record or block compression. You specify the compression type and codec via options in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause:
+
+| Write Option  | Value Description |
+|-------|-------------------------------------|
+| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing fixed-width text data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
+| COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
+
+## <a id="fixedwidth_write_example"></a>Example: Writing Fixed-Width Text Data to HDFS
+
+This example utilizes the data schema introduced in [Example: Reading Fixed-Width Text Data on HDFS](#fixedwidth_read_example). 
+
+| Column Name  | Width | Data Type |
+|-------|-------------------------------------|
+| location | 15 | text |
+| month | 4 | text |
+| number\_of\_orders | 6 | int |
+| total\_sales | 10 | float8 |
+
+This example also optionally uses the Greenplum Database external table named `pxf_hdfs_fixedwidth_r` that you created in that exercise.
+
+#### <a id="fixedwidth_write_proc" class="no-quick-link"></a>Procedure
+
+Perform the following procedure to create a Greenplum Database writable external table utilizing the same data schema as described above.You will use the PXF `hdfs:fixedwidth` profile and the default PXF server to write data to the underlying HDFS directory. You will also create a separate, readable external table to read the data that you wrote to the HDFS directory.
+
+1. Create a Greenplum Database writable external table utilizing the data schema described above. Write to the HDFS directory `/data/pxf_examples/fixedwidth_write`. Create the table specifying `\n` as the line delimiter:
+
+    ``` sql
+    postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_hdfs_fixedwidth_w(location text, month text, num_orders int, total_sales float8)
+                 LOCATION ('pxf://data/pxf_examples/fixedwidth_write?PROFILE=hdfs:fixedwidth')
+               FORMAT 'CUSTOM' (formatter='fixedwidth_out', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\n');
+    ```
+    
+2. Write a few individual records to the `fixedwidth_write` HDFS directory by `INSERT`ing into the `pxf_hdfs_fixedwidth_w` table:
+
+    ``` sql
+    postgres=# INSERT INTO pxf_hdfs_fixedwidth_w VALUES ( 'Frankfurt', 'Mar', 777, 3956.98 );
+    postgres=# INSERT INTO pxf_hdfs_fixedwidth_w VALUES ( 'Cleveland', 'Oct', 3812, 96645.37 );
+    ```
+
+3. (Optional) Insert the data from the `pxf_hdfs_fixedwidth_r` table that you created in [Example: Reading Fixed-Width Text Data on HDFS](#fixedwidth_read_example) into `pxf_hdfs_fixedwidth_w`:
+
+    ``` sql
+    postgres=# INSERT INTO pxf_hdfs_fixedwidth_w SELECT * FROM pxf_hdfs_fixedwidth_r;
+    ```
+
+4. In another terminal window, display the data that you just added to HDFS by `cat`ing the contents of the `fixedwidth_write` directory:
+
+    ``` shell
+    $ hdfs dfs -cat /data/pxf_examples/fixedwidth_write/*
+    Frankfurt      Mar 777   3956.98   
+    Cleveland      Oct 3812  96645.37  
+    Rome           Mar 87    1557.39   
+    Prague         Jan 101   4875.33   
+    Bangalore      May 317   8936.99   
+    Beijing        Jul 411   11600.67  
+    ```
+
+5. Greenplum Database does not support directly querying a writable external table. To query the data that you just added to HDFS, you must create a readable external Greenplum Database table that references the HDFS directory:
+
+    ``` sql
+    postgres=# CREATE EXTERNAL TABLE pxf_hdfs_fixedwidth_r2(location text, month text, num_orders int, total_sales float8)
+                 LOCATION ('pxf://data/pxf_examples/fixedwidth_write?PROFILE=hdfs:fixedwidth')
+               FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\n');
+    ```
+
+6. Query the readable external table:
+
+    ``` sql
+    postgres=# SELECT * FROM pxf_hdfs_fixedwidth_r2 ORDER BY total_sales;
+    ```
+
+    ``` pre
+     location  | month | num_orders | total_sales 
+    -----------+-------+------------+-------------
+     Rome      | Mar   |         87 |     1557.39
+     Frankfurt | Mar   |        777 |     3956.98
+     Prague    | Jan   |        101 |     4875.33
+     Bangalore | May   |        317 |     8936.99
+     Beijing   | Jul   |        411 |    11600.67
+     Cleveland | Oct   |       3812 |    96645.37
+    (6 rows)
+    ```
+
+    The `pxf_hdfs_fixedwidth_r2` table includes the records you individually inserted, as well as the full contents of the `pxf_hdfs_fixedwidth_r` table if you chose to perform the optional step.
+

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -2,7 +2,7 @@
 title: Reading and Writing Fixed-Width Text Data
 ---
 
-The PXF HDFS Connector supports reading and writing fixed-width text using the Greenplum Database [fixed width custom formatter](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html). This section describes how to use PXF to access fixed-width text, including how to create, query, and insert data into an external table that references files in the HDFS data store.
+The PXF HDFS Connector supports reading and writing fixed-width text using the Greenplum Database [fixed width custom formatter](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html). This section describes how to use PXF to access fixed-width text, including how to create, query, and insert data into an external table that references files in the HDFS data store.
 
 PXF supports reading or writing fixed-width text that is compressed with the `default`, `bzip2`, and `gzip` codecs.
 
@@ -21,7 +21,7 @@ LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:fixedwidth[&SERVER=<server_nam
 FORMAT 'CUSTOM' (FORMATTER='fixedwidth_in', <field_name>='<width>' [, ...] [, line_delim[=|<space>][E]'<delim_value>']);
 ```
 
-The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
 
 | Keyword  | Value |
 |-------|-------------------------------------|
@@ -40,13 +40,13 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 
 Greenplum Database loads all fields in a line of fixed-width data in their physical order. The `<field_name>`s that you specify in the `FORMAT` options must match the order that you define the columns in the `CREATE [WRITABLE] EXTERNAL TABLE` command. You specify the size of each field in the `<width>` value.
 
-Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
+Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
 
 ## <a id="about_lineend"></a>About the line_delim and NEWLINE Formatter Options
 
 By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` option in the external table `LOCATION` clause, and set the value to `CR`, `CRLF` or the set of bytecode characters, respectively.
 
-Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
+Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
 
 ## <a id="fixedwidth_read_example"></a>Example: Reading Fixed-Width Text Data on HDFS
 
@@ -130,7 +130,7 @@ FORMAT 'CUSTOM' (FORMATTER='fixedwidth_out' [, <field_name>='<width>'] [, ...] [
 [DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
 ```
 
-The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
 
 | Keyword  | Value |
 |-------|-------------------------------------|

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -29,7 +29,7 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | PROFILE    | Use `PROFILE=hdfs:fixedwidth` when \<path-to-hdfs-file\> references fixed-width text data. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
 | NEWLINE=\<bytecode\>    | When `line_delim` contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
-| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty dataset. |
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `FORMATTER='fixedwidth_in'` (read). |
 | \<field_name>='\<width>'    | The name and the width of the field. For example: `first_name='15'` specifies that the `first_name` field is `15` characters long. By default, when the field value is less than `<width>` size, Greenplum Database expects the field to be right-padded with spaces to that size. |
 | line_delim    | The line delimiter character in the data. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `line_delim=E'\n'`, `line_delim 'aaa'`. The default value is `'\n'`.|

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -44,7 +44,7 @@ Refer to the Greenplum Database [fixed width custom formatter documentation](htt
 
 ## <a id="about_lineend"></a>About the line_delim and NEWLINE Formatter Options
 
-By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` option in the external table `LOCATION` clause, and set the value to `CR`, `CRLF` or the set of bytecode characters, respectively.
+By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` formatter option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` option in the external table `LOCATION` clause, and set the value to `CR`, `CRLF` or the set of bytecode characters, respectively.
 
 Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
 

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -206,7 +206,7 @@ Perform the following procedure to create a Greenplum Database writable external
     ``` sql
     postgres=# CREATE EXTERNAL TABLE pxf_hdfs_fixedwidth_r2(location text, month text, num_orders int, total_sales float8)
                  LOCATION ('pxf://data/pxf_examples/fixedwidth_write?PROFILE=hdfs:fixedwidth')
-               FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\n');
+               FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10');
     ```
 
 6. Query the readable external table:

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -93,7 +93,7 @@ Perform the following procedure to create a sample text file, copy the file to H
 
     ``` sql
     postgres=# CREATE EXTERNAL TABLE pxf_hdfs_fixedwidth_r(location text, month text, num_orders int, total_sales float8)
-                 LOCATION ('pxf://data/pxf_examples/pxf_hdfs_fixedwidth.txt?PROFILE=hdfs:fixedwidth')
+                 LOCATION ('pxf://data/pxf_examples/pxf_hdfs_fixedwidth.txt?PROFILE=hdfs:fixedwidth&NEWLINE=CRLF')
                FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\r\n');
     ```
               

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -159,8 +159,8 @@ This example utilizes the data schema introduced in [Example: Reading Fixed-Widt
 |-------|-------------------------------------|
 | location | 15 | text |
 | month | 4 | text |
-| number\_of\_orders | 6 | int |
-| total\_sales | 10 | float8 |
+| number_of_orders | 6 | int |
+| total_sales | 10 | float8 |
 
 This example also optionally uses the Greenplum Database external table named `pxf_hdfs_fixedwidth_r` that you created in that exercise.
 

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -173,7 +173,7 @@ Perform the following procedure to create a Greenplum Database writable external
     ``` sql
     postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_hdfs_fixedwidth_w(location text, month text, num_orders int, total_sales float8)
                  LOCATION ('pxf://data/pxf_examples/fixedwidth_write?PROFILE=hdfs:fixedwidth')
-               FORMAT 'CUSTOM' (formatter='fixedwidth_out', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\n');
+               FORMAT 'CUSTOM' (formatter='fixedwidth_out', location='15', month='4', num_orders='6', total_sales='10');
     ```
     
 2. Write a few individual records to the `fixedwidth_write` HDFS directory by `INSERT`ing into the `pxf_hdfs_fixedwidth_w` table:

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -166,7 +166,7 @@ This example also optionally uses the Greenplum Database external table named `p
 
 #### <a id="fixedwidth_write_proc" class="no-quick-link"></a>Procedure
 
-Perform the following procedure to create a Greenplum Database writable external table utilizing the same data schema as described above.You will use the PXF `hdfs:fixedwidth` profile and the default PXF server to write data to the underlying HDFS directory. You will also create a separate, readable external table to read the data that you wrote to the HDFS directory.
+Perform the following procedure to create a Greenplum Database writable external table utilizing the same data schema as described above. You will use the PXF `hdfs:fixedwidth` profile and the default PXF server to write data to the underlying HDFS directory. You will also create a separate, readable external table to read the data that you wrote to the HDFS directory.
 
 1. Create a Greenplum Database writable external table utilizing the data schema described above. Write to the HDFS directory `/data/pxf_examples/fixedwidth_write`. Create the table specifying `\n` as the line delimiter:
 
@@ -176,7 +176,7 @@ Perform the following procedure to create a Greenplum Database writable external
                FORMAT 'CUSTOM' (formatter='fixedwidth_out', location='15', month='4', num_orders='6', total_sales='10');
     ```
     
-2. Write a few individual records to the `fixedwidth_write` HDFS directory by `INSERT`ing into the `pxf_hdfs_fixedwidth_w` table:
+2. Write a few individual records to the `fixedwidth_write` HDFS directory by using the `INSERT` command on the `pxf_hdfs_fixedwidth_w` table:
 
     ``` sql
     postgres=# INSERT INTO pxf_hdfs_fixedwidth_w VALUES ( 'Frankfurt', 'Mar', 777, 3956.98 );
@@ -189,7 +189,7 @@ Perform the following procedure to create a Greenplum Database writable external
     postgres=# INSERT INTO pxf_hdfs_fixedwidth_w SELECT * FROM pxf_hdfs_fixedwidth_r;
     ```
 
-4. In another terminal window, display the data that you just added to HDFS by `cat`ing the contents of the `fixedwidth_write` directory:
+4. In another terminal window, use the `cat` command on the `fixedwidth_write` directory to display the data that you just added to HDFS:
 
     ``` shell
     $ hdfs dfs -cat /data/pxf_examples/fixedwidth_write/*

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -162,8 +162,6 @@ This example utilizes the data schema introduced in [Example: Reading Fixed-Widt
 | number_of_orders | 6 | int |
 | total_sales | 10 | float8 |
 
-This example also optionally uses the Greenplum Database external table named `pxf_hdfs_fixedwidth_r` that you created in that exercise.
-
 #### <a id="fixedwidth_write_proc" class="no-quick-link"></a>Procedure
 
 Perform the following procedure to create a Greenplum Database writable external table utilizing the same data schema as described above. You will use the PXF `hdfs:fixedwidth` profile and the default PXF server to write data to the underlying HDFS directory. You will also create a separate, readable external table to read the data that you wrote to the HDFS directory.
@@ -183,22 +181,12 @@ Perform the following procedure to create a Greenplum Database writable external
     postgres=# INSERT INTO pxf_hdfs_fixedwidth_w VALUES ( 'Cleveland', 'Oct', 3812, 96645.37 );
     ```
 
-3. (Optional) Insert the data from the `pxf_hdfs_fixedwidth_r` table that you created in [Example: Reading Fixed-Width Text Data on HDFS](#fixedwidth_read_example) into `pxf_hdfs_fixedwidth_w`:
-
-    ``` sql
-    postgres=# INSERT INTO pxf_hdfs_fixedwidth_w SELECT * FROM pxf_hdfs_fixedwidth_r;
-    ```
-
 4. In another terminal window, use the `cat` command on the `fixedwidth_write` directory to display the data that you just added to HDFS:
 
     ``` shell
     $ hdfs dfs -cat /data/pxf_examples/fixedwidth_write/*
     Frankfurt      Mar 777   3956.98   
     Cleveland      Oct 3812  96645.37  
-    Rome           Mar 87    1557.39   
-    Prague         Jan 101   4875.33   
-    Bangalore      May 317   8936.99   
-    Beijing        Jul 411   11600.67  
     ```
 
 5. Greenplum Database does not support directly querying a writable external table. To query the data that you just added to HDFS, you must create a readable external Greenplum Database table that references the HDFS directory:
@@ -218,14 +206,8 @@ Perform the following procedure to create a Greenplum Database writable external
     ``` pre
      location  | month | num_orders | total_sales 
     -----------+-------+------------+-------------
-     Rome      | Mar   |         87 |     1557.39
      Frankfurt | Mar   |        777 |     3956.98
-     Prague    | Jan   |        101 |     4875.33
-     Bangalore | May   |        317 |     8936.99
-     Beijing   | Jul   |        411 |    11600.67
      Cleveland | Oct   |       3812 |    96645.37
-    (6 rows)
+    (2 rows)
     ```
-
-    The `pxf_hdfs_fixedwidth_r2` table includes the records you individually inserted, as well as the full contents of the `pxf_hdfs_fixedwidth_r` table if you chose to perform the optional step.
 

--- a/docs/content/nfs_pxf.html.md.erb
+++ b/docs/content/nfs_pxf.html.md.erb
@@ -9,6 +9,7 @@ You can use PXF to read data that resides on a network file system mounted on yo
 | delimited single line text | file:text | read, write |
 | delimited single line comma-separated values of text | file:csv | read, write |
 | delimited text with quoted linefeeds | file:text:multi | read |
+| single line fixed width | file:fixedwidth | read, write |
 | Avro | file:avro | read, write |
 | JSON | file:json | read |
 | ORC | file:orc | read, write |

--- a/docs/content/nfs_pxf.html.md.erb
+++ b/docs/content/nfs_pxf.html.md.erb
@@ -9,7 +9,7 @@ You can use PXF to read data that resides on a network file system mounted on yo
 | delimited single line text | file:text | read, write |
 | delimited single line comma-separated values of text | file:csv | read, write |
 | delimited text with quoted linefeeds | file:text:multi | read |
-| single line fixed width | file:fixedwidth | read, write |
+| fixed width single line text | file:fixedwidth | read, write |
 | Avro | file:avro | read, write |
 | JSON | file:json | read |
 | ORC | file:orc | read, write |

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -214,7 +214,7 @@ Perform the following procedure to create a Greenplum Database writable external
     ``` sql
     postgres=# CREATE EXTERNAL TABLE pxf_s3_fixedwidth_r2(location text, month text, num_orders int, total_sales float8)
                  LOCATION ('pxf://BUCKET/pxf_examples/fixedwidth_write?PROFILE=s3:fixedwidth&SERVER=s3srvcfg')
-               FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\n');
+               FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10');
     ```
 
 6. Query the readable external table:

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -57,7 +57,7 @@ Refer to the Greenplum Database [fixed width custom formatter documentation](htt
 
 ## <a id="about_lineend"></a>About the line_delim and NEWLINE Formatter Options
 
-By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` option in the external table `LOCATION` clause, and set the value to `CR`, `CRLF`, or the set of bytecode characters, respectively.
+By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` formatter option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` option in the external table `LOCATION` clause, and set the value to `CR`, `CRLF`, or the set of bytecode characters, respectively.
 
 Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
 

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -2,7 +2,7 @@
 title: Reading and Writing Fixed-Width Text Data in an Object Store
 ---
 
-The PXF object store connectors support reading and writing fixed-width text using the Greenplum Database [fixed width custom formatter](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html). This section describes how to use PXF to access fixed-width text, including how to create, query, and insert data into an external table that references files in the object store.
+The PXF object store connectors support reading and writing fixed-width text using the Greenplum Database [fixed width custom formatter](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html). This section describes how to use PXF to access fixed-width text, including how to create, query, and insert data into an external table that references files in the object store.
 
 **Note**: Accessing fixed-width text data from an object store is very similar to accessing such data in HDFS.
 
@@ -31,7 +31,7 @@ LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:fixedwidth[&SERVER=<server_na
 FORMAT 'CUSTOM' (FORMATTER='fixedwidth_in', <field_name>='<width>' [, ...] [, line_delim[=|<space>][E]'<delim_value>']);
 ```
 
-The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
 
 | Keyword  | Value |
 |-------|-------------------------------------|
@@ -52,14 +52,14 @@ If you are accessing an S3 object store, you can provide S3 credentials via cust
 
 Greenplum Database loads all fields in a line of fixed-width data in their physical order. The `<field_name>`s that you specify in the `FORMAT` options must match the order that you define the columns in the `CREATE [WRITABLE] EXTERNAL TABLE` command. You specify the size of each field in the `<width>` value.
 
-Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
+Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
 
 
 ## <a id="about_lineend"></a>About the line_delim and NEWLINE Formatter Options
 
 By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` option in the external table `LOCATION` clause, and set the value to `CR`, `CRLF`, or the set of bytecode characters, respectively.
 
-Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
+Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
 
 ## <a id="fixedwidth_read_example"></a>Example: Reading Fixed-Width Text Data on S3
 
@@ -150,7 +150,7 @@ FORMAT 'CUSTOM' (FORMATTER='fixedwidth_out' [, <field_name>='<width>'] [, ...] [
 [DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
 ```
 
-The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
 
 | Keyword  | Value |
 |-------|-------------------------------------|

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -1,0 +1,239 @@
+---
+title: Reading and Writing Fixed-Width Text Data in an Object Store
+---
+
+The PXF object store connectors support reading and writing fixed-width text using the Greenplum Database [fixed width custom formatter](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html). This section describes how to use PXF to access fixed-width text, including how to create, query, and insert data into an external table that references files in the object store.
+
+**Note**: Accessing fixed-width text data from an object store is very similar to accessing such data in HDFS.
+
+## <a id="prereq"></a>Prerequisites
+
+Ensure that you have met the PXF Object Store [Prerequisites](access_objstore.html#objstore_prereq) before you attempt to read data from or write data to an object store.
+
+## <a id="profile_fixedwidth"></a>Reading Text Data with Fixed Widths
+
+Use the `<objstore>:fixedwidth` profile when you read fixed-width text from an object store where each line is a single record.  PXF supports the following `<objstore>` profile prefixes:
+
+| Object Store  | Profile Prefix |
+|-------|-------------------------------------|
+| Azure Blob Storage   | wasbs |
+| Azure Data Lake    | adl |
+| Google Cloud Storage    | gs |
+| MinIO    | s3 |
+| S3    | s3 |
+
+The following syntax creates a Greenplum Database readable external table that references such a text file in an object store: 
+
+``` sql
+CREATE EXTERNAL TABLE <table_name> 
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:fixedwidth[&SERVER=<server_name>][&NEWLINE=<bytecode>][&IGNORE_MISSING_PATH=<boolean>]')
+FORMAT 'CUSTOM' (FORMATTER='fixedwidth_in', <field_name>='<width>' [, ...] [, line_delim[=|<space>][E]'<delim_value>']);
+```
+
+The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<path&#8209;to&#8209;file\>    | The path to the directory or file in the object store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
+| PROFILE=\<objstore\>:fixedwidth | The `PROFILE` must identify the specific object store. For example, `s3:fixedwidth`. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
+| NEWLINE=\<bytecode\>    | When `line_delim` contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
+| FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `FORMATTER='fixedwidth_in'` (read). |
+| \<field_name>='\<width>'    | The name and the width of the field. For example: `first_name='15'` specifies that the `first_name` field is `15` characters long. By default, when the field value is less than `<width>` size, Greenplum Database expects the field to be right-padded with spaces to that size. |
+| line_delim    | The line delimiter character in the data. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `line_delim=E'\n'`, `line_delim 'aaa'`. The default value is `'\n'`.|
+
+**Note**: PXF does not support the `(HEADER)` formatter option in the `CREATE EXTERNAL TABLE` command.
+
+If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
+
+## <a id="about_fields"></a>About Specifying field_name and width
+
+Greenplum Database loads all fields in a line of fixed-width data in their physical order. The `<field_name>`s that you specify in the `FORMAT` options must match the order that you define the columns in the `CREATE [WRITABLE] EXTERNAL TABLE` command. You specify the size of each field in the `<width>` value.
+
+Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
+
+
+## <a id="about_lineend"></a>About the line_delim and NEWLINE Formatter Options
+
+By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` formatter option, and set the value to `CR`, `CRLF`, or the set of bytecode characters, respectively.
+
+Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
+
+## <a id="fixedwidth_read_example"></a>Example: Reading Fixed-Width Text Data on S3
+
+Perform the following procedure to create a sample text file, copy the file to S3, and use the `s3:fixedwidth` profile to create a PXF external table to query the data.
+
+To run this example, you must:
+
+- Have the AWS CLI tools installed on your system
+- Know your AWS access ID and secret key
+- Have write permission to an S3 bucket
+
+Procedure:
+
+1. Create a directory in S3 for PXF example data files. For example, if you have write access to an S3 bucket named `BUCKET`:
+
+    ``` shell
+    $ aws s3 mb s3://BUCKET/pxf_examples
+    ```
+1. Locally create a plain text data file named `pxf_s3_fixedwidth.txt`:
+
+    ``` shell
+    $ echo 'Prague         Jan 101   4875.33   
+    Rome           Mar 87    1557.39   
+    Bangalore      May 317   8936.99   
+    Beijing        Jul 411   11600.67  ' > /tmp/pxf_s3_fixedwidth.txt
+    ```
+
+    In this sample file, the first field is 15 characters long, the second is 4 characters, the third is 6 characters, and the last field is 10 characters long.
+
+    > **Note** Open the `/tmp/pxf_s3_fixedwidth.txt` file in the editor of your choice, and ensure that the last field is right-padded with spaces to 10 characters in size.
+
+1. Copy the data file to the S3 directory that you created in Step 1:
+
+    ``` shell
+    $ aws s3 cp /tmp/pxf_s3_fixedwidth.txt s3://BUCKET/pxf_examples/
+    ```
+
+1. Verify that the file now resides in S3:
+
+    ``` shell
+    $ aws s3 ls s3://BUCKET/pxf_examples/pxf_s3s_fixedwidth.txt
+    ```
+
+1. Start the `psql` subsystem:
+
+    ``` shell
+    $ psql -d postgres
+    ```
+
+1. Use the PXF `s3:fixedwidth` profile to create a Greenplum Database external table that references the `pxf_s3_fixedwidth.txt` file that you just created and added to S3. For example, if your server name is `s3srvcfg`:
+
+    ``` sql
+    postgres=# CREATE EXTERNAL TABLE pxf_s3_fixedwidth_r(location text, month text, num_orders int, total_sales float8)
+                 LOCATION ('pxf://data/pxf_examples/pxf_s3_fixedwidth.txt?PROFILE=s3:fixedwidth&SERVER=s3srvcfg')
+               FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\r\n');
+    ```
+              
+2. Query the external table:
+
+    ``` sql
+    postgres=# SELECT * FROM pxf_s3_fixedwidth_r;
+    ```
+
+    ``` pre
+       location    | month | num_orders | total_sales 
+    ---------------+-------+------------+-------------
+     Prague        | Jan   |        101 |     4875.33
+     Rome          | Mar   |         87 |     1557.39
+     Bangalore     | May   |        317 |     8936.99
+     Beijing       | Jul   |        411 |    11600.67
+    (4 rows)
+    ```
+
+## <a id="s3write_text"></a>Writing Fixed-Width Text Data
+
+The `<objstore>:fixedwidth` profiles support writing fixed-width text to an object store. When you create a writable external table with PXF, you specify the name of a directory. When you insert records into a writable external table, the block(s) of data that you insert are written to one or more files in the directory that you specified.
+
+**Note**: External tables that you create with a writable profile can only be used for `INSERT` operations. If you want to query the data that you inserted, you must create a separate readable external table that references the directory.
+
+Use the following syntax to create a Greenplum Database writable external table that references an object store directory: 
+
+``` sql
+CREATE WRITABLE EXTERNAL TABLE <table_name> 
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<path-to-dir>
+    ?PROFILE=<objstore>:fixedwidth[&SERVER=<server_name>][&NEWLINE=<bytecode>][&<write-option>=<value>[...]]')
+FORMAT 'CUSTOM' (FORMATTER='fixedwidth_out' [, <field_name>='<width>'] [, ...] [, line_delim[=|<space>][E]'<delim_value>']);
+[DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
+```
+
+The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
+
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<path&#8209;to&#8209;dir\>    | The path to the directory in the data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;dir\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;dir\> must not specify a relative path nor include the dollar sign (`$`) character. |
+| PROFILE=\<objstore\>:fixedwidth | The `PROFILE` must identify the specific object store. For example, `s3:fixedwidth`. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
+| NEWLINE=\<bytecode\>    | When `line_delim` contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
+| \<write&#8209;option\>=\<value\>  | \<write-option\>s are described below.|
+| FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `FORMATTER='fixedwidth_out'` (write). |
+| \<field_name>='\<width>'    | The name and the width of the field. For example: `first_name='15'` specifies that the `first_name` field is `15` characters long. By default, when writing to the external file and the field value is less than `<width>` size, Greenplum Database right-pads the field with spaces to `<width>` size. |
+| line_delim    | The line delimiter character in the data. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `line_delim=E'\n'`, `line_delim 'aaa'`. The default value is `'\n'`. |
+| DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or `<column_name>` on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
+
+Writable external tables that you create using the `<objstore>:fixedwidth` profile can optionally use record or block compression. You specify the compression type and codec via options in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause:
+
+| Write Option  | Value Description |
+|-------|-------------------------------------|
+| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing fixed-width text data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
+| COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
+
+## <a id="fixedwidth_write_example"></a>Example: Writing Fixed-Width Text Data to S3
+
+This example utilizes the data schema introduced in [Example: Reading Fixed-Width Text Data on S3](#fixedwidth_read_example). 
+
+| Column Name  | Width | Data Type |
+|-------|-------------------------------------|
+| location | 15 | text |
+| month | 4 | text |
+| number\_of\_orders | 6 | int |
+| total\_sales | 10 | float8 |
+
+This example also optionally uses the Greenplum Database external table named `pxf_s3_fixedwidth_r` that you created in that exercise.
+
+#### <a id="fixedwidth_write_proc" class="no-quick-link"></a>Procedure
+
+Perform the following procedure to create a Greenplum Database writable external table utilizing the same data schema as described above. You will use the PXF `s3:fixedwidth` profile to write data to S3. You will also create a separate, readable external table to read the data that you wrote to #3.
+
+1. Create a Greenplum Database writable external table utilizing the data schema described above. Write to the S3 directory `BUCKET/pxf_examples/fixedwidth_write`. Create the table specifying `\n` as the line delimiter. For example, if your server name is `s3srvcfg`:
+
+    ``` sql
+    postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_s3_fixedwidth_w(location text, month text, num_orders int, total_sales float8)
+                 LOCATION ('pxf://BUCKET/pxf_examples/fixedwidth_write?PROFILE=s3:fixedwidth&SERVER=s3srvcfg')
+               FORMAT 'CUSTOM' (formatter='fixedwidth_out', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\n');
+    ```
+    
+2. Write a few individual records to the `fixedwidth_write` S3 directory by `INSERT`ing into the `pxf_s3_fixedwidth_w` table:
+
+    ``` sql
+    postgres=# INSERT INTO pxf_s3_fixedwidth_w VALUES ( 'Frankfurt', 'Mar', 777, 3956.98 );
+    postgres=# INSERT INTO pxf_s3_fixedwidth_w VALUES ( 'Cleveland', 'Oct', 3812, 96645.37 );
+    ```
+
+3. (Optional) Insert the data from the `pxf_s3_fixedwidth_r` table that you created in [Example: Reading Fixed-Width Text Data on S3](#fixedwidth_read_example) into `pxf_s3_fixedwidth_w`:
+
+    ``` sql
+    postgres=# INSERT INTO pxf_s3_fixedwidth_w SELECT * FROM pxf_s3_fixedwidth_r;
+    ```
+
+5. Greenplum Database does not support directly querying a writable external table. To query the data that you just added to S3, you must create a readable external Greenplum Database table that references the S3 directory:
+
+    ``` sql
+    postgres=# CREATE EXTERNAL TABLE pxf_s3_fixedwidth_r2(location text, month text, num_orders int, total_sales float8)
+                 LOCATION ('pxf://BUCKET/pxf_examples/fixedwidth_write?PROFILE=s3:fixedwidth&SERVER=s3srvcfg')
+               FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\n');
+    ```
+
+6. Query the readable external table:
+
+    ``` sql
+    postgres=# SELECT * FROM pxf_s3_fixedwidth_r2 ORDER BY total_sales;
+    ```
+
+    ``` pre
+     location  | month | num_orders | total_sales 
+    -----------+-------+------------+-------------
+     Rome      | Mar   |         87 |     1557.39
+     Frankfurt | Mar   |        777 |     3956.98
+     Prague    | Jan   |        101 |     4875.33
+     Bangalore | May   |        317 |     8936.99
+     Beijing   | Jul   |        411 |    11600.67
+     Cleveland | Oct   |       3812 |    96645.37
+    (6 rows)
+    ```
+
+    The `pxf_s3_fixedwidth_r2` table includes the records you individually inserted, as well as the full contents of the `pxf_s3_fixedwidth_r` table if you chose to perform the optional step.
+

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -179,8 +179,8 @@ This example utilizes the data schema introduced in [Example: Reading Fixed-Widt
 |-------|-------------------------------------|
 | location | 15 | text |
 | month | 4 | text |
-| number\_of\_orders | 6 | int |
-| total\_sales | 10 | float8 |
+| number_of_orders | 6 | int |
+| total_sales | 10 | float8 |
 
 This example also optionally uses the Greenplum Database external table named `pxf_s3_fixedwidth_r` that you created in that exercise.
 

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -38,7 +38,7 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | \<path&#8209;to&#8209;file\>    | The path to the directory or file in the object store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
 | PROFILE=\<objstore\>:fixedwidth | The `PROFILE` must identify the specific object store. For example, `s3:fixedwidth`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
-| NEWLINE=\<bytecode\>    | When `line_delim` contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
+| NEWLINE=\<bytecode\>    | When the `line_delim` formatter option contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
 | IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `FORMATTER='fixedwidth_in'` (read). |
 | \<field_name>='\<width>'    | The name and the width of the field. For example: `first_name='15'` specifies that the `first_name` field is `15` characters long. By default, when the field value is less than `<width>` size, Greenplum Database expects the field to be right-padded with spaces to that size. |
@@ -57,7 +57,7 @@ Refer to the Greenplum Database [fixed width custom formatter documentation](htt
 
 ## <a id="about_lineend"></a>About the line_delim and NEWLINE Formatter Options
 
-By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` formatter option, and set the value to `CR`, `CRLF`, or the set of bytecode characters, respectively.
+By default, Greenplum Database uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `line_delim` option. If the `line_delim` option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must specify the `NEWLINE` option in the external table `LOCATION` clause, and set the value to `CR`, `CRLF`, or the set of bytecode characters, respectively.
 
 Refer to the Greenplum Database [fixed width custom formatter documentation](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-load-topics-g-importing-and-exporting-fixed-width-data.html) for more information about the formatter options.
 
@@ -157,7 +157,7 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://doc
 | \<path&#8209;to&#8209;dir\>    | The path to the directory in the data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;dir\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;dir\> must not specify a relative path nor include the dollar sign (`$`) character. |
 | PROFILE=\<objstore\>:fixedwidth | The `PROFILE` must identify the specific object store. For example, `s3:fixedwidth`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
-| NEWLINE=\<bytecode\>    | When `line_delim` contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
+| NEWLINE=\<bytecode\>    | When the `line_delim` formatter option contains `\r`, `\r\n`, or a set of custom escape characters, you must set `<bytecode>` to `CR`, `CRLF`, or the set of bytecode characters, respectively. |
 | \<write&#8209;option\>=\<value\>  | \<write-option\>s are described below.|
 | FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `FORMATTER='fixedwidth_out'` (write). |
 | \<field_name>='\<width>'    | The name and the width of the field. For example: `first_name='15'` specifies that the `first_name` field is `15` characters long. By default, when writing to the external file and the field value is less than `<width>` size, Greenplum Database right-pads the field with spaces to `<width>` size. |

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -20,7 +20,7 @@ Use the `<objstore>:fixedwidth` profile when you read fixed-width text from an o
 | Azure Data Lake    | adl |
 | Google Cloud Storage    | gs |
 | MinIO    | s3 |
-| S3    | s3 |
+| AWS S3    | s3 |
 
 The following syntax creates a Greenplum Database readable external table that references such a text file in an object store: 
 

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -193,7 +193,7 @@ Perform the following procedure to create a Greenplum Database writable external
     ``` sql
     postgres=# CREATE WRITABLE EXTERNAL TABLE pxf_s3_fixedwidth_w(location text, month text, num_orders int, total_sales float8)
                  LOCATION ('pxf://BUCKET/pxf_examples/fixedwidth_write?PROFILE=s3:fixedwidth&SERVER=s3srvcfg')
-               FORMAT 'CUSTOM' (formatter='fixedwidth_out', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\n');
+               FORMAT 'CUSTOM' (formatter='fixedwidth_out', location='15', month='4', num_orders='6', total_sales='10');
     ```
     
 2. Write a few individual records to the `fixedwidth_write` S3 directory by `INSERT`ing into the `pxf_s3_fixedwidth_w` table:

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -113,7 +113,7 @@ Procedure:
 
     ``` sql
     postgres=# CREATE EXTERNAL TABLE pxf_s3_fixedwidth_r(location text, month text, num_orders int, total_sales float8)
-                 LOCATION ('pxf://data/pxf_examples/pxf_s3_fixedwidth.txt?PROFILE=s3:fixedwidth&SERVER=s3srvcfg')
+                 LOCATION ('pxf://data/pxf_examples/pxf_s3_fixedwidth.txt?PROFILE=s3:fixedwidth&SERVER=s3srvcfg&NEWLINE=CRLF')
                FORMAT 'CUSTOM' (formatter='fixedwidth_in', location='15', month='4', num_orders='6', total_sales='10', line_delim=E'\r\n');
     ```
               

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -196,7 +196,7 @@ Perform the following procedure to create a Greenplum Database writable external
                FORMAT 'CUSTOM' (formatter='fixedwidth_out', location='15', month='4', num_orders='6', total_sales='10');
     ```
     
-2. Write a few individual records to the `fixedwidth_write` S3 directory by `INSERT`ing into the `pxf_s3_fixedwidth_w` table:
+2. Write a few individual records to the `fixedwidth_write` S3 directory by using the `INSERT` command on the `pxf_s3_fixedwidth_w` table:
 
     ``` sql
     postgres=# INSERT INTO pxf_s3_fixedwidth_w VALUES ( 'Frankfurt', 'Mar', 777, 3956.98 );

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -182,8 +182,6 @@ This example utilizes the data schema introduced in [Example: Reading Fixed-Widt
 | number_of_orders | 6 | int |
 | total_sales | 10 | float8 |
 
-This example also optionally uses the Greenplum Database external table named `pxf_s3_fixedwidth_r` that you created in that exercise.
-
 #### <a id="fixedwidth_write_proc" class="no-quick-link"></a>Procedure
 
 Perform the following procedure to create a Greenplum Database writable external table utilizing the same data schema as described above. You will use the PXF `s3:fixedwidth` profile to write data to S3. You will also create a separate, readable external table to read the data that you wrote to #3.
@@ -203,12 +201,6 @@ Perform the following procedure to create a Greenplum Database writable external
     postgres=# INSERT INTO pxf_s3_fixedwidth_w VALUES ( 'Cleveland', 'Oct', 3812, 96645.37 );
     ```
 
-3. (Optional) Insert the data from the `pxf_s3_fixedwidth_r` table that you created in [Example: Reading Fixed-Width Text Data on S3](#fixedwidth_read_example) into `pxf_s3_fixedwidth_w`:
-
-    ``` sql
-    postgres=# INSERT INTO pxf_s3_fixedwidth_w SELECT * FROM pxf_s3_fixedwidth_r;
-    ```
-
 5. Greenplum Database does not support directly querying a writable external table. To query the data that you just added to S3, you must create a readable external Greenplum Database table that references the S3 directory:
 
     ``` sql
@@ -226,14 +218,8 @@ Perform the following procedure to create a Greenplum Database writable external
     ``` pre
      location  | month | num_orders | total_sales 
     -----------+-------+------------+-------------
-     Rome      | Mar   |         87 |     1557.39
      Frankfurt | Mar   |        777 |     3956.98
-     Prague    | Jan   |        101 |     4875.33
-     Bangalore | May   |        317 |     8936.99
-     Beijing   | Jul   |        411 |    11600.67
      Cleveland | Oct   |       3812 |    96645.37
-    (6 rows)
+    (2 rows)
     ```
-
-    The `pxf_s3_fixedwidth_r2` table includes the records you individually inserted, as well as the full contents of the `pxf_s3_fixedwidth_r` table if you chose to perform the optional step.
 

--- a/docs/content/overview_pxf.html.md.erb
+++ b/docs/content/overview_pxf.html.md.erb
@@ -47,7 +47,7 @@ And these data formats:
 - Parquet
 - RCFile
 - SequenceFile
-- Text (plain, delimited, embedded line feeds)
+- Text (plain, delimited, embedded line feeds, fixed width)
 
 ## <a id="basic_usage"></a> Basic Usage
 

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -81,7 +81,7 @@ CREATE EXTERNAL TABLE ext_part_87 (id int, some_date date)
 FORMAT 'CUSTOM' (formatter = 'pxfwritable_import');
 ```
 
-The `IGNORE_MISSING_PATH` custom option applies only to file-based profiles, including `*:text`, `*:parquet`, `*:avro`, `*:json`, `*:AvroSequenceFile`, and `*:SequenceFile`. This option is *not available* when the external table specifies the `hbase`, `hive[:*]`, or `jdbc` profiles, or when reading from S3 using S3-Select.
+The `IGNORE_MISSING_PATH` custom option applies only to file-based profiles, including `*:text`, `*:fixedwidth`, `*:parquet`, `*:avro`, `*:json`, `*:AvroSequenceFile`, and `*:SequenceFile`. This option is *not available* when the external table specifies the `hbase`, `hive[:*]`, or `jdbc` profiles, or when reading from S3 using S3-Select.
 
 
 ## <a id="hive-metastore"></a>Addressing Hive MetaStore Connection Errors

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -81,7 +81,7 @@ CREATE EXTERNAL TABLE ext_part_87 (id int, some_date date)
 FORMAT 'CUSTOM' (formatter = 'pxfwritable_import');
 ```
 
-The `IGNORE_MISSING_PATH` custom option applies only to file-based profiles, including `*:text`, `*:fixedwidth`, `*:parquet`, `*:avro`, `*:json`, `*:AvroSequenceFile`, and `*:SequenceFile`. This option is *not available* when the external table specifies the `hbase`, `hive[:*]`, or `jdbc` profiles, or when reading from S3 using S3-Select.
+The `IGNORE_MISSING_PATH` custom option applies only to file-based profiles, including `*:text`, `*:csv`, `*:fixedwidth`, `*:parquet`, `*:avro`, `*:json`, `*:AvroSequenceFile`, and `*:SequenceFile`. This option is *not available* when the external table specifies the `hbase`, `hive[:*]`, or `jdbc` profiles, or when reading from S3 using S3-Select.
 
 
 ## <a id="hive-metastore"></a>Addressing Hive MetaStore Connection Errors


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/949.

in this PR:
- update misc references to the list of profiles
- per the strategy for other profiles, create a using page for both HDFS and object stores.  the pages are very similar, the DDL in the examples obviously differ.
- i tested the hdfs example, but not the S3 example.
- i explain a little about the syntax of the custom formatter and then xref off to the greenplum custom formatter docs.

i pulled this together pretty quickly, so please do review thoroughly.

doc review site links:
- hdfs topic:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/fixedwidth/tanzu-greenplum-platform-extension-framework/GUID-hdfs_fixedwidth.html
- objstore topic:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/fixedwidth/tanzu-greenplum-platform-extension-framework/GUID-objstore_fixedwidth.html