### PR TITLE
docs - rework the host/port topic, add section for listen address

### DIFF
--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -93,7 +93,7 @@ Perform the following procedure to configure the port number of the PXF server o
 
 If you have chosen the [alternate deployment topology](deployment_topos.html#alt_topo) for PXF, you must set the `PXF_HOST` environment variable on each Greenplum segment host to inform Greenplum of the location of the PXF service.
 
-Perform the following procedure to configure the PXF host on each Greenplum Database segmet host:
+Perform the following procedure to configure the PXF host on each Greenplum Database segment host:
 
 <div class="note"><b>Note:</b> You must restart Greenplum Database when you configure the host in this manner. Consider performing this configuration during a scheduled down time.</div>
 

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -117,6 +117,12 @@ Perform the following procedure to configure the PXF server host on one or more 
         ```
     4. Save the file and exit the editor.
 
+1. Source the `.bashrc` that file you just updated:
+
+    ``` shell
+    gpadmin@gpmaster$ source ~/.bashrc
+    ```
+
 3. Restart Greenplum Database as described in [Restarting Greenplum Database](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-managing-startstop.html#restarting-greenplum-database) in the Greenplum Documentation.
 
 5. Verify that PXF is running on the reconfigured host by invoking `http://<PXF_HOST>:<PXF_PORT>/actuator/health` to view PXF monitoring information as described in [About PXF Service Runtime Monitoring](monitor_pxf.html#about_rtm).

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -2,12 +2,12 @@
 title: Service Listen Address, Host, and Port
 ---
 
-By default, the PXF Service starts on a Greenplum host and listens on `0.0.0.0:5888`. With this configuration, the PXF Service listens on all network interfaces of the Greenplum host and accepts network requests from anywhere. You can configure PXF to listen on a different local address. You can also configure PXF to listen on a different port number, or to run on a different host. To change the default configuration, you set one or more of the properties identified below:
+In the default deployment topology, the PXF Service starts on a Greenplum host and listens on `0.0.0.0:5888`. With this configuration, the PXF Service listens on all network interfaces of the Greenplum host and accepts network requests from anywhere. You can configure PXF to listen on a different local address. You can also configure PXF to listen on a different port number, or to run on a different host. To change the default configuration, you set one or more of the properties identified below:
 
 |   Property |  Type | Description      | Default |
 |-------------------------|-------------------|-----|
 |   server.address  | `pxf-application.properties` property | The PXF server listen address. | `0.0.0.0`  |
-|   PXF_HOST  | Environment variable | The host name or IP address on which the PXF server is running. | `localhost`  |
+|   PXF_HOST  | Environment variable | The name or IP address of the (non-Greenpum) host on which the PXF Service is running. | `localhost`  |
 |   PXF_PORT  | Environment variable | The port number on which the PXF server listens for requests on the host. | `5888`  |
 
 
@@ -91,9 +91,11 @@ Perform the following procedure to configure the port number of the PXF server o
 
 ## <a id="host"></a>Configuring the Host
 
-<div class="note"><b>Note:</b> You must restart Greenplum Database when you configure the host in this manner. Consider performing this configuration during a scheduled down time.</div>
+If you have chosen the [alternate deployment topology](deployment_topos.html#alt_topo) for PXF, you must set the `PXF_HOST` environment variable on each Greenplum segment host to inform Greenplum of the location of the PXF service.
 
-Perform the following procedure to configure the PXF server host on one or more Greenplum Database hosts:
+Perform the following procedure to configure the PXF host on each Greenplum Database segmet host:
+
+<div class="note"><b>Note:</b> You must restart Greenplum Database when you configure the host in this manner. Consider performing this configuration during a scheduled down time.</div>
 
 1. Log in to your Greenplum Database master host:
 
@@ -101,10 +103,10 @@ Perform the following procedure to configure the PXF server host on one or more 
     $ ssh gpadmin@<gpmaster>
     ```
 
-2. For each Greenplum Database host:
+2. For each Greenplum Database segment host:
 
     1. Identify the host name or IP address of a PXF Server.
-    3. Log in to the Greenplum Database host:
+    3. Log in to the Greenplum Database segment host:
 
         ``` shell
         $ ssh gpadmin@<seghost>

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -2,7 +2,7 @@
 title: Service Listen Address, Host, and Port
 ---
 
-By default, the PXF Service starts on a Greenplum host and listens on `0.0.0.0:5888`. You can configure PXF to listen on a different local address. You can also configure PXF to listen on a different port number, or to run on a different host. To change the default configuration, you set one or more of the properties identified below:
+By default, the PXF Service starts on a Greenplum host and listens on `0.0.0.0:5888`. With this configuration, the PXF Service listens on all network interfaces of the Greenplum host and accepts network requests from anywhere. You can configure PXF to listen on a different local address. You can also configure PXF to listen on a different port number, or to run on a different host. To change the default configuration, you set one or more of the properties identified below:
 
 |   Property |  Type | Description      | Default |
 |-------------------------|-------------------|-----|
@@ -15,7 +15,7 @@ By default, the PXF Service starts on a Greenplum host and listens on `0.0.0.0:5
 
 The `server.address` property identifies the IP address or hostname of the network interface on which the PXF service listens. The default PXF service listen address is `0.0.0.0`.
 
-To secure communications and restrict PXF to listen only on the loopback interface, set the `server.address` to `localhost`:
+When the PXF Service runs on Greenplum Database hosts, to secure communications and restrict PXF to listen only on the loopback interface set the `server.address` to `localhost`:
 
 1. Log in to your Greenplum Database master host:
 
@@ -72,6 +72,12 @@ Perform the following procedure to configure the port number of the PXF server o
         ```
     1. Save the file and exit the editor.
 
+1. Source the `.bashrc` that file you just updated:
+
+    ``` shell
+    gpadmin@gpmaster$ source ~/.bashrc
+    ```
+
 3. Restart Greenplum Database as described in [Restarting Greenplum Database](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-managing-startstop.html#restarting-greenplum-database) in the Greenplum Documentation.
 
 4. Restart PXF on each Greenplum Database host:
@@ -85,7 +91,7 @@ Perform the following procedure to configure the port number of the PXF server o
 
 ## <a id="host"></a>Configuring the Host
 
-<div class="note"><b>Note:</b> You must restart both Greenplum Database and PXF when you configure the host in this manner. Consider performing this configuration during a scheduled down time.</div>
+<div class="note"><b>Note:</b> You must restart Greenplum Database when you configure the host in this manner. Consider performing this configuration during a scheduled down time.</div>
 
 Perform the following procedure to configure the PXF server host on one or more Greenplum Database hosts:
 
@@ -112,12 +118,6 @@ Perform the following procedure to configure the PXF server host on one or more 
     4. Save the file and exit the editor.
 
 3. Restart Greenplum Database as described in [Restarting Greenplum Database](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-managing-startstop.html#restarting-greenplum-database) in the Greenplum Documentation.
-
-4. Restart PXF:
-
-    ``` shell
-    gpadmin@gpmaster$ pxf cluster restart
-    ```
 
 5. Verify that PXF is running on the reconfigured host and/or port by invoking `http://<PXF_HOST>:<PXF_PORT>/actuator/health` to view PXF monitoring information as described in [About PXF Service Runtime Monitoring](monitor_pxf.html#about_rtm).
 

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -15,7 +15,7 @@ By default, the PXF Service starts on a Greenplum host and listens on `0.0.0.0:5
 
 The `server.address` property identifies the IP address or hostname of the network interface on which the PXF service listens. The default PXF service listen address is `0.0.0.0`.
 
-When the PXF Service runs on Greenplum Database hosts, to secure communications and restrict PXF to listen only on the loopback interface set the `server.address` to `localhost`:
+When the PXF Service runs on Greenplum Database hosts, to secure communications and restrict PXF to listen only on the loopback interface, set the `server.address` to `localhost`:
 
 1. Log in to your Greenplum Database master host:
 

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -1,21 +1,54 @@
 ---
-title: Service Host and Port
+title: Service Listen Address, Host, and Port
 ---
 
-By default, a PXF Service started on a Greenplum host listens on port number `5888` on `localhost`. You can configure PXF to start on a different port number, or use a different hostname or IP address. To change the default configuration, you will set one or both of the environment variables identified below:
+By default, the PXF Service starts on a Greenplum host and listens on `0.0.0.0:5888`. You can configure PXF to listen on a different local address. You can also configure PXF to listen on a different port number, or to run on a different host. To change the default configuration, you set one or more of the properties identified below:
 
-|   Environment Variable  |  Description      |
-|-------------------------|-------------------|
-|   PXF_HOST  | The name of the host or IP address. The default host name is `localhost`.  |
-|   PXF_PORT  | The port number on which the PXF Service listens for requests on the host. The default port number is `5888`.  |
+|   Property |  Type | Description      | Default |
+|-------------------------|-------------------|-----|
+|   server.address  | `pxf-application.properties` property | The PXF server listen address. | `0.0.0.0`  |
+|   PXF_HOST  | Environment variable | The host name or IP address on which the PXF server is running. | `localhost`  |
+|   PXF_PORT  | Environment variable | The port number on which the PXF server listens for requests on the host. | `5888`  |
 
-Set the environment variables in the `gpadmin` user's `.bashrc` shell login file on each Greenplum host.
 
-<div class="note"><b>Note:</b> You must restart both Greenplum Database and PXF when you configure the service host and/or port in this manner. Consider performing this configuration during a scheduled down time.</div>
+## <a id="listen_address"></a>Configuring the Listen Address
 
-## <a id="proc"></a>Procedure
+The `server.address` property identifies the IP address or hostname of the network interface on which the PXF service listens. The default PXF service listen address is `0.0.0.0`.
 
-Perform the following procedure to configure the PXF Service host and/or port number on one or more Greenplum Database hosts:
+To secure communications and restrict PXF to listen only on the loopback interface, set the `server.address` to `localhost`:
+
+1. Log in to your Greenplum Database master host:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    ```
+
+1. Locate the `pxf-application.properties` file in your PXF installation. If you did not relocate `$PXF_BASE`, the file resides here:
+
+    ``` pre
+    /usr/local/pxf-gp6/conf/pxf-application.properties
+    ```
+
+1. Open the file in the editor of your choice, and add the following line:
+
+    ``` pre
+    server.address=localhost
+    ```
+
+1. Save the file and exit the editor.
+
+1. Synchronize the PXF configuration and then restart PXF:
+
+    ``` shell
+    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@gpmaster$ pxf cluster restart
+    ```
+
+## <a id="port"></a>Configuring the Port Number
+
+<div class="note"><b>Note:</b> You must restart both Greenplum Database and PXF when you configure the service port number in this manner. Consider performing this configuration during a scheduled down time.</div>
+
+Perform the following procedure to configure the port number of the PXF server on one or more Greenplum Database hosts:
 
 1. Log in to your Greenplum Database master host:
 
@@ -25,24 +58,66 @@ Perform the following procedure to configure the PXF Service host and/or port nu
 
 2. For each Greenplum Database host:
 
-    1. Identify the host name or IP address of the PXF Service.
-    2. Identify the port number on which you want the PXF Service to run.
+    1. Identify the port number on which you want the PXF Service to listen.
+    1. Log in to the Greenplum Database host:
+
+        ``` shell
+        $ ssh gpadmin@<seghost>
+        ```
+    1. Open the `~/.bashrc` file in the editor of your choice.
+    1. Set the `PXF_PORT` environment variable. For example, to set the PXF Service port number to 5998, add the following to the `.bashrc` file:
+
+        ``` shell
+        export PXF_PORT=5998
+        ```
+    1. Save the file and exit the editor.
+
+3. Restart Greenplum Database as described in [Restarting Greenplum Database](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-managing-startstop.html#restarting-greenplum-database) in the Greenplum Documentation.
+
+4. Restart PXF on each Greenplum Database host:
+
+    ``` shell
+    gpadmin@gpmaster$ pxf cluster restart
+    ```
+
+5. Verify that PXF is running on the reconfigured port by invoking `http://<PXF_HOST>:<PXF_PORT>/actuator/health` to view PXF monitoring information as described in [About PXF Service Runtime Monitoring](monitor_pxf.html#about_rtm).
+
+
+## <a id="host"></a>Configuring the Host
+
+<div class="note"><b>Note:</b> You must restart both Greenplum Database and PXF when you configure the host in this manner. Consider performing this configuration during a scheduled down time.</div>
+
+Perform the following procedure to configure the PXF server host on one or more Greenplum Database hosts:
+
+1. Log in to your Greenplum Database master host:
+
+    ``` shell
+    $ ssh gpadmin@<gpmaster>
+    ```
+
+2. For each Greenplum Database host:
+
+    1. Identify the host name or IP address of a PXF Server.
     3. Log in to the Greenplum Database host:
 
         ``` shell
         $ ssh gpadmin@<seghost>
         ```
     4. Open the `~/.bashrc` file in the editor of your choice.
-    5. Set the `PXF_HOST` and/or `PXF_PORT` environment variables. For example, to set the PXF Service port number to 5998, add the following to the `.bashrc` file:
+    5. Set the `PXF_HOST` environment variable. For example, to set the PXF host to `pxfalthost1`, add the following to the `.bashrc` file:
 
         ``` shell
-        export PXF_PORT=5998
+        export PXF_HOST=pxfalthost1
         ```
     4. Save the file and exit the editor.
 
 3. Restart Greenplum Database as described in [Restarting Greenplum Database](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-managing-startstop.html#restarting-greenplum-database) in the Greenplum Documentation.
 
-4. Restart PXF on each Greenplum Database host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).
+4. Restart PXF:
+
+    ``` shell
+    gpadmin@gpmaster$ pxf cluster restart
+    ```
 
 5. Verify that PXF is running on the reconfigured host and/or port by invoking `http://<PXF_HOST>:<PXF_PORT>/actuator/health` to view PXF monitoring information as described in [About PXF Service Runtime Monitoring](monitor_pxf.html#about_rtm).
 

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -119,5 +119,5 @@ Perform the following procedure to configure the PXF server host on one or more 
 
 3. Restart Greenplum Database as described in [Restarting Greenplum Database](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-managing-startstop.html#restarting-greenplum-database) in the Greenplum Documentation.
 
-5. Verify that PXF is running on the reconfigured host and/or port by invoking `http://<PXF_HOST>:<PXF_PORT>/actuator/health` to view PXF monitoring information as described in [About PXF Service Runtime Monitoring](monitor_pxf.html#about_rtm).
+5. Verify that PXF is running on the reconfigured host by invoking `http://<PXF_HOST>:<PXF_PORT>/actuator/health` to view PXF monitoring information as described in [About PXF Service Runtime Monitoring](monitor_pxf.html#about_rtm).
 

--- a/docs/content/deployment_topos.html.md.erb
+++ b/docs/content/deployment_topos.html.md.erb
@@ -1,0 +1,17 @@
+---
+title: About the PXF Deployment Topology
+---
+
+The default PXF deployment topology is co-located; you install PXF on each Greenplum host, and the PXF Service starts and runs on each Greenplum segment host.
+
+You manage the PXF services deployed in a co-located topology using the [pxf cluster](ref/pxf-cluster.html) commands.
+
+
+## <a id="alt_topo"></a>Alternate Deployment Topology
+
+Running the PXF Service on non-Greenplum hosts is an alternate deployment topology. If you choose this topology, you must install PXF on both the non-Greenplum hosts and on all Greenplum hosts.
+
+In the alternate deployment topology, you manage the PXF services individually using the [pxf](ref/pxf.html) command on each host; you can not use the `pxf cluster` commands to collectively manage the PXF services in this topology.
+
+If you choose the alternate deployment topology, you must explicitly configure each Greenplum host to identify a host on which the PXF Service is running. This procedure is described in [Configuring the Host](cfghostport.html#host).
+


### PR DESCRIPTION
add some hardening info based on https://github.com/greenplum-db/pxf/issues/974 to the existing pxf docs.  note that this info will be further updated in a separate PR to address the introduction of server.address to pxf-application.properties in https://github.com/greenplum-db/pxf/pull/976.

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/tmpbranch/tanzu-greenplum-platform-extension-framework/GUID-cfghostport.html