### PR TITLE
Add support year with more than 4 digits in 'date' or 'timestamp'

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -364,7 +364,8 @@ public class JdbcBasePlugin extends BasePlugin {
             poolQualifier = configuration.get(JDBC_POOL_QUALIFIER_PROPERTY_NAME);
         }
 
-        // Optional parameter. Get the flag whether the year might contain more than 4 digits in `date` or 'timestamp' or not
+        // Optional parameter to determine if the year might contain more than 4 digits in `date` or 'timestamp'.
+        // Populate from the context if it exists, otherwise pull from the configuration. The default value is false.
         String dateWideRange = context.getOption(JDBC_DATE_WIDE_RANGE);
         if (dateWideRange != null) {
             isDateWideRange = Boolean.parseBoolean(dateWideRange);

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -96,7 +96,7 @@ public class JdbcBasePlugin extends BasePlugin {
     private static final String HIVE_URL_PREFIX = "jdbc:hive2://";
     private static final String HIVE_DEFAULT_DRIVER_CLASS = "org.apache.hive.jdbc.HiveDriver";
     private static final String MYSQL_DRIVER_PREFIX = "com.mysql.";
-    private static final String JDBC_DATE_WIDE_RANGE = "jdbc.date.wide-range";
+    private static final String JDBC_DATE_WIDE_RANGE = "jdbc.date.wideRange";
 
     private enum TransactionIsolation {
         READ_UNCOMMITTED(1),
@@ -365,13 +365,8 @@ public class JdbcBasePlugin extends BasePlugin {
         }
 
         // Optional parameter to determine if the year might contain more than 4 digits in `date` or 'timestamp'.
-        // Populate from the context if it exists, otherwise pull from the configuration. The default value is false.
-        String dateWideRange = context.getOption(JDBC_DATE_WIDE_RANGE);
-        if (dateWideRange != null) {
-            isDateWideRange = Boolean.parseBoolean(dateWideRange);
-        } else {
-            isDateWideRange = configuration.getBoolean(JDBC_DATE_WIDE_RANGE, false);
-        }
+        // The default value is false.
+        isDateWideRange = configuration.getBoolean(JDBC_DATE_WIDE_RANGE, false);
     }
 
     /**

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePlugin.java
@@ -96,6 +96,7 @@ public class JdbcBasePlugin extends BasePlugin {
     private static final String HIVE_URL_PREFIX = "jdbc:hive2://";
     private static final String HIVE_DEFAULT_DRIVER_CLASS = "org.apache.hive.jdbc.HiveDriver";
     private static final String MYSQL_DRIVER_PREFIX = "com.mysql.";
+    private static final String JDBC_DATE_WIDE_RANGE = "jdbc.date.wide-range";
 
     private enum TransactionIsolation {
         READ_UNCOMMITTED(1),
@@ -163,6 +164,9 @@ public class JdbcBasePlugin extends BasePlugin {
 
     private final ConnectionManager connectionManager;
     private final SecureLogin secureLogin;
+
+    // Flag which is used when the year might contain more than 4 digits in `date` or 'timestamp'
+    protected boolean isDateWideRange;
 
     static {
         // Deprecated as of Oct 22, 2019 in version 5.9.2+
@@ -358,6 +362,14 @@ public class JdbcBasePlugin extends BasePlugin {
             // get the qualifier for connection pool, if configured. Might be used when connection session authorization is employed
             // to switch effective user once connection is established
             poolQualifier = configuration.get(JDBC_POOL_QUALIFIER_PROPERTY_NAME);
+        }
+
+        // Optional parameter. Get the flag whether the year might contain more than 4 digits in `date` or 'timestamp' or not
+        String dateWideRange = context.getOption(JDBC_DATE_WIDE_RANGE);
+        if (dateWideRange != null) {
+            isDateWideRange = Boolean.parseBoolean(dateWideRange);
+        } else {
+            isDateWideRange = configuration.getBoolean(JDBC_DATE_WIDE_RANGE, false);
         }
     }
 

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
@@ -23,7 +23,9 @@ import org.greenplum.pxf.api.OneField;
 import org.greenplum.pxf.api.OneRow;
 import org.greenplum.pxf.api.io.DataType;
 import org.greenplum.pxf.api.model.Resolver;
+import org.greenplum.pxf.api.security.SecureLogin;
 import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+import org.greenplum.pxf.plugins.jdbc.utils.ConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +57,10 @@ import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
  * JDBC tables resolver
  */
 public class JdbcResolver extends JdbcBasePlugin implements Resolver {
+    /**
+     * LOCAL_DATE_GET_FORMATTER is used to format LocalDate to String.
+     * Examples: 2023-01-10 -> "2023-01-10 AD"; +12345-02-01 -> "12345-02-01 AD"; -0009-12-11 -> "0010-12-11 BC"
+     */
     private static final DateTimeFormatter LOCAL_DATE_GET_FORMATTER = (new DateTimeFormatterBuilder())
             .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
             .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
@@ -62,6 +68,11 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             .appendPattern(" G")
             .toFormatter();
 
+    /**
+     * LOCAL_DATE_TIME_GET_FORMATTER is used to format LocalDateTime to String.
+     * Examples: 2018-10-19T10:11 -> "2018-10-19 10:11:00 AD"; +123456-10-19T11:12:13 -> "123456-10-19 11:12:13 AD";
+     * -1233-10-19T10:11:15.456 -> "1234-10-19 10:11:15.456 BC"
+     */
     private static final DateTimeFormatter LOCAL_DATE_TIME_GET_FORMATTER = (new DateTimeFormatterBuilder())
             .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
             .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
@@ -70,6 +81,12 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             .appendPattern(" G")
             .toFormatter();
 
+
+    /**
+     * OFFSET_DATE_TIME_GET_FORMATTER is used to format OffsetDateTime to String.
+     * Examples: 1956-02-01T07:15:16Z -> "1956-02-01 07:15:16Z AD"; +12345-02-01T10:15:16Z -> "12345-02-01 10:15:16Z AD";
+     * -1999-02-01T04:15:16Z -> "2000-02-01 04:15:16Z BC"
+     */
     private static final DateTimeFormatter OFFSET_DATE_TIME_GET_FORMATTER = (new DateTimeFormatterBuilder())
             .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
             .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
@@ -78,6 +95,10 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             .appendPattern(" G")
             .toFormatter();
 
+    /**
+     * LOCAL_DATE_SET_FORMATTER is used to format String to LocalDate.
+     * Examples: "1977-12-11" -> 1977-12-11; "456789-12-11" -> +456789-12-11; "0010-12-11 BC" -> -0009-12-11
+     */
     private static final DateTimeFormatter LOCAL_DATE_SET_FORMATTER = (new DateTimeFormatterBuilder())
             .appendValue(ChronoField.YEAR_OF_ERA, 1, 9, SignStyle.NORMAL).appendLiteral('-')
             .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
@@ -85,11 +106,15 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             .optionalStart().appendPattern(" G").optionalEnd()
             .toFormatter();
 
+    /**
+     * LOCAL_DATE_TIME_SET_FORMATTER is used to transfer String to LocalDateTime.
+     * Examples: "1980-08-10 17:10:20" -> 1980-08-10T17:10:20; "123456-10-19 11:12:13" -> +123456-10-19T11:12:13;
+     * "1234-10-19 10:11:15.456 BC" -> -1233-10-19T10:11:15.456
+     */
     private static final DateTimeFormatter LOCAL_DATE_TIME_SET_FORMATTER = (new DateTimeFormatterBuilder())
             .appendValue(ChronoField.YEAR_OF_ERA, 1, 9, SignStyle.NORMAL).appendLiteral('-')
             .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NORMAL).appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NORMAL)
-            .appendLiteral(" ")
+            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NORMAL).appendLiteral(" ")
             .append(ISO_LOCAL_TIME)
             .optionalStart().appendPattern(" G").optionalEnd()
             .toFormatter();
