### PR TITLE
docs - new prop for parquet numeric overflow, upgrade instructs

### DIFF
--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -112,7 +112,7 @@ You configure properties in the `pxf-site.xml` file for a PXF server when one or
 | pxf.fs.basePath | Identifies the base path or share point on the remote file system. This property is applicable when the server configuration is used with a profile that accesses a file. | None; this property is commented out by default. |
 | pxf.ppd.hive<sup>1</sup> | Specifies whether or not predicate pushdown is enabled for queries on external tables that specify the `hive`, `hive:rc`, or `hive:orc` profiles. | True; predicate pushdown is enabled. |
 | pxf.sasl.connection.retries | Specifies the maximum number of times that PXF retries a SASL connection request after a refused connection returns a `GSS initiate failed` error. | 5 |
-| pxf.parquet.write.decimal.overflow | Specifies the action that PXF takes when numeric data that it writes to a Parquet file exceeds the maximum precision of 38 and [overflows](hdfs_parquet.html#overflow). | round |
+| pxf.parquet.write.decimal.overflow | Specifies the action (round, error, ignore) that PXF takes when numeric data that it writes to a Parquet file exceeds the maximum precision of 38 and [overflows](hdfs_parquet.html#overflow). | round |
 
 </br><sup>1</sup>&nbsp;Should you need to, you can override this setting on a per-table basis by specifying the `&PPD=<boolean>` option in the `LOCATION` clause when you create the external table.
 

--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -88,7 +88,7 @@ To configure a PXF server, refer to the connector configuration topic:
 
 ## <a id="pxf-site"></a>About the pxf-site.xml Configuration File
 
-PXF includes a template file named `pxf-site.xml` for PXF-specific configuration parameters. You can use the `pxf-site.xml` template file to specify Kerberos and/or user impersonation settings for server configurations, or to specify a base directory for file access.
+PXF includes a template file named `pxf-site.xml` for PXF-specific configuration parameters. You can use the `pxf-site.xml` template file to specify Kerberos and/or user impersonation settings for server configurations, specify a base directory for file access, or to direct the action of PXF when it detects an overflow condition writing Parquet data.
 
 <div class="note"><b>Note:</b> The Kerberos and user impersonation settings in this file may apply only to Hadoop and JDBC server configurations; they do not apply to file system or object store server configurations.</div>
 
@@ -112,6 +112,7 @@ You configure properties in the `pxf-site.xml` file for a PXF server when one or
 | pxf.fs.basePath | Identifies the base path or share point on the remote file system. This property is applicable when the server configuration is used with a profile that accesses a file. | None; this property is commented out by default. |
 | pxf.ppd.hive<sup>1</sup> | Specifies whether or not predicate pushdown is enabled for queries on external tables that specify the `hive`, `hive:rc`, or `hive:orc` profiles. | True; predicate pushdown is enabled. |
 | pxf.sasl.connection.retries | Specifies the maximum number of times that PXF retries a SASL connection request after a refused connection returns a `GSS initiate failed` error. | 5 |
+| pxf.parquet.write.decimal.overflow | Specifies the action that PXF takes when numeric data that it writes to a Parquet file exceeds the maximum precision of 38 and [overflows](hdfs_parquet.html#overflow). | round |
 
 </br><sup>1</sup>&nbsp;Should you need to, you can override this setting on a per-table basis by specifying the `&PPD=<boolean>` option in the `LOCATION` clause when you create the external table.
 

--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -88,7 +88,7 @@ To configure a PXF server, refer to the connector configuration topic:
 
 ## <a id="pxf-site"></a>About the pxf-site.xml Configuration File
 
-PXF includes a template file named `pxf-site.xml` for PXF-specific configuration parameters. You can use the `pxf-site.xml` template file to specify Kerberos and/or user impersonation settings for server configurations, specify a base directory for file access, or to direct the action of PXF when it detects an overflow condition writing Parquet data.
+PXF includes a template file named `pxf-site.xml` for PXF-specific configuration parameters. You can use the `pxf-site.xml` template file to specify Kerberos and/or user impersonation settings for server configurations, specify a base directory for file access, or to direct the action of PXF when it detects an overflow condition while writing Parquet data.
 
 <div class="note"><b>Note:</b> The Kerberos and user impersonation settings in this file may apply only to Hadoop and JDBC server configurations; they do not apply to file system or object store server configurations.</div>
 

--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -88,7 +88,11 @@ To configure a PXF server, refer to the connector configuration topic:
 
 ## <a id="pxf-site"></a>About the pxf-site.xml Configuration File
 
-PXF includes a template file named `pxf-site.xml` for PXF-specific configuration parameters. You can use the `pxf-site.xml` template file to specify Kerberos and/or user impersonation settings for server configurations, specify a base directory for file access, or to direct the action of PXF when it detects an overflow condition while writing Parquet data.
+PXF includes a template file named `pxf-site.xml` for PXF-specific configuration parameters. You can use the `pxf-site.xml` template file to configure:
+
+- Kerberos and/or user impersonation settings for server configurations
+- a base directory for file access
+- the action of PXF when it detects an overflow condition while writing numeric Parquet data
 
 <div class="note"><b>Note:</b> The Kerberos and user impersonation settings in this file may apply only to Hadoop and JDBC server configurations; they do not apply to file system or object store server configurations.</div>
 

--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -112,7 +112,7 @@ You configure properties in the `pxf-site.xml` file for a PXF server when one or
 | pxf.fs.basePath | Identifies the base path or share point on the remote file system. This property is applicable when the server configuration is used with a profile that accesses a file. | None; this property is commented out by default. |
 | pxf.ppd.hive<sup>1</sup> | Specifies whether or not predicate pushdown is enabled for queries on external tables that specify the `hive`, `hive:rc`, or `hive:orc` profiles. | True; predicate pushdown is enabled. |
 | pxf.sasl.connection.retries | Specifies the maximum number of times that PXF retries a SASL connection request after a refused connection returns a `GSS initiate failed` error. | 5 |
-| pxf.parquet.write.decimal.overflow | Specifies the action (round, error, ignore) that PXF takes when numeric data that it writes to a Parquet file exceeds the maximum precision of 38 and [overflows](hdfs_parquet.html#overflow). | round |
+| pxf.parquet.write.decimal.overflow | Specifies how PXF handles numeric data that exceeds the maximum precision of 38 and [overflows](hdfs_parquet.html#overflow) when writing to a Parquet file. Valid values are: round, error, or ignore | round |
 
 </br><sup>1</sup>&nbsp;Should you need to, you can override this setting on a per-table basis by specifying the `&PPD=<boolean>` option in the `LOCATION` clause when you create the external table.
 

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -265,6 +265,5 @@ PXF can take one of three actions when it detects an overflow while writing nume
 | `error` | PXF reports an error when it encounters an overflow, and the transaction fails. |
 | `ignore` | PXF writes a NULL value. (This was PXF's behavior prior to version 6.6.0.) |
 
-PXF always reports an exception when it detects an overflow, regardless of the `pxf.parquet.write.decimal.overflow` property setting.
-
+PXF always logs an warning when it detects an overflow, regardless of the `pxf.parquet.write.decimal.overflow` property setting.
 

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -257,9 +257,7 @@ A precision overflow condition can result when:
 - You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38; for example, `NUMERIC(55)`.
 - You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`.
 
-PXF can take one of three actions when it detects an overflow while writing numeric data to a Parquet file: round the value (the default), return an error, or ignore the overflow.
-
-The `pxf.parquet.write.decimal.overflow` property in the `pxf-site.xml` server configuration file directs the action that PXF takes when it encounters an overflow. Valid values for this property follow:
+PXF can take one of three actions when it detects an overflow while writing numeric data to a Parquet file: round the value (the default), return an error, or ignore the overflow. The `pxf.parquet.write.decimal.overflow` property in the `pxf-site.xml` server configuration governs PXF's action in this circumstance; valid values for this property follow:
 
 | Value  | PXF Action |
 |-------|-------------------------------------|

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -254,7 +254,7 @@ When you define a `NUMERIC` column in an external table without specifying a pre
 A precision overflow condition can result when:
 
 - You define a `NUMERIC` column in the external table, and a value exceeds 20 (38 - 18) integer digits.
-- You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38; for example, `NUMERIC(55)`.
+- You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38. For example, `NUMERIC(55)`.
 - You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`.
 
 PXF can take one of three actions when it detects an overflow while writing numeric data to a Parquet file: round the value (the default), return an error, or ignore the overflow. The `pxf.parquet.write.decimal.overflow` property in the `pxf-site.xml` server configuration governs PXF's action in this circumstance; valid values for this property follow:

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -253,7 +253,7 @@ When you define a `NUMERIC` column in an external table without specifying a pre
 
 A precision overflow condition can result when:
 
-- You define a `NUMERIC` column in the external table, and a value exceeds 20 (38 - 18) integer digits.
+- You define a `NUMERIC` column in the external table, and the integer digit count of a value exceeds maximum precision 38. For example, `1234567890123456789012345678901234567890.12345`.
 - You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38. For example, `NUMERIC(55)`.
 - You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`.
 

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -245,3 +245,28 @@ In this example, you create a Parquet-format writable external table that uses t
     (2 rows)
     ```
 
+## <a id="overflow"></a>Understanding Overflow Conditions When Writing Numeric Data
+
+PXF uses the `HiveDecimal` class to write numeric Parquet data. `HiveDecimal` limits both the precision and the scale of a numeric type to a maximum of 38.
+
+When you define a `NUMERIC` column in an external table without specifying a precision or scale, PXF internally maps the column to a `DECIMAL(38, 18)`.
+
+A precision overflow condition can result when:
+
+- You define a `NUMERIC` column in the external table, and a value exceeds 20 (38 - 18) integer digits.
+- You defie a `NUMERIC(<precision>)` column with a `<precision>` greater than 38; for example, `NUMERIC(55)`.
+- You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`.
+
+PXF can take one of three actions when it detects an overflow while writing numeric data to a Parquet file: round the value (the default), return an error, or ignore the overflow.
+
+The `pxf.parquet.write.decimal.overflow` property in the `pxf-site.xml` server configuration file directs the action that PXF takes when it encounters an overflow. Valid values for this property follow:
+
+| Value  | PXF Action |
+|-------|-------------------------------------|
+| `round` | When PXF encounters an overflow, it attempts to round the value before writing and logs a warning. PXF reports an error if rounding fails. This may potentially leave an incomplete data set in the external system.  `round` is the default. |
+| `error` | PXF reports an error when it encounters an overflow, and the transaction fails. |
+| `ignore` | PXF writes a NULL value. (This was PXF's behavior prior to version 6.6.0.) |
+
+PXF always reports an exception when it detects an overflow, regardless of the `pxf.parquet.write.decimal.overflow` property setting.
+
+

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -253,9 +253,9 @@ When you define a `NUMERIC` column in an external table without specifying a pre
 
 A precision overflow condition can result when:
 
-- You define a `NUMERIC` column in the external table, and the integer digit count of a value exceeds maximum precision 38. For example, `1234567890123456789012345678901234567890.12345`.
+- You define a `NUMERIC` column in the external table, and the integer digit count of a value exceeds maximum precision 38. For example, `1234567890123456789012345678901234567890.12345`, which has an integer digit count of 45.
 - You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38. For example, `NUMERIC(55)`.
-- You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`.
+- You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`, which has an integer digit count of 19, which is greater than 20-4=16.
 
 PXF can take one of three actions when it detects an overflow while writing numeric data to a Parquet file: round the value (the default), return an error, or ignore the overflow. The `pxf.parquet.write.decimal.overflow` property in the `pxf-site.xml` server configuration governs PXF's action in this circumstance; valid values for this property follow:
 

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -254,7 +254,7 @@ When you define a `NUMERIC` column in an external table without specifying a pre
 A precision overflow condition can result when:
 
 - You define a `NUMERIC` column in the external table, and a value exceeds 20 (38 - 18) integer digits.
-- You defie a `NUMERIC(<precision>)` column with a `<precision>` greater than 38; for example, `NUMERIC(55)`.
+- You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38; for example, `NUMERIC(55)`.
 - You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`.
 
 PXF can take one of three actions when it detects an overflow while writing numeric data to a Parquet file: round the value (the default), return an error, or ignore the overflow.

--- a/docs/content/upgrade_6.html.md.erb
+++ b/docs/content/upgrade_6.html.md.erb
@@ -125,7 +125,7 @@ After you install the new version of PXF, perform the following procedure:
 
     where `NEW_VALUE` is `error` or `ignore`.
 
-    Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_parquet.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters an numeric overflow while writing to a Parquet file.
+    Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_parquet.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters a numeric overflow while writing to a Parquet file.
 
 1. Synchronize the PXF configuration from the master host to the standby master host and each Greenplum Database segment host. For example:
 

--- a/docs/content/upgrade_6.html.md.erb
+++ b/docs/content/upgrade_6.html.md.erb
@@ -114,6 +114,19 @@ After you install the new version of PXF, perform the following procedure:
         <Logger name="org.greenplum.pxf" level="${env:PXF_LOG_LEVEL:-${spring:pxf.log.level}}"/>
         ```
 
+1. **If you are upgrading <i>from</i> PXF version 6.5.x or earlier <i>to</i> PXF version 6.6.0 or later**, and you want to change the value of the new `pxf.parquet.write.decimal.overflow` property from the default of `round`, add the following to the `pxf-site.xml` file for your PXF server:
+
+    ``` pre
+    <property>
+      <name>pxf.parquet.write.decimal.overflow</name>
+      <value>NEW_VALUE</value>
+    </property>
+    ```
+
+    where `NEW_VALUE` is `error` or `ignore`.
+
+    Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_parquet.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters an numeric overflow while writing to a Parquet file.
+
 1. Synchronize the PXF configuration from the master host to the standby master host and each Greenplum Database segment host. For example:
 
     ``` shell


### PR DESCRIPTION
docs for docs for https://github.com/greenplum-db/pxf/pull/940.

in this PR:
- add a new topic "Understanding Overflow Conditions When Writing Numeric Data" to the hdfs parquet page that discusses overflow and the new `pxf.parquet.write.decimal.overflow` property.  (i am not sure if i am characterizing this correctly.)
- update the upgrade instructions to include an optional step to add the property to the pxf-site.xml file for a pxf server if a value other than the default is desired.

doc review site links (behind vpn):
- new topic:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/overflow/tanzu-greenplum-platform-extension-framework/GUID-hdfs_parquet.html#understanding-overflow-conditions-when-writing-numeric-data-7
- upgrade (Step 7):  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/overflow/tanzu-greenplum-platform-extension-framework/GUID-upgrade_6.html#pxfup