### PR TITLE
docs - default listen address change

### DIFF
--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -13,7 +13,7 @@ In the default deployment topology, since PXF 6.7.0, the PXF Service starts on a
 
 ## <a id="listen_address"></a>Configuring the Listen Address
 
-The `server.address` property identifies the IP address or hostname of the network interface on which the PXF service listens. The default PXF service listen address is `localhost`.
+The `server.address` property identifies the IP address or hostname of the network interface on which the PXF service listens. The default PXF service listen address is `localhost`. You may choose to change the listen address to allow traffic from other hosts to send requests to PXF (for example, when you have chosen the [alternate deployment topology](deployment_topos.html#alt_topo) or to retrieve PXF monitoring data).
 
 Perform the following procedure to change the PXF listen address:
 
@@ -34,6 +34,8 @@ Perform the following procedure to change the PXF listen address:
     ``` pre
     server.address=<new_listen_addr>
     ```
+
+    Changing the listen address to `0.0.0.0` allows PXF to listen for requests from all hosts.
 
 1. Save the file and exit the editor.
 

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -2,7 +2,7 @@
 title: Service Listen Address, Host, and Port
 ---
 
-In the default deployment topology, the PXF Service starts on a Greenplum host and listens on `localhost:5888`. With this configuration, the PXF Service listens for local traffic on the Greenplum host. You can configure PXF to listen on a different listen address. You can also configure PXF to listen on a different port number, or to run on a different host. To change the default configuration, you set one or more of the properties identified below:
+In the default deployment topology, since PXF 6.7.0, the PXF Service starts on a Greenplum host and listens on `localhost:5888`. With this configuration, the PXF Service listens for local traffic on the Greenplum host. You can configure PXF to listen on a different listen address. You can also configure PXF to listen on a different port number, or to run on a different host. To change the default configuration, you set one or more of the properties identified below:
 
 |   Property |  Type | Description      | Default |
 |-------------------------|-------------------|-----|

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -29,7 +29,7 @@ Perform the following procedure to change the PXF listen address:
     /usr/local/pxf-gp6/conf/pxf-application.properties
     ```
 
-1. Open the file in the editor of your choice, and uncomment and set the following line:
+1. Open the file in the editor of your choice,  uncomment and set the following line:
 
     ``` pre
     server.address=<new_listen_addr>

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -2,20 +2,20 @@
 title: Service Listen Address, Host, and Port
 ---
 
-In the default deployment topology, the PXF Service starts on a Greenplum host and listens on `0.0.0.0:5888`. With this configuration, the PXF Service listens on all network interfaces of the Greenplum host and accepts network requests from anywhere. You can configure PXF to listen on a different local address. You can also configure PXF to listen on a different port number, or to run on a different host. To change the default configuration, you set one or more of the properties identified below:
+In the default deployment topology, the PXF Service starts on a Greenplum host and listens on `localhost:5888`. With this configuration, the PXF Service listens for local traffic on the Greenplum host. You can configure PXF to listen on a different listen address. You can also configure PXF to listen on a different port number, or to run on a different host. To change the default configuration, you set one or more of the properties identified below:
 
 |   Property |  Type | Description      | Default |
 |-------------------------|-------------------|-----|
-|   server.address  | `pxf-application.properties` property | The PXF server listen address. | `0.0.0.0`  |
+|   server.address  | `pxf-application.properties` property | The PXF server listen address. | `localhost`  |
 |   PXF_HOST  | Environment variable | The name or IP address of the (non-Greenpum) host on which the PXF Service is running. | `localhost`  |
 |   PXF_PORT  | Environment variable | The port number on which the PXF server listens for requests on the host. | `5888`  |
 
 
 ## <a id="listen_address"></a>Configuring the Listen Address
 
-The `server.address` property identifies the IP address or hostname of the network interface on which the PXF service listens. The default PXF service listen address is `0.0.0.0`.
+The `server.address` property identifies the IP address or hostname of the network interface on which the PXF service listens. The default PXF service listen address is `localhost`.
 
-When the PXF Service runs on Greenplum Database hosts, to secure communications and restrict PXF to listen only on the loopback interface, set the `server.address` to `localhost`:
+Perform the following procedure to change the PXF listen address:
 
 1. Log in to your Greenplum Database master host:
 
@@ -29,10 +29,10 @@ When the PXF Service runs on Greenplum Database hosts, to secure communications 
     /usr/local/pxf-gp6/conf/pxf-application.properties
     ```
 
-1. Open the file in the editor of your choice, and add the following line:
+1. Open the file in the editor of your choice, and uncomment and set the following line:
 
     ``` pre
-    server.address=localhost
+    server.address=<new_listen_addr>
     ```
 
 1. Save the file and exit the editor.
@@ -91,7 +91,7 @@ Perform the following procedure to configure the port number of the PXF server o
 
 ## <a id="host"></a>Configuring the Host
 
-If you have chosen the [alternate deployment topology](deployment_topos.html#alt_topo) for PXF, you must set the `PXF_HOST` environment variable on each Greenplum segment host to inform Greenplum of the location of the PXF service.
+If you have chosen the [alternate deployment topology](deployment_topos.html#alt_topo) for PXF, you must set the `PXF_HOST` environment variable on each Greenplum segment host to inform Greenplum of the location of the PXF service. You must also set the listen address as described in [Configuring the Listen Address](#listen_address).
 
 Perform the following procedure to configure the PXF host on each Greenplum Database segment host:
 
@@ -124,6 +124,8 @@ Perform the following procedure to configure the PXF host on each Greenplum Data
     ``` shell
     gpadmin@gpmaster$ source ~/.bashrc
     ```
+
+1. Configure the listen address of the PXF Service as described in [Configuring the Listen Address](#listen_address).
 
 3. Restart Greenplum Database as described in [Restarting Greenplum Database](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-managing-startstop.html#restarting-greenplum-database) in the Greenplum Documentation.
 

--- a/docs/content/config_files.html.md.erb
+++ b/docs/content/config_files.html.md.erb
@@ -46,6 +46,7 @@ The `pxf-application.properties` file exposes these PXF Service application conf
 | pxf.task.pool.max-size | The maximum allowed number of core streaming threads. | pxf.max.threads if set, or 200 |
 | [pxf.log.level](cfg_logging.html) | The log level for the PXF Service. | info  |
 | pxf.fragmenter-cache.expiration | The amount of time after which an entry expires and is removed from the fragment cache. | 10s (10 seconds) |
+| [server.address](cfghostport.html) | The PXF server listen address. | localhost |
 
 To change the value of a PXF Service application property, you may first need to add the property to, or uncomment the property in, the `pxf-application.properties` file before you can set the new value.
 

--- a/docs/content/deployment_topos.html.md.erb
+++ b/docs/content/deployment_topos.html.md.erb
@@ -13,5 +13,5 @@ Running the PXF Service on non-Greenplum hosts is an alternate deployment topolo
 
 In the alternate deployment topology, you manage the PXF services individually using the [pxf](ref/pxf.html) command on each host; you can not use the `pxf cluster` commands to collectively manage the PXF services in this topology.
 
-If you choose the alternate deployment topology, you must explicitly configure each Greenplum host to identify a host on which the PXF Service is running. This procedure is described in [Configuring the Host](cfghostport.html#host).
+If you choose the alternate deployment topology, you must explicitly configure each Greenplum host to identify the host and listen address on which the PXF Service is running. These procedures are described in [Configuring the Host](cfghostport.html#host) and [Configuring the Listen Address](cfghostport.html#listen_address).
 

--- a/docs/content/monitor_pxf.html.md.erb
+++ b/docs/content/monitor_pxf.html.md.erb
@@ -57,10 +57,16 @@ PXF exposes the following HTTP endpoints that you can use to monitor a running P
 
 Any user can access the HTTP endpoints and view the monitoring information that PXF returns.
 
-You can view the data associated with a specific endpoint by viewing in a browser, or `curl`-ing, a URL of the following format:
+You can view the data associated with a specific endpoint by viewing in a browser, or `curl`-ing, a URL of the following format (default PXF deployment topology):
 
 ``` pre
 http://localhost:5888/<endpoint>[/<name>]
+```
+
+If you chose the [alternate deployment topology](deployment_topos.html#alt_topo) for PXF, the URL is:
+
+``` pre
+http://<pxf_listen_address>:<port>/<endpoint>[/<name>]
 ```
 
 For example, to view the build information for the PXF service running on `localhost`, query the `actuator/info` endpoint:

--- a/docs/content/upgrade_6.html.md.erb
+++ b/docs/content/upgrade_6.html.md.erb
@@ -127,6 +127,8 @@ After you install the new version of PXF, perform the following procedure:
 
     Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_parquet.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters a numeric overflow while writing to a Parquet file.
 
+1. **If you are upgrading <i>from</i> PXF version 6.6.x or earlier <i>to</i> PXF version 6.7.0 or later**, and you want to retain the previous PXF listen address (`0.0.0.0`), change the value of the `server.address` `pxf-application.properties` property as described in [Configuring the Listen Address](cfghostport.html#listen_address).
+
 1. Synchronize the PXF configuration from the master host to the standby master host and each Greenplum Database segment host. For example:
 
     ``` shell


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/976.

default server address is now localhost.  in this PR:
- update the newly-added topology topic and the configuring topic for listenaddress/host/port
- add server.address to pxf-application.properties config file topic
- add an upgrade step for retaining old listen address

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/tmpbranch/tanzu-greenplum-platform-extension-framework/GUID-cfghostport.html