@@ -111,6 +136,23 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
     );
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcResolver.class);
+
+    /**
+     * Creates a new instance of the JdbcResolver
+     */
+    public JdbcResolver() {
+        super();
+    }
+
+    /**
+     * Creates a new instance of the resolver with provided connection manager.
+     *
+     * @param connectionManager connection manager
+     * @param secureLogin       the instance of the secure login
+     */
+    JdbcResolver(ConnectionManager connectionManager, SecureLogin secureLogin) {
+        super(connectionManager, secureLogin);
+    }
 
     /**
      * getFields() implementation
@@ -390,7 +432,7 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                         statement.setNull(i, Types.TIMESTAMP);
                     } else {
                         if (field.val instanceof LocalDateTime) {
-                            statement.setObject(i, (LocalDateTime) field.val);
+                            statement.setObject(i, field.val);
                         } else {
                             statement.setTimestamp(i, (Timestamp) field.val);
                         }
@@ -401,7 +443,7 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                         statement.setNull(i, Types.DATE);
                     } else {
                         if (field.val instanceof LocalDate) {
-                            statement.setObject(i, (LocalDate) field.val);
+                            statement.setObject(i, field.val);
                         } else {
                             statement.setDate(i, (Date) field.val);
                         }

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
@@ -57,6 +57,8 @@ import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
  * JDBC tables resolver
  */
 public class JdbcResolver extends JdbcBasePlugin implements Resolver {
+    // Signifies the ERA format
+    final private static String DATE_TIME_FORMATTER_SPECIFIER = " G";
     /**
      * LOCAL_DATE_GET_FORMATTER is used to format LocalDate to String.
      * Examples: 2023-01-10 -> "2023-01-10 AD"; +12345-02-01 -> "12345-02-01 AD"; -0009-12-11 -> "0010-12-11 BC"
@@ -65,7 +67,7 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
             .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
             .appendValue(ChronoField.DAY_OF_MONTH, 2)
-            .appendPattern(" G")
+            .appendPattern(DATE_TIME_FORMATTER_SPECIFIER)
             .toFormatter();
 
     /**
@@ -78,7 +80,7 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
             .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral(" ")
             .append(ISO_LOCAL_TIME)
-            .appendPattern(" G")
+            .appendPattern(DATE_TIME_FORMATTER_SPECIFIER)
             .toFormatter();
 
 
@@ -92,7 +94,7 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
             .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral(" ")
             .append(ISO_OFFSET_TIME)
-            .appendPattern(" G")
+            .appendPattern(DATE_TIME_FORMATTER_SPECIFIER)
             .toFormatter();
 
     /**
@@ -103,7 +105,7 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             .appendValue(ChronoField.YEAR_OF_ERA, 1, 9, SignStyle.NORMAL).appendLiteral('-')
             .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
             .appendValue(ChronoField.DAY_OF_MONTH, 2)
-            .optionalStart().appendPattern(" G").optionalEnd()
+            .optionalStart().appendPattern(DATE_TIME_FORMATTER_SPECIFIER).optionalEnd()
             .toFormatter();
 
     /**
@@ -116,7 +118,7 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NORMAL).appendLiteral('-')
             .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NORMAL).appendLiteral(" ")
             .append(ISO_LOCAL_TIME)
-            .optionalStart().appendPattern(" G").optionalEnd()
+            .optionalStart().appendPattern(DATE_TIME_FORMATTER_SPECIFIER).optionalEnd()
             .toFormatter();
 
     private static final Set<DataType> DATATYPES_SUPPORTED = EnumSet.of(

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
@@ -36,15 +36,64 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_TIME;
+
 /**
  * JDBC tables resolver
  */
 public class JdbcResolver extends JdbcBasePlugin implements Resolver {
+    private static final DateTimeFormatter LOCAL_DATE_GET_FORMATTER = (new DateTimeFormatterBuilder())
+            .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .appendPattern(" G")
+            .toFormatter();
+
+    private static final DateTimeFormatter LOCAL_DATE_TIME_GET_FORMATTER = (new DateTimeFormatterBuilder())
+            .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral(" ")
+            .append(ISO_LOCAL_TIME)
+            .appendPattern(" G")
+            .toFormatter();
+
+    private static final DateTimeFormatter OFFSET_DATE_TIME_GET_FORMATTER = (new DateTimeFormatterBuilder())
+            .appendValue(ChronoField.YEAR_OF_ERA, 4, 9, SignStyle.NORMAL).appendLiteral("-")
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2).appendLiteral(" ")
+            .append(ISO_OFFSET_TIME)
+            .appendPattern(" G")
+            .toFormatter();
+
+    private static final DateTimeFormatter LOCAL_DATE_SET_FORMATTER = (new DateTimeFormatterBuilder())
+            .appendValue(ChronoField.YEAR_OF_ERA, 1, 9, SignStyle.NORMAL).appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .optionalStart().appendPattern(" G").optionalEnd()
+            .toFormatter();
+
+    private static final DateTimeFormatter LOCAL_DATE_TIME_SET_FORMATTER = (new DateTimeFormatterBuilder())
+            .appendValue(ChronoField.YEAR_OF_ERA, 1, 9, SignStyle.NORMAL).appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NORMAL).appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NORMAL)
+            .appendLiteral(" ")
+            .append(ISO_LOCAL_TIME)
+            .optionalStart().appendPattern(" G").optionalEnd()
+            .toFormatter();
+
     private static final Set<DataType> DATATYPES_SUPPORTED = EnumSet.of(
             DataType.VARCHAR,
             DataType.BPCHAR,
@@ -117,10 +166,31 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                     value = result.getString(colName);
                     break;
                 case DATE:
-                    value = result.getDate(colName);
+                    if (isDateWideRange) {
+                        LocalDate localDate = result.getObject(colName, LocalDate.class);
+                        value = localDate != null ? localDate.format(LOCAL_DATE_GET_FORMATTER) : null;
+                    } else {
+                        value = result.getDate(colName);
+                    }
                     break;
                 case TIMESTAMP:
-                    value = result.getTimestamp(colName);
+                    if (isDateWideRange) {
+                        LocalDateTime localDateTime = result.getObject(colName, LocalDateTime.class);
+                        value = localDateTime != null ? localDateTime.format(LOCAL_DATE_TIME_GET_FORMATTER) : null;
+                    } else {
+                        value = result.getTimestamp(colName);
+                    }
+                    break;
+                case TIMESTAMP_WITH_TIME_ZONE:
+                    if (isDateWideRange) {
+                        OffsetDateTime offsetDateTime = result.getObject(colName, OffsetDateTime.class);
+                        value = offsetDateTime != null ? offsetDateTime.format(OFFSET_DATE_TIME_GET_FORMATTER) : null;
+                    } else {
+                        throw new UnsupportedOperationException(
+                                String.format("Field type '%s' (column '%s') is not supported",
+                                        DataType.get(oneField.type),
+                                        column));
+                    }
                     break;
                 default:
                     throw new UnsupportedOperationException(
@@ -211,10 +281,18 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                         oneField.val = new BigDecimal(rawVal);
                         break;
                     case TIMESTAMP:
-                        oneField.val = Timestamp.valueOf(rawVal);
+                        if (isDateWideRange) {
+                            oneField.val = getLocalDateTime(rawVal);
+                        } else {
+                            oneField.val = Timestamp.valueOf(rawVal);
+                        }
                         break;
                     case DATE:
-                        oneField.val = Date.valueOf(rawVal);
+                        if (isDateWideRange) {
+                            oneField.val = getLocalDate(rawVal);
+                        } else {
+                            oneField.val = Date.valueOf(rawVal);
+                        }
                         break;
                     default:
                         throw new UnsupportedOperationException(
@@ -311,19 +389,55 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                     if (field.val == null) {
                         statement.setNull(i, Types.TIMESTAMP);
                     } else {
-                        statement.setTimestamp(i, (Timestamp) field.val);
+                        if (field.val instanceof LocalDateTime) {
+                            statement.setObject(i, (LocalDateTime) field.val);
+                        } else {
+                            statement.setTimestamp(i, (Timestamp) field.val);
+                        }
                     }
                     break;
                 case DATE:
                     if (field.val == null) {
                         statement.setNull(i, Types.DATE);
                     } else {
-                        statement.setDate(i, (Date) field.val);
+                        if (field.val instanceof LocalDate) {
+                            statement.setObject(i, (LocalDate) field.val);
+                        } else {
+                            statement.setDate(i, (Date) field.val);
+                        }
                     }
                     break;
                 default:
                     throw new IOException("The data tuple from JdbcResolver is corrupted");
             }
+        }
+    }
+
+    /**
+     * Convert a string to LocalDate class with formatter
+     *
+     * @param rawVal the LocalDate in a string format
+     * @return LocalDate
+     */
+    private LocalDate getLocalDate(String rawVal) {
+        try {
+            return LocalDate.parse(rawVal, LOCAL_DATE_SET_FORMATTER);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to convert date '" + rawVal + "' to LocalDate class: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Convert a string to LocalDateTime class with formatter
+     *
+     * @param rawVal the LocalDateTime in a string format
+     * @return LocalDateTime
+     */
+    private LocalDateTime getLocalDateTime(String rawVal) {
+        try {
+            return LocalDateTime.parse(rawVal, LOCAL_DATE_TIME_SET_FORMATTER);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to convert timestamp '" + rawVal + "' to the LocalDateTime class: " + e.getMessage(), e);
         }
     }
 }

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.anyInt;
@@ -482,6 +483,15 @@ public class JdbcBasePluginTest {
         connProps.setProperty("bar", "bar-val");
 
         verify(mockConnectionManager).getConnection("test-server", "test-url", connProps, false, null, null);
+    }
+
+    @Test
+    public void testDateWideRangeFromConfiguration() throws SQLException {
+        configuration.set("jdbc.driver", "org.greenplum.pxf.plugins.jdbc.FakeJdbcDriver");
+        configuration.set("jdbc.url", "test-url");
+        configuration.set("jdbc.date.wide-range", "true");
+        JdbcBasePlugin plugin = getPlugin(mockConnectionManager, mockSecureLogin, context);
+        assertTrue(plugin.isDateWideRange);
     }
 
     private JdbcBasePlugin getPlugin(ConnectionManager mockConnectionManager, SecureLogin mockSecureLogin, RequestContext context) {

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcBasePluginTest.java
@@ -489,7 +489,7 @@ public class JdbcBasePluginTest {
     public void testDateWideRangeFromConfiguration() throws SQLException {
         configuration.set("jdbc.driver", "org.greenplum.pxf.plugins.jdbc.FakeJdbcDriver");
         configuration.set("jdbc.url", "test-url");
-        configuration.set("jdbc.date.wide-range", "true");
+        configuration.set("jdbc.date.wideRange", "true");
         JdbcBasePlugin plugin = getPlugin(mockConnectionManager, mockSecureLogin, context);
         assertTrue(plugin.isDateWideRange);
     }

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
@@ -26,8 +26,9 @@ import java.util.List;
 import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 
@@ -232,6 +233,23 @@ class JdbcResolverTest {
     }
 
     @Test
+    void setFieldDateWithoutWideRangeWithLeadingZeroTest() throws ParseException {
+        isDateWideRange = false;
+        String date = "0003-5-4";
+        Date expectedDate = Date.valueOf(date);
+        OneField oneField = setFields(date, DataType.DATE.getOID(), "date");
+        assertTrue(oneField.val instanceof Date);
+        assertEquals(expectedDate, oneField.val);
+    }
+
+    @Test
+    void setFieldDateWithoutWideRangeWithoutLeadingZeroTest() {
+        isDateWideRange = false;
+        String date = "3-5-4";
+        assertThrows(IllegalArgumentException.class, () -> setFields(date, DataType.DATE.getOID(), "date"));
+    }
+
+    @Test
     void setFieldDateWithMoreThan4digitsInYearTest() throws ParseException {
         isDateWideRange = true;
         LocalDate expectedLocalDate = LocalDate.of(+12345678, 12, 11);
@@ -239,6 +257,13 @@ class JdbcResolverTest {
         OneField oneField = setFields(date, DataType.DATE.getOID(), "date");
         assertTrue(oneField.val instanceof LocalDate);
         assertEquals(expectedLocalDate, oneField.val);
+    }
+
+    @Test
+    void setFieldDateWithMoreThan4digitsInYearWithoutWideRangeTest() throws ParseException {
+        isDateWideRange = false;
+        String date = "12345678-12-11";
+        assertThrows(IllegalArgumentException.class, () -> setFields(date, DataType.DATE.getOID(), "date"));
     }
 
     @Test
@@ -259,6 +284,13 @@ class JdbcResolverTest {
         OneField oneField = setFields(date, DataType.DATE.getOID(), "date");
         assertTrue(oneField.val instanceof LocalDate);
         assertEquals(expectedLocalDate, oneField.val);
+    }
+
+    @Test
+    void setFieldDateWithEraWithoutWideRangeTest() {
+        isDateWideRange = false;
+        String date = "1235-11-01 BC";
+        assertThrows(IllegalArgumentException.class, () -> setFields(date, DataType.DATE.getOID(), "date"));
     }
 
     @Test
@@ -292,6 +324,16 @@ class JdbcResolverTest {
     }
 
     @Test
+    void setFieldDateTimeWithoutWideRangeWithLeadingZeroTest() throws ParseException {
+        isDateWideRange = false;
+        String timestamp = "0003-05-04 01:02:01.23";
+        Timestamp expectedTimestamp = Timestamp.valueOf(timestamp);
+        OneField oneField = setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertTrue(oneField.val instanceof Timestamp);
+        assertEquals(expectedTimestamp, oneField.val);
+    }
+
+    @Test
     void setFieldDateTimeWithMoreThan4digitsInYearTest() throws ParseException {
         isDateWideRange = true;
         LocalDateTime expectedLocalDateTime = LocalDateTime.of(+12345678, 12, 11, 15, 35);
@@ -299,6 +341,13 @@ class JdbcResolverTest {
         OneField oneField = setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
         assertTrue(oneField.val instanceof LocalDateTime);
         assertEquals(expectedLocalDateTime, oneField.val);
+    }
+
+    @Test
+    void setFieldDateTimeWithMoreThan4digitsInYearWithoutWideRangeTest() {
+        isDateWideRange = false;
+        String timestamp = "12345678-12-11 15:35 AD";
+        assertThrows(IllegalArgumentException.class, () -> setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp"));
     }
 
     @Test
@@ -319,6 +368,13 @@ class JdbcResolverTest {
         OneField oneField = setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
         assertTrue(oneField.val instanceof LocalDateTime);
         assertEquals(expectedLocalDateTime, oneField.val);
+    }
+
+    @Test
+    void setFieldDateTimeWithEraWithoutWideRangeTest() throws ParseException {
+        isDateWideRange = false;
+        String timestamp = "1235-11-01 16:20 BC";
+        assertThrows(IllegalArgumentException.class, () -> setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp"));
     }
 
     private OneField getOneField(Object date, int dataTypeOid, String typeName) throws SQLException {

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
@@ -1,0 +1,554 @@
+package org.greenplum.pxf.plugins.jdbc;
+
+import org.greenplum.pxf.api.OneField;
+import org.greenplum.pxf.api.OneRow;
+import org.greenplum.pxf.api.io.DataType;
+import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.api.utilities.ColumnDescriptor;
+import org.greenplum.pxf.api.utilities.SpringContext;
+import org.greenplum.pxf.plugins.jdbc.utils.ConnectionManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+
+@ExtendWith(MockitoExtension.class)
+class JdbcResolverTest {
+    @Mock
+    private OneRow row;
+    @Mock
+    private ResultSet result;
+    RequestContext context = new RequestContext();
+    List<ColumnDescriptor> columnDescriptors = new ArrayList<>();
+    List<OneField> oneFieldList = new ArrayList<>();
+    private JdbcResolver resolver;
+
+    @Test
+    void getFieldDateWithWideRangeTest() throws SQLException {
+        LocalDate localDate = LocalDate.of(1977, 12, 11);
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertEquals("1977-12-11 AD", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateNullWithWideRangeTest() throws SQLException {
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDate.class)).thenReturn(null);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertNull(oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateWithWideRangeWithLeadingZeroTest() throws SQLException {
+        LocalDate localDate = LocalDate.of(3, 5, 4);
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertEquals("0003-05-04 AD", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateWithMoreThan4digitsInYearTest() throws SQLException {
+        LocalDate localDate = LocalDate.of(+12345678, 12, 11);
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertEquals("12345678-12-11 AD", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateWithEraWithMoreThan4digitsInYearTest() throws SQLException {
+        LocalDate localDate = LocalDate.of(-1234567, 6, 1);
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            // The year -1234567 is transferred to 1234568 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
+            assertEquals("1234568-06-01 BC", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateWithEraTest() throws SQLException {
+        LocalDate localDate = LocalDate.of(-1234, 6, 1);
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            // The year -1234 is transferred to 1235 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
+            assertEquals("1235-06-01 BC", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateTimeWithWideRangeTest() throws SQLException {
+        LocalDateTime localDateTime = LocalDateTime.parse("1977-12-11T11:15:30.1234");
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(localDateTime);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertEquals("1977-12-11 11:15:30.1234 AD", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateNullTimeWithWideRangeTest() throws SQLException {
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(null);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertNull(oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateTimeWithWideRangeWithLeadingZeroTest() throws SQLException {
+        LocalDateTime localDateTime = LocalDateTime.parse("0003-01-02T04:05:06.0000015");
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(localDateTime);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertEquals("0003-01-02 04:05:06.0000015 AD", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateTimeWithMoreThan4digitsInYearTest() throws SQLException {
+        LocalDateTime localDateTime = LocalDateTime.parse("+9876543-12-11T11:15:30.1234");
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(localDateTime);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertEquals("9876543-12-11 11:15:30.1234 AD", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldDateTimeWithEraTest() throws SQLException {
+        LocalDateTime localDateTime = LocalDateTime.parse("-3456-12-11T11:15:30");
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(localDateTime);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            // The year -3456 is transferred to 3457 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
+            assertEquals("3457-12-11 11:15:30 BC", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldOffsetDateTimeWithWideRangeTest() throws SQLException {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("1977-12-11T10:15:30.1234+05:00");
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(offsetDateTime);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertEquals("1977-12-11 10:15:30.1234+05:00 AD", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldOffsetDateTimeNullWithWideRangeTest() throws SQLException {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(null);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertNull(oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldOffsetDateTimeWithWideRangeWithLeadingZeroTest() throws SQLException {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("0003-01-02T04:05:06.0000015+03:00");
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(offsetDateTime);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertEquals("0003-01-02 04:05:06.0000015+03:00 AD", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldOffsetDateTimeWithMoreThan4digitsInYearTest() throws SQLException {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("+9876543-12-11T11:15:30.1234-03:00");
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(offsetDateTime);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            assertEquals("9876543-12-11 11:15:30.1234-03:00 AD", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void getFieldOffsetDateTimeWithEraTest() throws SQLException {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("-3456-12-11T11:15:30+02:00");
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
+        context.setTupleDescription(columnDescriptors);
+        when(row.getData()).thenReturn(result);
+        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(offsetDateTime);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            List<OneField> oneFields = resolver.getFields(row);
+            // The year -3456 is transferred to 3457 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
+            assertEquals("3457-12-11 11:15:30+02:00 BC", oneFields.get(0).val);
+        }
+    }
+
+    @Test
+    void setFieldDateWithWideRangeTest() throws ParseException {
+        LocalDate expectedLocalDate = LocalDate.of(1977, 12, 11);
+        String date = "1977-12-11";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
+            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+
+    @Test
+    void setFieldDateWithWideRangeWithLeadingZeroTest() throws ParseException {
+        LocalDate expectedLocalDate = LocalDate.of(3, 5, 4);
+        String date = "0003-05-04";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
+            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+
+    @Test
+    void setFieldDateWithMoreThan4digitsInYearTest() throws ParseException {
+        LocalDate expectedLocalDate = LocalDate.of(+12345678, 12, 11);
+        String date = "12345678-12-11";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
+            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+
+    @Test
+    void setFieldDateWithEraWithMoreThan4digitsInYearTest() throws ParseException {
+        LocalDate expectedLocalDate = LocalDate.of(-1234567, 6, 1);
+        String date = "1234568-06-01 BC";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
+            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+
+    @Test
+    void setFieldDateWithEraTest() throws ParseException {
+        LocalDate expectedLocalDate = LocalDate.of(-1234, 11, 1);
+        String date = "1235-11-01 BC";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
+            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+
+    @Test
+    void setFieldDateTimeWithWideRangeTest() throws ParseException {
+        LocalDateTime expectedLocalDateTime = LocalDateTime.of(1977, 12, 11, 15, 12, 11, 123456789);
+        String date = "1977-12-11 15:12:11.123456789";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
+            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+
+    @Test
+    void setFieldDateTimeWithWideRangeWithLeadingZeroTest() throws ParseException {
+        LocalDateTime expectedLocalDateTime = LocalDateTime.of(3, 5, 4, 1, 2, 1);
+        String date = "0003-05-04 01:02:01";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
+            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+
+    @Test
+    void setFieldDateTimeWithMoreThan4digitsInYearTest() throws ParseException {
+        LocalDateTime expectedLocalDateTime = LocalDateTime.of(+12345678, 12, 11, 15, 35);
+        String date = "12345678-12-11 15:35 AD";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
+            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+
+    @Test
+    void setFieldDateTimeWithEraWithMoreThan4digitsInYearTest() throws ParseException {
+        LocalDateTime expectedLocalDateTime = LocalDateTime.of(-1234567, 6, 1, 19, 56, 43, 12);
+        String date = "1234568-06-01 19:56:43.000000012 BC";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
+            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+
+    @Test
+    void setFieldDateTimeWithEraTest() throws ParseException {
+        LocalDateTime expectedLocalDateTime = LocalDateTime.of(-1234, 11, 1, 16, 20);
+        String date = "1235-11-01 16:20 BC";
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        boolean isDateWideRange = true;
+        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
+        context.setTupleDescription(columnDescriptors);
+
+        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
+            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
+            resolver = new JdbcResolver();
+            resolver.columns = context.getTupleDescription();
+            resolver.isDateWideRange = isDateWideRange;
+            OneRow oneRow = resolver.setFields(oneFieldList);
+            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
+            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+        }
+    }
+}

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
@@ -4,17 +4,19 @@ import org.greenplum.pxf.api.OneField;
 import org.greenplum.pxf.api.OneRow;
 import org.greenplum.pxf.api.io.DataType;
 import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.api.security.SecureLogin;
 import org.greenplum.pxf.api.utilities.ColumnDescriptor;
-import org.greenplum.pxf.api.utilities.SpringContext;
 import org.greenplum.pxf.plugins.jdbc.utils.ConnectionManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,9 +28,7 @@ import java.util.TimeZone;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -37,518 +37,318 @@ class JdbcResolverTest {
     private OneRow row;
     @Mock
     private ResultSet result;
+    @Mock
+    private ConnectionManager mockConnectionManager;
+    @Mock
+    private SecureLogin mockSecureLogin;
     RequestContext context = new RequestContext();
     List<ColumnDescriptor> columnDescriptors = new ArrayList<>();
     List<OneField> oneFieldList = new ArrayList<>();
     private JdbcResolver resolver;
+    private boolean isDateWideRange;
+
+    @BeforeEach
+    void setup() {
+        resolver = new JdbcResolver(mockConnectionManager, mockSecureLogin);
+    }
 
     @Test
     void getFieldDateWithWideRangeTest() throws SQLException {
+        isDateWideRange = true;
         LocalDate localDate = LocalDate.of(1977, 12, 11);
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
+        OneField oneField = getOneField(localDate, DataType.DATE.getOID(), "date");
+        assertEquals("1977-12-11 AD", oneField.val);
+    }
 
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertEquals("1977-12-11 AD", oneFields.get(0).val);
-        }
+    @Test
+    void getFieldDateWithoutWideRangeTest() throws SQLException {
+        isDateWideRange = false;
+        Date date = Date.valueOf("1977-12-11");
+        OneField oneField = getOneField(date, DataType.DATE.getOID(), "date");
+        assertEquals("1977-12-11", oneField.toString());
     }
 
     @Test
     void getFieldDateNullWithWideRangeTest() throws SQLException {
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDate.class)).thenReturn(null);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertNull(oneFields.get(0).val);
-        }
+        isDateWideRange = true;
+        OneField oneField = getOneField(null, DataType.DATE.getOID(), "date");
+        assertNull(oneField.val);
     }
 
     @Test
     void getFieldDateWithWideRangeWithLeadingZeroTest() throws SQLException {
+        isDateWideRange = true;
         LocalDate localDate = LocalDate.of(3, 5, 4);
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertEquals("0003-05-04 AD", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(localDate, DataType.DATE.getOID(), "date");
+        assertEquals("0003-05-04 AD", oneField.val);
     }
 
     @Test
     void getFieldDateWithMoreThan4digitsInYearTest() throws SQLException {
+        isDateWideRange = true;
         LocalDate localDate = LocalDate.of(+12345678, 12, 11);
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertEquals("12345678-12-11 AD", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(localDate, DataType.DATE.getOID(), "date");
+        assertEquals("12345678-12-11 AD", oneField.val);
     }
 
     @Test
     void getFieldDateWithEraWithMoreThan4digitsInYearTest() throws SQLException {
+        isDateWideRange = true;
         LocalDate localDate = LocalDate.of(-1234567, 6, 1);
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            // The year -1234567 is transferred to 1234568 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
-            assertEquals("1234568-06-01 BC", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(localDate, DataType.DATE.getOID(), "date");
+        // The year -1234567 is transferred to 1234568 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
+        assertEquals("1234568-06-01 BC", oneField.val);
     }
 
     @Test
     void getFieldDateWithEraTest() throws SQLException {
+        isDateWideRange = true;
         LocalDate localDate = LocalDate.of(-1234, 6, 1);
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDate.class)).thenReturn(localDate);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            // The year -1234 is transferred to 1235 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
-            assertEquals("1235-06-01 BC", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(localDate, DataType.DATE.getOID(), "date");
+        // The year -1234 is transferred to 1235 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
+        assertEquals("1235-06-01 BC", oneField.val);
     }
 
     @Test
     void getFieldDateTimeWithWideRangeTest() throws SQLException {
+        isDateWideRange = true;
         LocalDateTime localDateTime = LocalDateTime.parse("1977-12-11T11:15:30.1234");
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(localDateTime);
+        OneField oneField = getOneField(localDateTime, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertEquals("1977-12-11 11:15:30.1234 AD", oneField.val);
+    }
 
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertEquals("1977-12-11 11:15:30.1234 AD", oneFields.get(0).val);
-        }
+    @Test
+    void getFieldDateTimeWithoutWideRangeTest() throws SQLException {
+        boolean isDateWideRange = false;
+        Timestamp timestamp = Timestamp.valueOf("1977-12-11 11:15:30.1234");
+        OneField oneField = getOneField(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertEquals("1977-12-11 11:15:30.1234", oneField.toString());
     }
 
     @Test
     void getFieldDateNullTimeWithWideRangeTest() throws SQLException {
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(null);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertNull(oneFields.get(0).val);
-        }
+        isDateWideRange = true;
+        OneField oneField = getOneField(null, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertNull(oneField.val);
     }
 
     @Test
     void getFieldDateTimeWithWideRangeWithLeadingZeroTest() throws SQLException {
+        isDateWideRange = true;
         LocalDateTime localDateTime = LocalDateTime.parse("0003-01-02T04:05:06.0000015");
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(localDateTime);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertEquals("0003-01-02 04:05:06.0000015 AD", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(localDateTime, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertEquals("0003-01-02 04:05:06.0000015 AD", oneField.val);
     }
 
     @Test
     void getFieldDateTimeWithMoreThan4digitsInYearTest() throws SQLException {
+        isDateWideRange = true;
         LocalDateTime localDateTime = LocalDateTime.parse("+9876543-12-11T11:15:30.1234");
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(localDateTime);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertEquals("9876543-12-11 11:15:30.1234 AD", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(localDateTime, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertEquals("9876543-12-11 11:15:30.1234 AD", oneField.val);
     }
 
     @Test
     void getFieldDateTimeWithEraTest() throws SQLException {
+        isDateWideRange = true;
         LocalDateTime localDateTime = LocalDateTime.parse("-3456-12-11T11:15:30");
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", LocalDateTime.class)).thenReturn(localDateTime);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            // The year -3456 is transferred to 3457 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
-            assertEquals("3457-12-11 11:15:30 BC", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(localDateTime, DataType.TIMESTAMP.getOID(), "timestamp");
+        // The year -3456 is transferred to 3457 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
+        assertEquals("3457-12-11 11:15:30 BC", oneField.val);
     }
 
     @Test
     void getFieldOffsetDateTimeWithWideRangeTest() throws SQLException {
+        isDateWideRange = true;
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         OffsetDateTime offsetDateTime = OffsetDateTime.parse("1977-12-11T10:15:30.1234+05:00");
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(offsetDateTime);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertEquals("1977-12-11 10:15:30.1234+05:00 AD", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(offsetDateTime, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertEquals("1977-12-11 10:15:30.1234+05:00 AD", oneField.val);
     }
 
     @Test
     void getFieldOffsetDateTimeNullWithWideRangeTest() throws SQLException {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(null);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertNull(oneFields.get(0).val);
-        }
+        isDateWideRange = true;
+        OneField oneField = getOneField(null, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertNull(oneField.val);
     }
 
     @Test
     void getFieldOffsetDateTimeWithWideRangeWithLeadingZeroTest() throws SQLException {
+        isDateWideRange = true;
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         OffsetDateTime offsetDateTime = OffsetDateTime.parse("0003-01-02T04:05:06.0000015+03:00");
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(offsetDateTime);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertEquals("0003-01-02 04:05:06.0000015+03:00 AD", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(offsetDateTime, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertEquals("0003-01-02 04:05:06.0000015+03:00 AD", oneField.val);
     }
 
     @Test
     void getFieldOffsetDateTimeWithMoreThan4digitsInYearTest() throws SQLException {
+        isDateWideRange = true;
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         OffsetDateTime offsetDateTime = OffsetDateTime.parse("+9876543-12-11T11:15:30.1234-03:00");
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(offsetDateTime);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            assertEquals("9876543-12-11 11:15:30.1234-03:00 AD", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(offsetDateTime, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertEquals("9876543-12-11 11:15:30.1234-03:00 AD", oneField.val);
     }
 
     @Test
     void getFieldOffsetDateTimeWithEraTest() throws SQLException {
+        isDateWideRange = true;
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         OffsetDateTime offsetDateTime = OffsetDateTime.parse("-3456-12-11T11:15:30+02:00");
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 1, "timestamptz", null));
-        context.setTupleDescription(columnDescriptors);
-        when(row.getData()).thenReturn(result);
-        when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn(offsetDateTime);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            List<OneField> oneFields = resolver.getFields(row);
-            // The year -3456 is transferred to 3457 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
-            assertEquals("3457-12-11 11:15:30+02:00 BC", oneFields.get(0).val);
-        }
+        OneField oneField = getOneField(offsetDateTime, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        // The year -3456 is transferred to 3457 BC: https://en.wikipedia.org/wiki/Astronomical_year_numbering
+        assertEquals("3457-12-11 11:15:30+02:00 BC", oneField.val);
     }
 
     @Test
     void setFieldDateWithWideRangeTest() throws ParseException {
+        isDateWideRange = true;
         LocalDate expectedLocalDate = LocalDate.of(1977, 12, 11);
         String date = "1977-12-11";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
+        OneField oneField = setFields(date, DataType.DATE.getOID(), "date");
+        assertTrue(oneField.val instanceof LocalDate);
+        assertEquals(expectedLocalDate, oneField.val);
+    }
 
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
-            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
-        }
+    @Test
+    void setFieldDateWithoutWideRangeTest() throws ParseException {
+        isDateWideRange = false;
+        String date = "1977-12-11";
+        Date expectedDate = Date.valueOf(date);
+        OneField oneField = setFields(date, DataType.DATE.getOID(), "date");
+        assertTrue(oneField.val instanceof Date);
+        assertEquals(expectedDate, oneField.val);
     }
 
     @Test
     void setFieldDateWithWideRangeWithLeadingZeroTest() throws ParseException {
+        isDateWideRange = true;
         LocalDate expectedLocalDate = LocalDate.of(3, 5, 4);
         String date = "0003-05-04";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
-            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
-        }
+        OneField oneField = setFields(date, DataType.DATE.getOID(), "date");
+        assertTrue(oneField.val instanceof LocalDate);
+        assertEquals(expectedLocalDate, oneField.val);
     }
 
     @Test
     void setFieldDateWithMoreThan4digitsInYearTest() throws ParseException {
+        isDateWideRange = true;
         LocalDate expectedLocalDate = LocalDate.of(+12345678, 12, 11);
         String date = "12345678-12-11";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
-            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
-        }
+        OneField oneField = setFields(date, DataType.DATE.getOID(), "date");
+        assertTrue(oneField.val instanceof LocalDate);
+        assertEquals(expectedLocalDate, oneField.val);
     }
 
     @Test
     void setFieldDateWithEraWithMoreThan4digitsInYearTest() throws ParseException {
+        isDateWideRange = true;
         LocalDate expectedLocalDate = LocalDate.of(-1234567, 6, 1);
         String date = "1234568-06-01 BC";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
-            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
-        }
+        OneField oneField = setFields(date, DataType.DATE.getOID(), "date");
+        assertTrue(oneField.val instanceof LocalDate);
+        assertEquals(expectedLocalDate, oneField.val);
     }
 
     @Test
     void setFieldDateWithEraTest() throws ParseException {
+        isDateWideRange = true;
         LocalDate expectedLocalDate = LocalDate.of(-1234, 11, 1);
         String date = "1235-11-01 BC";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.DATE.getOID(), 0, "date", null));
-        context.setTupleDescription(columnDescriptors);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDate);
-            assertEquals(expectedLocalDate, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
-        }
+        OneField oneField = setFields(date, DataType.DATE.getOID(), "date");
+        assertTrue(oneField.val instanceof LocalDate);
+        assertEquals(expectedLocalDate, oneField.val);
     }
 
     @Test
     void setFieldDateTimeWithWideRangeTest() throws ParseException {
+        isDateWideRange = true;
         LocalDateTime expectedLocalDateTime = LocalDateTime.of(1977, 12, 11, 15, 12, 11, 123456789);
-        String date = "1977-12-11 15:12:11.123456789";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
+        String timestamp = "1977-12-11 15:12:11.123456789";
+        OneField oneField = setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertTrue(oneField.val instanceof LocalDateTime);
+        assertEquals(expectedLocalDateTime, oneField.val);
+    }
 
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
-            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
-        }
+    @Test
+    void setFieldDateTimeWithoutWideRangeTest() throws ParseException {
+        isDateWideRange = false;
+        String timestamp = "1977-12-11 15:12:11.123456789";
+        Timestamp expectedDateTime = Timestamp.valueOf(timestamp);
+        OneField oneField = setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertTrue(oneField.val instanceof Timestamp);
+        assertEquals(expectedDateTime, oneField.val);
     }
 
     @Test
     void setFieldDateTimeWithWideRangeWithLeadingZeroTest() throws ParseException {
+        isDateWideRange = true;
         LocalDateTime expectedLocalDateTime = LocalDateTime.of(3, 5, 4, 1, 2, 1);
-        String date = "0003-05-04 01:02:01";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
-            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
-        }
+        String timestamp = "0003-05-04 01:02:01";
+        OneField oneField = setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertTrue(oneField.val instanceof LocalDateTime);
+        assertEquals(expectedLocalDateTime, oneField.val);
     }
 
     @Test
     void setFieldDateTimeWithMoreThan4digitsInYearTest() throws ParseException {
+        isDateWideRange = true;
         LocalDateTime expectedLocalDateTime = LocalDateTime.of(+12345678, 12, 11, 15, 35);
-        String date = "12345678-12-11 15:35 AD";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
-            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
-        }
+        String timestamp = "12345678-12-11 15:35 AD";
+        OneField oneField = setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertTrue(oneField.val instanceof LocalDateTime);
+        assertEquals(expectedLocalDateTime, oneField.val);
     }
 
     @Test
     void setFieldDateTimeWithEraWithMoreThan4digitsInYearTest() throws ParseException {
+        isDateWideRange = true;
         LocalDateTime expectedLocalDateTime = LocalDateTime.of(-1234567, 6, 1, 19, 56, 43, 12);
-        String date = "1234568-06-01 19:56:43.000000012 BC";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
-
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
-            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
-        }
+        String timestamp = "1234568-06-01 19:56:43.000000012 BC";
+        OneField oneField = setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertTrue(oneField.val instanceof LocalDateTime);
+        assertEquals(expectedLocalDateTime, oneField.val);
     }
 
     @Test
     void setFieldDateTimeWithEraTest() throws ParseException {
+        isDateWideRange = true;
         LocalDateTime expectedLocalDateTime = LocalDateTime.of(-1234, 11, 1, 16, 20);
-        String date = "1235-11-01 16:20 BC";
-        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
-        boolean isDateWideRange = true;
-        columnDescriptors.add(new ColumnDescriptor("birth_date", DataType.TIMESTAMP.getOID(), 1, "timestamp", null));
-        context.setTupleDescription(columnDescriptors);
+        String timestamp = "1235-11-01 16:20 BC";
+        OneField oneField = setFields(timestamp, DataType.TIMESTAMP.getOID(), "timestamp");
+        assertTrue(oneField.val instanceof LocalDateTime);
+        assertEquals(expectedLocalDateTime, oneField.val);
+    }
 
-        try (MockedStatic<SpringContext> springContextMockedStatic = mockStatic(SpringContext.class)) {
-            springContextMockedStatic.when(() -> SpringContext.getBean(ConnectionManager.class)).thenReturn(mock(ConnectionManager.class));
-            resolver = new JdbcResolver();
-            resolver.columns = context.getTupleDescription();
-            resolver.isDateWideRange = isDateWideRange;
-            OneRow oneRow = resolver.setFields(oneFieldList);
-            assertTrue(((OneField) ((List<?>) oneRow.getData()).get(0)).val instanceof LocalDateTime);
-            assertEquals(expectedLocalDateTime, ((OneField) ((List<?>) oneRow.getData()).get(0)).val);
+    private OneField getOneField(Object date, int dataTypeOid, String typeName) throws SQLException {
+        when(row.getData()).thenReturn(result);
+        if (date instanceof LocalDate) {
+            when(result.getObject("birth_date", LocalDate.class)).thenReturn((LocalDate) date);
+        } else if (date instanceof Date) {
+            when(result.getDate("birth_date")).thenReturn((Date) date);
+        } else if (date instanceof LocalDateTime) {
+            when(result.getObject("birth_date", LocalDateTime.class)).thenReturn((LocalDateTime) date);
+        } else if (date instanceof Timestamp) {
+            when(result.getTimestamp("birth_date")).thenReturn((Timestamp) date);
+        } else if (date instanceof OffsetDateTime) {
+            when(result.getObject("birth_date", OffsetDateTime.class)).thenReturn((OffsetDateTime) date);
         }
+        columnDescriptors.add(new ColumnDescriptor("birth_date", dataTypeOid, 1, typeName, null));
+        context.setTupleDescription(columnDescriptors);
+        resolver.columns = context.getTupleDescription();
+        resolver.isDateWideRange = isDateWideRange;
+        List<OneField> oneFields = resolver.getFields(row);
+        return oneFields.get(0);
+    }
+
+    private OneField setFields(String date, int dataTypeOid, String typeName) throws ParseException {
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), date));
+        columnDescriptors.add(new ColumnDescriptor("birth_date", dataTypeOid, 0, typeName, null));
+        context.setTupleDescription(columnDescriptors);
+        resolver.columns = context.getTupleDescription();
+        resolver.isDateWideRange = isDateWideRange;
+        OneRow oneRow = resolver.setFields(oneFieldList);
+        return (OneField) ((List<?>) oneRow.getData()).get(0);
     }
 }

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -43,6 +43,7 @@ under the License.
             <mapping option="batch_size" property="jdbc.statement.batchSize"/>
             <mapping option="fetch_size" property="jdbc.statement.fetchSize"/>
             <mapping option="query_timeout" property="jdbc.statement.queryTimeout"/>
+            <mapping option="date_wide_range" property="jdbc.date.wide-range"/>
         </optionMappings>
     </profile>
 

--- a/server/pxf-service/src/main/resources/pxf-profiles-default.xml
+++ b/server/pxf-service/src/main/resources/pxf-profiles-default.xml
@@ -43,7 +43,7 @@ under the License.
             <mapping option="batch_size" property="jdbc.statement.batchSize"/>
             <mapping option="fetch_size" property="jdbc.statement.fetchSize"/>
             <mapping option="query_timeout" property="jdbc.statement.queryTimeout"/>
-            <mapping option="date_wide_range" property="jdbc.date.wide-range"/>
+            <mapping option="date_wide_range" property="jdbc.date.wideRange"/>
         </optionMappings>
     </profile>
 


### PR DESCRIPTION
Some users want to save dates that contain a year with more than 4 digits. The current `JdbcResolver` doesn't allow us to do this. It uses `java.sql.Date` or `java.sql.Timestamp` which cannot understand the date with more than 4 digits in the year. Moreover, the  `JdbcResolver` doesn't understand dates with `BC` (see example in the bottom).

This PR adds an opportunity to work with dates that contain the year with more than 4 digits. A special parameter `<mapping option="date_wide_range" property="jdbc.date.wideRange"/>` was added into the `pxf-profiles-default.xml` profile. It might be used as a parameter in the `LOCATION` (`date_wide_range=true`) or as a parameter in the `jdbc-site.xml` file (`jdbc.date.wideRange`). The default value is `false`. It means that the previous logic will be used and `JdbcResolver` will use `java.sql.Date` or `java.sql.Timestamp`.

Setting `jdbc.date.wideRange` to `true` or `date_wide_range` to `true` means:
1.  `JdbcResolver` starts to use `LocalDate`, `LocalDateTime`, `OffsetDateTime` classes. These classes can work with years that contain more than 4 digits.
2.  `JdbcResolver` understands  the difference between dates with `BC` and `AD`.

**How to use:** 

**In the `jdbc-site.xml` file**
```xml
<property>
    <name>jdbc.date.wideRange</name>
    <value>true</value>
    <description>Set the value to 'true' if a year might contain more than 4 digits in a 'date' or in a 'timestamp'</description>
</property>
```
**In the `LOCATION`**
```
--- WRITABLE TABLE 
CREATE WRITABLE EXTERNAL TABLE wide_year_write(
  birth_date date,
  birth_date_dad timestamp)
LOCATION ('pxf://wide_year_dist?PROFILE=Jdbc&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://10.10.10.2:5432/postgres&USER=ext_user&date_wide_range=true') 
FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');

--- READABLE TABLE 
CREATE EXTERNAL TABLE wide_year_read(
  birth_date date,
  birth_date_dad timestamp,
  birth_date_mom timestamp with time zone)
LOCATION ('pxf://wide_year_dist?PROFILE=Jdbc&JDBC_DRIVER=org.postgresql.Driver&DB_URL=jdbc:postgresql://10.10.10.2:5432/postgres&USER=ext_user&date_wide_range=true') 
FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
```
**Example of dates, timestamps and timestamps with time zone that can be processed with the new parameter:**
date: `0010-12-11 BC`
date: `456789-12-11`
timestamp: `1234-10-19 10:11:15.456 BC`
timestamp: `123456-10-19 11:12:13`
timestamp with time zone: `12345-02-01 10:15:16+00` (only for READABLE EXTERNAL tables)
timestamp with time zone: `2000-02-01 04:15:16.123457+00 BC` (only for READABLE EXTERNAL tables)