### PR TITLE
FDW: Fix for skipping the dropped and correctly counting Projection Index 

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -657,7 +657,7 @@ public abstract class TableFactory {
     }
 
     /**
-     * Generate a PXF External Writable or Foreign Table using JDBC profile.
+     * Prepares PXF Readable External or Foreign Table for custom data format.
      *
      * @param name name of the external table which will be generated
      * @param fields fields of the external table

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -3,6 +3,7 @@ package org.greenplum.pxf.automation.structures.tables.utils;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.automation.enums.EnumPartitionType;
 
 import org.greenplum.pxf.automation.enums.EnumPxfDefaultProfiles;
@@ -653,6 +654,29 @@ public abstract class TableFactory {
     public static ExternalTable getPxfJdbcWritableTable(String name, String[] fields, String dataSourcePath, String server) {
         String customParameter = server != null ? "SERVER=" + server : null;
         return getPxfJdbcWritableTable(name, fields, dataSourcePath, null, null, null, customParameter);
+    }
+
+    /**
+     * Generate a PXF External Writable or Foreign Table using JDBC profile.
+     *
+     * @param name name of the external table which will be generated
+     * @param fields fields of the external table
+     * @param path for external table path
+     * @param dataFormat dataFormat for the external table
+     * @return PXF Readable External or Foreign table
+     */
+    public static ReadableExternalTable getPxfReadableCustomTable(String name,
+                                                                  String[] fields,
+                                                                  String path,
+                                                                  String dataFormat) {
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name, fields, path, "CUSTOM");
+        exTable.setFormatter("pxfwritable_import");
+
+        if (StringUtils.isNotBlank(dataFormat)) {
+            exTable.setProfile(ProtocolUtils.getProtocol().value() + ":" + dataFormat);
+        }
+
+        return exTable;
     }
 
     // ============ FDW Adapter ============

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -55,8 +55,8 @@ public class ColumnProjectionTest extends BaseFeature {
         // SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
         // SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
         if (gpdb.getVersion() >= 7) {
-            /** The below query is acting differently for external-table and FDW, As it is projecting for the FDW so the results are little different
-             * from the external table. The Call stack is different in case of external-table and FDW.
+            /** The below query (mentioned in above comment as well) is propagating for FDW but not for external-table, so a different test set for FDW.
+             * The Call stack is different in case of external-table and FDW.
 
              SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
              value |  colprojvalue

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -55,7 +55,7 @@ public class ColumnProjectionTest extends BaseFeature {
         // SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
         // SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
         if (gpdb.getVersion() >= 7) {
-            /** The below query (mentioned in above comment as well) is propagating for FDW but not for external-table,
+            /* The below query (mentioned in above comment as well) is propagating for FDW but not for external-table,
              *  so use a different test set for FDW.
              * The Call stack is different in case of external-table and FDW.
 
@@ -133,7 +133,7 @@ public class ColumnProjectionTest extends BaseFeature {
              Memory used:  128000kB
              Execution Time: 117.692 ms
              (16 rows)
-             **/
+             */
             if (FDWUtils.useFDW) {
                 runTincTest("pxf.features.columnprojection.checkColumnProjection_fdw.runTest");
             }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -54,25 +54,22 @@ public class ColumnProjectionTest extends BaseFeature {
         // TODO: revert when 2 queries with GP7 planner start propagating projection info to foreign scans
         // SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
         // SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
-        if (gpdb.getVersion() >= 7 && !FDWUtils.useFDW) {
-            runTincTest("pxf.features.columnprojection.checkColumnProjection_gp7.runTest");
-        } else if (FDWUtils.useFDW) {
-            /** For FDW ( irrespective of GP 6 or GP 7), the query below is projecting the columns so the results are different.
-                 SELECT * FROM test_column_projection ORDER BY t0;
-                 t0 | a1 | b2 |     colprojvalue
-                ----+----+----+-----------------------
-                 A  |  0 | t  | t0|a1|b2|colprojvalue
-                 B  |  1 | f  | t0|a1|b2|colprojvalue
-                 C  |  2 | t  | t0|a1|b2|colprojvalue
-                 D  |  3 | f  | t0|a1|b2|colprojvalue
-                 E  |  4 | t  | t0|a1|b2|colprojvalue
-                 F  |  5 | f  | t0|a1|b2|colprojvalue
-                 G  |  6 | t  | t0|a1|b2|colprojvalue
-                 H  |  7 | f  | t0|a1|b2|colprojvalue
-                 I  |  8 | t  | t0|a1|b2|colprojvalue
-                 J  |  9 | f  | t0|a1|b2|colprojvalue
+        if (gpdb.getVersion() >= 7) {
+            /** The below query is acting differently for external-table and FDW, As it is projecting for the FDW so the results are little different
+             * from the external table. The Call stack is different in case of external-table and FDW.
+
+             SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+             value |  colprojvalue
+             -------+-----------------
+             50 | t0|colprojvalue
+             (1 row)
              **/
-            runTincTest("pxf.features.columnprojection.checkColumnProjection_fdw.runTest");
+            if (FDWUtils.useFDW) {
+                runTincTest("pxf.features.columnprojection.checkColumnProjection_fdw.runTest");
+            }
+            else {
+                runTincTest("pxf.features.columnprojection.checkColumnProjection_gp7.runTest");
+            }
         } else {
             runTincTest("pxf.features.columnprojection.checkColumnProjection.runTest");
         }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -55,7 +55,8 @@ public class ColumnProjectionTest extends BaseFeature {
         // SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
         // SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
         if (gpdb.getVersion() >= 7) {
-            /** The below query (mentioned in above comment as well) is propagating for FDW but not for external-table, so a different test set for FDW.
+            /** The below query (mentioned in above comment as well) is propagating for FDW but not for external-table,
+             *  so use a different test set for FDW.
              * The Call stack is different in case of external-table and FDW.
 
              SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
@@ -64,8 +65,8 @@ public class ColumnProjectionTest extends BaseFeature {
              50 | t0|colprojvalue
              (1 row)
 
-             There is the explain plan for the external-table and FDW for the same query, '
-             that might be the reason for one it's projecting and for other it's not.
+             Following are the explain plans for the external-table and FDW for the same query,
+             The different explain plans explains that for one it is projecting and for other it's not.
              External Table:
 
              pxfautomation=# \d+ e_test_column_projection

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -63,6 +63,75 @@ public class ColumnProjectionTest extends BaseFeature {
              -------+-----------------
              50 | t0|colprojvalue
              (1 row)
+
+             There is the explain plan for the external-table and FDW for the same query, '
+             that might be the reason for one it's projecting and for other it's not.
+             External Table:
+
+             pxfautomation=# \d+ e_test_column_projection
+             Foreign table "public.e_test_column_projection"
+             Column    |  Type   | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description
+             --------------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+             t0           | text    |           |          |         |             | extended |              |
+             a1           | integer |           |          |         |             | plain    |              |
+             b2           | boolean |           |          |         |             | plain    |              |
+             colprojvalue | text    |           |          |         |             | extended |              |
+             FDW options: (format 'text', delimiter ',', "null" E'\\N', escape E'\\', format_type 't', location_uris 'pxf://dummy_path?PROFILE=test:text&FRAGMENTER=org.greenplum.pxf.automation.testplugin.ColumnProjectionVerifyFragmenter&ACCESSOR=org.greenplum.pxf.automation.testplugin.ColumnProjectionVerifyAccessor&RESOLVER=org.greenplum.pxf.plugins.hdfs.StringPassResolver', execute_on 'ALL_SEGMENTS', log_errors 'f', encoding '6', is_writable 'false')
+
+             pxfautomation=# explain analyze SELECT b.value, a.colprojvalue FROM e_test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+             QUERY PLAN
+             ---------------------------------------------------------------------------------------------------------------------------------------------------
+             Gather Motion 3:1  (slice1; segments: 3)  (cost=2306.08..20789139.42 rows=77900000 width=36) (actual time=78.603..78.606 rows=1 loops=1)
+             ->  Hash Join  (cost=2306.08..19750472.75 rows=25966667 width=36) (actual time=52.602..63.398 rows=1 loops=1)
+             Hash Cond: (a.t0 = (b.key)::text)
+             Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
+             ->  Foreign Scan on e_test_column_projection a  (cost=0.00..11000.00 rows=1000000 width=64) (actual time=51.045..51.076 rows=10 loops=1)
+             ->  Hash  (cost=1332.33..1332.33 rows=77900 width=12) (actual time=0.039..0.040 rows=1 loops=1)
+             Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1332.33 rows=77900 width=12) (actual time=0.013..0.014 rows=1 loops=1)
+             ->  Seq Scan on t0_values b  (cost=0.00..293.67 rows=25967 width=12) (actual time=1.760..1.762 rows=1 loops=1)
+             Optimizer: Postgres query optimizer
+             Planning Time: 1.151 ms
+             (slice0)    Executor memory: 106K bytes.
+             (slice1)    Executor memory: 4253K bytes avg x 3 workers, 4253K bytes max (seg0).  Work_mem: 4097K bytes max.
+             (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+             Memory used:  128000kB
+             Execution Time: 8581.766 ms
+             (16 rows)
+
+             FDW:
+
+             pxfautomation=# \d+ test_column_projection
+             Foreign table "public.test_column_projection"
+             Column    |  Type   | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description
+             --------------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+             t0           | text    |           |          |         |             | extended |              |
+             a1           | integer |           |          |         |             | plain    |              |
+             b2           | boolean |           |          |         |             | plain    |              |
+             colprojvalue | text    |           |          |         |             | extended |              |
+             Server: default_test
+             FDW options: (resource 'dummy_path', format 'text', fragmenter 'org.greenplum.pxf.automation.testplugin.ColumnProjectionVerifyFragmenter', accessor 'org.greenplum.pxf.automation.testplugin.ColumnProjectionVerifyAccessor', resolver 'org.greenplum.pxf.plugins.hdfs.StringPassResolver', delimiter ',')
+
+             pxfautomation=# explain analyze SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+             QUERY PLAN
+             ------------------------------------------------------------------------------------------------------------------------------------------------------------
+             Gather Motion 3:1  (slice1; segments: 3)  (cost=50077.50..52328.93 rows=77900 width=36) (actual time=117.120..117.133 rows=1 loops=1)
+             ->  Hash Join  (cost=50077.50..51290.27 rows=25967 width=36) (actual time=111.568..112.709 rows=1 loops=1)
+             Hash Cond: ((b.key)::text = a.t0)
+             Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 10 of 262144 buckets.
+             ->  Seq Scan on t0_values b  (cost=0.00..293.67 rows=25967 width=12) (actual time=0.964..0.966 rows=1 loops=1)
+             ->  Hash  (cost=50040.00..50040.00 rows=3000 width=64) (actual time=110.975..110.976 rows=10 loops=1)
+             Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=50000.00..50040.00 rows=3000 width=64) (actual time=110.902..110.906 rows=10 loops=1)
+             ->  Foreign Scan on test_column_projection a  (cost=50000.00..50000.00 rows=1000 width=64) (actual time=1.312..1.329 rows=10 loops=1)
+             Optimizer: Postgres query optimizer
+             Planning Time: 0.592 ms
+             (slice0)    Executor memory: 38K bytes.
+             (slice1)    Executor memory: 2101K bytes avg x 3 workers, 2101K bytes max (seg0).  Work_mem: 2049K bytes max.
+             (slice2)    Executor memory: 90K bytes avg x 3 workers, 97K bytes max (seg2).
+             Memory used:  128000kB
+             Execution Time: 117.692 ms
+             (16 rows)
              **/
             if (FDWUtils.useFDW) {
                 runTincTest("pxf.features.columnprojection.checkColumnProjection_fdw.runTest");

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/columnprojection/ColumnProjectionTest.java
@@ -1,6 +1,6 @@
 package org.greenplum.pxf.automation.features.columnprojection;
 
-import annotations.FailsWithFDW;
+import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.components.cluster.PhdCluster;
 import org.greenplum.pxf.automation.features.BaseFeature;
 import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;
@@ -10,7 +10,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 
 /** Functional PXF column projection cases */
-@FailsWithFDW
+@WorksWithFDW
 public class ColumnProjectionTest extends BaseFeature {
 
     String testPackageLocation = "/org/greenplum/pxf/automation/testplugin/";

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
@@ -169,6 +169,7 @@ public class AlterTableTest extends BaseFeature {
 
         runTincTest("pxf.features.general.alter.csv.runTest");
     }
+
     private void setParamsAndVerifyTable() throws Exception
     {
         exTable.setHost(pxfHost);

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
@@ -92,14 +92,12 @@ public class AlterTableTest extends BaseFeature {
 
         exTable = TableFactory.getPxfReadableCustomTable(PXF_ALTER_PARQUET_TABLE,
                 PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, "parquet");
-        exTable.setHost(pxfHost);
-        exTable.setPort(pxfPort);
-        gpdb.createTableAndVerify(exTable);
+        setParamsAndVerifyTable();
 
         runTincTest("pxf.features.general.alter.pxfwritable_import.with_column_projection.runTest");
     }
 
-    // It is failing with the below class cast exception:
+    // TODO: Determine the reason why FDW is failing with the below class cast exception:
     //
     // ERROR:  PXF server error : class java.io.DataInputStream cannot be cast to class java.lang.String
     // (java.io.DataInputStream and java.lang.String are in module java.base of loader 'bootstrap')
@@ -110,26 +108,20 @@ public class AlterTableTest extends BaseFeature {
         // Create source table
         exTable = TableFactory.getPxfReadableCustomTable(PXF_PARQUET_TABLE_SOURCE,
                 PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, "parquet");
-        exTable.setHost(pxfHost);
-        exTable.setPort(pxfPort);
-        gpdb.createTableAndVerify(exTable);
+        setParamsAndVerifyTable();
 
         // Create writable table
         exTable = TableFactory.getPxfWritableTextTable(PXF_ALTER_WRITE_PARQUET_TABLE,
                 PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet-write/" + PARQUET_WRITE_PRIMITIVES, null);
-        exTable.setHost(pxfHost);
-        exTable.setPort(pxfPort);
         exTable.setFormatter("pxfwritable_export");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
         exTable.setFormat("CUSTOM");
-        gpdb.createTableAndVerify(exTable);
+        setParamsAndVerifyTable();
 
         // Create validation table
         exTable = TableFactory.getPxfReadableCustomTable(PXF_ALTER_WRITE_PARQUET_TABLE + "_r",
                 PARQUET_TABLE_SUBSET_COLUMNS, hdfsPath + "/parquet-write/" + PARQUET_WRITE_PRIMITIVES, "parquet");
-        exTable.setHost(pxfHost);
-        exTable.setPort(pxfPort);
-        gpdb.createTableAndVerify(exTable);
+        setParamsAndVerifyTable();
 
         runTincTest("pxf.features.general.alter.pxfwritable_export.parquet.runTest");
     }
@@ -146,9 +138,7 @@ public class AlterTableTest extends BaseFeature {
                 "type_long bigint",
                 "type_bytes bytea",
                 "type_boolean bool"}, hdfsPath + "/avro/" + AVRO_TYPES_FILE_NAME + SUFFIX_AVRO, "avro");
-        exTable.setHost(pxfHost);
-        exTable.setPort(pxfPort);
-        gpdb.createTableAndVerify(exTable);
+        setParamsAndVerifyTable();
 
         // Verify results
         runTincTest("pxf.features.general.alter.pxfwritable_import.without_column_projection.runTest");
@@ -175,10 +165,14 @@ public class AlterTableTest extends BaseFeature {
                         "longNum bigint",
                         "bool boolean"
                 }, hdfsPath + "/csv/" + fileName, ",");
+        setParamsAndVerifyTable();
+
+        runTincTest("pxf.features.general.alter.csv.runTest");
+    }
+    private void setParamsAndVerifyTable() throws Exception
+    {
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
         gpdb.createTableAndVerify(exTable);
-
-        runTincTest("pxf.features.general.alter.csv.runTest");
     }
 }

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
@@ -99,6 +99,10 @@ public class AlterTableTest extends BaseFeature {
         runTincTest("pxf.features.general.alter.pxfwritable_import.with_column_projection.runTest");
     }
 
+    // It is failing with the below class cast exception:
+    //
+    // ERROR:  PXF server error : class java.io.DataInputStream cannot be cast to class java.lang.String
+    // (java.io.DataInputStream and java.lang.String are in module java.base of loader 'bootstrap')
     @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security"})
     public void dropColumnsPxfWritableExport() throws Exception {

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
@@ -1,13 +1,14 @@
 package org.greenplum.pxf.automation.features.general;
 
+import annotations.FailsWithFDW;
+import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.features.BaseFeature;
 import org.greenplum.pxf.automation.structures.tables.basic.Table;
-import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;
-import org.greenplum.pxf.automation.structures.tables.pxf.WritableExternalTable;
 import org.greenplum.pxf.automation.structures.tables.utils.TableFactory;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 import org.testng.annotations.Test;
 
+@WorksWithFDW
 public class AlterTableTest extends BaseFeature {
 
     private static final String AVRO_TYPES_FILE_NAME = "supported_primitive_types";
@@ -89,11 +90,12 @@ public class AlterTableTest extends BaseFeature {
     @Test(groups = {"features", "gpdb", "security"})
     public void dropAndAddColumnsPxfWritableImportWithColumnProjectionSupport() throws Exception {
 
-        exTable = new ReadableExternalTable(PXF_ALTER_PARQUET_TABLE,
-                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, "custom");
+        exTable = TableFactory.getPxfReadableTextTable(PXF_ALTER_PARQUET_TABLE,
+                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, null);
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
         exTable.setFormatter("pxfwritable_import");
+        exTable.setFormat("CUSTOM");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
 
         gpdb.createTableAndVerify(exTable);
@@ -101,34 +103,38 @@ public class AlterTableTest extends BaseFeature {
         runTincTest("pxf.features.general.alter.pxfwritable_import.with_column_projection.runTest");
     }
 
+    @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security"})
     public void dropColumnsPxfWritableExport() throws Exception {
 
         // Create source table
-        exTable = new ReadableExternalTable(PXF_PARQUET_TABLE_SOURCE,
-                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, "custom");
+        exTable = TableFactory.getPxfReadableTextTable(PXF_PARQUET_TABLE_SOURCE,
+                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, null);
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
         exTable.setFormatter("pxfwritable_import");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
+        exTable.setFormat("CUSTOM");
         gpdb.createTableAndVerify(exTable);
 
         // Create writable table
-        exTable = new WritableExternalTable(PXF_ALTER_WRITE_PARQUET_TABLE,
-                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet-write/" + PARQUET_WRITE_PRIMITIVES, "custom");
+        exTable = TableFactory.getPxfWritableTextTable(PXF_ALTER_WRITE_PARQUET_TABLE,
+                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet-write/" + PARQUET_WRITE_PRIMITIVES, null);
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
         exTable.setFormatter("pxfwritable_export");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
+        exTable.setFormat("CUSTOM");
         gpdb.createTableAndVerify(exTable);
 
         // Create validation table
-        exTable = new ReadableExternalTable(PXF_ALTER_WRITE_PARQUET_TABLE + "_r",
-                PARQUET_TABLE_SUBSET_COLUMNS, hdfsPath + "/parquet-write/" + PARQUET_WRITE_PRIMITIVES, "custom");
+        exTable = TableFactory.getPxfReadableTextTable(PXF_ALTER_WRITE_PARQUET_TABLE + "_r",
+                PARQUET_TABLE_SUBSET_COLUMNS, hdfsPath + "/parquet-write/" + PARQUET_WRITE_PRIMITIVES, null);
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
         exTable.setFormatter("pxfwritable_import");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
+        exTable.setFormat("CUSTOM");
         gpdb.createTableAndVerify(exTable);
 
         runTincTest("pxf.features.general.alter.pxfwritable_export.parquet.runTest");
@@ -137,7 +143,7 @@ public class AlterTableTest extends BaseFeature {
     @Test(groups = {"features", "gpdb", "security"})
     public void dropAndAddColumnsPxfWritableImportWithoutColumnProjectionSupport() throws Exception {
         // default external table with common settings
-        exTable = new ReadableExternalTable(PXF_ALTER_AVRO_TABLE, new String[]{
+        exTable = TableFactory.getPxfReadableTextTable(PXF_ALTER_AVRO_TABLE, new String[]{
                 "type_int int",
                 "type_double float8",
                 "type_string text",
@@ -145,10 +151,11 @@ public class AlterTableTest extends BaseFeature {
                 "col_does_not_exist text",
                 "type_long bigint",
                 "type_bytes bytea",
-                "type_boolean bool"}, hdfsPath + "/avro/" + AVRO_TYPES_FILE_NAME + SUFFIX_AVRO, "custom");
+                "type_boolean bool"}, hdfsPath + "/avro/" + AVRO_TYPES_FILE_NAME + SUFFIX_AVRO, null);
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
         exTable.setFormatter("pxfwritable_import");
+        exTable.setFormat("CUSTOM");
         exTable.setProfile(ProtocolUtils.getProtocol().value() + ":avro");
 
         gpdb.createTableAndVerify(exTable);

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/general/AlterTableTest.java
@@ -90,14 +90,10 @@ public class AlterTableTest extends BaseFeature {
     @Test(groups = {"features", "gpdb", "security"})
     public void dropAndAddColumnsPxfWritableImportWithColumnProjectionSupport() throws Exception {
 
-        exTable = TableFactory.getPxfReadableTextTable(PXF_ALTER_PARQUET_TABLE,
-                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, null);
+        exTable = TableFactory.getPxfReadableCustomTable(PXF_ALTER_PARQUET_TABLE,
+                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, "parquet");
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
-        exTable.setFormatter("pxfwritable_import");
-        exTable.setFormat("CUSTOM");
-        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
-
         gpdb.createTableAndVerify(exTable);
 
         runTincTest("pxf.features.general.alter.pxfwritable_import.with_column_projection.runTest");
@@ -108,13 +104,10 @@ public class AlterTableTest extends BaseFeature {
     public void dropColumnsPxfWritableExport() throws Exception {
 
         // Create source table
-        exTable = TableFactory.getPxfReadableTextTable(PXF_PARQUET_TABLE_SOURCE,
-                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, null);
+        exTable = TableFactory.getPxfReadableCustomTable(PXF_PARQUET_TABLE_SOURCE,
+                PARQUET_TABLE_COLUMNS, hdfsPath + "/parquet/" + PARQUET_PRIMITIVE_TYPES, "parquet");
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
-        exTable.setFormatter("pxfwritable_import");
-        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
-        exTable.setFormat("CUSTOM");
         gpdb.createTableAndVerify(exTable);
 
         // Create writable table
@@ -128,13 +121,10 @@ public class AlterTableTest extends BaseFeature {
         gpdb.createTableAndVerify(exTable);
 
         // Create validation table
-        exTable = TableFactory.getPxfReadableTextTable(PXF_ALTER_WRITE_PARQUET_TABLE + "_r",
-                PARQUET_TABLE_SUBSET_COLUMNS, hdfsPath + "/parquet-write/" + PARQUET_WRITE_PRIMITIVES, null);
+        exTable = TableFactory.getPxfReadableCustomTable(PXF_ALTER_WRITE_PARQUET_TABLE + "_r",
+                PARQUET_TABLE_SUBSET_COLUMNS, hdfsPath + "/parquet-write/" + PARQUET_WRITE_PRIMITIVES, "parquet");
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
-        exTable.setFormatter("pxfwritable_import");
-        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":parquet");
-        exTable.setFormat("CUSTOM");
         gpdb.createTableAndVerify(exTable);
 
         runTincTest("pxf.features.general.alter.pxfwritable_export.parquet.runTest");
@@ -143,7 +133,7 @@ public class AlterTableTest extends BaseFeature {
     @Test(groups = {"features", "gpdb", "security"})
     public void dropAndAddColumnsPxfWritableImportWithoutColumnProjectionSupport() throws Exception {
         // default external table with common settings
-        exTable = TableFactory.getPxfReadableTextTable(PXF_ALTER_AVRO_TABLE, new String[]{
+        exTable = TableFactory.getPxfReadableCustomTable(PXF_ALTER_AVRO_TABLE, new String[]{
                 "type_int int",
                 "type_double float8",
                 "type_string text",
@@ -151,13 +141,9 @@ public class AlterTableTest extends BaseFeature {
                 "col_does_not_exist text",
                 "type_long bigint",
                 "type_bytes bytea",
-                "type_boolean bool"}, hdfsPath + "/avro/" + AVRO_TYPES_FILE_NAME + SUFFIX_AVRO, null);
+                "type_boolean bool"}, hdfsPath + "/avro/" + AVRO_TYPES_FILE_NAME + SUFFIX_AVRO, "avro");
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);
-        exTable.setFormatter("pxfwritable_import");
-        exTable.setFormat("CUSTOM");
-        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":avro");
-
         gpdb.createTableAndVerify(exTable);
 
         // Verify results

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection_fdw/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection_fdw/expected/query01.ans
@@ -13,17 +13,17 @@ SET optimizer = off;
 SET
 SELECT * FROM test_column_projection ORDER BY t0;
  t0 | a1 | b2 |     colprojvalue
-----+----+----+-----------------------
- A  |  0 | t  | t0|a1|b2|colprojvalue
- B  |  1 | f  | t0|a1|b2|colprojvalue
- C  |  2 | t  | t0|a1|b2|colprojvalue
- D  |  3 | f  | t0|a1|b2|colprojvalue
- E  |  4 | t  | t0|a1|b2|colprojvalue
- F  |  5 | f  | t0|a1|b2|colprojvalue
- G  |  6 | t  | t0|a1|b2|colprojvalue
- H  |  7 | f  | t0|a1|b2|colprojvalue
- I  |  8 | t  | t0|a1|b2|colprojvalue
- J  |  9 | f  | t0|a1|b2|colprojvalue
+----+----+----+----------------------
+ A  |  0 | t  | No Column Projection
+ B  |  1 | f  | No Column Projection
+ C  |  2 | t  | No Column Projection
+ D  |  3 | f  | No Column Projection
+ E  |  4 | t  | No Column Projection
+ F  |  5 | f  | No Column Projection
+ G  |  6 | t  | No Column Projection
+ H  |  7 | f  | No Column Projection
+ I  |  8 | t  | No Column Projection
+ J  |  9 | f  | No Column Projection
 (10 rows)
 
 SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
@@ -113,12 +113,12 @@ SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
 
 SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
  t0 |    colprojvalue
-----+--------------------
- A  | t0|a1|colprojvalue
- B  | t0|a1|colprojvalue
- C  | t0|a1|colprojvalue
- D  | t0|a1|colprojvalue
- E  | t0|a1|colprojvalue
+----+----------------------
+ A  | No Column Projection
+ B  | No Column Projection
+ C  | No Column Projection
+ D  | No Column Projection
+ E  | No Column Projection
 (5 rows)
 
 SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
@@ -184,17 +184,17 @@ SET optimizer = on;
 SET
 SELECT * FROM test_column_projection ORDER BY t0;
  t0 | a1 | b2 |     colprojvalue
-----+----+----+-----------------------
- A  |  0 | t  | t0|a1|b2|colprojvalue
- B  |  1 | f  | t0|a1|b2|colprojvalue
- C  |  2 | t  | t0|a1|b2|colprojvalue
- D  |  3 | f  | t0|a1|b2|colprojvalue
- E  |  4 | t  | t0|a1|b2|colprojvalue
- F  |  5 | f  | t0|a1|b2|colprojvalue
- G  |  6 | t  | t0|a1|b2|colprojvalue
- H  |  7 | f  | t0|a1|b2|colprojvalue
- I  |  8 | t  | t0|a1|b2|colprojvalue
- J  |  9 | f  | t0|a1|b2|colprojvalue
+----+----+----+----------------------
+ A  |  0 | t  | No Column Projection
+ B  |  1 | f  | No Column Projection
+ C  |  2 | t  | No Column Projection
+ D  |  3 | f  | No Column Projection
+ E  |  4 | t  | No Column Projection
+ F  |  5 | f  | No Column Projection
+ G  |  6 | t  | No Column Projection
+ H  |  7 | f  | No Column Projection
+ I  |  8 | t  | No Column Projection
+ J  |  9 | f  | No Column Projection
 (10 rows)
 
 SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection_fdw/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection_fdw/expected/query01.ans
@@ -1,0 +1,358 @@
+-- start_ignore
+-- end_ignore
+-- start_ignore
+DROP TABLE IF EXISTS t0_values;
+DROP TABLE
+CREATE TABLE t0_values(key char(1), value int) DISTRIBUTED BY (key);
+CREATE TABLE
+INSERT INTO t0_values VALUES('A', 50);
+INSERT 0 1
+-- end_ignore
+-- @description query01 for PXF Column Projection Support
+SET optimizer = off;
+SET
+SELECT * FROM test_column_projection ORDER BY t0;
+ t0 | a1 | b2 |     colprojvalue
+----+----+----+-----------------------
+ A  |  0 | t  | t0|a1|b2|colprojvalue
+ B  |  1 | f  | t0|a1|b2|colprojvalue
+ C  |  2 | t  | t0|a1|b2|colprojvalue
+ D  |  3 | f  | t0|a1|b2|colprojvalue
+ E  |  4 | t  | t0|a1|b2|colprojvalue
+ F  |  5 | f  | t0|a1|b2|colprojvalue
+ G  |  6 | t  | t0|a1|b2|colprojvalue
+ H  |  7 | f  | t0|a1|b2|colprojvalue
+ I  |  8 | t  | t0|a1|b2|colprojvalue
+ J  |  9 | f  | t0|a1|b2|colprojvalue
+(10 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
+ t0 |  colprojvalue
+----+-----------------
+ A  | t0|colprojvalue
+ B  | t0|colprojvalue
+ C  | t0|colprojvalue
+ D  | t0|colprojvalue
+ E  | t0|colprojvalue
+ F  | t0|colprojvalue
+ G  | t0|colprojvalue
+ H  | t0|colprojvalue
+ I  | t0|colprojvalue
+ J  | t0|colprojvalue
+(10 rows)
+
+SELECT colprojvalue FROM test_column_projection ORDER BY t0;
+  colprojvalue
+-----------------
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+(10 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|b2|colprojvalue
+ C  | t0|b2|colprojvalue
+ E  | t0|b2|colprojvalue
+ G  | t0|b2|colprojvalue
+ I  | t0|b2|colprojvalue
+(5 rows)
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+ t0 | a1 |     colprojvalue
+----+----+-----------------------
+ B  |  1 | t0|a1|b2|colprojvalue
+ D  |  3 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+  round  |     colprojvalue
+---------+-----------------------
+ 1.00000 | t0|a1|b2|colprojvalue
+ 1.73205 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+  round  |     colprojvalue
+---------+-----------------------
+ 1.00000 | t0|a1|b2|colprojvalue
+ 1.73205 | t0|a1|b2|colprojvalue
+ 2.23607 | t0|a1|b2|colprojvalue
+ 2.64575 | t0|a1|b2|colprojvalue
+ 3.00000 | t0|a1|b2|colprojvalue
+(5 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+(5 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+ F  | t0|a1|colprojvalue
+(6 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+(5 rows)
+
+SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+ value |  colprojvalue
+-------+-----------------
+    50 | t0|colprojvalue
+(1 row)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ I  | t0|a1|colprojvalue
+ J  | t0|a1|colprojvalue
+(4 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+ F  | t0|a1|colprojvalue
+ G  | t0|a1|colprojvalue
+ H  | t0|a1|colprojvalue
+ I  | t0|a1|colprojvalue
+ J  | t0|a1|colprojvalue
+(8 rows)
+
+SELECT t0, colprojvalue, round(sqrt(a1)::numeric, 5) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    |  round
+----+--------------------+---------
+ A  | t0|a1|colprojvalue | 0.00000
+ B  | t0|a1|colprojvalue | 1.00000
+ C  | t0|a1|colprojvalue | 1.41421
+ D  | t0|a1|colprojvalue | 1.73205
+ E  | t0|a1|colprojvalue | 2.00000
+ F  | t0|a1|colprojvalue | 2.23607
+ G  | t0|a1|colprojvalue | 2.44949
+ H  | t0|a1|colprojvalue | 2.64575
+ I  | t0|a1|colprojvalue | 2.82843
+ J  | t0|a1|colprojvalue | 3.00000
+(10 rows)
+
+-- Casting boolean column to int
+SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    | sqrt
+----+--------------------+------
+ A  | t0|b2|colprojvalue |    1
+ B  | t0|b2|colprojvalue |    0
+ C  | t0|b2|colprojvalue |    1
+ D  | t0|b2|colprojvalue |    0
+ E  | t0|b2|colprojvalue |    1
+ F  | t0|b2|colprojvalue |    0
+ G  | t0|b2|colprojvalue |    1
+ H  | t0|b2|colprojvalue |    0
+ I  | t0|b2|colprojvalue |    1
+ J  | t0|b2|colprojvalue |    0
+(10 rows)
+
+SET optimizer = on;
+SET
+SELECT * FROM test_column_projection ORDER BY t0;
+ t0 | a1 | b2 |     colprojvalue
+----+----+----+-----------------------
+ A  |  0 | t  | t0|a1|b2|colprojvalue
+ B  |  1 | f  | t0|a1|b2|colprojvalue
+ C  |  2 | t  | t0|a1|b2|colprojvalue
+ D  |  3 | f  | t0|a1|b2|colprojvalue
+ E  |  4 | t  | t0|a1|b2|colprojvalue
+ F  |  5 | f  | t0|a1|b2|colprojvalue
+ G  |  6 | t  | t0|a1|b2|colprojvalue
+ H  |  7 | f  | t0|a1|b2|colprojvalue
+ I  |  8 | t  | t0|a1|b2|colprojvalue
+ J  |  9 | f  | t0|a1|b2|colprojvalue
+(10 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
+ t0 |  colprojvalue
+----+-----------------
+ A  | t0|colprojvalue
+ B  | t0|colprojvalue
+ C  | t0|colprojvalue
+ D  | t0|colprojvalue
+ E  | t0|colprojvalue
+ F  | t0|colprojvalue
+ G  | t0|colprojvalue
+ H  | t0|colprojvalue
+ I  | t0|colprojvalue
+ J  | t0|colprojvalue
+(10 rows)
+
+SELECT colprojvalue FROM test_column_projection ORDER BY t0;
+  colprojvalue
+-----------------
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+ t0|colprojvalue
+(10 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|b2|colprojvalue
+ C  | t0|b2|colprojvalue
+ E  | t0|b2|colprojvalue
+ G  | t0|b2|colprojvalue
+ I  | t0|b2|colprojvalue
+(5 rows)
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+ t0 | a1 |     colprojvalue
+----+----+-----------------------
+ B  |  1 | t0|a1|b2|colprojvalue
+ D  |  3 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+  round  |     colprojvalue
+---------+-----------------------
+ 1.00000 | t0|a1|b2|colprojvalue
+ 1.73205 | t0|a1|b2|colprojvalue
+(2 rows)
+
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+  round  |     colprojvalue
+---------+-----------------------
+ 1.00000 | t0|a1|b2|colprojvalue
+ 1.73205 | t0|a1|b2|colprojvalue
+ 2.23607 | t0|a1|b2|colprojvalue
+ 2.64575 | t0|a1|b2|colprojvalue
+ 3.00000 | t0|a1|b2|colprojvalue
+(5 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+(5 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+ F  | t0|a1|colprojvalue
+(6 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+(5 rows)
+
+SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+ value |  colprojvalue
+-------+-----------------
+    50 | t0|colprojvalue
+(1 row)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ A  | t0|a1|colprojvalue
+ B  | t0|a1|colprojvalue
+ I  | t0|a1|colprojvalue
+ J  | t0|a1|colprojvalue
+(4 rows)
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
+ t0 |    colprojvalue
+----+--------------------
+ C  | t0|a1|colprojvalue
+ D  | t0|a1|colprojvalue
+ E  | t0|a1|colprojvalue
+ F  | t0|a1|colprojvalue
+ G  | t0|a1|colprojvalue
+ H  | t0|a1|colprojvalue
+ I  | t0|a1|colprojvalue
+ J  | t0|a1|colprojvalue
+(8 rows)
+
+SELECT t0, colprojvalue, round(sqrt(a1)::numeric, 5) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    |  round
+----+--------------------+---------
+ A  | t0|a1|colprojvalue | 0.00000
+ B  | t0|a1|colprojvalue | 1.00000
+ C  | t0|a1|colprojvalue | 1.41421
+ D  | t0|a1|colprojvalue | 1.73205
+ E  | t0|a1|colprojvalue | 2.00000
+ F  | t0|a1|colprojvalue | 2.23607
+ G  | t0|a1|colprojvalue | 2.44949
+ H  | t0|a1|colprojvalue | 2.64575
+ I  | t0|a1|colprojvalue | 2.82843
+ J  | t0|a1|colprojvalue | 3.00000
+(10 rows)
+
+-- Casting boolean column to int
+SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;
+ t0 |    colprojvalue    | sqrt
+----+--------------------+------
+ A  | t0|b2|colprojvalue |    1
+ B  | t0|b2|colprojvalue |    0
+ C  | t0|b2|colprojvalue |    1
+ D  | t0|b2|colprojvalue |    0
+ E  | t0|b2|colprojvalue |    1
+ F  | t0|b2|colprojvalue |    0
+ G  | t0|b2|colprojvalue |    1
+ H  | t0|b2|colprojvalue |    0
+ I  | t0|b2|colprojvalue |    1
+ J  | t0|b2|colprojvalue |    0
+(10 rows)
+
+-- cleanup
+-- start_ignore
+DROP TABLE IF EXISTS t0_values;
+DROP TABLE
+-- end_ignore

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection_fdw/runTest.py
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection_fdw/runTest.py
@@ -1,0 +1,12 @@
+from mpp.models import SQLTestCase
+from mpp.models import SQLConcurrencyTestCase
+
+class PxfColumnProjection(SQLConcurrencyTestCase):
+    """
+    @db_name pxfautomation
+    @concurrency 1
+    @gpdiff True
+    """
+    sql_dir = 'sql'
+    ans_dir = 'expected'
+    out_dir = 'output'

--- a/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection_fdw/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/columnprojection/checkColumnProjection_fdw/sql/query01.sql
@@ -1,0 +1,77 @@
+-- start_ignore
+DROP TABLE IF EXISTS t0_values;
+CREATE TABLE t0_values(key char(1), value int) DISTRIBUTED BY (key);
+INSERT INTO t0_values VALUES('A', 50);
+-- end_ignore
+-- @description query01 for PXF Column Projection Support
+
+SET optimizer = off;
+
+SELECT * FROM test_column_projection ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
+
+SELECT colprojvalue FROM test_column_projection ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
+
+SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
+
+SELECT t0, colprojvalue, round(sqrt(a1)::numeric, 5) FROM test_column_projection ORDER BY t0;
+
+-- Casting boolean column to int
+SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;
+
+SET optimizer = on;
+
+SELECT * FROM test_column_projection ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection ORDER BY t0;
+
+SELECT colprojvalue FROM test_column_projection ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE b2 ORDER BY t0;
+
+SELECT t0, a1, colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE a1 < 5 AND b2 = false ORDER BY t0;
+
+SELECT round(sqrt(a1)::numeric, 5), colprojvalue FROM test_column_projection WHERE b2 = false ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 5 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 <= 5 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection GROUP BY t0, colprojvalue HAVING AVG(a1) < 5 ORDER BY t0;
+
+SELECT b.value, a.colprojvalue FROM test_column_projection a JOIN t0_values b ON a.t0 = b.key;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE a1 < 2 OR a1 >= 8 ORDER BY t0;
+
+SELECT t0, colprojvalue FROM test_column_projection WHERE sqrt(a1) > 1 ORDER BY t0;
+
+SELECT t0, colprojvalue, round(sqrt(a1)::numeric, 5) FROM test_column_projection ORDER BY t0;
+
+-- Casting boolean column to int
+SELECT t0, colprojvalue, sqrt(b2::int) FROM test_column_projection ORDER BY t0;
+
+-- cleanup
+-- start_ignore
+DROP TABLE IF EXISTS t0_values;
+-- end_ignore

--- a/automation/tincrepo/main/pxf/features/general/alter/csv/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/general/alter/csv/expected/query01.ans
@@ -18,6 +18,9 @@
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g
 --
+-- m/tmp\/pxf_automation_data\/(.*)/
+-- s/tmp\/pxf_automation_data\/(.*)/pxf:\/\/pxf_automation_data?PROFILE=*:text/g
+--
 -- end_matchsubs
 
 -- This query should error out with invalid input syntax for integer

--- a/automation/tincrepo/main/pxf/features/general/alter/csv/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/general/alter/csv/sql/query01.sql
@@ -16,6 +16,9 @@
 -- m/CONTEXT:.*line.*/
 -- s/line \d* of //g
 --
+-- m/tmp\/pxf_automation_data\/(.*)/
+-- s/tmp\/pxf_automation_data\/(.*)/pxf:\/\/pxf_automation_data?PROFILE=*:text/g
+--
 -- end_matchsubs
 
 -- This query should error out with invalid input syntax for integer

--- a/automation/tincrepo/main/pxf/features/general/alter/pxfwritable_import/without_column_projection/expected/query01.ans
+++ b/automation/tincrepo/main/pxf/features/general/alter/pxfwritable_import/without_column_projection/expected/query01.ans
@@ -8,6 +8,9 @@
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/
 --
+-- m/,.*line (.*)/
+-- s/,.*line (.*)//g
+--
 -- end_matchsubs
 -- sets the bytea output to the expected by the tests
 SET bytea_output='escape';

--- a/automation/tincrepo/main/pxf/features/general/alter/pxfwritable_import/without_column_projection/sql/query01.sql
+++ b/automation/tincrepo/main/pxf/features/general/alter/pxfwritable_import/without_column_projection/sql/query01.sql
@@ -7,6 +7,9 @@
 -- m/DETAIL/
 -- s/DETAIL/CONTEXT/
 --
+-- m/,.*line (.*)/
+-- s/,.*line (.*)//g
+--
 -- end_matchsubs
 
 -- sets the bytea output to the expected by the tests

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -72,7 +72,8 @@ PxfBridgeImportStart(PxfFdwScanState *pxfsstate)
 					 pxfsstate->options,
 					 pxfsstate->relation,
 					 pxfsstate->filter_str,
-					 pxfsstate->retrieved_attrs);
+					 pxfsstate->retrieved_attrs,
+					 pxfsstate->projectionInfo);
 
 	pxfsstate->churl_handle = churl_init_download(pxfsstate->uri.data, pxfsstate->churl_headers);
 
@@ -91,6 +92,7 @@ PxfBridgeExportStart(PxfFdwModifyState *pxfmstate)
 	BuildHttpHeaders(pxfmstate->churl_headers,
 					 pxfmstate->options,
 					 pxfmstate->relation,
+					 NULL,
 					 NULL,
 					 NULL);
 	pxfmstate->churl_handle = churl_init_upload(pxfmstate->uri.data, pxfmstate->churl_headers);

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -52,6 +52,7 @@ typedef struct PxfFdwScanState
 	List	   *retrieved_attrs;
 	PxfOptions *options;
 	CopyState	cstate;
+	ProjectionInfo *projectionInfo;
 } PxfFdwScanState;
 
 /*

--- a/fdw/pxf_deparse.c
+++ b/fdw/pxf_deparse.c
@@ -33,7 +33,6 @@ deparseTargetList(Relation rel, Bitmapset *attrs_used, List **retrieved_attrs)
 
 	if (have_wholerow)
 		return;
-	int droppedAttrsCount = 0;
 
 	for (i = 1; i <= tupdesc->natts; i++)
 	{
@@ -41,23 +40,11 @@ deparseTargetList(Relation rel, Bitmapset *attrs_used, List **retrieved_attrs)
 
 		/* Ignore dropped attributes. */
 		if (attr->attisdropped)
-		{
-			droppedAttrsCount++;
 			continue;
-		}
 
 		if (bms_is_member(i - FirstLowInvalidHeapAttributeNumber, attrs_used))
 		{
-			// Dropped attributes count needs for proper indexing of the projected columns.
-			// For eg:
-			//  ---------------------------------------------
-			// |  col1  |  col2 (dropped)  |  col3  |  col4  |
-			//  ---------------------------------------------
-			//
-			// Let's assume that col1 and col4 are projected, the reported projected
-			// indices will be 0, 2. This is because we use 0-based indexing and because
-			// col2 was dropped, the indices for col3 and col4 get shifted by -1.
-			*retrieved_attrs = lappend_int(*retrieved_attrs, i - droppedAttrsCount);
+			*retrieved_attrs = lappend_int(*retrieved_attrs, i);
 		}
 	}
 }

--- a/fdw/pxf_deparse.c
+++ b/fdw/pxf_deparse.c
@@ -33,6 +33,7 @@ deparseTargetList(Relation rel, Bitmapset *attrs_used, List **retrieved_attrs)
 
 	if (have_wholerow)
 		return;
+	int droppedAttrsCount = 0;
 
 	for (i = 1; i <= tupdesc->natts; i++)
 	{
@@ -40,11 +41,23 @@ deparseTargetList(Relation rel, Bitmapset *attrs_used, List **retrieved_attrs)
 
 		/* Ignore dropped attributes. */
 		if (attr->attisdropped)
+		{
+			droppedAttrsCount++;
 			continue;
+		}
 
 		if (bms_is_member(i - FirstLowInvalidHeapAttributeNumber, attrs_used))
 		{
-			*retrieved_attrs = lappend_int(*retrieved_attrs, i);
+			// Dropped attributes count needs for proper indexing of the projected columns.
+			// For eg:
+			//  ---------------------------------------------
+			// |  col1  |  col2 (dropped)  |  col3  |  col4  |
+			//  ---------------------------------------------
+			//
+			// Let's assume that col1 and col4 are projected, the reported projected
+			// indices will be 0, 2. This is because we use 0-based indexing and because
+			// col2 was dropped, the indices for col3 and col4 get shifted by -1.
+			*retrieved_attrs = lappend_int(*retrieved_attrs, i - droppedAttrsCount);
 		}
 	}
 }

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -422,6 +422,7 @@ pxfBeginForeignScan(ForeignScanState *node, int eflags)
 	pxfsstate->quals = quals;
 	pxfsstate->relation = relation;
 	pxfsstate->retrieved_attrs = retrieved_attrs;
+	pxfsstate->projectionInfo = node->ss.ps.ps_ProjInfo;
 
     /* Set up callback to identify error foreign relation. */
     ErrorContextCallback errcallback;

--- a/fdw/pxf_header.c
+++ b/fdw/pxf_header.c
@@ -77,7 +77,7 @@ BuildHttpHeaders(CHURL_HEADERS headers,
 	if (projectionInfo != NULL)
 	{
 		/* add the list of attrs to the projection desc http headers */
-		AddProjectionDescHttpHeader(headers, retrieved_attrs,  relation);
+		AddProjectionDescHttpHeader(headers, retrieved_attrs, relation);
 	}
 
 	/* GP cluster configuration */
@@ -332,16 +332,17 @@ AddProjectionDescHttpHeader(CHURL_HEADERS headers, List *retrieved_attrs, Relati
 
 	for (int i = 1; i <= tupdesc->natts; i++)
 	{
-		// Dropped attributes count needs for proper indexing of the projected columns.
-		// For eg:
-		//  ---------------------------------------------
-		// |  col1  |  col2 (dropped)  |  col3  |  col4  |
-		//  ---------------------------------------------
-		//
-		// We use 0-based indexing and since col2 was dropped,
-		// the indices for col3 and col4 get shifted by -1.
-		// Let's assume that col1 and col4 are projected, the reported projected
-		// indices will then be 0, 2.
+		/* Dropped attributes count needs for proper indexing of the projected columns.
+		* For eg:
+		*  ---------------------------------------------
+		* |  col1  |  col2 (dropped)  |  col3  |  col4  |
+		*  ---------------------------------------------
+		*
+		* We use 0-based indexing and since col2 was dropped,
+		* the indices for col3 and col4 get shifted by -1.
+		* Let's assume that col1 and col4 are projected, the reported projected
+		* indices will then be 0, 2.
+		*/
 		if (TupleDescAttr(tupdesc, i-1)->attisdropped)
 		{
 			/* keep a counter of the number of dropped attributes */

--- a/fdw/pxf_header.c
+++ b/fdw/pxf_header.c
@@ -55,7 +55,8 @@ BuildHttpHeaders(CHURL_HEADERS headers,
 				 PxfOptions *options,
 				 Relation relation,
 				 char *filter_string,
-				 List *retrieved_attrs)
+				 List *retrieved_attrs,
+				 ProjectionInfo *projectionInfo)
 {
 	extvar_t	 ev;
 	char		 pxfPortString[sizeof(int32) * 8];
@@ -71,10 +72,12 @@ BuildHttpHeaders(CHURL_HEADERS headers,
 		relnamespace = GetNamespaceName(RelationGetNamespace(relation));
 	}
 
-	if (retrieved_attrs != NULL)
+	// If projectionInfo is Null, it means there should be no projection.
+	// We can skip the whole logic of adding projection desc to headers.
+	if (projectionInfo != NULL)
 	{
 		/* add the list of attrs to the projection desc http headers */
-		AddProjectionDescHttpHeader(headers, retrieved_attrs, relation);
+		AddProjectionDescHttpHeader(headers, retrieved_attrs,  relation);
 	}
 
 	/* GP cluster configuration */

--- a/fdw/pxf_header.c
+++ b/fdw/pxf_header.c
@@ -313,7 +313,7 @@ AddTupleDescriptionToHttpHeader(CHURL_HEADERS headers, Relation rel)
 static void
 AddProjectionDescHttpHeader(CHURL_HEADERS headers, List *retrieved_attrs, Relation rel)
 {
-	ListCell	*lc ;
+	ListCell	*lc = NULL;
 	char		long_number[sizeof(int32) * 8];
 	TupleDesc	tupdesc = RelationGetDescr(rel);
 	Bitmapset	*attrs_projected = NULL;
@@ -324,10 +324,10 @@ AddProjectionDescHttpHeader(CHURL_HEADERS headers, List *retrieved_attrs, Relati
 
 	foreach(lc, retrieved_attrs)
 	{
-		int		attno = lfirst_int(lc);
+		int 	attno = lfirst_int(lc);
 
 		attrs_projected = bms_add_member(attrs_projected,
-										 attno - FirstLowInvalidHeapAttributeNumber);
+							attno - FirstLowInvalidHeapAttributeNumber);
 	}
 
 	for (int i = 1; i <= tupdesc->natts; i++)

--- a/fdw/pxf_header.c
+++ b/fdw/pxf_header.c
@@ -74,8 +74,15 @@ BuildHttpHeaders(CHURL_HEADERS headers,
 
 	// If projectionInfo is Null, it means there should be no projection.
 	// We can skip the whole logic of adding projection desc to headers.
+	// projectionInfo can be NULL in some cases like "SELECT * FROM"
+	// because we are selecting all the columns here.
 	if (projectionInfo != NULL)
 	{
+		//TODO retrieved_attrs contains the list of columns being retrieved
+		// Ideally this should contains the correct projectionInfo but in some cases it isn't the case.
+		// For e.g. select * from TABLE_NAME
+		// Need to figure out if we should be using the projectionInfo or retrieved_attrs here for the projection.
+
 		/* add the list of attrs to the projection desc http headers */
 		AddProjectionDescHttpHeader(headers, retrieved_attrs, relation);
 	}

--- a/fdw/pxf_header.h
+++ b/fdw/pxf_header.h
@@ -38,6 +38,7 @@ extern void BuildHttpHeaders(CHURL_HEADERS headers,
 							 PxfOptions *options,
 							 Relation relation,
 							 char *filter_string,
-							 List *retrieved_attrs);
+							 List *retrieved_attrs,
+							 ProjectionInfo *projectionInfo);
 
 #endif							/* _PXFHEADERS_H_ */


### PR DESCRIPTION
When a column was dropped, The existing logic doesn't work properly : 

- It does not skip the dropped column thus causing the incorrect results. 
- The Projection Index was not getting calculated correctly. 

This PR fixes the issue. 
The above change can be validated with the AlterTableTest test. 

For AlterTableTest `dropColumnsPxfWritableExport` (profile :parquet) fails with the error `PXF server error : class java.io.DataInputStream cannot be cast to class java.lang.String (java.io.DataInputStream and java.lang.String are in module java.base of loader 'bootstrap') `  So skipping it for now as we are in process of fixing the FDW write separately. 