### PR TITLE
Update cloudbuild maven version

### DIFF
--- a/concourse/docker/pxf-dev-base/README.md
+++ b/concourse/docker/pxf-dev-base/README.md
@@ -45,6 +45,7 @@ command to build the image:
     pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb5-centos7-build-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
       --tag=gpdb5-centos7-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb5/centos7/Dockerfile \
       .

--- a/concourse/docker/pxf-dev-base/README.md
+++ b/concourse/docker/pxf-dev-base/README.md
@@ -29,7 +29,8 @@ directory. The `cloudbuild.yaml` file produces the following docker images:
 
 You can build these images individually by first setting these local variables:
 ```
-export GO_VERSION=1.19
+export GO_VERSION=1.19.6
+export MAVEN_VERSION=3.9.2
 ```
 ## Greenplum 5 Images
 
@@ -60,6 +61,7 @@ command to build the image:
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-centos7-test:latest \
       --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=MAVEN_VERSION=${MAVEN_VERSION} \
       --tag=gpdb6-centos7-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile \
       .
@@ -73,6 +75,8 @@ command to build the image:
     pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-rocky8-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=MAVEN_VERSION=${MAVEN_VERSION} \
       --tag=gpdb6-rocky8-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb6/rocky8/Dockerfile \
       .
@@ -87,6 +91,7 @@ command to build the image:
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-ubuntu18.04-test:latest \
       --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=MAVEN_VERSION=${MAVEN_VERSION} \
       --tag=gpdb6-ubuntu18.04-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile \
       .
@@ -101,6 +106,7 @@ following command to build the image:
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-oel7-test:latest \
       --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=MAVEN_VERSION=${MAVEN_VERSION} \
       --tag=gpdb6-oel7-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile \
       .
@@ -116,6 +122,8 @@ command to build the image:
     pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
     docker build \
       --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb7-rocky8-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=MAVEN_VERSION=${MAVEN_VERSION} \
       --tag=gpdb7-rocky8-test-pxf \
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb7/rocky8/Dockerfile \
       .

--- a/concourse/docker/pxf-dev-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-dev-base/cloudbuild.yaml
@@ -182,7 +182,7 @@ steps:
 
 substitutions:
   _GO_VERSION: '1.19.6' # default values
-  _MAVEN_VERSION: '3.9.2' #default values
+  _MAVEN_VERSION: '3.9.2' # default values
 
 # Push images to Cloud Build to Container Registry
 images:

--- a/concourse/docker/pxf-dev-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-dev-base/cloudbuild.yaml
@@ -60,6 +60,7 @@ steps:
   - 'build'
   - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-centos7-test:latest'
   - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=MAVEN_VERSION=${_MAVEN_VERSION}'
   - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-test-pxf:$COMMIT_SHA'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-test-pxf:latest'
@@ -85,6 +86,7 @@ steps:
   - 'build'
   - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-rocky8-test:latest'
   - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=MAVEN_VERSION=${_MAVEN_VERSION}'
   - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-rocky8-test-pxf:$COMMIT_SHA'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-rocky8-test-pxf:latest'
@@ -110,6 +112,7 @@ steps:
   - 'build'
   - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-ubuntu18.04-test:latest'
   - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=MAVEN_VERSION=${_MAVEN_VERSION}'
   - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-ubuntu18.04-test-pxf:$COMMIT_SHA'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-ubuntu18.04-test-pxf:latest'
@@ -136,6 +139,7 @@ steps:
   - 'build'
   - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-oel7-test:latest'
   - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=MAVEN_VERSION=${_MAVEN_VERSION}'
   - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-oel7-test-pxf:$COMMIT_SHA'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-oel7-test-pxf:latest'
@@ -166,6 +170,7 @@ steps:
     - 'build'
     - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb7-rocky8-test:latest'
     - '--build-arg=GO_VERSION=${_GO_VERSION}'
+    - '--build-arg=MAVEN_VERSION=${_MAVEN_VERSION}'
     - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:$COMMIT_SHA'
     - '--cache-from'
     - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:latest'
@@ -177,6 +182,7 @@ steps:
 
 substitutions:
   _GO_VERSION: '1.19.6' # default values
+  _MAVEN_VERSION: '3.9.2' #default values
 
 # Push images to Cloud Build to Container Registry
 images:

--- a/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile
@@ -24,7 +24,7 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
     && chmod +x /opt/minio/bin/minio \
     && chown -R minio:minio /opt/minio
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION
 ARG USER_HOME_DIR="/root"
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 

--- a/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
     && wget -O go.tgz -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
     && rm -rf /usr/local/go && tar -C /usr/local -xzf go.tgz && rm go.tgz
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION
 ARG USER_HOME_DIR="/root"
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 

--- a/concourse/docker/pxf-dev-base/gpdb6/rocky8/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/rocky8/Dockerfile
@@ -24,7 +24,7 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
     && chmod +x /opt/minio/bin/minio \
     && chown -R minio:minio /opt/minio
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION
 ARG USER_HOME_DIR="/root"
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 

--- a/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
 # install dependencies that are missing on the base images
 # install a specific version of perl for tinc
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION
 ARG USER_HOME_DIR="/root"
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 

--- a/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/centos7/Dockerfile
@@ -18,7 +18,7 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
     && chmod +x /opt/minio/bin/minio \
     && chown -R minio:minio /opt/minio
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION
 ARG USER_HOME_DIR="/root"
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 

--- a/concourse/docker/pxf-dev-base/gpdb7/rhel8/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/rhel8/Dockerfile
@@ -18,7 +18,7 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
     && chmod +x /opt/minio/bin/minio \
     && chown -R minio:minio /opt/minio
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION
 ARG USER_HOME_DIR="/root"
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 

--- a/concourse/docker/pxf-dev-base/gpdb7/rocky8/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/rocky8/Dockerfile
@@ -18,7 +18,7 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
     && chmod +x /opt/minio/bin/minio \
     && chown -R minio:minio /opt/minio
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION
 ARG USER_HOME_DIR="/root"
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 

--- a/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/ubuntu18.04/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
 # install dependencies that are missing on the base images
 # install a specific version of perl for tinc
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION
 ARG USER_HOME_DIR="/root"
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 


### PR DESCRIPTION
Currently we are using maven 3.6.3 in our docker images, but it's no longer available. In this PR we upgrade the maven version to 3.9.2.