### PR TITLE
FDW changes for JdbcTest

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -175,7 +175,7 @@ public class Gpdb extends DbSystemObject {
 		"default_hive",
 		"db_hive_jdbc", // Needed for JdbcHiveTest
 		"default_hbase",
-		"default_jdbc", //Needed for JdbcHiveTest and other JdbcTest which refers to the default server.
+		"default_jdbc", // Needed for JdbcHiveTest and other JdbcTest which refers to the default server.
 		"database_jdbc",
 		"db-session-params_jdbc",
 		"default_file",

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -174,7 +174,8 @@ public class Gpdb extends DbSystemObject {
 		"default_hdfs",
 		"default_hive",
 		"default_hbase",
-		"default_jdbc",
+		"database_jdbc",
+		"db-session-params_jdbc",
 		"default_file",
 		"default_s3",
 		"default_gs",
@@ -196,21 +197,8 @@ public class Gpdb extends DbSystemObject {
 
 			String pxfServerName = server.substring(0,server.lastIndexOf("_")); // strip protocol at the end
 			String fdwName = server.substring(server.lastIndexOf("_") + 1) + "_pxf_fdw"; // strip protocol at the end
-			String jdbc_server_string = "";
-			// We need extra information for the server default_jdbc for the tests like jdbc_driver and db_url
-			// In case of external table, this information is read directly from the jdbc-site.xml
-			if(FDWUtils.useFDW && foreignServerName.equals("default_jdbc")) {
-				// create jdbc connection string
-				jdbc_server_string = ", jdbc_driver 'org.postgresql.Driver'," +
-						"db_url 'jdbc:postgresql://localhost:7000/pxfautomation'";
-				runQuery(String.format("CREATE SERVER %s %s FOREIGN DATA WRAPPER %s OPTIONS(config '%s' " + jdbc_server_string +")",
-						option, foreignServerName, fdwName, pxfServerName), ignoreFail, false);
-			}
-			else{
-				runQuery(String.format("CREATE SERVER %s %s FOREIGN DATA WRAPPER %s OPTIONS(config '%s')",
-						option, foreignServerName, fdwName, pxfServerName), ignoreFail, false);
-			}
-
+			runQuery(String.format("CREATE SERVER %s %s FOREIGN DATA WRAPPER %s OPTIONS(config '%s')",
+					option, foreignServerName, fdwName, pxfServerName), ignoreFail, false);
 			runQuery(String.format("CREATE USER MAPPING %s FOR CURRENT_USER SERVER %s", option, foreignServerName),
 					ignoreFail, false);
 		}

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -196,8 +196,21 @@ public class Gpdb extends DbSystemObject {
 
 			String pxfServerName = server.substring(0,server.lastIndexOf("_")); // strip protocol at the end
 			String fdwName = server.substring(server.lastIndexOf("_") + 1) + "_pxf_fdw"; // strip protocol at the end
-			runQuery(String.format("CREATE SERVER %s %s FOREIGN DATA WRAPPER %s OPTIONS(config '%s')",
-					option, foreignServerName, fdwName, pxfServerName), ignoreFail, false);
+			String jdbc_server_string = "";
+			// We need extra information for the server default_jdbc for the tests like jdbc_driver and db_url
+			// In case of external table, this information is read directly from the jdbc-site.xml
+			if(FDWUtils.useFDW && foreignServerName.equals("default_jdbc")) {
+				// create jdbc connection string
+				jdbc_server_string = ", jdbc_driver 'org.postgresql.Driver'," +
+						"db_url 'jdbc:postgresql://localhost:7000/pxfautomation'";
+				runQuery(String.format("CREATE SERVER %s %s FOREIGN DATA WRAPPER %s OPTIONS(config '%s' " + jdbc_server_string +")",
+						option, foreignServerName, fdwName, pxfServerName), ignoreFail, false);
+			}
+			else{
+				runQuery(String.format("CREATE SERVER %s %s FOREIGN DATA WRAPPER %s OPTIONS(config '%s')",
+						option, foreignServerName, fdwName, pxfServerName), ignoreFail, false);
+			}
+
 			runQuery(String.format("CREATE USER MAPPING %s FOR CURRENT_USER SERVER %s", option, foreignServerName),
 					ignoreFail, false);
 		}

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -173,7 +173,9 @@ public class Gpdb extends DbSystemObject {
 		List<String> servers = Lists.newArrayList(
 		"default_hdfs",
 		"default_hive",
+		"db_hive_jdbc", //Needed for JdbcHiveTest
 		"default_hbase",
+		"default_jdbc", //Needed for JdbcHiveTest and other JdbcTest which refers to the default server.
 		"database_jdbc",
 		"db-session-params_jdbc",
 		"default_file",

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -173,7 +173,7 @@ public class Gpdb extends DbSystemObject {
 		List<String> servers = Lists.newArrayList(
 		"default_hdfs",
 		"default_hive",
-		"db_hive_jdbc", //Needed for JdbcHiveTest
+		"db_hive_jdbc", // Needed for JdbcHiveTest
 		"default_hbase",
 		"default_jdbc", //Needed for JdbcHiveTest and other JdbcTest which refers to the default server.
 		"database_jdbc",

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/pxf/ForeignTable.java
@@ -39,7 +39,7 @@ public class ForeignTable extends WritableExternalTable {
         String[] serverParameters = StringUtils.defaultIfBlank(getServer(), "default").split("=");
         // getServer() might return a string "server=<..>", strip the prefix
         int index = serverParameters.length > 1 ? 1 : 0;
-        return String.format(" SERVER %s_%s", serverParameters[index], getProtocol());
+        return String.format(" SERVER %s_%s", serverParameters[index].replace("-","_"), getProtocol());
     }
 
     protected String createOptions() {

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -496,8 +496,8 @@ public abstract class TableFactory {
         if (user != null) {
             userParameters.add("USER=" + user);
         }
-        if (server != null && !FDWUtils.useFDW ) {
-            userParameters.add("SERVER=" + server);
+        if (server != null ) {
+            exTable.setServer("SERVER=" + server);
         }
         if (customParameters != null) {
             userParameters.add(customParameters);

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -496,7 +496,7 @@ public abstract class TableFactory {
         if (user != null) {
             userParameters.add("USER=" + user);
         }
-        if (server != null ) {
+        if (server != null) {
             exTable.setServer("SERVER=" + server);
         }
         if (customParameters != null) {

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -496,7 +496,7 @@ public abstract class TableFactory {
         if (user != null) {
             userParameters.add("USER=" + user);
         }
-        if (server != null) {
+        if (server != null && !FDWUtils.useFDW ) {
             userParameters.add("SERVER=" + server);
         }
         if (customParameters != null) {

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
@@ -7,7 +7,6 @@ import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.structures.tables.basic.Table;
 import org.greenplum.pxf.automation.structures.tables.pxf.ExternalTable;
 import org.greenplum.pxf.automation.structures.tables.utils.TableFactory;
-import org.greenplum.pxf.automation.utils.system.FDWUtils;
 import org.testng.annotations.Test;
 
 import org.greenplum.pxf.automation.enums.EnumPartitionType;

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
@@ -405,15 +405,15 @@ public class JdbcTest extends BaseFeature {
     }
 
     @FailsWithFDW
+    // All the Writable Tests are failing with this Error:
+    // ERROR:  PXF server error : class java.io.DataInputStream cannot be cast to class
+    // [B (java.io.DataInputStream and [B are in module java.base of loader 'bootstrap')
     @Test(groups = {"features", "gpdb", "security", "jdbc"})
     public void jdbcWritableTable() throws Exception {
         runTincTest("pxf.features.jdbc.writable.runTest");
     }
 
     @FailsWithFDW
-    // All the Writable Tests are failing with this Error:
-    // ERROR:  PXF server error : class java.io.DataInputStream cannot be cast to class
-    // [B (java.io.DataInputStream and [B are in module java.base of loader 'bootstrap')
     @Test(groups = {"features", "gpdb", "security", "jdbc"})
     public void jdbcWritableTableNoBatch() throws Exception {
         runTincTest("pxf.features.jdbc.writable_nobatch.runTest");

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcTest.java
@@ -412,7 +412,7 @@ public class JdbcTest extends BaseFeature {
 
     @FailsWithFDW
     // All the Writable Tests are failing with this Error:
-    //< ERROR:  PXF server error : class java.io.DataInputStream cannot be cast to class
+    // ERROR:  PXF server error : class java.io.DataInputStream cannot be cast to class
     // [B (java.io.DataInputStream and [B are in module java.base of loader 'bootstrap')
     @Test(groups = {"features", "gpdb", "security", "jdbc"})
     public void jdbcWritableTableNoBatch() throws Exception {


### PR DESCRIPTION
This PR fixes/modifies JdbcTest to make it work with FDW (Readbale Tables).  

Following Tests are passing for FDW with this change: 

```
JdbcTest.jdbcColumnProjection...OK
JdbcTest.jdbcColumns...OK
JdbcTest.jdbcNamedQuery...OK
JdbcTest.jdbcReadableTableNoBatch...OK
JdbcTest.multipleFragmentsTables...OK
JdbcTest.readServerConfig...OK
JdbcTest.readViewSessionParams...OK
JdbcTest.singleFragmentTable...OK
```