### PR TITLE
Few more tests updated to worked with FDW

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/gpdb/Gpdb.java
@@ -252,7 +252,7 @@ public class Gpdb extends DbSystemObject {
 		List<String> servers = Lists.newArrayList(
 		"default_hdfs",
 		"default_hive",
-		"db_hive_jdbc", // Needed for JdbcHiveTest
+		"db-hive_jdbc", // Needed for JdbcHiveTest
 		"default_hbase",
 		"default_jdbc", // Needed for JdbcHiveTest and other JdbcTest which refers to the default server.
 		"database_jdbc",

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -229,6 +229,27 @@ public abstract class TableFactory {
     }
 
     /**
+     * Prepares PXF Readable External or Foreign Table for TEXT data, using TEXT format and "<protocol>:text" profile.
+     *
+     * @param name name of the table
+     * @param fields fields of the table
+     * @param path for external table path
+     * @param format format used in the external data
+     * @return PXF Readable External or Foreign table
+     */
+    public static ReadableExternalTable getPxfReadableJsonTable(String name,
+                                                                String[] fields,
+                                                                String path,
+                                                                String format) {
+        ReadableExternalTable exTable = getReadableExternalOrForeignTable(name, fields, path, format);
+        if (StringUtils.equals(format, "custom")) {
+            exTable.setFormatter("pxfwritable_import");
+        }
+        exTable.setProfile(ProtocolUtils.getProtocol().value() + ":json");
+        return exTable;
+    }
+
+    /**
      * Prepares PXF Readable External or Foreign Table for CSV data, using CSV format and "<protocol>:csv" profile.
      *
      * @param name name of the table

--- a/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/structures/tables/utils/TableFactory.java
@@ -229,7 +229,7 @@ public abstract class TableFactory {
     }
 
     /**
-     * Prepares PXF Readable External or Foreign Table for TEXT data, using TEXT format and "<protocol>:text" profile.
+     * Prepares PXF Readable External or Foreign Table for Json data, using custom format or CSV format and "<protocol>:json" profile.
      *
      * @param name name of the table
      * @param fields fields of the table

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcHiveTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/jdbc/JdbcHiveTest.java
@@ -1,5 +1,7 @@
 package org.greenplum.pxf.automation.features.jdbc;
 
+import annotations.FailsWithFDW;
+import annotations.WorksWithFDW;
 import jsystem.framework.sut.SutFactory;
 import jsystem.framework.system.SystemManagerImpl;
 import jsystem.framework.system.SystemObject;
@@ -15,6 +17,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
+@WorksWithFDW
 public class JdbcHiveTest extends BaseFeature {
 
     private static final String HIVE_JDBC_DRIVER_CLASS = "org.apache.hive.jdbc.HiveDriver";
@@ -241,6 +244,8 @@ public class JdbcHiveTest extends BaseFeature {
         runTincTest("pxf.features.jdbc.hive.runTest");
     }
 
+    // Fails with the error: ERROR:  PXF server error : java.io.DataInputStream cannot be cast to [B
+    @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security"})
     public void jdbcHiveWrite() throws Exception {
         prepareDataForWriteTest();
@@ -266,6 +271,7 @@ public class JdbcHiveTest extends BaseFeature {
         runTincTest("pxf.features.jdbc.two_secured_hive.runTest");
     }
 
+    @FailsWithFDW
     @Test(groups = {"features", "multiClusterSecurity"})
     public void jdbcHiveWriteToTwoSecuredServers() throws Exception {
         prepareDataForWriteTest();
@@ -295,6 +301,7 @@ public class JdbcHiveTest extends BaseFeature {
         runTincTest("pxf.features.jdbc.secured_and_non_secured_hive.runTest");
     }
 
+    @FailsWithFDW
     @Test(groups = {"features", "multiClusterSecurity"})
     public void jdbcHiveWriteToSecureServerAndNonSecuredServer() throws Exception {
         if (hdfsNonSecure == null) return;

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/json/JsonReadTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/json/JsonReadTest.java
@@ -1,8 +1,11 @@
 package org.greenplum.pxf.automation.features.json;
 
+import annotations.FailsWithFDW;
+import annotations.WorksWithFDW;
 import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.automation.features.BaseFeature;
 import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;
+import org.greenplum.pxf.automation.structures.tables.utils.TableFactory;
 import org.greenplum.pxf.automation.utils.system.ProtocolEnum;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 import org.testng.annotations.Test;
@@ -10,6 +13,7 @@ import org.testng.annotations.Test;
 /**
  * Tests for Json plugin to read HDFS files in JSON format.
  */
+@WorksWithFDW
 public class JsonReadTest extends BaseFeature {
 
     private String hdfsPath;
@@ -249,6 +253,16 @@ public class JsonReadTest extends BaseFeature {
      *
      * @throws Exception if test fails to run
      */
+    // Some of these tests failing because the returned error has extra quotes "
+    // For e.g.:
+    // ""[truncated 73 chars]; line: 3, column: 22]'. invalid JSON record
+    //  Instead of
+    // "[truncated 73 chars]; line: 3, column: 22]'. invalid JSON record
+    // This is getting appended in toCsvField method of GreenplumCSV.java
+    // And is happening only for the error cases. Adding escape "\" doesn't help here as well.
+
+    // TODO: May be create a separate test suite for all these failing tests
+    @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security", "hcfs"})
     public void malformedRecord() throws Exception {
         prepareExternalTable("jsontest_malformed_record", TWEETS_FIELDS, hdfsPath + FILENAME_BROKEN + SUFFIX_JSON, "custom");
@@ -271,6 +285,7 @@ public class JsonReadTest extends BaseFeature {
      *
      * @throws Exception if test fails to run
      */
+    @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security"})
     public void malformedRecordWithCsvWireFormat() throws Exception {
         prepareExternalTable("jsontest_malformed_record", TWEETS_FIELDS, hdfsPath + FILENAME_BROKEN + SUFFIX_JSON, "CSV");
@@ -292,6 +307,7 @@ public class JsonReadTest extends BaseFeature {
      *
      * @throws Exception if test fails to run
      */
+    @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security", "hcfs"})
     public void malformedRecordWithRejectLimit() throws Exception {
         prepareExternalTable("jsontest_malformed_record_with_reject_limit", TWEETS_FIELDS, hdfsPath + FILENAME_BROKEN + SUFFIX_JSON, "custom");
@@ -317,6 +333,7 @@ public class JsonReadTest extends BaseFeature {
      *
      * @throws Exception if test fails to run
      */
+    @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security", "hcfs"})
     public void malformedRecordWithRejectLimitWithCsvWireFormat() throws Exception {
         prepareExternalTable("jsontest_malformed_record_with_reject_limit", TWEETS_FIELDS, hdfsPath + FILENAME_BROKEN + SUFFIX_JSON, "CSV");
@@ -344,6 +361,7 @@ public class JsonReadTest extends BaseFeature {
      *
      * @throws Exception if test fails to run
      */
+    @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security", "hcfs"})
     public void mismatchedTypes() throws Exception {
         prepareExternalTable("jsontest_mismatched_types", SUPPORTED_PRIMITIVE_FIELDS, hdfsPath + FILENAME_MISMATCHED_TYPES + SUFFIX_JSON, "custom");
@@ -361,6 +379,7 @@ public class JsonReadTest extends BaseFeature {
      *
      * @throws Exception if test fails to run
      */
+    @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security", "hcfs"})
     public void mismatchedTypesWithRejectLimit() throws Exception {
         prepareExternalTable("jsontest_mismatched_types_with_reject_limit", SUPPORTED_PRIMITIVE_FIELDS, hdfsPath + FILENAME_MISMATCHED_TYPES + SUFFIX_JSON, "custom");
@@ -397,7 +416,7 @@ public class JsonReadTest extends BaseFeature {
 
     private void prepareExternalTable(String name, String[] fields, String path, String format) {
         ProtocolEnum protocol = ProtocolUtils.getProtocol();
-        exTable = new ReadableExternalTable(name, fields,
+        exTable = TableFactory.getPxfReadableJsonTable(name, fields,
                 protocol.getExternalTablePath(hdfs.getBasePath(), path), format);
         exTable.setHost(pxfHost);
         exTable.setPort(pxfPort);

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/orc/OrcReadTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/orc/OrcReadTest.java
@@ -1,12 +1,14 @@
 package org.greenplum.pxf.automation.features.orc;
 
+import annotations.FailsWithFDW;
+import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.features.BaseFeature;
-import org.greenplum.pxf.automation.structures.tables.pxf.ReadableExternalTable;
 import org.greenplum.pxf.automation.structures.tables.utils.TableFactory;
 import org.greenplum.pxf.automation.utils.system.ProtocolEnum;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 import org.testng.annotations.Test;
 
+@WorksWithFDW
 public class OrcReadTest extends BaseFeature {
 
     private static final String ORC_PRIMITIVE_TYPES = "orc_types.orc";
@@ -155,6 +157,18 @@ public class OrcReadTest extends BaseFeature {
         runTincTest("pxf.features.orc.read.multidim_list_types.runTest");
     }
 
+    /*
+     * FDW fails for the data that have NUL. This behaviour is different from external-table but same as GPDB Heap
+     * FDW Failure: invalid byte sequence for encoding "UTF8": 0x00
+     *
+     * GPDB also throws the same error when copying the data with NUL
+     *
+     * postgres=# copy test from '/Users/pandeyhi/Documents/bad_data.txt' ;
+     * ERROR:  invalid byte sequence for encoding "UTF8": 0x00
+     * TODO Do we need to do some changes to make sure the external-table behaves the same way as GPDB/FDW?
+     *
+     */
+    @FailsWithFDW
     @Test(groups = {"features", "gpdb", "security", "hcfs"})
     public void orcReadStringsContainingNullByte() throws Exception {
         prepareReadableExternalTable("pxf_orc_null_in_string", ORC_NULL_IN_STRING_COLUMNS, hdfsPath + ORC_NULL_IN_STRING);

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/orc/OrcReadTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/orc/OrcReadTest.java
@@ -158,10 +158,10 @@ public class OrcReadTest extends BaseFeature {
     }
 
     /*
-     * FDW fails for the data that have NUL. This behaviour is different from external-table but same as GPDB Heap
+     * FDW fails for the data that contain a NUL-byte (i.e. '\/u000'"). This behaviour is different from external-table but same as GPDB Heap
      * FDW Failure: invalid byte sequence for encoding "UTF8": 0x00
      *
-     * GPDB also throws the same error when copying the data with NUL
+     * GPDB also throws the same error when copying the data containing a NUL-byte
      *
      * postgres=# copy test from '/Users/pandeyhi/Documents/bad_data.txt' ;
      * ERROR:  invalid byte sequence for encoding "UTF8": 0x00

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetReadTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/parquet/ParquetReadTest.java
@@ -1,5 +1,6 @@
 package org.greenplum.pxf.automation.features.parquet;
 
+import annotations.WorksWithFDW;
 import org.greenplum.pxf.automation.features.BaseFeature;
 import org.greenplum.pxf.automation.structures.tables.basic.Table;
 import org.greenplum.pxf.automation.structures.tables.utils.TableFactory;
@@ -8,6 +9,7 @@ import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 import org.testng.annotations.Test;
 import java.io.File;
 
+@WorksWithFDW
 public class ParquetReadTest extends BaseFeature {
     private static final String NUMERIC_TABLE = "numeric_precision";
     private static final String NUMERIC_UNDEFINED_PRECISION_TABLE = "numeric_undefined_precision";


### PR DESCRIPTION
This PR modified these tests for FDW: 

- JsonTest
- JdbcHiveTest
- OrcReadTest
- ParquetTest





**OrcReadTest**: All the tests except  orcReadStringsContainingNullByte are working fine. This test orcReadStringsContainingNullByte  is failing because:

```
FDW fails for the data that have NUL. This behaviour is different from external-table but same as GPDB Heap
FDW Failure: invalid byte sequence for encoding "UTF8": 0x00

GPDB also throws the same error when copying the data with NUL

 postgres=# copy test from '/Users/pandeyhi/Documents/bad_data.txt' ;
ERROR: invalid byte sequence for encoding "UTF8": 0x00

Do we need to do some changes to make sure the external-table behaves the same way as GPDB/FDW?

```

**JsonTest**:

All Tests except the following are failing. Reason, extra quote getting appended in the output for FDW:


```
  JsonTest.malformedRecord
  JsonTest.malformedRecordWithCsvWireFormat
  JsonTest.malformedRecordWithRejectLimit
  JsonTest.mismatchedTypes
  JsonTest.mismatchedTypesWithRejectLimit
```


These tests failing because the returned error has extra quotes "

```
For e.g.:
""[truncated 73 chars]; line: 3, column: 22]'. invalid JSON record
Instead of
"[truncated 73 chars]; line: 3, column: 22]'. invalid JSON record
This is getting appended in toCsvField method of GreenplumCSV.java
And is happening only for the error cases. Adding escape "\" doesn't help here as well.

```
May be add a separate output file for these ? but for now skipped these.

**ParquetReadTest**:  Working fine 
**JdbcHiveTest**: Working fine

