### PR TITLE
docs - multibyte delimiter support for csv

### DIFF
--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -395,7 +395,7 @@ PXF recognizes the following formatter options when reading data that contains a
 | DELIMITER=\<delim_string\> | The single-byte or multi-byte delimiter string that separates columns. The string may be up to 32 bytes in length, and may not contain quote or escape characters. **Required** | None |
 | QUOTE=\<char\> | The single one-byte ASCII quotation character for all columns. | None |
 | ESCAPE=\<char\> | The single one-byte ASCII character used to escape special characters (for example, the `DELIM`, `QUOTE`,  or `NEWLINE` value, or the `ESCAPE` value itself). | None, or the `QUOTE` value if that is set |
-| NEWLINE=\<value\> | The end-of-line indicator that designates the end of a row. Preface the \<value\> with an `E` when the value is an escape sequence. Examples: `NEWLINE=E'\r'`, `NEWLINE 'aaa'`. | `\n` |
+| NEWLINE=\<bytecode\> | The end-of-line indicator that designates the end of a row. Valid values are `LF` (line feed), `CR` (carriage return), or `CRLF` (carriage return plus line feed. | `LF` |
 
 The following sections provide further information about, and examples for, specifying the delimiter, quote, escape, and new line options.
 
@@ -452,9 +452,17 @@ When PXF reads data that contains a multi-byte or multi-character delimiter, its
 
 ### <a id="about_newline"></a>About the NEWLINE Options
 
-Every line in the file must be terminated with the specified new line value.
+PXF requires that every line in the file be terminated with the same new line value.
 
-By default, PXF uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `NEWLINE` formatter option. If the `NEWLINE` formatter option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must also specify the `NEWLINE` option in the external table `LOCATION` URI, and set the value to `CR`, `CRLF` or the set of bytecode characters, respectively.
+By default, PXF uses the line feed character (`LF`) for the new line delimiter. When the new line delimiter for the external file is also a line feed, you need not specify the `NEWLINE` formatter option.
+
+If the `NEWLINE` formatter option is provided and contains `CR` or `CRLF`, you must also specify the same `NEWLINE` option in the external table `LOCATION` URI. For example, if the new line delimiter is `CRLF`, create the external table as follows:
+
+```
+CREATE READABLE EXTERNAL TABLE mbyte_newline_crlf (id int, city text, country text)
+  LOCATION ('pxf://multibyte_example_crlf?PROFILE=hdfs:csv&NEWLINE=CRLF')
+FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤', NEWLINE='CRLF');
+```
 
 ### <a id="mbd_examples"></a>Examples
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -395,9 +395,9 @@ PXF recognizes the following formatter options when reading data that contains a
 | DELIMITER=\<delim_string\> | The single-byte or multi-byte delimiter string that separates columns. The string may be up to 32 bytes in length, and may not contain quote or escape characters. **Required** | None |
 | QUOTE=\<char\> | The single one-byte ASCII quotation character for all columns. | None |
 | ESCAPE=\<char\> | The single one-byte ASCII character used to escape special characters (for example, the `DELIM`, `QUOTE`,  or `NEWLINE` value, or the `ESCAPE` value itself). | None, or the `QUOTE` value if that is set |
-| NEWLINE=\<bytecode\> | The end-of-line indicator that designates the end of a row. Every line in the file must be terminated with the specified newline value. When you set the `NEWLINE` formatter option, you must also set `NEWLINE` in the `LOCATION` URI. Valid values are `LF` (line feed, `0x0A`), `CR` (carriage return, `0x0D`), or `CRLF` (carriage return plus line feed, `0x0D` `0x0A`). | `LF` |
+| NEWLINE=\<value\> | The end-of-line indicator that designates the end of a row. Preface the \<value\> with an `E` when the value is an escape sequence. Examples: `NEWLINE=E'\r'`, `NEWLINE 'aaa'`. | `\n` |
 
-The following sections provide further information about, and examples for, specifying the delimiter, quote, and escape options.
+The following sections provide further information about, and examples for, specifying the delimiter, quote, escape, and new line options.
 
 ### <a id="about_delim"></a>Specifying the Delimiter
 
@@ -449,6 +449,12 @@ When PXF reads data that contains a multi-byte or multi-character delimiter, its
 <sup>2</sup> All data columns must quoted when you specify a quote character.
 
 > **Note** PXF expects that there are no extraneous characters between the quote value and the delimiter value, nor between the quote value and the end-of-line value. Additionally, there must be no white space between delimiters and quotes.
+
+### <a id="about_newline"></a>About the NEWLINE Options
+
+Every line in the file must be terminated with the specified new line value.
+
+By default, PXF uses the `\n` (LF) character for the new line delimiter. When the line delimiter for the external file is also `\n`, you need not specify the `NEWLINE` formatter option. If the `NEWLINE` formatter option is provided and contains `\r` (CR), `\r\n` (CRLF), or a set of custom escape characters, you must also specify the `NEWLINE` option in the external table `LOCATION` URI, and set the value to `CR`, `CRLF` or the set of bytecode characters, respectively.
 
 ### <a id="mbd_examples"></a>Examples
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -367,7 +367,7 @@ Perform the following procedure to create Greenplum Database writable external t
 
 ## <a id="multibyte_delim"></a>About Reading Data Containing Multi-Byte or Multi-Character Delimiters
 
-When data contains a multi-byte delimiter or multiple delimiter characters, you can use only a `*:text` or `*:csv` PXF profile to read the text. The syntax for creating a readable external table for such data follows:
+When data contains a multi-byte delimiter or multiple delimiter characters, you can use only a `*:text` or `*:csv` PXF profile to read the data. The syntax for creating a readable external table for such data follows:
 
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
@@ -383,8 +383,8 @@ PXF recognizes the following formatter options:
 | Option Name  | Description | Default Value |
 |-------|---------------|---------------|
 | DELIMITER | The single-byte or multi-byte delimiter string that separates columns. The string may be up to 32 bytes in length, and may not contain quote or escape characters. **Required** | None |
-| QUOTE | When reading CSV data with a `*:csv` profile, the single ASCII quotation character for all columns. | `"` (double quote) |
-| ESCAPE | The single ASCII character used to escape special characters (for example, the `DELIM`, `QUOTE`,  or `NEWLINE` value, or the `ESCAPE` value itself). | The `QUOTE` value. |
+| QUOTE | When reading CSV data with a `*:csv` profile, the single one-byte ASCII quotation character for all columns. | `"` (double quote) |
+| ESCAPE | The single one-byte ASCII character used to escape special characters (for example, the `DELIM`, `QUOTE`,  or `NEWLINE` value, or the `ESCAPE` value itself). | The `QUOTE` value. |
 | NEWLINE | The end-of-line indicator that designates the end of a row. Every line in the file must be terminated with the specified newline value. Valid values are `LF` (line feed, `0x0A`), `CRLF` (carriage return, `0x0D`), or `CR` (carriage return plus line feed, `0x0D` `0x0A`). | `LF` |
 
 The following sections provide further information about the delimiter, quote, and escape options.
@@ -393,7 +393,7 @@ The following sections provide further information about the delimiter, quote, a
 
 You can directly specify the delimiter or provide its byte representation.
 
-When you directly specify the delimiter, PXF converts between the file encoding and the database encoding for you. The following example directly specifies the `¤` currency symbol for the delimiter:
+When you directly specify the delimiter, Greenplum Database converts between the file encoding and the database encoding for you. The following example directly specifies the `¤` currency symbol for the delimiter:
 
 ```
 CREATE READABLE EXTERNAL TABLE mbyte_delim (id int, city text, state text)

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -367,14 +367,9 @@ Perform the following procedure to create Greenplum Database writable external t
 
 ## <a id="about_encoding"></a>About Setting the External Table Encoding
 
-When the external file encoding differs from the database encoding, you must set the external table `ENCODING` to match that of the data file, create the external table as follows.
-
-For example, if the database encoding is `UTF8`, the file encoding is `LATIN1`, and the delimiter is the `¤` currency symbol:
+When the external file encoding differs from the database encoding, you must set the external table `ENCODING` to match that of the data file. For example, if the database encoding is `UTF8`, the file encoding is `LATIN1`, and the delimiter is the `¤` currency symbol, create the external table as follows:
 
 ```
-CREATE READABLE EXTERNAL TABLE byterep_delim (id int, city text, state text)
-  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:csv')
-FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤') ENCODING 'LATIN1';
 CREATE EXTERNAL TABLE pxf_csv_latin1(location text, month text, num_orders int, total_sales float8)
   LOCATION ('pxf://data/pxf_examples/pxf_hdfs_simple.txt?PROFILE=hdfs:csv')
 FORMAT 'CSV' ENCODING 'LATIN1';
@@ -458,6 +453,7 @@ When PXF reads data that contains a multi-byte or multi-character delimiter, its
 ### <a id="mbd_examples"></a>Examples
 
 #### <a id="qe_example"></a>Delimiter with Quoted Data
+
 Given the following sample data that uses the double-quote (`"`) quote character and the delimiter `¤`:
 
 ```
@@ -490,9 +486,14 @@ CREATE READABLE EXTERNAL TABLE mybte_delim_quoted_escaped (sentence text, num in
 FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤', QUOTE '"', ESCAPE '\');
 ```
 
-Given this external table definition, PXF reads the `sentence` text field as:
+With this external table definition, PXF reads the `sentence` text field as:
 
 ```
-"hello, my name is jane" she said. let's escape something \
+SELECT sentence FROM mbyte_delim_quoted_escaped;
+
+                          sentence 
+-------------------------------------------------------------
+ "hello, my name is jane" she said. let's escape something \
+(1 row)
 ```
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -365,59 +365,100 @@ Perform the following procedure to create Greenplum Database writable external t
 
     To query data from the newly-created HDFS directory named `pxfwritable_hdfs_textsimple2`, you can create a readable external Greenplum Database table as described above that references this HDFS directory and specifies `FORMAT 'CSV' (delimiter=':')`.
 
+## <a id="about_encoding"></a>About Setting the External Table Encoding
+
+When the external file encoding differs from the database encoding, you must set the external table `ENCODING` to match that of the data file, create the external table as follows.
+
+For example, if the database encoding is `UTF8`, the file encoding is `LATIN1`, and the delimiter is the `¤` currency symbol:
+
+```
+CREATE READABLE EXTERNAL TABLE byterep_delim (id int, city text, state text)
+  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:csv')
+FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤') ENCODING 'LATIN1';
+CREATE EXTERNAL TABLE pxf_csv_latin1(location text, month text, num_orders int, total_sales float8)
+  LOCATION ('pxf://data/pxf_examples/pxf_hdfs_simple.txt?PROFILE=hdfs:csv')
+FORMAT 'CSV' ENCODING 'LATIN1';
+```
+
 ## <a id="multibyte_delim"></a>About Reading Data Containing Multi-Byte or Multi-Character Delimiters
 
-When data contains a multi-byte delimiter or multiple delimiter characters, you can use only a `*:text` or `*:csv` PXF profile to read the data. The syntax for creating a readable external table for such data follows:
+You can use only a `*:csv` PXF profile to read data that contains a multi-byte delimiter or multiple delimiter characters. The syntax for creating a readable external table for such data follows:
 
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:text|csv[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>][&SKIP_HEADER_COUNT=<numlines>]')
+LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:csv[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>][&SKIP_HEADER_COUNT=<numlines>]')
 FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import' <option>[=|<space>][E]'<value>');
 ```
 
-Note the `FORMAT` line in the syntax block. While the syntax is similar to that of reading plain text or CSV, PXF requires a custom formatter to read data containing a multi-byte or multi-character delimiter. You must specify the `'CUSTOM'` format and the `pxfdelimited_import` formatter. You must also specify a delimiter in the formatter options.
+Note the `FORMAT` line in the syntax block. While the syntax is similar to that of reading CSV, PXF requires a custom formatter to read data containing a multi-byte or multi-character delimiter. You must specify the `'CUSTOM'` format and the `pxfdelimited_import` formatter. You must also specify a delimiter in the formatter options.
 
-PXF recognizes the following formatter options:
+PXF recognizes the following formatter options when reading data that contains a multi-byte or multi-character delimiter:
 
-| Option Name  | Description | Default Value |
+| Option Name  | Value Description | Default Value |
 |-------|---------------|---------------|
-| DELIMITER | The single-byte or multi-byte delimiter string that separates columns. The string may be up to 32 bytes in length, and may not contain quote or escape characters. **Required** | None |
-| QUOTE | When reading CSV data with a `*:csv` profile, the single one-byte ASCII quotation character for all columns. | `"` (double quote) |
-| ESCAPE | The single one-byte ASCII character used to escape special characters (for example, the `DELIM`, `QUOTE`,  or `NEWLINE` value, or the `ESCAPE` value itself). | The `QUOTE` value. |
-| NEWLINE | The end-of-line indicator that designates the end of a row. Every line in the file must be terminated with the specified newline value. Valid values are `LF` (line feed, `0x0A`), `CRLF` (carriage return, `0x0D`), or `CR` (carriage return plus line feed, `0x0D` `0x0A`). | `LF` |
+| DELIMITER=\<delim_string\> | The single-byte or multi-byte delimiter string that separates columns. The string may be up to 32 bytes in length, and may not contain quote or escape characters. **Required** | None |
+| QUOTE=\<char\> | The single one-byte ASCII quotation character for all columns. | None |
+| ESCAPE=\<char\> | The single one-byte ASCII character used to escape special characters (for example, the `DELIM`, `QUOTE`,  or `NEWLINE` value, or the `ESCAPE` value itself). | None, or the `QUOTE` value if that is set |
+| NEWLINE=\<bytecode\> | The end-of-line indicator that designates the end of a row. Every line in the file must be terminated with the specified newline value. Valid values are `LF` (line feed, `0x0A`), `CRLF` (carriage return, `0x0D`), or `CR` (carriage return plus line feed, `0x0D` `0x0A`). | `LF` |
 
-The following sections provide further information about the delimiter, quote, and escape options.
+The following sections provide further information about, and examples for, specifying the delimiter, quote, and escape options.
 
 ### <a id="about_delim"></a>Specifying the Delimiter
 
-You can directly specify the delimiter or provide its byte representation.
-
-When you directly specify the delimiter, Greenplum Database converts between the file encoding and the database encoding for you. The following example directly specifies the `¤` currency symbol for the delimiter:
+You must directly specify the delimiter or provide its byte representation. For example, given the following sample data that uses a `¤` currency symbol delimiter:
 
 ```
-CREATE READABLE EXTERNAL TABLE mbyte_delim (id int, city text, state text)
-  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:text')
+133¤Austin¤USA
+321¤Boston¤USA
+987¤Paris¤France
+```
+
+Create the external table as follows:
+
+```
+CREATE READABLE EXTERNAL TABLE mbyte_delim (id int, city text, country text)
+  LOCATION ('pxf://multibyte_currency?PROFILE=hdfs:csv')
 FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤'); 
 ```
 
-Because some characters have different byte representations in different encodings, when you specify the byte representation for the delimiter, you must represent it in the database encoding. For example, if the database encoding is `UTF8`, the file encoding is `LATIN1`, and the delimiter is the `¤` currency symbol, you must specify the `UTF8` byte representation for `¤` (`\xC2\xA4`):
+#### <a id="delim_byterep"></a>About Specifying the Byte Representation of the Delimiter
+
+You can directly specify the delimiter or provide its byte representation. If you choose to specify the byte representation of the delimiter:
+
+- You must specify the byte representation of the delimiter in `E'<value>'` format.
+- Because some characters have different byte representations in different encodings, you must specify the byte representation of the delimiter in the *database encoding*.
+
+For example, if the database encoding is `UTF8`, the file encoding is `LATIN1`, and the delimiter is the `¤` currency symbol, you must specify the `UTF8` byte representation for `¤`, which is `\xC2\xA4`:
 
 ```
-CREATE READABLE EXTERNAL TABLE byterep_delim (id int, city text, state text)
-  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:text')
+CREATE READABLE EXTERNAL TABLE byterep_delim (id int, city text, country text)
+  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:csv')
 FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER=E'\xC2\xA4') ENCODING 'LATIN1';
 ```
 
-### <a id="about_quote"></a>Specifying the Quotation Character
+### <a id="about_qe"></a>About Specifying Quote and Escape Characters
 
-If you do not specify a quotation character for CSV data, PXF assumes that all columns are unquoted.
+When PXF reads data that contains a multi-byte or multi-character delimiter, its behavior depends on the quote and escape character settings:
 
-When you specify a quotation character, PXF expects that all columns are quoted, and you must also specify an escape character. PXF reads any content between quote characters as-is, except for escaped characters.
+| QUOTE Set? | ESCAPE Set? | PXF Behaviour |
+|-------------|--------------|----------|
+| No<sup>1</sup> | No | PXF reads the data as-is. |
+| Yes<sup>2</sup> | Yes (the default is the quote value). | PXF reads data between the quotes as-is except for escaped characters. |
+| Yes<sup>2</sup> | No (`ESCAPE 'OFF'`) | PXF reads the data between quote characters as-is. |
+| No<sup>1</sup> | Yes | PXF reads the data as-is and un-escapes only the delimiter, newline, and escape itself. |
+| Yes<sup>2</sup> | Yes | PXF reads the data between quote characters as-is and un-escapes only the quote and escape characters. |
 
-PXF expects that there are no extraneous characters between the quote value and the delimiter value, nor between the quote value and the end-of-line value. Additionally, there must be no white space between delimiters and quotes.
+<sup>1</sup> All data columns must be un-quoted when you do not specify a quote character.
 
-For example, given the following sample data that uses the default quote character (`"`) and the delimiter `¤`:
+<sup>2</sup> All data columns must quoted when you specify a quote character.
+
+> **Note** PXF expects that there are no extraneous characters between the quote value and the delimiter value, nor between the quote value and the end-of-line value. Additionally, there must be no white space between delimiters and quotes.
+
+### <a id="mbd_examples"></a>Examples
+
+#### <a id="qe_example"></a>Delimiter with Quoted Data
+Given the following sample data that uses the double-quote (`"`) quote character and the delimiter `¤`:
 
 ```
 "133"¤"Austin"¤"USA"
@@ -428,16 +469,14 @@ For example, given the following sample data that uses the default quote charact
 Create the external table as follows:
 
 ```
-CREATE READABLE EXTERNAL TABLE quoted_delim (id int, city text, state text)
-  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:csv')
+CREATE READABLE EXTERNAL TABLE mbyte_delim_quoted (id int, city text, country text)
+  LOCATION ('pxf://multibyte_q?PROFILE=hdfs:csv')
 FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤', QUOTE '"'); 
 ```
 
-### <a id="about_escape"></a>Specifying the Escape Character
+#### <a id="qe_example"></a>Delimiter with Quoted and Escaped Data
 
-When you specify both an escape character and a quotation character, PXF un-escapes only these characters.
-
-For example, given the following sample data that uses the default quote character (`"`), the escape character `\`, and the delimiter `¤`:
+Given the following sample data that uses the quote character `"`, the escape character `\`, and the delimiter `¤`:
 
 ```
 "\"hello, my name is jane\" she said. let's escape something \\"¤"123"
@@ -446,16 +485,14 @@ For example, given the following sample data that uses the default quote charact
 Create the external table as follows:
 
 ```
-CREATE READABLE EXTERNAL TABLE qe_delim (sentence text, num int)
-  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:csv')
-FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤', ESCAPE '\');
+CREATE READABLE EXTERNAL TABLE mybte_delim_quoted_escaped (sentence text, num int)
+  LOCATION ('pxf://multibyte_qe?PROFILE=hdfs:csv')
+FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤', QUOTE '"', ESCAPE '\');
 ```
 
-And with this external table definition, PXF reads the text field as:
+Given this external table definition, PXF reads the `sentence` text field as:
 
 ```
 "hello, my name is jane" she said. let's escape something \
 ```
-
-When you specify an escape character and do not specify a quote character, PXF assumes that all columns are unquoted and escapes only the delimiter, newline, and escape itself.
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -365,3 +365,97 @@ Perform the following procedure to create Greenplum Database writable external t
 
     To query data from the newly-created HDFS directory named `pxfwritable_hdfs_textsimple2`, you can create a readable external Greenplum Database table as described above that references this HDFS directory and specifies `FORMAT 'CSV' (delimiter=':')`.
 
+## <a id="multibyte_delim"></a>About Reading Data Containing Multi-Byte or Multi-Character Delimiters
+
+When data contains a multi-byte delimiter or multiple delimiter characters, you can use only a `*:text` or `*:csv` PXF profile to read the text. The syntax for creating a readable external table for such data follows:
+
+``` sql
+CREATE EXTERNAL TABLE <table_name>
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:text|csv[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>][&SKIP_HEADER_COUNT=<numlines>]')
+FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import' <option>[=|<space>][E]'<value>');
+```
+
+Note the `FORMAT` line in the syntax block. While the syntax is similar to that of reading plain text or CSV, PXF requires a custom formatter to read data containing a multi-byte or multi-character delimiter. You must specify the `'CUSTOM'` format and the `pxfdelimited_import` formatter. You must also specify a delimiter in the formatter options.
+
+PXF recognizes the following formatter options:
+
+| Option Name  | Description | Default Value |
+|-------|---------------|---------------|
+| DELIMITER | The single-byte or multi-byte delimiter string that separates columns. The string may be up to 32 bytes in length, and may not contain quote or escape characters. **Required** | None |
+| QUOTE | When reading CSV data with a `*:csv` profile, the single ASCII quotation character for all columns. | `"` (double quote) |
+| ESCAPE | The single ASCII character used to escape special characters (for example, the `DELIM`, `QUOTE`,  or `NEWLINE` value, or the `ESCAPE` value itself). | The `QUOTE` value. |
+| NEWLINE | The end-of-line indicator that designates the end of a row. Every line in the file must be terminated with the specified newline value. Valid values are `LF` (line feed, `0x0A`), `CRLF` (carriage return, `0x0D`), or `CR` (carriage return plus line feed, `0x0D` `0x0A`). | `LF` |
+
+The following sections provide further information about the delimiter, quote, and escape options.
+
+### <a id="about_delim"></a>Specifying the Delimiter
+
+You can directly specify the delimiter or provide its byte representation.
+
+When you directly specify the delimiter, PXF converts between the file encoding and the database encoding for you. The following example directly specifies the `¤` currency symbol for the delimiter:
+
+```
+CREATE READABLE EXTERNAL TABLE mbyte_delim (id int, city text, state text)
+  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:text')
+FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤'); 
+```
+
+Because some characters have different byte representations in different encodings, when you specify the byte representation for the delimiter, you must represent it in the database encoding. For example, if the database encoding is `UTF8`, the file encoding is `LATIN1`, and the delimiter is the `¤` currency symbol, you must specify the `UTF8` byte representation for `¤` (`\xC2\xA4`):
+
+```
+CREATE READABLE EXTERNAL TABLE byterep_delim (id int, city text, state text)
+  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:text')
+FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER=E'\xC2\xA4') ENCODING 'LATIN1';
+```
+
+### <a id="about_quote"></a>Specifying the Quotation Character
+
+If you do not specify a quotation character for CSV data, PXF assumes that all columns are unquoted.
+
+When you specify a quotation character, PXF expects that all columns are quoted, and you must also specify an escape character. PXF reads any content between quote characters as-is, except for escaped characters.
+
+PXF expects that there are no extraneous characters between the quote value and the delimiter value, nor between the quote value and the end-of-line value. Additionally, there must be no white space between delimiters and quotes.
+
+For example, given the following sample data that uses the default quote character (`"`) and the delimiter `¤`:
+
+```
+"133"¤"Austin"¤"USA"
+"321"¤"Boston"¤"USA"
+"987"¤"Paris"¤"France"
+```
+
+Create the external table as follows:
+
+```
+CREATE READABLE EXTERNAL TABLE quoted_delim (id int, city text, state text)
+  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:csv')
+FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤', QUOTE '"'); 
+```
+
+### <a id="about_escape"></a>Specifying the Escape Character
+
+When you specify both an escape character and a quotation character, PXF un-escapes only these characters.
+
+For example, given the following sample data that uses the default quote character (`"`), the escape character `\`, and the delimiter `¤`:
+
+```
+"\"hello, my name is jane\" she said. let's escape something \\"¤"123"
+```
+
+Create the external table as follows:
+
+```
+CREATE READABLE EXTERNAL TABLE qe_delim (sentence text, num int)
+  LOCATION ('pxf://multibyte_example?PROFILE=hdfs:csv')
+FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import', DELIMITER='¤', ESCAPE '\');
+```
+
+And with this external table definition, PXF reads the text field as:
+
+```
+"hello, my name is jane" she said. let's escape something \
+```
+
+When you specify an escape character and do not specify a quote character, PXF assumes that all columns are unquoted and escapes only the delimiter, newline, and escape itself.
+

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -367,7 +367,7 @@ Perform the following procedure to create Greenplum Database writable external t
 
 ## <a id="about_encoding"></a>About Setting the External Table Encoding
 
-When the external file encoding differs from the database encoding, you must set the external table `ENCODING` to match that of the data file. For example, if the database encoding is `UTF8`, the file encoding is `LATIN1`, and the delimiter is the `¤` currency symbol, create the external table as follows:
+When the external file encoding differs from the database encoding, you must set the external table `ENCODING` to match that of the data file. For example, if the database encoding is `UTF8` and the file encoding is `LATIN1`, create the external table as follows:
 
 ```
 CREATE EXTERNAL TABLE pxf_csv_latin1(location text, month text, num_orders int, total_sales float8)
@@ -382,7 +382,7 @@ You can use only a `*:csv` PXF profile to read data that contains a multi-byte d
 ``` sql
 CREATE EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:csv[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>][&SKIP_HEADER_COUNT=<numlines>]')
+LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:csv[&SERVER=<server_name>][&IGNORE_MISSING_PATH=<boolean>][&SKIP_HEADER_COUNT=<numlines>][&NEWLINE=<bytecode>]')
 FORMAT 'CUSTOM' (FORMATTER='pxfdelimited_import' <option>[=|<space>][E]'<value>');
 ```
 
@@ -395,7 +395,7 @@ PXF recognizes the following formatter options when reading data that contains a
 | DELIMITER=\<delim_string\> | The single-byte or multi-byte delimiter string that separates columns. The string may be up to 32 bytes in length, and may not contain quote or escape characters. **Required** | None |
 | QUOTE=\<char\> | The single one-byte ASCII quotation character for all columns. | None |
 | ESCAPE=\<char\> | The single one-byte ASCII character used to escape special characters (for example, the `DELIM`, `QUOTE`,  or `NEWLINE` value, or the `ESCAPE` value itself). | None, or the `QUOTE` value if that is set |
-| NEWLINE=\<bytecode\> | The end-of-line indicator that designates the end of a row. Every line in the file must be terminated with the specified newline value. Valid values are `LF` (line feed, `0x0A`), `CRLF` (carriage return, `0x0D`), or `CR` (carriage return plus line feed, `0x0D` `0x0A`). | `LF` |
+| NEWLINE=\<bytecode\> | The end-of-line indicator that designates the end of a row. Every line in the file must be terminated with the specified newline value. When you set the `NEWLINE` formatter option, you must also set `NEWLINE` in the `LOCATION` URI. Valid values are `LF` (line feed, `0x0A`), `CR` (carriage return, `0x0D`), or `CRLF` (carriage return plus line feed, `0x0D` `0x0A`). | `LF` |
 
 The following sections provide further information about, and examples for, specifying the delimiter, quote, and escape options.
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -439,10 +439,9 @@ When PXF reads data that contains a multi-byte or multi-character delimiter, its
 | QUOTE Set? | ESCAPE Set? | PXF Behaviour |
 |-------------|--------------|----------|
 | No<sup>1</sup> | No | PXF reads the data as-is. |
-| Yes<sup>2</sup> | Yes (the default is the quote value). | PXF reads data between the quotes as-is except for escaped characters. |
+| Yes<sup>2</sup> | Yes | PXF reads the data between quote characters as-is and un-escapes only the quote and escape characters. |
 | Yes<sup>2</sup> | No (`ESCAPE 'OFF'`) | PXF reads the data between quote characters as-is. |
 | No<sup>1</sup> | Yes | PXF reads the data as-is and un-escapes only the delimiter, newline, and escape itself. |
-| Yes<sup>2</sup> | Yes | PXF reads the data between quote characters as-is and un-escapes only the quote and escape characters. |
 
 <sup>1</sup> All data columns must be un-quoted when you do not specify a quote character.
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/956.

the `*:text` and `*:csv profiles` support now multi-byte and multiple character delimiters.  in this PR:
- add a topic "About Reading Data Containing Multi-Byte or Multi-Character Delimiters" to the hdfs page to describe the new feature.
- add a few example CREATE EXTERNAL TABLE calls, didn't create a step-by-step

notes:
- CREATE EXTERNAL TABLE supports DELIMITER/QUOTE/ESCAPE/NEWLINE.  this new formatter does as well, but it is based on the COPY framework.  COPY supports these as well.  i tried to call out what was different with this new formatter, not sure if i covered everything.
- it didn't seem to me that we needed any upgrade doc modifications, we already instruct the user to `ALTER EXTENSION pxf UPDATE` after they `pxf cluster register`.
- when the content is approved, i will add a parallel section or xref in the object store docs.

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/mbdelim/tanzu-greenplum-platform-extension-framework/GUID-hdfs_text.html#about-reading-data-containing-multibyte-or-multicharacter-delimiters-7