### PR TITLE
docs - jdbc connector supports years with >4 chars

### DIFF
--- a/docs/content/jdbc_cfg.html.md.erb
+++ b/docs/content/jdbc_cfg.html.md.erb
@@ -144,6 +144,14 @@ Example: To set the `search_path` parameter before running a query in a PostgreS
 
 Ensure that the JDBC driver for the external SQL database supports any property that you specify.
 
+### <a id="other"></a>Other Properties
+
+Other properties supported by the PXF JDBC Connector:
+
+| Property       | Description                                | Default Value |
+|----------------|--------------------------------------------|---------------|
+| jdbc.date.wideRange | Boolean that enables special parsing of dates when the year contains more than four alphanumeric characters. When set to `true`, PXF uses extended classes to parse dates, and recognizes years that specify `BC` or `AD`. | false |
+
 ### <a id="jdbcconpool"></a>About JDBC Connection Pooling
 
 The PXF JDBC Connector uses JDBC connection pooling implemented by [HikariCP](https://github.com/brettwooldridge/HikariCP). When a user queries or writes to an external table, the Connector establishes a connection pool for the associated server configuration the first time that it encounters a unique combination of `jdbc.url`, `jdbc.user`, `jdbc.password`, connection property, and pool property settings. The Connector reuses connections in the pool subject to certain connection and timeout settings.

--- a/docs/content/jdbc_pxf.html.md.erb
+++ b/docs/content/jdbc_pxf.html.md.erb
@@ -101,6 +101,7 @@ You include JDBC connector custom options in the `LOCATION` URI, prefacing each 
 | BATCH_SIZE | Write | Integer that identifies the number of `INSERT` operations to batch to the external SQL database. Write batching is activated by default; the default value is 100. |
 | FETCH_SIZE | Read | Integer that identifies the number of rows to buffer when reading from an external SQL database. Read row batching is activated by default. The default read fetch size for MySQL is `-2147483648` (`Integer.MIN_VALUE`). The default read fetch size for all other databases is 1000. |
 | QUERY_TIMEOUT | Read/Write | Integer that identifies the amount of time (in seconds) that the JDBC driver waits for a statement to run. The default wait time is infinite. |
+| DATE_WIDE_RANGE | Read/Write | Boolean that enables special parsing of dates when the year contains more than four alphanumeric characters. The default value is `false`. When set to `true`, PXF uses extended classes to parse dates, and recognizes years that specify `BC` or `AD`. |
 | POOL_SIZE | Write | Activate thread pooling on `INSERT` operations and identify the number of threads in the pool. Thread pooling is deactivated by default. |
 | PARTITION_BY | Read | Activates read partitioning. The partition column, \<column-name\>:\<column-type\>. You may specify only one partition column. The JDBC connector supports `date`, `int`, and `enum` \<column-type\> values, where `int` represents any JDBC integral type. If you do not identify a `PARTITION_BY` column, a single PXF instance services the read request. |
 | RANGE | Read | Required when `PARTITION_BY` is specified. The query range; used as a hint to aid the creation of partitions. The `RANGE` format is dependent upon the data type of the partition column. When the partition column is an `enum` type, `RANGE` must specify a list of values, \<value\>:\<value\>[:\<value\>[...]], each of which forms its own fragment. If the partition column is an `int` or `date` type, `RANGE` must specify \<start-value\>:\<end-value\> and represents the interval from \<start-value\> through \<end-value\>, inclusive. The `RANGE` for an `int` partition column may span any 64-bit signed integer values. If the partition column is a `date` type, use the `yyyy-MM-dd` date format. |
@@ -244,6 +245,7 @@ You can override certain properties in a JDBC server configuration for a specifi
 | BATCH_SIZE | jdbc.statement.batchSize |
 | FETCH_SIZE | jdbc.statement.fetchSize |
 | QUERY_TIMEOUT | jdbc.statement.queryTimeout |
+| DATE_WIDE_RANGE | jdbc.date.wideRange |
 
 Example JDBC connection strings specified via custom options:
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/960.

treating this property similar to that of query timeout; both do not currently have commented out entries in jdbc-site.xml.  add a new section for the jdbc.date.wideRange property to jdbc config topic, add external table option DATE_WIDE_RANGE to the jdbc "using" topic.