### PR TITLE
Bump snappy-java to 1.1.10.1

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -21,7 +21,7 @@
         <hdp.hbase.version>1.3.2.1</hdp.hbase.version>
         <hdp.hive.version>1.1.0</hdp.hive.version>
         <orc.version>1.6.13</orc.version>
-        <snappy.java.version>1.1.1.7</snappy.java.version>
+        <snappy.java.version>1.1.10.1</snappy.java.version>
         <powermock.version>1.6.4</powermock.version>
     </properties>
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -111,7 +111,7 @@ configure(javaProjects) {
             dependency("org.threeten:threeten-extra:1.5.0")
             dependency("org.tukaani:xz:1.8")
             dependency("org.wildfly.openssl:wildfly-openssl:1.0.7.Final")
-            dependency("org.xerial.snappy:snappy-java:1.1.8.4")
+            dependency("org.xerial.snappy:snappy-java:1.1.10.1")
 
             // Hadoop dependencies
             dependencySet(group:"org.apache.hadoop", version:"${hadoopVersion}") {


### PR DESCRIPTION
This PR replaces https://github.com/greenplum-db/pxf/pull/985 for bumping the snappy-java version to 1.1.10.1.

 