### PR TITLE
docs - pxf supports writing json data

### DIFF
--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -111,7 +111,7 @@ The PXF Hadoop connectors expose the following profiles to read, and in many cas
 | HDFS | fixed width single line [text](hdfs_fixedwidth.html) | hdfs:fixedwidth | n/a | Read, Write |
 | HDFS | delimited [text with quoted linefeeds](hdfs_text.html#profile_textmulti) | hdfs:text:multi | n/a | Read |
 | HDFS | [Avro](hdfs_avro.html) | hdfs:avro | n/a | Read, Write |
-| HDFS | [JSON](hdfs_json.html) | hdfs:json | n/a | Read |
+| HDFS | [JSON](hdfs_json.html) | hdfs:json | n/a | Read, Write |
 | HDFS | [ORC](hdfs_orc.html) | hdfs:orc | n/a | Read, Write |
 | HDFS | [Parquet](hdfs_parquet.html) | hdfs:parquet | n/a | Read, Write |
 | HDFS | AvroSequenceFile | hdfs:AvroSequenceFile | n/a | Read, Write |

--- a/docs/content/access_objstore.html.md.erb
+++ b/docs/content/access_objstore.html.md.erb
@@ -55,7 +55,7 @@ The PXF connectors to Azure expose the following profiles to read, and in many c
 | delimited [text with quoted linefeeds](objstore_text.html) | wasbs:text:multi | adl:text:multi | Read |
 | fixed width single line [text](objstore_fixedwidth.html) | wasbs:fixedwidth | adl:fixedwidth | Read, Write |
 | [Avro](objstore_avro.html) | wasbs:avro | adl:avro | Read, Write |
-| [JSON](objstore_json.html) | wasbs:json | adl:json | Read |
+| [JSON](objstore_json.html) | wasbs:json | adl:json | Read, Write |
 | [ORC](objstore_orc.html) | wasbs:orc | adl:orc | Read, Write |
 | [Parquet](objstore_parquet.html) | wasbs:parquet | adl:parquet | Read, Write |
 | AvroSequenceFile | wasbs:AvroSequenceFile | adl:AvroSequenceFile | Read, Write |

--- a/docs/content/hdfs_fileasrow.html.md.erb
+++ b/docs/content/hdfs_fileasrow.html.md.erb
@@ -6,7 +6,7 @@ You can use the PXF HDFS connector to read one or more multi-line text files in 
 
 PXF supports reading only text and JSON files in this manner.
 
-**Note**: Refer to the [Reading JSON Data from HDFS](hdfs_json.html) topic if you want to use PXF to read JSON files that include more than one record.
+**Note**: Refer to the [Reading and Writing JSON Data in HDFS](hdfs_json.html) topic if you want to use PXF to read JSON files that include more than one record.
 
 
 ## <a id="prereq"></a>Prerequisites

--- a/docs/content/hdfs_fixedwidth.html.md.erb
+++ b/docs/content/hdfs_fixedwidth.html.md.erb
@@ -144,12 +144,11 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://doc
 | line_delim    | The line delimiter character in the data. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `line_delim=E'\n'`, `line_delim 'aaa'`. The default value is `'\n'`. |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or `<column_name>` on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
-Writable external tables that you create using the `hdfs:fixedwidth` profile can optionally use record or block compression. You specify the compression type and codec via options in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause:
+Writable external tables that you create using the `hdfs:fixedwidth` profile can optionally use record or block compression. You specify the compression codec via an option in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause:
 
 | Write Option  | Value Description |
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing fixed-width text data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
-| COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 
 ## <a id="fixedwidth_write_example"></a>Example: Writing Fixed-Width Text Data to HDFS
 

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -102,9 +102,11 @@ PXF uses the following data type mapping when reading JSON data:
 | number  | { bigint &#124; float8 &#124; integer &#124; numeric &#124; real &#124; smallint } |
 | string | text |
 | string (base64-encoded value) | bytea |
+| string (date, time, timestamp in a text format that Greenplum understands) | text |
 | Array (one dimension) of type boolean[] | boolean[] |
 | Array (one dimension) of type number[] | { bigint[] &#124; float8[] &#124; integer[] &#124; numeric[] &#124; real[] &#124; smallint[] } |
 | Array (one dimension) of type string[] (base64-encoded value) | bytea[] |
+| Array (one dimension) of type string[] (date, time, timestamp in a text format that Greenplum understands) | string[] |
 | Array (one dimension) of type string[] | text[] |
 | Array of other types | text[] |
 | Object                | Use dot `.` notation to specify each level of projection (nesting) to a member of a primitive or Array type.                                                                                         |

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Reading JSON Data from HDFS
+title: Reading and Writing JSON Data in HDFS
 ---
 
 <!--
@@ -21,19 +21,117 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Use the PXF HDFS Connector to read JSON-format data. This section describes how to use PXF to access JSON data in HDFS, including how to create and query an external table that references a JSON file in the HDFS data store.
+Use the PXF HDFS Connector to read and write JSON-format data. This section describes how to use PXF to access JSON data in HDFS, including how to create, query, and insert into an external table that references a JSON file or directory in the HDFS data store.
 
 ## <a id="prereq"></a>Prerequisites
 
-Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq) before you attempt to read data from HDFS.
+Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_prereq) before you attempt to read data from or write data to HDFS.
 
 ## <a id="hdfsjson_work"></a>Working with JSON Data
 
-JSON is a text-based data-interchange format. JSON data is typically stored in a file with a `.json` suffix. 
+JSON is a text-based data-interchange format. A JSON data file contains one or more JSON objects. A JSON object is a collection of unordered name/value pairs. A value can be a string, a number, true, false, null, or an object or an array. You can define nested JSON objects and arrays.
 
-A `.json` file will contain a collection of objects. A JSON object is a collection of unordered name/value pairs. A value can be a string, a number, true, false, null, or an object or an array. You can define nested JSON objects and arrays.
+JSON data is typically stored in a file with a `.json` or `.jsonl` (JSON Lines) suffix as described in the sections below.
 
-Sample JSON data file content:
+### <a id="topic_jsonmodes"></a>About the PXF JSON Data Access Modes
+
+PXF supports two data access modes for JSON files. The default mode expects one full JSON record per row (JSONL). PXF also supports an access mode that expects one JSON object per file where the JSON records may (but are not required to) span multiple lines.
+
+#### <a id="jsonl"></a>Single Object Per Row
+
+A JSON file can contain a single JSON object per row, where each row represents a database tuple. A JSON file that contains a single object per row may have a `.json`, or `.jsonl` suffix.
+
+Excerpt of sample single-object-per-row JSON data file:
+
+``` pre
+{"id":1,"color":"red"}
+{"id":2,"color":"yellow"}
+{"id":3,"color":"green"}
+```
+
+Refer to [JSON Lines](https://jsonlines.org/) for detailed information about this JSON syntax.
+
+#### <a id="arrayobject"></a>Single Object Per File
+
+A JSON file can also contain a single, named, root level JSON object whose value is an array of JSON objects. Each JSON object in the array represents a database tuple. JSON files of this type have the `.json` suffix.
+
+In the following example JSON data file, the root-level `records` object is an array of three objects (tuples):
+
+``` pre
+{"records":[
+{"id":1,"color":"red"}
+,{"id":2,"color":"yellow"}
+,{"id":3,"color":"green"}
+]}
+```
+
+The records in the single JSON object may also span multiple lines:
+
+``` pre
+{
+  "records":[
+    {
+      "id":1,
+      "color":"red"
+    },
+    {
+      "id":2,
+      "color":"yellow"
+    },
+    {
+      "id":3,
+      "color":"green"
+    }
+  ]
+}
+```
+
+Refer to [Introducing JSON](http://www.json.org/) for detailed information about this JSON syntax.
+
+## <a id="datatypemap"></a>Data Type Mapping
+
+To represent JSON data in Greenplum Database, map data values that use a primitive data type to Greenplum Database columns of the same type. JSON supports complex data types including projections and arrays.
+
+### <a id="datatypemap_read"></a>Read Mapping
+
+PXF uses the following data type mapping when reading JSON data:
+
+| JSON Data Type    | PXF/Greenplum Data Type |
+|-------------------|-------------------------------------------|
+| boolean | boolean |
+| number  | { bigint &#124; float8 &#124; integer &#124; numeric &#124; real &#124; smallint } |
+| string | text |
+| string (base64-encoded value) | bytea |
+| Array (one dimension) of type boolean[] | boolean[] |
+| Array (one dimension) of type number[] | { bigint[] &#124; float8[] &#124; integer[] &#124; numeric[] &#124; real[] &#124; smallint[] } |
+| Array (one dimension) of type string[] (base64-encoded value) | bytea[] |
+| Array (one dimension) of type string[] | text[] |
+| Array of other types | text[] |
+| Object                | Use dot `.` notation to specify each level of projection (nesting) to a member of a primitive or Array type.                                                                                         |
+When reading, you can use N-level projection to map members of nested objects and arrays to primitive data types.
+
+### <a id="datatypemap_write"></a>Write Mapping
+
+PXF supports writing primitive types and single dimension arrays of primitive types. PXF supports writing other complex types to JSON as string.
+
+PXF uses the following data type mapping when writing JSON data:
+
+| PXF/Greenplum Data Type | JSON Data Type |
+|-------------------|----------------------|
+| bigint, float8, integer, numeric, real, smallint | number |
+| boolean | boolean |
+| bpchar, text, varchar | string |
+| bytea | string (base64-encoded value) |
+| date, time, timestamp, timestamptz | string |
+| boolean[] | boolean[] |
+| bigint[], float8[], int[], numeric[], real[], smallint[] | number[] |
+| bytea[] | string[] (base64-encoded value)  |
+| date[], time[], timestamp[], timestamptz[] | string[] |
+
+## <a id="projection"></a>About Using Projection (Read)
+
+In the example JSON data file excerpt below, `user` is an object composed of fields named `id` and `location`:
+
 
 ``` json
   {
@@ -53,7 +151,7 @@ Sample JSON data file content:
   }
 ```
 
-In the sample above, `user` is an object composed of fields named `id` and `location`. To specify the nested fields in the `user` object as Greenplum Database external table columns, use `.` projection:
+To specify the nested fields in the `user` object directly as Greenplum Database external table columns, use `.` projection:
 
 ``` pre
 user.id
@@ -62,49 +160,80 @@ user.location
 
 `coordinates` is an object composed of a text field named `type` and an array of integers named `values`. 
 
-To retrieve all of the elements of the `values` array in a single column, define the corresponding Greenplum Database external table column as type `TEXT[]`.
+To read all of the elements of the `values` array in a single column, define the corresponding Greenplum Database external table column as type `int[]`.
 
 ``` pre
-"coordinates.values" TEXT[]
+"coordinates.values" int[]
 ```
 
-Refer to [Introducing JSON](http://www.json.org/) for detailed information on JSON syntax.
+## <a id="profile_cet"></a>Creating the External Table
 
-### <a id="datatypemap_json"></a>JSON to Greenplum Database Data Type Mapping</a>
+Use the `hdfs:json` profile to read or write JSON-format data in HDFS. The following syntax creates a Greenplum Database external table that references such a file:
 
-To represent JSON data in Greenplum Database, map data values that use a primitive data type to Greenplum Database columns of the same type. JSON supports complex data types including projections and arrays. Use N-level projection to map members of nested objects and arrays to primitive data types.
+``` sql
+CREATE [WRITABLE] EXTERNAL TABLE <table_name>
+    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
+LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:json[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import'|'pxfwritable_export')
+[DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
+```
 
-The following table summarizes external mapping rules for JSON data.
+The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
 
-<caption><span class="tablecap">Table 1. JSON Mapping</span></caption>
+| Keyword  | Value |
+|-------|-------------------------------------|
+| \<path&#8209;to&#8209;hdfs&#8209;file\>    | The path to the directory or file in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
+| PROFILE    | The `PROFILE` keyword must specify `hdfs:json`. |
+| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
+| \<custom&#8209;option\>  | \<custom-option\>s for read and write operations are identified below.|
+| FORMAT 'CUSTOM' | Use `FORMAT` '`CUSTOM`' with `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
 
-<a id="topic_table_jsondatamap"></a>
+<a id="customopts"></a>
+PXF supports reading from and writing to JSON files that contain either an object per row (the default) or that contain a JSON single object. When the JSON file(s) that you want to read or write contains a single object, you must provide an `IDENTIFIER` \<custom-option\> and value. Use this option to identify the name of a field whose parent JSON object you want PXF to return or write as an individual tuple.
 
-| JSON Data Type                                                    | PXF/Greenplum Data Type                                                                                                                                                                                            |
-|-------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Primitive type (integer, float, string, boolean, null) | Use the corresponding Greenplum Database built-in data type; see [Greenplum Database Data Types](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-data_types.html). |
-| Array                         | Use `TEXT[]` to retrieve the JSON array as a Greenplum text array.                                                                                           |
-| Object                | Use dot `.` notation to specify each level of projection (nesting) to a member of a primitive or Array type.                                                                                         |
+The `hdfs:json` profile supports the following custom **read** options:
 
-### <a id="topic_jsonreadmodes"></a>JSON Data Read Modes
+| Option Keyword  | Description |
+|-------|-----------------------|
+| IDENTIFIER=\<value\> | When the JSON data that you are reading is comprised of a single JSON object, you must specify an `IDENTIFIER` to identify the name of the field whose parent JSON object you want PXF to return as an individual tuple. | 
+| SPLIT_BY_FILE=\<boolean\> | Specify how PXF splits the data in \<path-to-hdfs-file\>. The default value is `false`, PXF creates multiple splits for each file that it will process in parallel. When set to `true`, PXF creates and processes a single split per file. |
+| IGNORE_MISSING_PATH=\<boolean\> | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
 
-PXF supports two data read modes. The default mode expects one full JSON record per line.  PXF also supports a read mode operating on JSON records that span multiple lines.
+<div class="note"><b>Note:</b> When a nested object in a single object JSON file includes a field with the same name as that of a parent object field <i>and</i> the field name is also specified as the <code>IDENTIFIER</code>, there is a possibility that PXF could return incorrect results. Should you need to, you can work around this edge case by compressing the JSON file, and using PXF to read the compressed file.</div>
 
-In upcoming examples, you will use both read modes to operate on a sample data set. The schema of the sample data set defines objects with the following member names and value data types:
+The `hdfs:json` profile supports the following custom **write** options:
 
-   - "created_at" - text
-   - "id_str" - text
-   - "user" - object
-      - "id" - integer
-      - "location" - text
-   - "coordinates" - object (optional)
-      - "type" - text
-      - "values" - array
-         - [0] - integer
-         - [1] - integer
+| Option  | Value Description |
+|-------|-------------------------------------|
+| IDENTIFIER=\<value\> | When the JSON data that you are writing is comprised of a single JSON object, you must specify an `IDENTIFIER` to identify the name of the field whose parent JSON object you want PXF to write as individual tuples. | 
+| ROOT=\<value\>    | When writing to a single JSON object (`IDENTIFIER` will also be set), identifies the name of the root-level object attribute. |
+| COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing json data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
+| COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
+| DISTRIBUTED BY    | If you are loading data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or `<column_name>` on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
+When you specify compression for a JSON write operation, PXF names the files that it writes `<basename>.<json_file_type>.<compression_extension>`. For example: `jan_sales.jsonl.gz`.
 
-The single-JSON-record-per-line data set follows:
+## <a id="json_read"></a>Read Examples
+
+### <a id="example_datasets"></a>Example Data Sets
+
+In upcoming read examples, you use both JSON access modes to operate on a sample data set. The schema of the sample data set defines objects with the following member names and value data types:
+
+- "created_at" - text
+- "id_str" - text
+- "user" - object
+
+    - "id" - integer
+    - "location" - text
+- "coordinates" - object (optional)
+
+    - "type" - text
+    - "values" - array
+
+        - [0] - integer
+        - [1] - integer
+
+The data set for the single-object-per-row (JSONL) access mode follows:
 
 ``` pre
 {"created_at":"FriJun0722:45:03+00002013","id_str":"343136551322136576","user":{"id":395504494,"location":"NearCornwall"},"coordinates":{"type":"Point","values": [ 6, 50 ]}},
@@ -112,7 +241,7 @@ The single-JSON-record-per-line data set follows:
 {"created_at":"FriJun0722:45:02+00002013","id_str":"343136547136233472","user":{"id":287819058,"location":""}, "coordinates": null}
 ```
 
-This is the data set for the multi-line JSON record data set:
+The data set for the single-object-per-file JSON access mode follows:
 
 ``` json
 {
@@ -149,137 +278,88 @@ This is the data set for the multi-line JSON record data set:
 
 You will create JSON files for the sample data sets and add them to HDFS in the next section.
 
-## <a id="jsontohdfs"></a>Loading the Sample JSON Data to HDFS
+### <a id="jsontohdfs"></a>Loading the Sample JSON Data to HDFS
 
-The PXF HDFS connector reads native JSON stored in HDFS. Before you can use Greenplum Database to query JSON format data, the data must reside in your HDFS data store.
+The PXF HDFS connector can read and write native JSON stored in HDFS.
 
-Copy and paste the single line JSON record sample data set above to a file named `singleline.json`. Similarly, copy and paste the multi-line JSON record data set to a file named `multiline.json`.
+Copy and paste the object-per-row JSON sample data set above to a file named `objperrow.jsonl`. Similarly, copy and paste the single object per file JSON record data set to a file named `singleobj.json`.
 
-**Note**: Ensure that there are **no** blank lines in your JSON files.
+> **Note** Ensure that there are **no** blank lines in your JSON files.
 
 Copy the JSON data files that you just created to your HDFS data store. Create the `/data/pxf_examples` directory if you did not do so in a previous exercise. For example:
 
 ``` shell
 $ hdfs dfs -mkdir /data/pxf_examples
-$ hdfs dfs -put singleline.json /data/pxf_examples
-$ hdfs dfs -put multiline.json /data/pxf_examples
+$ hdfs dfs -put objperrow.jsonl /data/pxf_examples/
+$ hdfs dfs -put singleobj.json /data/pxf_examples/
 ```
 
-Once the data is loaded to HDFS, you can use Greenplum Database and PXF to query and analyze the JSON data.
+Once the data is loaded to HDFS, you can use Greenplum Database and PXF to query and add to the JSON data.
 
+### <a id="read_example1"></a>Example: Single Object Per Row (Read)
 
-## <a id="json_cet"></a>Creating the External Table
-
-Use the `hdfs:json` profile to read JSON-format files from HDFS. The following syntax creates a Greenplum Database readable external table that references such a file:
-
-``` sql
-CREATE EXTERNAL TABLE <table_name>
-    ( <column_name> <data_type> [, ...] | LIKE <other_table> )
-LOCATION ('pxf://<path-to-hdfs-file>?PROFILE=hdfs:json[&SERVER=<server_name>][&<custom-option>=<value>[...]]')
-FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
-```
-
-The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
-
-| Keyword  | Value |
-|-------|-------------------------------------|
-| \<path&#8209;to&#8209;hdfs&#8209;file\>    | The path to the directory or file in the HDFS data store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;hdfs&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;hdfs&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
-| PROFILE    | The `PROFILE` keyword must specify `hdfs:json`. |
-| SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. PXF uses the `default` server if not specified. |
-| \<custom&#8209;option\>  | \<custom-option\>s are discussed below.|
-| FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `hdfs:json` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
-
-<a id="customopts"></a>
-PXF supports single- and multi- line JSON records. When you want to read multi-line JSON records, you must provide an `IDENTIFIER` \<custom-option\> and value. Use this \<custom-option\> to identify the name of a field whose parent JSON object you want to be returned as individual tuples.
-
-The `hdfs:json` profile supports the following \<custom-option\>s:
-
-| Option Keyword  | &nbsp;&nbsp;Syntax,&nbsp;&nbsp;Example(s)&nbsp;&nbsp; | Description |
-|-------|--------------|-----------------------|
-| IDENTIFIER  | `&IDENTIFIER=<value>`<br>`&IDENTIFIER=created_at`| You must include the `IDENTIFIER` keyword and \<value\> in the `LOCATION` string only when you are accessing JSON data comprised of multi-line records. Use the \<value\> to identify the name of the field whose parent JSON object you want to be returned as individual tuples. | 
-| SPLIT_BY_FILE | `&SPLIT_BY_FILE=<boolean>` | Specify how PXF splits the data in \<path-to-hdfs-file\>. The default value is `false`, PXF creates multiple splits for each file that it will process in parallel. When set to `true`, PXF creates and processes a single split per file. |
-| IGNORE_MISSING_PATH | `&IGNORE_MISSING_PATH=<boolean>` | Specify the action to take when \<path-to-hdfs-file\> is missing or invalid. The default value is `false`, PXF returns an error in this situation. When the value is `true`, PXF ignores missing path errors and returns an empty fragment. |
-
-<div class="note"><b>Note:</b> When a nested object in a multi-line record JSON file includes a field with the same name as that of a parent object field <i>and</i> the field name is also specified as the <code>IDENTIFIER</code>, there is a possibility that PXF could return incorrect results. Should you need to, you can work around this edge case by compressing the JSON file, and having PXF read the compressed file.</div>
-
-
-## <a id="jsonexample1"></a>Example: Reading a JSON File with Single Line Records
-
-Use the following [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) SQL command to create a readable external table that references the single-line-per-record JSON data file and uses the PXF default server.
+Use the following [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) SQL command to create a readable external table that references the single-object-per-row JSON data file and uses the PXF default server.
 
 ```sql
-CREATE EXTERNAL TABLE singleline_json_tbl(
+CREATE EXTERNAL TABLE objperrow_json_tbl(
   created_at TEXT,
   id_str TEXT,
   "user.id" INTEGER,
   "user.location" TEXT,
-  "coordinates.values" TEXT[]
+  "coordinates.values" INTEGER[]
 )
-LOCATION('pxf://data/pxf_examples/singleline.json?PROFILE=hdfs:json')
+LOCATION('pxf://data/pxf_examples/objperrow.jsonl?PROFILE=hdfs:json')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 ```
 
-Notice the use of `.` projection to access the nested fields in the `user` and `coordinates` objects.
+This table reads selected fields in the JSON file. Notice the use of `.` projection to access the nested fields in the `user` and `coordinates` objects.
 
-To query the JSON data in the external table:
+To view the JSON data in the file, query the external table:
 
 ``` sql
-SELECT * FROM singleline_json_tbl;
+SELECT * FROM objperrow_json_tbl;
 ```
 
 To access specific elements of the `coordinates.values` array, you can specify the array subscript number in square brackets:
 
 ```sql
-SELECT "coordinates.values"[1], "coordinates.values"[2] FROM singleline_json_tbl;
+SELECT "coordinates.values"[1], "coordinates.values"[2] FROM objperrow_json_tbl;
 ```
 
-To access the array elements as some type other than `TEXT`, you can either cast the whole column:
+### <a id="read_example2"></a>Example: Single Object Per File (Read)
 
-```sql
-SELECT "coordinates.values"::int[] FROM singleline_json_tbl;
-```
-
-or cast specific elements:
-
-```sql
-SELECT "coordinates.values"[1]::int, "coordinates.values"[2]::float FROM singleline_json_tbl;
-```
-
-
-## <a id="jsonexample2"></a>Example: Reading a JSON file with Multi-Line Records
-
-The SQL command to create a readable external table from the multi-line-per-record JSON file is very similar to that of the single line data set above. You must additionally specify the `LOCATION` clause `IDENTIFIER` keyword and an associated value when you want to read multi-line JSON records. For example:
+The SQL command to create a readable external table for a single object JSON file is very similar to that of the single object per row data set above. You must additionally specify the `LOCATION` clause `IDENTIFIER` keyword and an associated value. For example:
 
 ``` sql
-CREATE EXTERNAL TABLE multiline_json_tbl(
+CREATE EXTERNAL TABLE singleobj_json_tbl(
   created_at TEXT,
   id_str TEXT,
   "user.id" INTEGER,
   "user.location" TEXT,
-  "coordinates.values" TEXT[]
+  "coordinates.values" INTEGER[]
 )
-LOCATION('pxf://data/pxf_examples/multiline.json?PROFILE=hdfs:json&IDENTIFIER=created_at')
+LOCATION('pxf://data/pxf_examples/singleobj.json?PROFILE=hdfs:json&IDENTIFIER=created_at')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 ```
 
 `created_at` identifies the member name of the first field in the JSON record `record_obj` in the sample data schema.
 
-To query the JSON data in this external table:
+To view the JSON data in the file, query the external table:
 
 ``` sql
-SELECT * FROM multiline_json_tbl;
+SELECT * FROM singleobj_json_tbl;
 ```
 
-## <a id="array_other"></a> Other Methods to Read a JSON Array
+### <a id="array_other"></a> Other Methods to Read a JSON Array
 
 Starting in version 6.2.0, PXF supports reading a JSON array into a `TEXT[]` column. PXF still supports the old methods of using array element projection or a single text-type column to read a JSON array. These access methods are described here.
 
-### <a id="arrayelproj"></a>Using Array Element Projection
+#### <a id="arrayelproj"></a>Using Array Element Projection
 
 PXF supports accessing specific elements of a JSON array using the syntax `[n]` in the table definition to identify the specific element.
 
 ```sql
-CREATE EXTERNAL TABLE singleline_json_tbl_aep(
+CREATE EXTERNAL TABLE objperrow_json_tbl_aep(
   created_at TEXT,
   id_str TEXT,
   "user.id" INTEGER,
@@ -287,7 +367,7 @@ CREATE EXTERNAL TABLE singleline_json_tbl_aep(
   "coordinates.values[0]" INTEGER,
   "coordinates.values[1]" INTEGER
 )
-LOCATION('pxf://data/pxf_examples/singleline.json?PROFILE=hdfs:json')
+LOCATION('pxf://data/pxf_examples/objperrow.jsonl?PROFILE=hdfs:json')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 ```
 
@@ -296,24 +376,24 @@ FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 If your existing external table definition uses array element projection and you want to read the array into a `TEXT[]` column, you can use the `ALTER EXTERNAL TABLE` command to update the table definition. For example:
 
 ```sql
-ALTER EXTERNAL TABLE singleline_json_tbl_aep DROP COLUMN "coordinates.values[0]", DROP COLUMN "coordinates.values[1]", ADD COLUMN "coordinates.values" TEXT[];
+ALTER EXTERNAL TABLE objperrow_json_tbl_aep DROP COLUMN "coordinates.values[0]", DROP COLUMN "coordinates.values[1]", ADD COLUMN "coordinates.values" TEXT[];
 ```
 
 If you choose to alter the external table definition in this manner, be sure to update any existing queries on the external table to account for the changes to column name and type.
 
-### <a id="singletextcol"></a> Specifying a Single Text-type Column
+#### <a id="singletextcol"></a> Specifying a Single Text-type Column
 
 PXF supports accessing all of the elements within an array as a single string containing the serialized JSON array by defining the corresponding Greenplum table column with one of the following data types: `TEXT`, `VARCHAR`, or `BPCHAR`.
 
 ```sql
-CREATE EXTERNAL TABLE singleline_json_tbl_stc(
+CREATE EXTERNAL TABLE objperrow_json_tbl_stc(
   created_at TEXT,
   id_str TEXT,
   "user.id" INTEGER,
   "user.location" TEXT,
   "coordinates.values" TEXT
 )
-LOCATION('pxf://data/pxf_examples/singleline.json?PROFILE=hdfs:json')
+LOCATION('pxf://data/pxf_examples/objperrow.jsonl?PROFILE=hdfs:json')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 ```
 
@@ -322,7 +402,7 @@ If you retrieve the JSON array in a single text-type column and wish to convert 
 ```sql
 SELECT user.id,
        ARRAY(SELECT json_array_elements_text(coordinates.values::json))::int[] AS coords
-FROM singleline_json_tbl_stc;
+FROM objperrow_json_tbl_stc;
 ```
 
 **Note**: This conversion is possible only when you are using PXF with Greenplum Database 6.x; the function `json_array_elements_text()` is not available in Greenplum 5.x.
@@ -330,8 +410,133 @@ FROM singleline_json_tbl_stc;
 If your external table definition uses a single text-type column for a JSON array and you want to read the array into a `TEXT[]` column, you can use the `ALTER EXTERNAL TABLE` command to update the table definition. For example:
 
 ```sql
-ALTER EXTERNAL TABLE singleline_json_tbl_stc ALTER COLUMN "coordinates.values" TYPE TEXT[];
+ALTER EXTERNAL TABLE objperrow_json_tbl_stc ALTER COLUMN "coordinates.values" TYPE TEXT[];
 ```
 
 If you choose to alter the external table definition in this manner, be sure to update any existing queries on the external table to account for the change in column type.
+
+## <a id="json_write"></a>Writing JSON Data
+
+To write JSON data, you create a writable external table that references the name of a directory on HDFS. When you insert records into the writable external table, PXF writes the block(s) of data that you insert to one or more files in the directory that you specified. In the default case (single object per row), PXF writes the data to a `.jsonl` file. When you specify an `IDENTIFIER` and a `ROOT` attribute (single object per file), PXF writes to a `.json` file.
+
+> **Note** When you use PXF to write JSON data, you must flatten the objects into scalar or array table columns. PXF does not support column projection when writing JSON data.
+
+Writable external tables can only be used for `INSERT` operations. If you want to query the data that you inserted, you must create a separate readable external table that references the HDFS directory and read from that table.
+
+The write examples use a data schema similar to that of the read examples.
+
+### <a id="write_example1"></a>Example: Single Object Per Row (Write)
+
+In this example, we add data to a directory named `jsopr`.
+
+Use the following [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) SQL command to create a writable external table that writes JSON data in single-object-per-row format and uses the PXF default server.
+
+```sql
+CREATE WRITABLE EXTERNAL TABLE add_objperrow_json_tbl(
+  created_at TEXT,
+  id_str TEXT,
+  id INTEGER,
+  location TEXT,
+  coordinates INTEGER[]
+)
+LOCATION('pxf://data/pxf_examples/jsopr?PROFILE=hdfs:json')
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
+```
+
+Write data to the table:
+
+``` sql
+INSERT INTO add_objperrow_json_tbl VALUES ( 'SunJun0912:59:07+00002013', '343136551111111111', 311111111, 'FarAway', '{ 6, 50 }' );
+INSERT INTO add_objperrow_json_tbl VALUES ( 'MonJun1002:12:06+00002013', '343136557777777777', 377777777, 'NearHere', '{ 13, 93 }' );
+```
+
+Read the data that you just wrote. Recall that you must first create a readable external table:
+
+``` sql
+CREATE EXTERNAL TABLE jsopr_tbl(
+  created_at TEXT,
+  id_str TEXT,
+  id INTEGER,
+  location TEXT,
+  coordinates INTEGER[]
+)
+LOCATION('pxf://data/pxf_examples/jsopr?PROFILE=hdfs:json')
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+```
+
+Query the table:
+
+``` sql
+SELECT * FROM jsopr_tbl;
+```
+
+View the files added to HDFS:
+
+```
+$ hdfs dfs -cat /data/pxf_examples/jsopr/*
+{"created_at":"SunJun0912:59:07+00002013","id_str":"343136551111111111","id":311111111,"location":"FarAway","coordinates":[6,50]}
+{"created_at":"MonJun1002:12:06+00002013","id_str":"343136557777777777","id":377777777,"location":"NearHere","coordinates":[13,93]}
+```
+
+Notice that PXF creates a flat JSON structure.
+
+### <a id="write_example2"></a>Example: Single Object Per File (Write)
+
+Use the following [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) SQL command to create a writable external table that writes JSON data in single object format and uses the PXF default server.
+
+You must specify the `ROOT` and `IDENTIFIER` keywords and associated values in the `LOCATION` clause. For example:
+
+``` sql
+CREATE WRITABLE EXTERNAL TABLE add_singleobj_json_tbl(
+  created_at TEXT,
+  id_str TEXT,
+  id INTEGER,
+  location TEXT,
+  coordinates INTEGER[]
+)
+LOCATION('pxf://data/pxf_examples/jso?PROFILE=hdfs:json&ROOT=root&IDENTIFIER=created_at')
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
+```
+
+`root` identifies the name of the root attribute of the single object. `created_at` identifies the member name of the first field in each JSON record.
+
+Write data to the table:
+
+``` sql
+INSERT INTO add_singleobj_json_tbl VALUES ( 'SunJun0912:59:07+00002013', '343136551111111111', 311111111, 'FarAway', '{ 6, 50 }' );
+INSERT INTO add_singleobj_json_tbl VALUES ( 'WedJun1212:37:02+00002013', '333333333333333333', 333333333, 'NetherWorld', '{ 9, 63 }' );
+```
+
+Read the data that you just wrote. Recall that you must first create a new readable external table:
+
+``` sql
+CREATE EXTERNAL TABLE jso_tbl(
+  created_at TEXT,
+  id_str TEXT,
+  id INTEGER,
+  location TEXT,
+  coordinates INTEGER[]
+)
+LOCATION('pxf://data/pxf_examples/jso?PROFILE=hdfs:json&IDENTIFIER=created_at')
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+
+The column names that you specify in the create command must match those of the writable external table.
+
+Query the table to read the data:
+
+``` sql
+SELECT * FROM jso_tbl;
+```
+
+View the files added to HDFS:
+
+```
+$ hdfs dfs -cat /data/pxf_examples/jso/*
+{"root":[
+{"created_at":"SunJun0912:59:07+00002013","id_str":"343136551111111111","id":311111111,"location":"FarAway","coordinates":[6,50]}
+]}
+{"root":[
+{"created_at":"WedJun1212:37:02+00002013","id_str":"333333333333333333","id":333333333,"location":"NetherWorld","coordinates":[9,63]}
+]}
+```
 

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -205,7 +205,6 @@ The `hdfs:json` profile supports the following custom **write** options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|
-| IDENTIFIER=\<value\> | When the JSON data that you are writing is comprised of a single JSON object, you must specify an `IDENTIFIER` to identify the name of the field whose parent JSON object you want PXF to write as individual tuples. | 
 | ROOT=\<value\>    | When writing to a single JSON object, identifies the name of the root-level object attribute. |
 | COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing json data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
@@ -520,7 +519,7 @@ CREATE EXTERNAL TABLE jso_tbl(
 LOCATION('pxf://data/pxf_examples/jso?PROFILE=hdfs:json&IDENTIFIER=created_at')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
 
-The column names that you specify in the create command must match those of the writable external table.
+The column names that you specify in the create command must match those of the writable external table. And recall that to read a JSON file that contains a single object, you must specify the `IDENTIFIER` option.
 
 Query the table to read the data:
 

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -206,7 +206,7 @@ The `hdfs:json` profile supports the following custom **write** options:
 | Option  | Value Description |
 |-------|-------------------------------------|
 | IDENTIFIER=\<value\> | When the JSON data that you are writing is comprised of a single JSON object, you must specify an `IDENTIFIER` to identify the name of the field whose parent JSON object you want PXF to write as individual tuples. | 
-| ROOT=\<value\>    | When writing to a single JSON object (`IDENTIFIER` will also be set), identifies the name of the root-level object attribute. |
+| ROOT=\<value\>    | When writing to a single JSON object, identifies the name of the root-level object attribute. |
 | COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing json data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
 | COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | DISTRIBUTED BY    | If you are loading data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or `<column_name>` on both tables. Doing so will avoid extra motion of data between segments on the load operation. |

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -470,6 +470,12 @@ Query the table:
 
 ``` sql
 SELECT * FROM jsopr_tbl;
+
+        created_at         |       id_str       |    id     | location | coordinates 
+---------------------------+--------------------+-----------+----------+-------------
+ MonJun1002:12:06+00002013 | 343136557777777777 | 377777777 | NearHere | {13,93}
+ SunJun0912:59:07+00002013 | 343136551111111111 | 311111111 | FarAway  | {6,50}
+(2 rows)
 ```
 
 View the files added to HDFS:
@@ -528,6 +534,14 @@ Query the table to read the data:
 
 ``` sql
 SELECT * FROM jso_tbl;
+
+        created_at         |       id_str       |    id     |   location   | coo
+rdinates 
+---------------------------+--------------------+-----------+--------------+----
+---------
+ WedJun1212:37:02+00002013 | 333333333333333333 | 333333333 | NetherWorld  | {9,63}
+ SunJun0912:59:07+00002013 | 343136551111111111 | 311111111 | FarAway      | {6,50}
+(2 rows)
 ```
 
 View the files added to HDFS:

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -498,7 +498,7 @@ LOCATION('pxf://data/pxf_examples/jso?PROFILE=hdfs:json&ROOT=root&IDENTIFIER=cre
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
 ```
 
-`root` identifies the name of the root attribute of the single object. `created_at` identifies the member name of the first field in each JSON record.
+`root` identifies the name of the root attribute of the single object.
 
 Write data to the table:
 

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -207,7 +207,6 @@ The `hdfs:json` profile supports the following custom **write** options:
 |-------|-------------------------------------|
 | ROOT=\<value\>    | When writing to a single JSON object, identifies the name of the root-level object attribute. |
 | COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing json data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
-| COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 | DISTRIBUTED BY    | If you are loading data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or `<column_name>` on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
 When you specify compression for a JSON write operation, PXF names the files that it writes `<basename>.<json_file_type>.<compression_extension>`. For example: `jan_sales.jsonl.gz`.

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -102,14 +102,16 @@ PXF uses the following data type mapping when reading JSON data:
 | number  | { bigint &#124; float8 &#124; integer &#124; numeric &#124; real &#124; smallint } |
 | string | text |
 | string (base64-encoded value) | bytea |
-| string (date, time, timestamp in a text format that Greenplum understands) | text |
+| string (date, time, timestamp, timestamptz in a text format that Greenplum understands)<sup>1</sup> | { date &#124; time &#124; timestamp &#124; timestamptz } |
 | Array (one dimension) of type boolean[] | boolean[] |
 | Array (one dimension) of type number[] | { bigint[] &#124; float8[] &#124; integer[] &#124; numeric[] &#124; real[] &#124; smallint[] } |
 | Array (one dimension) of type string[] (base64-encoded value) | bytea[] |
-| Array (one dimension) of type string[] (date, time, timestamp in a text format that Greenplum understands) | string[] |
+| Array (one dimension) of type string[] (date, time, timestamp in a text format that Greenplum understands)<sup>1</sup> | { date[] &#124; time[] &#124; timestamp[] &#124; timestamptz[] } |
 | Array (one dimension) of type string[] | text[] |
 | Array of other types | text[] |
 | Object                | Use dot `.` notation to specify each level of projection (nesting) to a member of a primitive or Array type.                                                                                         |
+<sup>1</sup> PXF returns an error if Greenplum cannot convert the date or time string to the target type.
+
 When reading, you can use N-level projection to map members of nested objects and arrays to primitive data types.
 
 ### <a id="datatypemap_write"></a>Write Mapping

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -494,7 +494,7 @@ CREATE WRITABLE EXTERNAL TABLE add_singleobj_json_tbl(
   location TEXT,
   coordinates INTEGER[]
 )
-LOCATION('pxf://data/pxf_examples/jso?PROFILE=hdfs:json&ROOT=root&IDENTIFIER=created_at')
+LOCATION('pxf://data/pxf_examples/jso?PROFILE=hdfs:json&ROOT=root')
 FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
 ```
 

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -484,7 +484,7 @@ Notice that PXF creates a flat JSON structure.
 
 Use the following [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) SQL command to create a writable external table that writes JSON data in single object format and uses the PXF default server.
 
-You must specify the `ROOT` and `IDENTIFIER` keywords and associated values in the `LOCATION` clause. For example:
+You must specify the `ROOT` keyword and associated value in the `LOCATION` clause. For example:
 
 ``` sql
 CREATE WRITABLE EXTERNAL TABLE add_singleobj_json_tbl(

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -53,7 +53,7 @@ Refer to [JSON Lines](https://jsonlines.org/) for detailed information about thi
 
 #### <a id="arrayobject"></a>Single Object Per File
 
-A JSON file can also contain a single, named, root level JSON object whose value is an array of JSON objects. Each JSON object in the array represents a database tuple. JSON files of this type have the `.json` suffix.
+A JSON file can also contain a single, named, root level JSON object whose value is an array of JSON objects. When reading, the array may contain objects with arbitrary complexity and nesting, and PXF forms database tuples from objects that have a property named the same as that specified for the `IDENTIFIER` (discussed below). When writing, each JSON object in the array represents a database tuple. JSON files of this type have the `.json` suffix.
 
 In the following example JSON data file, the root-level `records` object is an array of three objects (tuples):
 

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -417,7 +417,7 @@ If you choose to alter the external table definition in this manner, be sure to 
 
 ## <a id="json_write"></a>Writing JSON Data
 
-To write JSON data, you create a writable external table that references the name of a directory on HDFS. When you insert records into the writable external table, PXF writes the block(s) of data that you insert to one or more files in the directory that you specified. In the default case (single object per row), PXF writes the data to a `.jsonl` file. When you specify an `IDENTIFIER` and a `ROOT` attribute (single object per file), PXF writes to a `.json` file.
+To write JSON data, you create a writable external table that references the name of a directory on HDFS. When you insert records into the writable external table, PXF writes the block(s) of data that you insert to one or more files in the directory that you specified. In the default case (single object per row), PXF writes the data to a `.jsonl` file. When you specify a `ROOT` attribute (single object per file), PXF writes to a `.json` file.
 
 > **Note** When you use PXF to write JSON data, you must flatten the objects into scalar or array table columns. PXF does not support column projection when writing JSON data.
 

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -29,7 +29,7 @@ Ensure that you have met the PXF Hadoop [Prerequisites](access_hdfs.html#hadoop_
 
 ## <a id="hdfsjson_work"></a>Working with JSON Data
 
-JSON is a text-based data-interchange format. A JSON data file contains one or more JSON objects. A JSON object is a collection of unordered name/value pairs. A value can be a string, a number, true, false, null, or an object or an array. You can define nested JSON objects and arrays.
+JSON is a text-based data-interchange format. A JSON data file contains one or more JSON objects. A JSON object is a collection of unordered name/value pairs. A value can be a string, a number, true, false, null, an object, or an array. You can define nested JSON objects and arrays.
 
 JSON data is typically stored in a file with a `.json` or `.jsonl` (JSON Lines) suffix as described in the sections below.
 

--- a/docs/content/hdfs_json.html.md.erb
+++ b/docs/content/hdfs_json.html.md.erb
@@ -21,7 +21,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Use the PXF HDFS Connector to read and write JSON-format data. This section describes how to use PXF to access JSON data in HDFS, including how to create, query, and insert into an external table that references a JSON file or directory in the HDFS data store.
+Use the PXF HDFS Connector to read and write JSON-format data. This section describes how to use PXF and external tables to access and write JSON data in HDFS.
 
 ## <a id="prereq"></a>Prerequisites
 
@@ -39,7 +39,7 @@ PXF supports two data access modes for JSON files. The default mode expects one 
 
 #### <a id="jsonl"></a>Single Object Per Row
 
-A JSON file can contain a single JSON object per row, where each row represents a database tuple. A JSON file that contains a single object per row may have a `.json`, or `.jsonl` suffix.
+A JSON file can contain a single JSON object per row, where each row represents a database tuple. A JSON file that PXF reads that contains a single object per row may have any or no suffix. When writing, PXF creates the file with a `.jsonl` suffix.
 
 Excerpt of sample single-object-per-row JSON data file:
 
@@ -419,7 +419,7 @@ If you choose to alter the external table definition in this manner, be sure to 
 
 To write JSON data, you create a writable external table that references the name of a directory on HDFS. When you insert records into the writable external table, PXF writes the block(s) of data that you insert to one or more files in the directory that you specified. In the default case (single object per row), PXF writes the data to a `.jsonl` file. When you specify a `ROOT` attribute (single object per file), PXF writes to a `.json` file.
 
-> **Note** When you use PXF to write JSON data, you must flatten the objects into scalar or array table columns. PXF does not support column projection when writing JSON data.
+> **Note** When writing JSON data, PXF supports only scalar or one dimensional arrays of Greenplum data types. PXF does not support column projection when writing JSON data.
 
 Writable external tables can only be used for `INSERT` operations. If you want to query the data that you inserted, you must create a separate readable external table that references the HDFS directory and read from that table.
 

--- a/docs/content/hdfs_text.html.md.erb
+++ b/docs/content/hdfs_text.html.md.erb
@@ -247,12 +247,11 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://doc
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma (`,`). Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or `<column_name>` on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
-Writable external tables that you create using the `hdfs:text` or the `hdfs:csv` profiles can optionally use record or block compression. You specify the compression type and codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:text` and `hdfs:csv` profiles support the following custom write options:
+Writable external tables that you create using the `hdfs:text` or the `hdfs:csv` profiles can optionally use record or block compression. You specify the compression codec via a custom option in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `hdfs:text` and `hdfs:csv` profiles support the following custom write option:
 
 | Option  | Value Description |
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing text data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
-| COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 
 ### <a id="write_hdfstextsimple_example"></a>Example: Writing Text Data to HDFS
 

--- a/docs/content/nfs_pxf.html.md.erb
+++ b/docs/content/nfs_pxf.html.md.erb
@@ -11,7 +11,7 @@ You can use PXF to read data that resides on a network file system mounted on yo
 | delimited text with quoted linefeeds | file:text:multi | read |
 | fixed width single line text | file:fixedwidth | read, write |
 | Avro | file:avro | read, write |
-| JSON | file:json | read |
+| JSON | file:json | read, write |
 | ORC | file:orc | read, write |
 | Parquet | file:parquet | read, write |
 

--- a/docs/content/objstore_fixedwidth.html.md.erb
+++ b/docs/content/objstore_fixedwidth.html.md.erb
@@ -164,12 +164,11 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://doc
 | line_delim    | The line delimiter character in the data. Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `line_delim=E'\n'`, `line_delim 'aaa'`. The default value is `'\n'`. |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or `<column_name>` on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
-Writable external tables that you create using the `<objstore>:fixedwidth` profile can optionally use record or block compression. You specify the compression type and codec via options in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause:
+Writable external tables that you create using the `<objstore>:fixedwidth` profile can optionally use record or block compression. You specify the compression codec via an option in the `CREATE WRITABLE EXTERNAL TABLE` `LOCATION` clause:
 
 | Write Option  | Value Description |
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing fixed-width text data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
-| COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 
 ## <a id="fixedwidth_write_example"></a>Example: Writing Fixed-Width Text Data to S3
 

--- a/docs/content/objstore_json.html.md.erb
+++ b/docs/content/objstore_json.html.md.erb
@@ -21,9 +21,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The PXF object store connectors support reading JSON-format data. This section describes how to use PXF to access JSON data in an object store, including how to create and query an external table that references a JSON file in the store.
+The PXF object store connectors support reading and writing JSON-format data. This section describes how to use PXF and external tables to access and write JSON data in an object store.
 
-**Note**: Accessing JSON-format data from an object store is very similar to accessing JSON-format data in HDFS. This topic identifies object store-specific information required to read JSON data, and links to the [PXF HDFS JSON documentation](hdfs_json.html) where appropriate for common information.
+**Note**: Accessing JSON-format data from an object store is very similar to accessing JSON-format data in HDFS. This topic identifies object store-specific information required to read and write JSON data, and links to the [PXF HDFS JSON documentation](hdfs_json.html) where appropriate for common information.
 
 ## <a id="prereq"></a>Prerequisites
 
@@ -33,9 +33,13 @@ Ensure that you have met the PXF Object Store [Prerequisites](access_objstore.ht
 
 Refer to [Working with JSON Data](hdfs_json.html#hdfsjson_work) in the PXF HDFS JSON documentation for a description of the JSON text-based data-interchange format.
 
+## <a id="datatype"></a>Data Type Mapping
+
+Refer to [Data Type Mapping](hdfs_json.html#datatypemap) in the PXF HDFS JSON documentation for a description of the JSON to Greenplum and Greenplum to JSON type mappings.
+
 ## <a id="json_cet"></a>Creating the External Table
 
-Use the `<objstore>:json` profile to read JSON-format files from an object store. PXF supports the following `<objstore>` profile prefixes:
+Use the `<objstore>:json` profile to read or write JSON-format files in an object store. PXF supports the following `<objstore>` profile prefixes:
 
 | Object Store  | Profile Prefix |
 |-------|-------------------------------------|
@@ -45,13 +49,14 @@ Use the `<objstore>:json` profile to read JSON-format files from an object store
 | MinIO    | s3 |
 | S3    | s3 |
 
-The following syntax creates a Greenplum Database readable external table that references a JSON-format file:
+The following syntax creates a Greenplum Database external table that references JSON-format data:
 
 ``` sql
-CREATE EXTERNAL TABLE <table_name>
+CREATE [WRITABLE] EXTERNAL TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table> )
 LOCATION ('pxf://<path-to-file>?PROFILE=<objstore>:json&SERVER=<server_name>[&<custom-option>=<value>[...]]')
-FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import'|'pxfwritable_export')
+[DISTRIBUTED BY (<column_name> [, ... ] ) | DISTRIBUTED RANDOMLY];
 ```
 
 The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL TABLE](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/ref_guide-sql_commands-CREATE_EXTERNAL_TABLE.html) command are described in the table below.
@@ -61,33 +66,32 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | \<path&#8209;to&#8209;file\>    | The path to the directory or file in the object store. When the `<server_name>` configuration includes a [`pxf.fs.basePath`](cfg_server.html#pxf-fs-basepath) property setting, PXF considers \<path&#8209;to&#8209;file\> to be relative to the base path specified. Otherwise, PXF considers it to be an absolute path. \<path&#8209;to&#8209;file\> must not specify a relative path nor include the dollar sign (`$`) character. |
 | PROFILE=\<objstore\>:json    | The `PROFILE` keyword must identify the specific object store. For example, `s3:json`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
-| \<custom&#8209;option\>=\<value\> | JSON supports the custom option named `IDENTIFIER` as described in the [PXF HDFS JSON documentation](hdfs_json.html#customopts). |
-| FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  the `<objstore>:json` profile. The `CUSTOM` `FORMAT` requires that you specify `(FORMATTER='pxfwritable_import')`. |
+| \<custom&#8209;option\>=\<value\> | JSON supports the custom options described in the [PXF HDFS JSON documentation](hdfs_json.html#customopts). |
+| FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  (FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
 
 If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 
-## <a id="example"></a>Example
+## <a id="read_example"></a>Read Example
 
-Refer to [Loading the Sample JSON Data to HDFS](hdfs_json.html#jsontohdfs) and [Example: Reading a JSON File with Single Line Records](hdfs_json.html#jsonexample1) in the PXF HDFS JSON documentation for a JSON example. Modifications that you must make to run the example with an object store include:
+Refer to [Loading the Sample JSON Data to HDFS](hdfs_json.html#jsontohdfs) and the [Read Example](hdfs_json.html#read_example1) in the PXF HDFS JSON documentation for a JSON read example. Modifications that you must make to run the example with an object store include:
 
 - Copying the file to the object store instead of HDFS. For example, to copy the file to S3:
 
     ``` shell
-    $ aws s3 cp /tmp/singleline.json s3://BUCKET/pxf_examples/
-    $ aws s3 cp /tmp/multiline.json s3://BUCKET/pxf_examples/
+    $ aws s3 cp /tmp/objperrow.jsonl s3://BUCKET/pxf_examples/
     ```
 
 - Using the `CREATE EXTERNAL TABLE` syntax and `LOCATION` keywords and settings described above. For example, if your server name is `s3srvcfg`:
 
     ``` sql
-    CREATE EXTERNAL TABLE singleline_json_s3(
+    CREATE EXTERNAL TABLE objperrow_json_s3(
       created_at TEXT,
       id_str TEXT,
       "user.id" INTEGER,
       "user.location" TEXT,
-      "coordinates.values" TEXT[]
+      "coordinates.values" INTEGER[]
     )
-      LOCATION('pxf://BUCKET/pxf_examples/singleline.json?PROFILE=s3:json&SERVER=s3srvcfg')
+      LOCATION('pxf://BUCKET/pxf_examples/objperrow.jsonl?PROFILE=s3:json&SERVER=s3srvcfg')
     FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
     ```
 
@@ -97,3 +101,34 @@ Refer to [Loading the Sample JSON Data to HDFS](hdfs_json.html#jsontohdfs) and [
     SELECT "coordinates.values"[1], "coordinates.values"[2] FROM singleline_json_s3;
     ``` 
 
+## <a id="write_example"></a>Write Example
+
+Refer to the [Writing JSON Data](hdfs_json.html#json_write) in the PXF HDFS JSON documentation for write examples. Modifications that you must make to run the single-object-per-row write example with an object store include:
+
+- Using the `CREATE WRITABLE EXTERNAL TABLE` syntax and `LOCATION` keywords and settings described above. For example, if your server name is `s3srvcfg`:
+
+    ``` sql
+    CREATE WRITABLE EXTERNAL TABLE add_objperrow_json_s3(
+      created_at TEXT,
+      id_str TEXT,
+      id INTEGER,
+      location TEXT,
+      coordinates INTEGER[]
+    )
+      LOCATION('pxf://BUCKET/pxf_examples/jsopr?PROFILE=s3:json&SERVER=s3srvcfg')
+    FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
+    ```
+
+- Using the `CREATE EXTERNAL TABLE` syntax and `LOCATION` keywords and settings described above to read the data back. For example, if your server name is `s3srvcfg`:
+
+    ``` sql
+    CREATE EXTERNAL TABLE jsopr_tbl(
+      created_at TEXT,
+      id_str TEXT,
+      id INTEGER,
+      location TEXT,
+      coordinates INTEGER[]
+    )
+    LOCATION('pxf://BUCKET/pxf_examples/jsopr?PROFILE=s3:json')
+    FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
+    ```

--- a/docs/content/objstore_json.html.md.erb
+++ b/docs/content/objstore_json.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Reading JSON Data from an Object Store
+title: Reading and Writing JSON Data in an Object Store
 ---
 
 <!--

--- a/docs/content/objstore_json.html.md.erb
+++ b/docs/content/objstore_json.html.md.erb
@@ -67,7 +67,7 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 | PROFILE=\<objstore\>:json    | The `PROFILE` keyword must identify the specific object store. For example, `s3:json`. |
 | SERVER=\<server_name\>    | The named server configuration that PXF uses to access the data. |
 | \<custom&#8209;option\>=\<value\> | JSON supports the custom options described in the [PXF HDFS JSON documentation](hdfs_json.html#customopts). |
-| FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  (FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
+| FORMAT 'CUSTOM' | Use `FORMAT` `'CUSTOM'` with  `(FORMATTER='pxfwritable_export')` (write) or `(FORMATTER='pxfwritable_import')` (read). |
 
 If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 
@@ -91,7 +91,7 @@ Refer to [Loading the Sample JSON Data to HDFS](hdfs_json.html#jsontohdfs) and t
       "user.location" TEXT,
       "coordinates.values" INTEGER[]
     )
-      LOCATION('pxf://BUCKET/pxf_examples/objperrow.jsonl?PROFILE=s3:json&SERVER=s3srvcfg')
+    LOCATION('pxf://BUCKET/pxf_examples/objperrow.jsonl?PROFILE=s3:json&SERVER=s3srvcfg')
     FORMAT 'CUSTOM' (FORMATTER='pxfwritable_import');
     ```
 
@@ -115,7 +115,7 @@ Refer to the [Writing JSON Data](hdfs_json.html#json_write) in the PXF HDFS JSON
       location TEXT,
       coordinates INTEGER[]
     )
-      LOCATION('pxf://BUCKET/pxf_examples/jsopr?PROFILE=s3:json&SERVER=s3srvcfg')
+    LOCATION('pxf://BUCKET/pxf_examples/jsopr?PROFILE=s3:json&SERVER=s3srvcfg')
     FORMAT 'CUSTOM' (FORMATTER='pxfwritable_export');
     ```
 

--- a/docs/content/objstore_text.html.md.erb
+++ b/docs/content/objstore_text.html.md.erb
@@ -277,12 +277,11 @@ The specific keywords and values used in the [CREATE EXTERNAL TABLE](https://doc
 | delimiter    | The delimiter character in the data. For `FORMAT` `'CSV'`, the default \<delim_value\> is a comma (`,`). Preface the \<delim_value\> with an `E` when the value is an escape sequence. Examples: `(delimiter=E'\t')`, `(delimiter ':')`. |
 | DISTRIBUTED BY    | If you want to load data from an existing Greenplum Database table into the writable external table, consider specifying the same distribution policy or `<column_name>` on both tables. Doing so will avoid extra motion of data between segments on the load operation. |
 
-Writable external tables that you create using an `<objstore>:text|csv` profile can optionally use record or block compression. You specify the compression type and codec via custom options in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `<objstore>:text|csv` profiles support the following custom write options:
+Writable external tables that you create using an `<objstore>:text|csv` profile can optionally use record or block compression. You specify the compression codec via a custom option in the `CREATE EXTERNAL TABLE` `LOCATION` clause. The `<objstore>:text|csv` profiles support the following custom write options:
 
 | Option  | Value Description |
 |-------|-------------------------------------|
 | COMPRESSION_CODEC    | The compression codec alias. Supported compression codecs for writing text data include: `default`, `bzip2`, `gzip`, and `uncompressed`. If this option is not provided, Greenplum Database performs no data compression. |
-| COMPRESSION_TYPE    | The compression type to employ; supported values are `RECORD` (the default) or `BLOCK`. |
 
 If you are accessing an S3 object store, you can provide S3 credentials via custom options in the `CREATE EXTERNAL TABLE` command as described in [Overriding the S3 Server Configuration with DDL](access_s3.html#s3_override).
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/984 - pxf *:json profiles now support writing.

in this PR:
- misc table updates to include write support for json
- extensive updates to the JSON "using" topic, including reorganizing, revising read data type mapping, adding write data type mapping, adding write options and examples.

TODO:  when this PR is approved, i will add parallel updates to the object store JSON topic.

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/VMware-Greenplum-Platform-Extension-Framework/jsonwrite/greenplum-platform-extension-framework/GUID-hdfs_json.html