### PR TITLE
Add logging to the LineBreakAccessor for the write

### DIFF
--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -52,6 +52,7 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
     private FSDataOutputStream fsdos;
     private FileSystem fs;
     private Path file;
+    private int iterationCount;
 
     /**
      * Constructs a LineBreakAccessor.
@@ -132,19 +133,19 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
             InputStream inputStream = (InputStream) onerow.getData();
             final byte[] buffer = new byte[bufferSize];
 
-            // Log copy statistics every 32 MB
-            final int logIntervalBytes = 32 * 1024 * 1024;
-
             // The logic below is copied from IOUtils.copyLarge to add logging
             long count = 0;
             int n;
             while (-1 != (n = inputStream.read(buffer))) {
                 dos.write(buffer, 0, n);
                 count += n;
-                if (LOG.isDebugEnabled() && count % logIntervalBytes == 0) {
-                    // Log this message after every 32 MB
-                    LOG.debug("wrote {} additional bytes, total so far {} (buffer size {})", n, count, bufferSize);
+                if (LOG.isDebugEnabled() && iterationCount == 100) {
+                    // Log this message after every 100th Iteration
+                    LOG.debug("wrote {} bytes, total so far {} (buffer size {})", n, count, bufferSize);
+                    iterationCount = 0;
                 }
+
+                iterationCount++;
             }
 
             LOG.debug("Wrote {} bytes to outputStream using a buffer of size {}", count, bufferSize);

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -135,17 +135,16 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
             // The logic below is copied from IOUtils.copyLarge to add logging
             long count = 0;
             int n;
-            int iterationCount = 0;
+            long iterationCount = 0;
             long iterationByteCount = 0;
 
             while (-1 != (n = inputStream.read(buffer))) {
                 dos.write(buffer, 0, n);
                 count += n;
                 iterationByteCount += n;
-                if (LOG.isDebugEnabled() && iterationCount == 100) {
+                if (LOG.isDebugEnabled() && (iterationCount % 100 == 0)) {
                     // Log this message after every 100th Iteration
                     LOG.debug("wrote {} bytes, total so far {} (buffer size {})", iterationByteCount, count, bufferSize);
-                    iterationCount = 0;
                     iterationByteCount = 0;
                 }
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -53,6 +53,7 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
     private FileSystem fs;
     private Path file;
     private int iterationCount;
+    private long totalBytesCount;
 
     /**
      * Constructs a LineBreakAccessor.
@@ -141,10 +142,11 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
                 count += n;
                 if (LOG.isDebugEnabled() && iterationCount == 100) {
                     // Log this message after every 100th Iteration
-                    LOG.debug("wrote {} bytes, total so far {} (buffer size {})", n, count, bufferSize);
+                    LOG.debug("wrote {} bytes, total so far {} (buffer size {})", totalBytesCount, count, bufferSize);
                     iterationCount = 0;
+                    totalBytesCount = 0;
                 }
-
+                totalBytesCount +=n;
                 iterationCount++;
             }
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -133,18 +133,18 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
             final byte[] buffer = new byte[bufferSize];
 
             // The logic below is copied from IOUtils.copyLarge to add logging
-            long count = 0;
+            long totalByteCount = 0;
             int n;
             long iterationCount = 0;
             long iterationByteCount = 0;
 
             while (-1 != (n = inputStream.read(buffer))) {
                 dos.write(buffer, 0, n);
-                count += n;
+                totalByteCount += n;
                 iterationByteCount += n;
                 if (LOG.isDebugEnabled() && (iterationCount % 100 == 0)) {
                     // Log this message after every 100th Iteration
-                    LOG.debug("wrote {} bytes, total so far {} (buffer size {})", iterationByteCount, count, bufferSize);
+                    LOG.debug("wrote {} bytes, total so far {} (buffer size {})", iterationByteCount, totalByteCount, bufferSize);
                     iterationByteCount = 0;
                 }
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -132,9 +132,8 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
             InputStream inputStream = (InputStream) onerow.getData();
             final byte[] buffer = new byte[bufferSize];
 
-            // We want to log it about every 5 secs.
-            // We have seen the upload speed of 8MB/sec, so it is like 1000 buffers per sec or 5000 buffers per 5 sec
-            final int frequency = 5000 * bufferSize;
+            // Log copy statistics every 32 MB
+            final int logIntervalBytes = 32 * 1024 * 1024;
 
             // The logic below is copied from IOUtils.copyLarge to add logging
             long count = 0;
@@ -142,8 +141,8 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
             while (-1 != (n = inputStream.read(buffer))) {
                 dos.write(buffer, 0, n);
                 count += n;
-                if (LOG.isDebugEnabled() && n % frequency == 0) {
-                    // Log this message after every frequency*8K (default) bytes
+                if (LOG.isDebugEnabled() && count % logIntervalBytes == 0) {
+                    // Log this message after every 32 MB
                     LOG.debug("wrote {} additional bytes, total so far {} (buffer size {})", n, count, bufferSize);
                 }
             }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -151,8 +151,8 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
                 iterationCount++;
             }
 
-            LOG.debug("Wrote {} bytes to outputStream using a buffer of size {}", count, bufferSize);
-            return count > 0;
+            LOG.debug("Wrote {} bytes to outputStream using a buffer of size {}", iterationCount, bufferSize);
+            return iterationCount > 0;
         } else {
             dos.write((byte[]) onerow.getData());
         }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -151,8 +151,8 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
                 iterationCount++;
             }
 
-            LOG.debug("Wrote {} bytes to outputStream using a buffer of size {}", iterationCount, bufferSize);
-            return iterationCount > 0;
+            LOG.debug("Wrote {} bytes to outputStream using a buffer of size {}", totalByteCount, bufferSize);
+            return totalByteCount > 0;
         } else {
             dos.write((byte[]) onerow.getData());
         }

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -52,8 +52,6 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
     private FSDataOutputStream fsdos;
     private FileSystem fs;
     private Path file;
-    private int iterationCount;
-    private long totalBytesCount;
 
     /**
      * Constructs a LineBreakAccessor.
@@ -137,16 +135,20 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
             // The logic below is copied from IOUtils.copyLarge to add logging
             long count = 0;
             int n;
+            int iterationCount = 0;
+            long iterationByteCount = 0;
+
             while (-1 != (n = inputStream.read(buffer))) {
                 dos.write(buffer, 0, n);
                 count += n;
+                iterationByteCount += n;
                 if (LOG.isDebugEnabled() && iterationCount == 100) {
                     // Log this message after every 100th Iteration
-                    LOG.debug("wrote {} bytes, total so far {} (buffer size {})", totalBytesCount, count, bufferSize);
+                    LOG.debug("wrote {} bytes, total so far {} (buffer size {})", iterationByteCount, count, bufferSize);
                     iterationCount = 0;
-                    totalBytesCount = 0;
+                    iterationByteCount = 0;
                 }
-                totalBytesCount +=n;
+
                 iterationCount++;
             }
 

--- a/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
+++ b/server/pxf-hdfs/src/main/java/org/greenplum/pxf/plugins/hdfs/LineBreakAccessor.java
@@ -131,6 +131,9 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
 
             InputStream inputStream = (InputStream) onerow.getData();
             final byte[] buffer = new byte[bufferSize];
+
+            // We want to log it about every 5 secs.
+            // We have seen the upload speed of 8MB/sec, so it is like 1000 buffers per sec or 5000 buffers per 5 sec
             final int frequency = 5000 * bufferSize;
 
             // The logic below is copied from IOUtils.copyLarge to add logging
@@ -139,9 +142,9 @@ public class LineBreakAccessor extends HdfsSplittableDataAccessor {
             while (-1 != (n = inputStream.read(buffer))) {
                 dos.write(buffer, 0, n);
                 count += n;
-                if (LOG.isTraceEnabled() && n % frequency == 0) {
+                if (LOG.isDebugEnabled() && n % frequency == 0) {
                     // Log this message after every frequency*8K (default) bytes
-                    LOG.trace("wrote {} additional bytes, total so far {} (buffer size {})", n, count, bufferSize);
+                    LOG.debug("wrote {} additional bytes, total so far {} (buffer size {})", n, count, bufferSize);
                 }
             }
 


### PR DESCRIPTION
Add Log.trace logging to the LineBreakAccessor for the write. 
This will help in investigation in case we need to investigate any issues. 