### PR TITLE
Updated locations of GP artifacts in CI pipelines

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -471,7 +471,7 @@ resources:
     url: ((ud/pxf/secrets/ud-pipeline-bot-gp-releng-webhook))
 {% endif %}
 
-## ---------- Product Packages ----------
+## ---------- Greenplum Packages ----------
 {% set gp_ver = 5 %}
 {% for i in range(num_gpdb5_versions) %}
 - name: gpdb[[gp_ver]]_rhel7_rpm_latest-[[i]]
@@ -480,7 +480,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-(.*)-rhel7-x86_64.rpm
+    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel7-x86_64.rpm
 {% endfor %} {# range(num_gpdb5_versions) #}
 {% set gp_ver = None %}
 
@@ -492,7 +492,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-(.*)-rhel7-x86_64.rpm
+    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel7-x86_64.rpm
 
 - name: gpdb[[gp_ver]]_ubuntu18_deb_latest-[[i]]
   type: gcs
@@ -500,7 +500,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-(.*)-ubuntu18.04-amd64.deb
+    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-ubuntu18.04-amd64.deb
 {% endfor %} {# range(num_gpdb6_versions) #}
 {% set gp_ver = None %}
 
@@ -512,7 +512,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-(.*)-rhel8-x86_64.rpm
+    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel8-x86_64.rpm
 {% endfor %} {# range(num_gpdb6_versions) #}
 {% set gp_ver = None %}
 

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -523,7 +523,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/greenplum-db-(7.*)-el8-x86_64.rpm
+    regexp: server/released/main/greenplum-db-(7.*)-el8-x86_64.rpm
 
 ## ---------- PXF 5 (for GPDB 6) Artifact ---------------
 - name: pxf5_gp6_rhel7_released

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -529,7 +529,7 @@ resources:
 - name: pxf5_gp6_rhel7_released
   type: gcs
   source:
-    bucket: ((ud/pxf/[[ environment ]]/releng-drop-bucket-name))
+    bucket: ((ud/pxf/prod/releng-drop-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: ((ud/pxf/common/releng-drop-path))/gpdb6/pxf-gp6-5.(.*)-2.el7.x86_64.rpm
 

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -523,7 +523,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/released/main/greenplum-db-(7.*)-el8-x86_64.rpm
+    regexp: server/released/gpdb7/greenplum-db-(7.*)-el8-x86_64.rpm
 
 ## ---------- PXF 5 (for GPDB 6) Artifact ---------------
 - name: pxf5_gp6_rhel7_released

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -257,7 +257,7 @@ resources:
     url: ((ud-pipeline-bot-[[user]]-webhook))
 {% endif %}
 
-## ---------- Product Packages ----------
+## ---------- Greenplum Packages ----------
 {% set gp_ver = 5 %}
 - name: gpdb[[gp_ver]]_rhel7_rpm_latest-0
   type: gcs
@@ -265,7 +265,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-0_gpdb[[gp_ver]]/greenplum-db-(.*)-rhel7-x86_64.rpm
+    regexp: latest-0_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel7-x86_64.rpm
 {% set gp_ver = None %}
 
 {% set gp_ver = 6 %}
@@ -275,7 +275,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-0_gpdb[[gp_ver]]/greenplum-db-(.*)-rhel7-x86_64.rpm
+    regexp: latest-0_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel7-x86_64.rpm
 
 - name: gpdb[[gp_ver]]_ubuntu18_deb_latest-0
   type: gcs
@@ -283,7 +283,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-0_gpdb[[gp_ver]]/greenplum-db-(.*)-ubuntu18.04-amd64.deb
+    regexp: latest-0_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-ubuntu18.04-amd64.deb
 
 - name: gpdb[[gp_ver]]_rhel8_rpm_latest-0
   type: gcs
@@ -291,7 +291,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-0_gpdb[[gp_ver]]/greenplum-db-(6.*)-rhel8-x86_64.rpm
+    regexp: latest-0_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel8-x86_64.rpm
 {% set gp_ver = None %}
 
 ## ---------- Greenplum 7 Beta Builds ----------

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -301,7 +301,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/released/main/greenplum-db-(7.*)-el8-x86_64.rpm
+    regexp: server/released/gpdb7/greenplum-db-(7.*)-el8-x86_64.rpm
 
 ## ---------- PXF 5 Artifact ---------------
 {% if multinode %}

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -289,9 +289,9 @@ resources:
   type: gcs
   icon: google-drive
   source:
-    bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/greenplum-db-(6.*)-rhel8-x86_64.rpm
+    bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
+    json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
+    regexp: latest-0_gpdb[[gp_ver]]/greenplum-db-(6.*)-rhel8-x86_64.rpm
 {% set gp_ver = None %}
 
 ## ---------- Greenplum 7 Beta Builds ----------
@@ -301,7 +301,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/greenplum-db-(7.*)-el8-x86_64.rpm
+    regexp: server/released/main/greenplum-db-(7.*)-el8-x86_64.rpm
 
 ## ---------- PXF 5 Artifact ---------------
 {% if multinode %}

--- a/concourse/pipelines/templates/pr_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/pr_pipeline-tpl.yml
@@ -131,7 +131,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/greenplum-db-(7.*)-el8-x86_64.rpm
+    regexp: server/released/main/greenplum-db-(7.*)-el8-x86_64.rpm
 
 ## ======================================================================
 ## JOBS

--- a/concourse/pipelines/templates/pr_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/pr_pipeline-tpl.yml
@@ -131,7 +131,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/released/main/greenplum-db-(7.*)-el8-x86_64.rpm
+    regexp: server/released/gpdb7/greenplum-db-(7.*)-el8-x86_64.rpm
 
 ## ======================================================================
 ## JOBS

--- a/concourse/pipelines/templates/pr_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/pr_pipeline-tpl.yml
@@ -83,7 +83,7 @@ resources:
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
 {% set gp_ver = None %}
 
-## ---------- Product Packages ----------
+## ---------- Greenplum Packages ----------
 {% set gp_ver = 5 %}
 {% for i in range(num_gpdb5_versions) %}
 - name: gpdb[[gp_ver]]_rhel7_rpm_latest-[[i]]
@@ -92,7 +92,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-(.*)-rhel7-x86_64.rpm
+    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel7-x86_64.rpm
 {% endfor %} {# range(num_gpdb5_versions) #}
 {% set gp_ver = None %}
 
@@ -104,7 +104,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-(.*)-rhel7-x86_64.rpm
+    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel7-x86_64.rpm
 
 - name: gpdb[[gp_ver]]_rhel8_rpm_latest-[[i]]
   type: gcs
@@ -112,7 +112,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-(.*)-rhel8-x86_64.rpm
+    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel8-x86_64.rpm
 
 - name: gpdb[[gp_ver]]_ubuntu18_deb_latest-[[i]]
   type: gcs
@@ -120,7 +120,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-(.*)-ubuntu18.04-amd64.deb
+    regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-ubuntu18.04-amd64.deb
 {% endfor %} {# range(num_gpdb6_versions) #}
 {% set gp_ver = None %}
 


### PR DESCRIPTION
This PR fixes 2 issues:
- GP7 beta artifact now comes from the "released" bucket, not the "published" one
- GP6-RHEL8 artifact comes from the Pivnet mirror bucket, not the "released" bucket

GP7 artifact will continue to come from the "released" bucket and not Pivnet mirror for now until after GP7 GA as we do not yet guarantee backward / forward compatibility of PXF with GP7 beta releases other than the ones a given PXF version has been built with. 