### PR TITLE
docs - master -> coordinator for inclusive terminology

### DIFF
--- a/docs/content/about_pxf_dir.html.md.erb
+++ b/docs/content/about_pxf_dir.html.md.erb
@@ -22,7 +22,7 @@ The following PXF files and directories are installed to `<PXF_INSTALL_DIR>` whe
 | application/                | The PXF Server application JAR file.   |
 | bin/                | The PXF command line executable directory.   |
 | commit.sha          | The commit identifier for this PXF release.   |
-| gpextable/           | The PXF extension files. PXF copies the `pxf.control` file from this directory to the Greenplum installation (`$GPHOME`) on a single host when you run the `pxf register` command, or on all hosts in the cluster when you run the `pxf [cluster] register` command from the Greenplum master host.   |
+| gpextable/           | The PXF extension files. PXF copies the `pxf.control` file from this directory to the Greenplum installation (`$GPHOME`) on a single host when you run the `pxf register` command, or on all hosts in the cluster when you run the `pxf [cluster] register` command from the Greenplum coordinator host.   |
 | share/                | The directory for shared PXF files that you may require depending on the external data stores that you access. `share/` initially includes only the PXF HBase JAR file. |
 | templates/  | The PXF directory for server configuration file templates. |
 | version              | The PXF version.             |
@@ -49,13 +49,13 @@ PXF provides the [pxf [cluster] prepare](ref/pxf-cluster.html) command to prepar
 For example, to relocate `$PXF_BASE` to the `/path/to/dir` directory on all Greenplum hosts, run the command as follows:
 
 ``` shell
-gpadmin@gpmaster$ PXF_BASE=/path/to/dir pxf cluster prepare
+gpadmin@coordinator$ PXF_BASE=/path/to/dir pxf cluster prepare
 ```
 
 When your `$PXF_BASE` is different than `<PXF_INSTALL_DIR>`, inform PXF by setting the `PXF_BASE` environment variable when you run a `pxf` command:
 
 ``` pre
-gpadmin@gpmaster$ PXF_BASE=/path/to/dir pxf cluster start
+gpadmin@coordinator$ PXF_BASE=/path/to/dir pxf cluster start
 ```
 
 Set the environment variable in the `.bashrc` shell initialization script for the PXF installation owner (typically the `gpadmin` user) as follows:

--- a/docs/content/access_hdfs.html.md.erb
+++ b/docs/content/access_hdfs.html.md.erb
@@ -25,7 +25,7 @@ PXF is compatible with Cloudera, Hortonworks Data Platform, MapR, and generic Ap
 
 ## <a id="hdfs_arch"></a>Architecture
 
-HDFS is the primary distributed storage mechanism used by Apache Hadoop. When a user or application performs a query on a PXF external table that references an HDFS file, the Greenplum Database master host dispatches the query to all segment instances. Each segment instance contacts the PXF Service running on its host. When it receives the request from a segment instance, the PXF Service:
+HDFS is the primary distributed storage mechanism used by Apache Hadoop. When a user or application performs a query on a PXF external table that references an HDFS file, the Greenplum Database coordinator host dispatches the query to all segment instances. Each segment instance contacts the PXF Service running on its host. When it receives the request from a segment instance, the PXF Service:
 
 1. Allocates a worker thread to serve the request from the segment instance.
 2. Invokes the HDFS Java API to request metadata information for the HDFS file from the HDFS NameNode. 
@@ -36,7 +36,7 @@ HDFS is the primary distributed storage mechanism used by Apache Hadoop. When a 
 
 A PXF worker thread works on behalf of a segment instance. A worker thread uses its Greenplum Database `gp_segment_id` and the file block information described in the metadata to assign itself a specific portion of the query data. This data may reside on one or more HDFS DataNodes.
 
-The PXF worker thread invokes the HDFS Java API to read the data and delivers it to the segment instance. The segment instance delivers its portion of the data to the Greenplum Database master host. This communication occurs across segment hosts and segment instances in parallel.
+The PXF worker thread invokes the HDFS Java API to read the data and delivers it to the segment instance. The segment instance delivers its portion of the data to the Greenplum Database coordinator host. This communication occurs across segment hosts and segment instances in parallel.
 
 
 ## <a id="hadoop_prereq"></a>Prerequisites

--- a/docs/content/cfg_logging.html.md.erb
+++ b/docs/content/cfg_logging.html.md.erb
@@ -32,10 +32,10 @@ To change the PXF log directory, you must update the `$PXF_LOGDIR` property in t
 
 **Note:** The new log directory must exist on all Greenplum Database hosts, and must be accessible by the `gpadmin` user.
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 1. Use a text editor to uncomment the `export PXF_LOGDIR` line in `$PXF_BASE/conf/pxf-env.sh`, and replace the value with the new PXF log directory. For example:
@@ -48,7 +48,7 @@ To change the PXF log directory, you must update the `$PXF_LOGDIR` property in t
 2. Use the `pxf cluster sync` command to copy the updated `pxf-env.sh` file to all hosts in the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 3. Restart PXF on each Greenplum Database host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).
@@ -119,10 +119,10 @@ You can change the log level for the PXF Service running on a specific Greenplum
 
 To change the log level for the PXF service running on every host in the Greenplum Database cluster:
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 1. Use a text editor to uncomment the following line in the `$PXF_BASE/conf/pxf-application.properties` file and set the desired log level.  For example, to change the log level from `info` (the default) to `debug`:
@@ -134,13 +134,13 @@ To change the log level for the PXF service running on every host in the Greenpl
 1. Use the `pxf cluster sync` command to copy the updated `pxf-application.properties` file to all hosts in the Greenplum Database cluster. For example:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 1.  Restart PXF on each Greenplum Database host:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster restart
     ```
 
 1. Perform operations that exercise the PXF Service, and then collect and examine the information in `$PXF_LOGDIR/pxf-service.log`.

--- a/docs/content/cfg_mem.html.md.erb
+++ b/docs/content/cfg_mem.html.md.erb
@@ -11,16 +11,16 @@ Each PXF Service running on a Greenplum Database host is configured with a defau
 
 Perform the following procedure to increase the heap size for the PXF Service running on each host in your Greenplum Database cluster.
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Edit the `$PXF_BASE/conf/pxf-env.sh` file. For example:
 
     ``` shell
-    gpadmin@gpmaster$ vi $PXF_BASE/conf/pxf-env.sh
+    gpadmin@coordinator$ vi $PXF_BASE/conf/pxf-env.sh
     ```
 
 3. Locate the `PXF_JVM_OPTS` setting in the `pxf-env.sh` file, and update the `-Xmx` and/or `-Xms` options to the desired value. For example:
@@ -34,7 +34,7 @@ Perform the following procedure to increase the heap size for the PXF Service ru
 4. Use the `pxf cluster sync` command to copy the updated `pxf-env.sh` file to the Greenplum Database cluster. For example:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 5. Restart PXF on each Greenplum Database host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).
@@ -96,16 +96,16 @@ Refer to the configuration [procedure](#pxf-cfgoom_proc) below for the instructi
 
 Auto-termination of the PXF Service on OOM is deactivated by default. Heap dump generation on OOM is deactivated by default. To configure one or both of these properties, perform the following procedure:
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Edit the `$PXF_BASE/conf/pxf-env.sh` file. For example:
 
     ``` shell
-    gpadmin@gpmaster$ vi $PXF_BASE/conf/pxf-env.sh
+    gpadmin@coordinator$ vi $PXF_BASE/conf/pxf-env.sh
     ```
 
 3. If you want to configure (i.e. turn off, or turn back on) auto-termination of the PXF Service on OOM, locate the `PXF_OOM_KILL` property in the `pxf-env.sh` file. If the setting is commented out, uncomment it, and then update the value. For example, to turn off this behavior, set the value to `false`:
@@ -133,7 +133,7 @@ Auto-termination of the PXF Service on OOM is deactivated by default. Heap dump 
 6. Use the `pxf cluster sync` command to copy the updated `pxf-env.sh` file to the Greenplum Database cluster. For example:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 7. Restart PXF on each Greenplum Database host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).
@@ -151,16 +151,16 @@ If you plan to run large workloads on a large number of files in an external Hiv
 
 Perform the following procedure to set the maximum number of Tomcat threads for the PXF Service running on each host in your Greenplum Database deployment.
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Edit the `$PXF_BASE/conf/pxf-application.properties` file. For example:
 
     ``` shell
-    gpadmin@gpmaster$ vi $PXF_BASE/conf/pxf-application.properties
+    gpadmin@coordinator$ vi $PXF_BASE/conf/pxf-application.properties
     ```
 
 3. Locate the `pxf.max.threads` setting in the `pxf-application.properties` file. If the setting is commented out, uncomment it, and then update to the desired value. For example, to reduce the maximum number of Tomcat threads to 100:
@@ -174,7 +174,7 @@ Perform the following procedure to set the maximum number of Tomcat threads for 
 4. Use the `pxf cluster sync` command to copy the updated `pxf-application.properties` file to the Greenplum Database cluster. For example:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 5. Restart PXF on each Greenplum Database host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).

--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -25,7 +25,7 @@ The configuration information for a PXF server resides in one or more `<connecto
 PXF provides a template configuration file for each connector.  These server template configuration files are located in the `<PXF_INSTALL_DIR>/templates/` directory after you install PXF:
 
 ```
-gpadmin@gpmaster$ ls <PXF_INSTALL_DIR>/templates
+gpadmin@coordinator$ ls <PXF_INSTALL_DIR>/templates
 adl-site.xml   hbase-site.xml  jdbc-site.xml    pxf-site.xml    yarn-site.xml
 core-site.xml  hdfs-site.xml   mapred-site.xml  s3-site.xml
 gs-site.xml    hive-site.xml   minio-site.xml   wasbs-site.xml

--- a/docs/content/cfghostport.html.md.erb
+++ b/docs/content/cfghostport.html.md.erb
@@ -17,10 +17,10 @@ The `server.address` property identifies the IP address or hostname of the netwo
 
 When the PXF Service runs on Greenplum Database hosts, to secure communications and restrict PXF to listen only on the loopback interface, set the `server.address` to `localhost`:
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 1. Locate the `pxf-application.properties` file in your PXF installation. If you did not relocate `$PXF_BASE`, the file resides here:
@@ -40,8 +40,8 @@ When the PXF Service runs on Greenplum Database hosts, to secure communications 
 1. Synchronize the PXF configuration and then restart PXF:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster restart
     ```
 
 ## <a id="port"></a>Configuring the Port Number
@@ -50,10 +50,10 @@ When the PXF Service runs on Greenplum Database hosts, to secure communications 
 
 Perform the following procedure to configure the port number of the PXF server on one or more Greenplum Database hosts:
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. For each Greenplum Database host:
@@ -75,7 +75,7 @@ Perform the following procedure to configure the port number of the PXF server o
 1. Source the `.bashrc` that file you just updated:
 
     ``` shell
-    gpadmin@gpmaster$ source ~/.bashrc
+    gpadmin@coordinator$ source ~/.bashrc
     ```
 
 3. Restart Greenplum Database as described in [Restarting Greenplum Database](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-managing-startstop.html#restarting-greenplum-database) in the Greenplum Documentation.
@@ -83,7 +83,7 @@ Perform the following procedure to configure the port number of the PXF server o
 4. Restart PXF on each Greenplum Database host:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster restart
     ```
 
 5. Verify that PXF is running on the reconfigured port by invoking `http://<PXF_HOST>:<PXF_PORT>/actuator/health` to view PXF monitoring information as described in [About PXF Service Runtime Monitoring](monitor_pxf.html#about_rtm).
@@ -97,10 +97,10 @@ Perform the following procedure to configure the PXF host on each Greenplum Data
 
 <div class="note"><b>Note:</b> You must restart Greenplum Database when you configure the host in this manner. Consider performing this configuration during a scheduled down time.</div>
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. For each Greenplum Database segment host:
@@ -122,7 +122,7 @@ Perform the following procedure to configure the PXF host on each Greenplum Data
 1. Source the `.bashrc` that file you just updated:
 
     ``` shell
-    gpadmin@gpmaster$ source ~/.bashrc
+    gpadmin@coordinator$ source ~/.bashrc
     ```
 
 3. Restart Greenplum Database as described in [Restarting Greenplum Database](https://docs.vmware.com/en/VMware-Greenplum/6/greenplum-database/admin_guide-managing-startstop.html#restarting-greenplum-database) in the Greenplum Documentation.

--- a/docs/content/cfginitstart_pxf.html.md.erb
+++ b/docs/content/cfginitstart_pxf.html.md.erb
@@ -48,16 +48,16 @@ Before you start PXF in your Greenplum Database cluster, ensure that:
 
 Perform the following procedure to start PXF on each host in your Greenplum Database cluster.
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 3. Run the `pxf cluster start` command to start PXF on each host:
 
     ```shell
-    gpadmin@gpmaster$ pxf cluster start
+    gpadmin@coordinator$ pxf cluster start
     ```
 
 ## <a id="stop_pxf"></a>Stopping PXF
@@ -72,16 +72,16 @@ Before you stop PXF in your Greenplum Database cluster, ensure that your Greenpl
 
 Perform the following procedure to stop PXF on each host in your Greenplum Database cluster.
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 3. Run the `pxf cluster stop` command to stop PXF on each host:
 
     ```shell
-    gpadmin@gpmaster$ pxf cluster stop
+    gpadmin@coordinator$ pxf cluster stop
     ```
 
 ## <a id="restart_pxf"></a>Restarting PXF
@@ -98,15 +98,15 @@ Before you restart PXF in your Greenplum Database cluster, ensure that your Gree
 
 Perform the following procedure to restart PXF in your Greenplum Database cluster.
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Restart PXF:
 
     ```shell
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster restart
     ```
 

--- a/docs/content/client_instcfg.html.md.erb
+++ b/docs/content/client_instcfg.html.md.erb
@@ -8,19 +8,19 @@ PXF is compatible with Cloudera, Hortonworks Data Platform, MapR, and generic Ap
 
 ## <a id="prereq"></a>Prerequisites
 
-Configuring PXF Hadoop connectors involves copying configuration files from your Hadoop cluster to the Greenplum Database master host. If you are using the MapR Hadoop distribution, you must also copy certain JAR files to the master host. Before you configure the PXF Hadoop connectors, ensure that you can copy files from hosts in your Hadoop cluster to the Greenplum Database master.
+Configuring PXF Hadoop connectors involves copying configuration files from your Hadoop cluster to the Greenplum Database coordinator host. If you are using the MapR Hadoop distribution, you must also copy certain JAR files to the coordinator host. Before you configure the PXF Hadoop connectors, ensure that you can copy files from hosts in your Hadoop cluster to the Greenplum Database coordinator.
 
 
 ## <a id="client-pxf-config-steps"></a>Procedure
 
-Perform the following procedure to configure the desired PXF Hadoop-related connectors on the Greenplum Database master host. After you configure the connectors, you will use the `pxf cluster sync` command to copy the PXF configuration to the Greenplum Database cluster.
+Perform the following procedure to configure the desired PXF Hadoop-related connectors on the Greenplum Database coordinator host. After you configure the connectors, you will use the `pxf cluster sync` command to copy the PXF configuration to the Greenplum Database cluster.
 
-In this procedure, you use the `default`, or create a new PXF server configuration. You copy Hadoop configuration files to the server configuration directory on the Greenplum Database master host. You identify Kerberos and user impersonation settings required for access, if applicable. You may also copy libraries to `$PXF_BASE/lib` for MapR support. You then synchronize the PXF configuration on the master host to the standby master host and segment hosts.
+In this procedure, you use the `default`, or create a new PXF server configuration. You copy Hadoop configuration files to the server configuration directory on the Greenplum Database coordinator host. You identify Kerberos and user impersonation settings required for access, if applicable. You may also copy libraries to `$PXF_BASE/lib` for MapR support. You then synchronize the PXF configuration on the coordinator host to the standby coordinator host and segment hosts.
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Identify the name of your PXF Hadoop server configuration.
@@ -28,55 +28,55 @@ In this procedure, you use the `default`, or create a new PXF server configurati
 3. If you are not using the `default` PXF server, create the `$PXF_BASE/servers/<server_name>` directory. For example, use the following command to create a Hadoop server configuration named `hdp3`:
 
     ``` shell
-    gpadmin@gpmaster$ mkdir $PXF_BASE/servers/hdp3
+    gpadmin@coordinator$ mkdir $PXF_BASE/servers/hdp3
     ````
 
 4. Change to the server directory. For example:
 
     ```shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/default
+    gpadmin@coordinator$ cd $PXF_BASE/servers/default
     ```
 
     Or,
 
     ```shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/hdp3
+    gpadmin@coordinator$ cd $PXF_BASE/servers/hdp3
     ```
 
 2. PXF requires information from `core-site.xml` and other Hadoop configuration files. Copy the `core-site.xml`, `hdfs-site.xml`, `mapred-site.xml`, and `yarn-site.xml` Hadoop configuration files from your Hadoop cluster NameNode host to the current host using your tool of choice. Your file paths may differ based on the Hadoop distribution in use. For example, these commands use `scp` to copy the files:
 
     ``` shell
-    gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/core-site.xml .
-    gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/hdfs-site.xml .
-    gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/mapred-site.xml .
-    gpadmin@gpmaster$ scp hdfsuser@namenode:/etc/hadoop/conf/yarn-site.xml .
+    gpadmin@coordinator$ scp hdfsuser@namenode:/etc/hadoop/conf/core-site.xml .
+    gpadmin@coordinator$ scp hdfsuser@namenode:/etc/hadoop/conf/hdfs-site.xml .
+    gpadmin@coordinator$ scp hdfsuser@namenode:/etc/hadoop/conf/mapred-site.xml .
+    gpadmin@coordinator$ scp hdfsuser@namenode:/etc/hadoop/conf/yarn-site.xml .
     ```
         
-3. If you plan to use the PXF Hive connector to access Hive table data, similarly copy the Hive configuration to the Greenplum Database master host. For example:
+3. If you plan to use the PXF Hive connector to access Hive table data, similarly copy the Hive configuration to the Greenplum Database coordinator host. For example:
 
     ``` shell
-    gpadmin@gpmaster$ scp hiveuser@hivehost:/etc/hive/conf/hive-site.xml .
+    gpadmin@coordinator$ scp hiveuser@hivehost:/etc/hive/conf/hive-site.xml .
     ```
 
-4. If you plan to use the PXF HBase connector to access HBase table data, similarly copy the HBase configuration to the Greenplum Database master host. For example:
+4. If you plan to use the PXF HBase connector to access HBase table data, similarly copy the HBase configuration to the Greenplum Database coordinator host. For example:
     
     ``` shell
-    gpadmin@gpmaster$ scp hbaseuser@hbasehost:/etc/hbase/conf/hbase-site.xml .
+    gpadmin@coordinator$ scp hbaseuser@hbasehost:/etc/hbase/conf/hbase-site.xml .
     ```
 
-2. If you are using PXF with the MapR Hadoop distribution, you must copy certain JAR files from your MapR cluster to the Greenplum Database master host. (Your file paths may differ based on the version of MapR in use.) For example, these commands use `scp` to copy the files:
+2. If you are using PXF with the MapR Hadoop distribution, you must copy certain JAR files from your MapR cluster to the Greenplum Database coordinator host. (Your file paths may differ based on the version of MapR in use.) For example, these commands use `scp` to copy the files:
 
     ``` shell
-    gpadmin@gpmaster$ cd $PXF_BASE/lib
-    gpadmin@gpmaster$ scp mapruser@maprhost:/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/lib/maprfs-5.2.2-mapr.jar .
-    gpadmin@gpmaster$ scp mapruser@maprhost:/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/lib/hadoop-auth-2.7.0-mapr-1707.jar .
-    gpadmin@gpmaster$ scp mapruser@maprhost:/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/hadoop-common-2.7.0-mapr-1707.jar .
+    gpadmin@coordinator$ cd $PXF_BASE/lib
+    gpadmin@coordinator$ scp mapruser@maprhost:/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/lib/maprfs-5.2.2-mapr.jar .
+    gpadmin@coordinator$ scp mapruser@maprhost:/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/lib/hadoop-auth-2.7.0-mapr-1707.jar .
+    gpadmin@coordinator$ scp mapruser@maprhost:/opt/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/hadoop-common-2.7.0-mapr-1707.jar .
     ```
         
 5. Synchronize the PXF configuration to the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 4. PXF accesses Hadoop services on behalf of Greenplum Database end users. By default, PXF tries to access HDFS, Hive, and HBase using the identity of the Greenplum Database user account that logs into Greenplum Database. In order to support this functionality, you must configure proxy settings for Hadoop, as well as for Hive and HBase if you intend to use those PXF connectors. Follow procedures in [Configuring User Impersonation and Proxying](pxfuserimpers.html) to configure user impersonation and proxying for Hadoop services, or to turn off PXF user impersonation.
@@ -91,8 +91,8 @@ In this procedure, you use the `default`, or create a new PXF server configurati
 If you update your Hadoop, Hive, or HBase configuration while the PXF Service is running, you must copy the updated configuration to the `$PXF_BASE/servers/<server_name>` directory and re-sync the PXF configuration to your Greenplum Database cluster. For example:
 
 ``` shell
-gpadmin@gpmaster$ cd $PXF_BASE/servers/<server_name>
-gpadmin@gpmaster$ scp hiveuser@hivehost:/etc/hive/conf/hive-site.xml .
-gpadmin@gpmaster$ pxf cluster sync
+gpadmin@coordinator$ cd $PXF_BASE/servers/<server_name>
+gpadmin@coordinator$ scp hiveuser@hivehost:/etc/hive/conf/hive-site.xml .
+gpadmin@coordinator$ pxf cluster sync
 ```
 

--- a/docs/content/config_files.html.md.erb
+++ b/docs/content/config_files.html.md.erb
@@ -21,13 +21,13 @@ Procedure:
 1. Synchronize the PXF configuration to all hosts in the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 1. (Re)start PXF on all Greenplum hosts:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster restart
     ```
 
 
@@ -76,5 +76,5 @@ The [Logging](cfg_logging.html) advanced configuration topic describes how to en
 
 ## <a id="pxfprofiledef"></a>pxf-profiles.xml
 
-PXF defines its default profiles in the [`pxf-profiles-default.xml`](https://github.com/greenplum-db/pxf/blob/master/server/pxf-service/src/main/resources/pxf-profiles-default.xml) file. If you choose to add a custom profile, you configure the profile in `pxf-profiles.xml`.
+PXF defines its default profiles in the [`pxf-profiles-default.xml`](https://github.com/greenplum-db/pxf/blob/main/server/pxf-service/src/main/resources/pxf-profiles-default.xml) file. If you choose to add a custom profile, you configure the profile in `pxf-profiles.xml`.
 

--- a/docs/content/hdfs_orc.html.md.erb
+++ b/docs/content/hdfs_orc.html.md.erb
@@ -217,10 +217,10 @@ Procedure:
     $ hdfs dfs -put /tmp/sampledata.orc /data/pxf_examples/orc_example/
     ```
 
-1. Log in to the Greenplum Database master host and connect to a database. This command connects to the database named `testdb` as the `gpadmin` user:
+1. Log in to the Greenplum Database coordinator host and connect to a database. This command connects to the database named `testdb` as the `gpadmin` user:
 
     ``` shell
-    gpadmin@gpmaster$ psql -d testdb
+    gpadmin@coordinator$ psql -d testdb
     ```
 
 1. Create an external table named `sample_orc` that references the `/data/pxf_examples/orc_example/sampledata.orc` file on HDFS. This command creates the table with the column names specified in the ORC schema, and uses the `default` PXF server:

--- a/docs/content/hdfs_seqfile.html.md.erb
+++ b/docs/content/hdfs_seqfile.html.md.erb
@@ -202,28 +202,28 @@ Perform the following procedure to create the Java class and writable table.
 
     (Your Hadoop library classpath may differ.)
 
-3. Copy the `pxfex-customwritable.jar` file to the Greenplum Database master host. For example:
+3. Copy the `pxfex-customwritable.jar` file to the Greenplum Database coordinator host. For example:
 
     ``` shell
-    $ scp pxfex-customwritable.jar gpadmin@gpmaster:/home/gpadmin
+    $ scp pxfex-customwritable.jar gpadmin@coordinator:/home/gpadmin
     ```
 
-4. Log in to your Greenplum Database master host:
+4. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ````
 
 5. Copy the `pxfex-customwritable.jar` JAR file to the user runtime library directory, and note the location. For example, if `PXF_BASE=/usr/local/pxf-gp6`:
 
     ``` shell
-    gpadmin@gpmaster$ cp /home/gpadmin/pxfex-customwritable.jar /usr/local/pxf-gp6/lib/pxfex-customwritable.jar
+    gpadmin@coordinator$ cp /home/gpadmin/pxfex-customwritable.jar /usr/local/pxf-gp6/lib/pxfex-customwritable.jar
     ```
 
 5. Synchronize the PXF configuration to the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 3. Restart PXF on each Greenplum Database host as described in [Restarting PXF](cfginitstart_pxf.html#restart_pxf).

--- a/docs/content/hive_jdbc_cfg.html.md.erb
+++ b/docs/content/hive_jdbc_cfg.html.md.erb
@@ -50,10 +50,10 @@ Table heading key:
 
 Perform the following procedure to configure a PXF JDBC server for Hive:
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Choose a name for the JDBC server.
@@ -61,25 +61,25 @@ Perform the following procedure to configure a PXF JDBC server for Hive:
 3. Create the `$PXF_BASE/servers/<server_name>` directory. For example, use the following command to create a JDBC server configuration named `hivejdbc1`:
 
     ``` shell
-    gpadmin@gpmaster$ mkdir $PXF_BASE/servers/hivejdbc1
+    gpadmin@coordinator$ mkdir $PXF_BASE/servers/hivejdbc1
     ````
 
 3. Navigate to the server configuration directory. For example:
 
     ```shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/hivejdbc1
+    gpadmin@coordinator$ cd $PXF_BASE/servers/hivejdbc1
     ```
 
 4. Copy the PXF JDBC server template file to the server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/jdbc-site.xml .
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/jdbc-site.xml .
     ```
         
 4. When you access Hive secured with Kerberos, you also need to specify configuration properties in the `pxf-site.xml` file. *If this file does not yet exist in your server configuration*, copy the `pxf-site.xml` template file to the server config directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
         
 5. Open the `jdbc-site.xml` file in the editor of your choice and set the `jdbc.driver` and `jdbc.url` properties. Be sure to specify your Hive host, port, and database name:
@@ -186,6 +186,6 @@ Perform the following procedure to configure a PXF JDBC server for Hive:
 11. Use the `pxf cluster sync` command to copy the new server configuration to the Greenplum Database cluster:
     
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 

--- a/docs/content/install_java.html.md.erb
+++ b/docs/content/install_java.html.md.erb
@@ -11,26 +11,26 @@ Ensure that you have access to, or superuser permissions to install, Java 8 or J
 
 ## <a id="proc"></a>Procedure
 
-Perform the following procedure to install Java on the master host, standby master host, and on each segment host in your Greenplum Database cluster. You will use the `gpssh` utility where possible to run a command on multiple hosts.
+Perform the following procedure to install Java on the coordinator host, standby coordinator host, and on each segment host in your Greenplum Database cluster. You will use the `gpssh` utility where possible to run a command on multiple hosts.
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Determine the version(s) of Java installed on the system:
 
     ``` pre
-    gpadmin@gpmaster$ rpm -qa | grep java
+    gpadmin@coordinator$ rpm -qa | grep java
     ```
 
-3. If the system does not include a Java version 8 or 11 installation, install one of these Java versions on the master host, standby master host, and on each Greenplum Database segment host.
+3. If the system does not include a Java version 8 or 11 installation, install one of these Java versions on the coordinator host, standby coordinator host, and on each Greenplum Database segment host.
 
-    1. Create a text file that lists your Greenplum Database standby master host and segment hosts, one host name per line. For example, a file named `gphostfile` may include:
+    1. Create a text file that lists your Greenplum Database standby coordinator host and segment hosts, one host name per line. For example, a file named `gphostfile` may include:
 
         ``` pre
-        gpmaster
+        coordinator
         mstandby
         seghost1
         seghost2
@@ -39,7 +39,7 @@ Perform the following procedure to install Java on the master host, standby mast
     2. Install the Java package on each host. For example, to install Java version 8:
 
         ``` shell
-        gpadmin@gpmaster$ gpssh -e -v -f gphostfile sudo yum -y install java-1.8.0-openjdk-1.8.0*
+        gpadmin@coordinator$ gpssh -e -v -f gphostfile sudo yum -y install java-1.8.0-openjdk-1.8.0*
         ```
 
 4. Identify the Java 8 or 11 `$JAVA_HOME` setting for PXF. For example:

--- a/docs/content/instcfg_pxf.html.md.erb
+++ b/docs/content/instcfg_pxf.html.md.erb
@@ -1,17 +1,17 @@
 ---
 title: Configuring PXF
 ---
-Your Greenplum Database deployment consists of a master host, a standby master host, and multiple segment hosts. After you configure the Greenplum Platform Extension Framework (PXF), you start a single PXF JVM process (PXF Service) on each Greenplum Database host.
+Your Greenplum Database deployment consists of a coordinator host, a standby coordinator host, and multiple segment hosts. After you configure the Greenplum Platform Extension Framework (PXF), you start a single PXF JVM process (PXF Service) on each Greenplum Database host.
 
 PXF provides connectors to Hadoop, Hive, HBase, object stores, network file systems, and external SQL data stores. You must configure PXF to support the connectors that you plan to use.
 
 To configure PXF, you must:
 
 1. Install Java 8 or 11 on each Greenplum Database host as described in [Installing Java for PXF](install_java.html). If your `JAVA_HOME` is different from `/usr/java/default`, you must inform PXF of the $JAVA_HOME setting by specifying its value in the `pxf-env.sh` [configuration file](config_files.html). 
-    - Edit the `$PXF_BASE/conf/pxf-env.sh` file on the Greenplum master host.
+    - Edit the `$PXF_BASE/conf/pxf-env.sh` file on the Greenplum coordinator host.
 
         ``` shell        
-        gpadmin@gpmaster$ vi /usr/local/pxf-gp6/conf/pxf-env.sh
+        gpadmin@coordinator$ vi /usr/local/pxf-gp6/conf/pxf-env.sh
         ```
     - Locate the `JAVA_HOME` setting in the `pxf-env.sh` file, uncomment if necessary, and set it to your `$JAVA_HOME` value. For example:
 
@@ -22,7 +22,7 @@ To configure PXF, you must:
 1. Register the PXF extension with Greenplum Database (see [pxf cluster register](ref/pxf-cluster.html)). Run this command after your first installation of a PXF version 6.x, and/or after you upgrade your Greenplum Database installation:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster register
+    gpadmin@coordinator$ pxf cluster register
     ```
 
 1. If you plan to use the Hadoop, Hive, or HBase PXF connectors, you must perform the configuration procedure described in [Configuring PXF Hadoop Connectors](client_instcfg.html).
@@ -36,7 +36,7 @@ To configure PXF, you must:
 1. After making any configuration changes, synchronize the PXF configuration to all hosts in the cluster.
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 1. After synchronizing PXF configuration changes, [Start PXF](cfginitstart_pxf.html).

--- a/docs/content/intro_pxf.html.md.erb
+++ b/docs/content/intro_pxf.html.md.erb
@@ -35,7 +35,7 @@ PXF bundles all of the Hadoop JAR files on which it depends, and supports the fo
 
 ## <a id="arch"></a> Architectural Overview
 
-Your Greenplum Database deployment consists of a master host, a standby master host, and multiple segment hosts. A single PXF Service process runs on each Greenplum Database host. The PXF Service process running on a segment host allocates a worker thread for each segment instance on the host that participates in a query against an external table. The PXF Services on multiple segment hosts communicate with the external data store in parallel. The PXF Service process running on the master and standby master hosts are not currently involved in data transfer; these processes may be used for other purposes in the future.
+Your Greenplum Database deployment consists of a coordinator host, a standby coordinator host, and multiple segment hosts. A single PXF Service process runs on each Greenplum Database host. The PXF Service process running on a segment host allocates a worker thread for each segment instance on the host that participates in a query against an external table. The PXF Services on multiple segment hosts communicate with the external data store in parallel. The PXF Service process running on the coordinator and standby coordinator hosts are not currently involved in data transfer; these processes may be used for other purposes in the future.
 
 
 ## <a id="more"></a> About Connectors, Servers, and Profiles

--- a/docs/content/jdbc_cfg.html.md.erb
+++ b/docs/content/jdbc_cfg.html.md.erb
@@ -214,10 +214,10 @@ The `pxf.service.user.impersonation` property in the `jdbc-site.xml` configurati
 
 By default, PXF JDBC user impersonation is deactivated.  Perform the following procedure to turn PXF user impersonation on or off for a JDBC server configuration.
 
-1. Log in to your Greenplum Database master host as the administrative user:
+1. Log in to your Greenplum Database coordinator host as the administrative user:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Identify the name of the PXF JDBC server configuration that you want to update.
@@ -225,7 +225,7 @@ By default, PXF JDBC user impersonation is deactivated.  Perform the following p
 3. Navigate to the server configuration directory. For example, if the server is named `mysqldb`:
 
     ```shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/mysqldb
+    gpadmin@coordinator$ cd $PXF_BASE/servers/mysqldb
     ```
 
 5. Open the `jdbc-site.xml` file in the editor of your choice, and add or uncomment the user impersonation property and setting. For example, if you require user impersonation for this server configuration, set the `pxf.service.user.impersonation` property to `true`:
@@ -242,7 +242,7 @@ By default, PXF JDBC user impersonation is deactivated.  Perform the following p
 8. Use the `pxf cluster sync` command to synchronize the PXF JDBC server configuration to your Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 ## <a id="sessauth"></a>About Session Authorization
@@ -354,10 +354,10 @@ You can use the JDBC Connector to access Hive. Refer to [Configuring the JDBC Co
 
 In this procedure, you name and add a PXF JDBC server configuration for a PostgreSQL database and synchronize the server configuration(s) to the Greenplum Database cluster.
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Choose a name for the JDBC server. You will provide the name to Greenplum users that you choose to allow to reference tables in the external SQL database as the configured user.
@@ -367,13 +367,13 @@ In this procedure, you name and add a PXF JDBC server configuration for a Postgr
 3. Create the `$PXF_BASE/servers/<server_name>` directory. For example, use the following command to create a JDBC server configuration named `pg_user1_testdb`:
 
     ``` shell
-    gpadmin@gpmaster$ mkdir $PXF_BASE/servers/pg_user1_testdb
+    gpadmin@coordinator$ mkdir $PXF_BASE/servers/pg_user1_testdb
     ````
 
 4. Copy the PXF JDBC server template file to the server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/jdbc-site.xml $PXF_BASE/servers/pg_user1_testdb/
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/jdbc-site.xml $PXF_BASE/servers/pg_user1_testdb/
     ```
         
 5. Open the template server configuration file in the editor of your choice, and provide appropriate property values for your environment. For example, if you are configuring access to a PostgreSQL database named `testdb` on a PostgreSQL instance running on the host named `pgserverhost` for the user named `user1`:
@@ -404,6 +404,6 @@ In this procedure, you name and add a PXF JDBC server configuration for a Postgr
 7. Use the `pxf cluster sync` command to copy the new server configuration to the Greenplum Database cluster:
     
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 

--- a/docs/content/jdbc_pxf_mysql.html.md.erb
+++ b/docs/content/jdbc_pxf_mysql.html.md.erb
@@ -79,32 +79,32 @@ You must create a JDBC server configuration for MySQL, download the MySQL driver
 
 This procedure will typically be performed by the Greenplum Database administrator.
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 1. Download the MySQL JDBC driver and place it under `$PXF_BASE/lib`. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), make sure you use the updated location. You can download a MySQL JDBC driver from your preferred download location. The following example downloads the driver from Maven Central and places it under `$PXF_BASE/lib`:
 
-    1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum master:
+    1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum coordinator:
 
         ```shell
-        gpadmin@gpmaster$ cd /usr/local/pxf-gp<version>/lib
-        gpadmin@gpmaster$ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
+        gpadmin@gcoord$ cd /usr/local/pxf-gp<version>/lib
+        gpadmin@coordinator$ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
         ```
 
-    2. If you relocated `$PXF_BASE`, run the following from the Greenplum master:
+    2. If you relocated `$PXF_BASE`, run the following from the Greenplum coordinator:
 
         ```shell
-        gpadmin@gpmaster$ cd $PXF_BASE/lib
-        gpadmin@gpmaster$ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
+        gpadmin@coordinator$ cd $PXF_BASE/lib
+        gpadmin@coordinator$ wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar
         ```
 
 1. Synchronize the PXF configuration, and then restart PXF:
 
     ```shell
-    gpadmin@gpmaster$ pxf cluster sync
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster restart
     ```
 
 2. Create a JDBC server configuration for MySQL as described in [Example Configuration Procedure](jdbc_cfg.html#cfg_proc), naming the server directory `mysql`. The `jdbc-site.xml` file contents should look similar to the following (substitute your MySQL host system for `mysqlserverhost`):
@@ -138,7 +138,7 @@ This procedure will typically be performed by the Greenplum Database administrat
 3. Synchronize the PXF server configuration to the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 ## <a id="ex_readjdbc"></a>Read from the MySQL Table

--- a/docs/content/jdbc_pxf_named.html.md.erb
+++ b/docs/content/jdbc_pxf_named.html.md.erb
@@ -86,16 +86,16 @@ In this procedure you create a named query text file, add it to the `pgsrvcfg` J
 
 This procedure will typically be performed by the Greenplum Database administrator.
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Navigate to the JDBC server configuration directory `pgsrvcfg`. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/pgsrvcfg
+    gpadmin@coordinator$ cd $PXF_BASE/servers/pgsrvcfg
     ```
 
 3. Open a query text file named `pg_order_report.sql` in a text editor and copy/paste the following query into the file:
@@ -112,7 +112,7 @@ This procedure will typically be performed by the Greenplum Database administrat
 5. Synchronize these changes to the PXF configuration to the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 ## <a id="nq_readjdbc"></a>Read the Query Results

--- a/docs/content/jdbc_pxf_oracle.html.md.erb
+++ b/docs/content/jdbc_pxf_oracle.html.md.erb
@@ -82,25 +82,25 @@ You must create a JDBC server configuration for Oracle, download the Oracle driv
 
 This procedure will typically be performed by the Greenplum Database administrator.
 
-1. Download the Oracle JDBC driver and place it under `$PXF_BASE/lib` of your Greenplum Database master host. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), make sure you use the updated location. You can download a Oracle JDBC driver from your preferred download location. The following example places a driver downloaded from Oracle webiste under `$PXF_BASE/lib` of the Greenplum Database master:
+1. Download the Oracle JDBC driver and place it under `$PXF_BASE/lib` of your Greenplum Database coordinator host. If you [relocated $PXF_BASE](about_pxf_dir.html#movebase), make sure you use the updated location. You can download a Oracle JDBC driver from your preferred download location. The following example places a driver downloaded from Oracle webiste under `$PXF_BASE/lib` of the Greenplum Database coordinator:
 
-    1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum master:
+    1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum coordinator:
 
         ```shell
-        gpadmin@gpmaster$ scp ojdbc10.jar gpadmin@gpmaster:/usr/local/pxf-gp<version>/lib/
+        gpadmin@coordinator$ scp ojdbc10.jar gpadmin@coordinator:/usr/local/pxf-gp<version>/lib/
         ```
 
-    2. If you relocated `$PXF_BASE`, run the following from the Greenplum master:
+    2. If you relocated `$PXF_BASE`, run the following from the Greenplum coordinator:
 
         ```shell
-        gpadmin@gpmaster$ scp ojdbc10.jar gpadmin@gpmaster:$PXF_BASE/lib/
+        gpadmin@coordinator$ scp ojdbc10.jar gpadmin@coordinator:$PXF_BASE/lib/
         ```
 
 1. Synchronize the PXF configuration, and then restart PXF: 
 
     ```shell
-    gpadmin@gpmaster$ pxf cluster sync
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster restart
     ```
 
 2. Create a JDBC server configuration for Oracle as described in [Example Configuration Procedure](jdbc_cfg.html#cfg_proc), naming the server directory `oracle`. The `jdbc-site.xml` file contents should look similar to the following (substitute your Oracle host system for `oracleserverhost`, and the value of your Oracle service name for `orcl`):
@@ -134,7 +134,7 @@ This procedure will typically be performed by the Greenplum Database administrat
 3. Synchronize the PXF server configuration to the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 ## <a id="ex_readjdbc"></a>Read from the Oracle Table

--- a/docs/content/jdbc_pxf_postgresql.html.md.erb
+++ b/docs/content/jdbc_pxf_postgresql.html.md.erb
@@ -84,10 +84,10 @@ You must create a JDBC server configuration for PostgreSQL and synchronize the P
 
 This procedure will typically be performed by the Greenplum Database administrator.
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Create a JDBC server configuration for PostgreSQL as described in [Example Configuration Procedure](jdbc_cfg.html#cfg_proc), naming the server directory `pgsrvcfg`. The `jdbc-site.xml` file contents should look similar to the following (substitute your PostgreSQL host system for `pgserverhost`):
@@ -117,7 +117,7 @@ This procedure will typically be performed by the Greenplum Database administrat
 3. Synchronize the PXF server configuration to the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 ## <a id="ex_readjdbc"></a>Read from the PostgreSQL Table

--- a/docs/content/jdbc_pxf_trino.html.md.erb
+++ b/docs/content/jdbc_pxf_trino.html.md.erb
@@ -32,10 +32,10 @@ You must create a JDBC server configuration for Trino, download the Trino driver
 
 This procedure will typically be performed by the Greenplum Database administrator.
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ```shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 1. Download the Trino JDBC driver and place it under `$PXF_BASE/lib`.
@@ -43,25 +43,25 @@ This procedure will typically be performed by the Greenplum Database administrat
    See [Trino Documentation - JDBC Driver](https://trino.io/docs/current/client/jdbc.html#installing) for instructions on downloading the Trino JDBC driver.
    The following example downloads the driver and places it under `$PXF_BASE/lib`:
 
-    1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum master:
+    1. If you did not relocate `$PXF_BASE`, run the following from the Greenplum coordinator:
 
         ```shell
-        gpadmin@gpmaster$ cd /usr/local/pxf-gp<version>/lib
-        gpadmin@gpmaster$ wget <url-to-trino-jdbc-driver>
+        gpadmin@coordinator$ cd /usr/local/pxf-gp<version>/lib
+        gpadmin@coordinator$ wget <url-to-trino-jdbc-driver>
         ```
 
-    2. If you relocated `$PXF_BASE`, run the following from the Greenplum master:
+    2. If you relocated `$PXF_BASE`, run the following from the Greenplum coordinator:
 
         ```shell
-        gpadmin@gpmaster$ cd $PXF_BASE/lib
-        gpadmin@gpmaster$ wget <url-to-trino-jdbc-driver>
+        gpadmin@coordinator$ cd $PXF_BASE/lib
+        gpadmin@coordinator$ wget <url-to-trino-jdbc-driver>
         ```
 
 1. Synchronize the PXF configuration, and then restart PXF:
 
     ```shell
-    gpadmin@gpmaster$ pxf cluster sync
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster restart
     ```
 
 1. Create a JDBC server configuration for Trino as described in [Example Configuration Procedure](jdbc_cfg.html#cfg_proc), naming the server directory `trino`.
@@ -134,7 +134,7 @@ This procedure will typically be performed by the Greenplum Database administrat
 1. Synchronize the PXF server configuration to the Greenplum Database cluster:
 
     ```shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 ## <a id="ex_readjdbc"></a>Read from a Trino Table

--- a/docs/content/monitor_pxf.html.md.erb
+++ b/docs/content/monitor_pxf.html.md.erb
@@ -34,16 +34,16 @@ Only the `gpadmin` user can request the status of the PXF Service.
 
 Perform the following procedure to request the PXF status of your Greenplum Database cluster.
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Run the `pxf cluster status` command:
 
     ```shell
-    gpadmin@gpmaster$ pxf cluster status
+    gpadmin@coordinator$ pxf cluster status
     ```
 
 ## <a id="about_rtm"></a> About PXF Service Runtime Monitoring

--- a/docs/content/nfs_pxf.html.md.erb
+++ b/docs/content/nfs_pxf.html.md.erb
@@ -39,10 +39,10 @@ Use the server template configuration file `<PXF_INSTALL_DIR>/templates/pxf-site
 
 PXF does not support user impersonation when you access a network file system; you must explicitly turn off user impersonation in a network file system server configuration.
 
-1. Log in to the Greenplum Database master host:
+1. Log in to the Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Choose a name for the file system server. You will provide the name to Greenplum users that you choose to allow to read from or write to files on the network file system.
@@ -52,13 +52,13 @@ PXF does not support user impersonation when you access a network file system; y
 3. Create the `$PXF_BASE/servers/<server_name>` directory. For example, use the following command to create a file system server configuration named `nfssrvcfg`:
 
     ``` shell
-    gpadmin@gpmaster$ mkdir $PXF_BASE/servers/nfssrvcfg
+    gpadmin@coordinator$ mkdir $PXF_BASE/servers/nfssrvcfg
     ````
 
 4. Copy the PXF `pxf-site.xml` template file to the `nfssrvcfg` server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml $PXF_BASE/servers/nfssrvcfg/
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml $PXF_BASE/servers/nfssrvcfg/
     ```
 
 5. Open the template server configuration file in the editor of your choice, and uncomment and provide property values appropriate for your environment. For example, if the file system share point is the directory named `/mnt/extdata/pxffs`, uncomment and set these server properties:
@@ -85,7 +85,7 @@ PXF does not support user impersonation when you access a network file system; y
 7. Synchronize the PXF server configuration to the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ``` 
 
 ## <a id="queryextdata"></a>Creating the External Table
@@ -115,7 +115,7 @@ The specific keywords and values used in the Greenplum Database [CREATE EXTERNAL
 
 ## <a id="example_nfscsv"></a>Example: Reading From and Writing to a CSV File on a Network File System
 
-This example assumes that you have configured and mounted a network file system with the share point `/mnt/extdata/pxffs` on the Greenplum Database master host, the standby master host, and on each segment host.
+This example assumes that you have configured and mounted a network file system with the share point `/mnt/extdata/pxffs` on the Greenplum Database coordinator host, the standby coordinator host, and on each segment host.
 
 In this example, you:
 
@@ -131,7 +131,7 @@ In this example, you:
 1.  Create a directory (relative to the network file system share point) named `/mnt/extdata/pxffs/ex1`:
 
     ``` shell
-    gpadmin@gpmaster$ mkdir -p /mnt/extdata/pxffs/ex1
+    gpadmin@coordinator$ mkdir -p /mnt/extdata/pxffs/ex1
     ````
 
 2. Create a CSV file named `somedata.csv` in the directory:

--- a/docs/content/objstore_cfg.html.md.erb
+++ b/docs/content/objstore_cfg.html.md.erb
@@ -49,12 +49,12 @@ The template configuration file for Google Cloud Storage is `<PXF_INSTALL_DIR>/t
 
 ## <a id="cfg_proc"></a>Example Server Configuration Procedure
 
-In this procedure, you name and add a PXF server configuration in the `$PXF_BASE/servers` directory on the Greenplum Database master host for the Google Cloud Storate (GCS) connector. You then use the `pxf cluster sync` command to sync the server configuration(s) to the Greenplum Database cluster.
+In this procedure, you name and add a PXF server configuration in the `$PXF_BASE/servers` directory on the Greenplum Database coordinator host for the Google Cloud Storate (GCS) connector. You then use the `pxf cluster sync` command to sync the server configuration(s) to the Greenplum Database cluster.
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Choose a name for the server. You will provide the name to end users that need to reference files in the object store.
@@ -62,13 +62,13 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_BASE
 3. Create the `$PXF_BASE/servers/<server_name>` directory. For example, use the following command to create a server configuration for a Google Cloud Storage server named `gs_public`:
 
     ``` shell
-    gpadmin@gpmaster$ mkdir $PXF_BASE/servers/gs_public
+    gpadmin@coordinator$ mkdir $PXF_BASE/servers/gs_public
     ````
 
 3. Copy the PXF template file for GCS to the server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/gs-site.xml $PXF_BASE/servers/gs_public/
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/gs-site.xml $PXF_BASE/servers/gs_public/
     ```
         
 4. Open the template server configuration file in the editor of your choice, and provide appropriate property values for your environment. For example, if your Google Cloud Storage key file is located in `/home/gpadmin/keys/gcs-account.key.json`:
@@ -95,6 +95,6 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_BASE
 4. Use the `pxf cluster sync` command to copy the new server configurations to the Greenplum Database cluster:
     
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 

--- a/docs/content/pxf_gpupgrade_post.html.md.erb
+++ b/docs/content/pxf_gpupgrade_post.html.md.erb
@@ -16,8 +16,8 @@ Perform the following steps after running `gpupgrade`:
     1. Run the following commands to roll back your PXF installation to its previous state (before you ran `pxf-pre-gpupgrade`):
 
         ``` shell
-        gpadmin@gpmaster$ export GPHOME=<greenplum5-install-dir>
-        gpadmin@gpmaster$ /usr/local/pxf-gp5/bin/pxf-post-gpupgrade
+        gpadmin@coordinator$ export GPHOME=<greenplum5-install-dir>
+        gpadmin@coordinator$ /usr/local/pxf-gp5/bin/pxf-post-gpupgrade
         ```
 
         **Note:** The `pxf-post-upgrade` script must connect to your running Greenplum Database 5.x cluster. By default, it attempts to connect to the `gpadmin` database on `localhost` on port `5432` as the `gpadmin` user, no password. If you need to customize these settings, refer to [Customizing the Greenplum Connection Parameters](#env) for instructions on setting environment variables for this purpose.
@@ -25,7 +25,7 @@ Perform the following steps after running `gpupgrade`:
     1. Restart the PXF that was running in your Greenplum Database 5.x installation.
 
         ``` shell
-        gpadmin@gpmaster$ /usr/local/pxf-gp5/bin/pxf cluster start
+        gpadmin@coordinator$ /usr/local/pxf-gp5/bin/pxf cluster start
         ```
 
     1. You may choose to uninstall the PXF for Greenplum 6 package.
@@ -37,8 +37,8 @@ Perform the following steps after running `gpupgrade`:
 1. Configure PXF as though it was a fresh install in Greenplum Database 6.x:
 
     ``` shell
-    gpadmin@gpmaster$ export GPHOME=<greenplum6-install-dir>
-    gpadmin@gpmaster$ /usr/local/pxf-gp6/bin/pxf-post-gpupgrade
+    gpadmin@coordinator$ export GPHOME=<greenplum6-install-dir>
+    gpadmin@coordinator$ /usr/local/pxf-gp6/bin/pxf-post-gpupgrade
     ```
 
     **Note:** The `pxf-post-upgrade` script must connect to your running Greenplum Database 6.x cluster. By default, it attempts to connect to the `gpadmin` database on `localhost` on port `5432` as the `gpadmin` user, no password. If you need to customize these settings, refer to [Customizing the Greenplum Connection Parameters](#env) for instructions on setting environment variables for this purpose.
@@ -46,21 +46,21 @@ Perform the following steps after running `gpupgrade`:
 1. If you nave not relocated your `$PXF_BASE`, you must copy the PXF configuration from the PXF Greenplum Database 5.x install location to the PXF Greenplum Database 6.x install location. For example:
 
     ``` bash
-    gpadmin@gpmaster$ for dir in conf lib servers keytabs; do
+    gpadmin@coordinator$ for dir in conf lib servers keytabs; do
         cp -aiv /usr/local/pxf-gp5/$dir/. /usr/local/pxf-gp6/$dir/
     done
     ```
 
-1. Synchronize the PXF configuration from the Greenplum Database master host to the standby and segment hosts:
+1. Synchronize the PXF configuration from the Greenplum Database coordinator host to the standby and segment hosts:
 
     ``` shell
-    gpadmin@gpmaster$ /usr/local/pxf-gp6/bin/pxf cluster sync
+    gpadmin@coordinator$ /usr/local/pxf-gp6/bin/pxf cluster sync
     ```
 
 1. Start the PXF installed for Greenplum Database 6.x.
 
     ``` shell
-    gpadmin@gpmaster$ /usr/local/pxf-gp6/bin/pxf cluster start
+    gpadmin@coordinator$ /usr/local/pxf-gp6/bin/pxf cluster start
     ```
 
 1. Update the `$PATH` in `.bashrc` or `.bash_profile` shell initialization scripts, replacing any occurrences of `/usr/local/pxf-gp5` with `/usr/local/pxf-gp6`.
@@ -79,8 +79,8 @@ The PXF scripts that you run before and after `gpupgrade` must connect to your r
 
 | Environment Variable | Default Value | Description                                           |
 |----------------------|---------------|-------------------------------------------------------|
-| `$PGHOST`            | localhost     | The host name or IP address of the Greenplum Database master host. |
-| `$PGPORT`            | 5432          | The port number to connect to on the master host.     |
+| `$PGHOST`            | localhost     | The host name or IP address of the Greenplum Database coordinator host. |
+| `$PGPORT`            | 5432          | The port number to connect to on the coordinator host.     |
 | `$PGDATABASE`        | gpadmin       | The name of the database. |
 | `$PGUSER`            | gpadmin       | The Greenplum Database user name.     |
 | `$PGPASSWORD`        | _none_        | The password for the user. |

--- a/docs/content/pxf_gpupgrade_pre.html.md.erb
+++ b/docs/content/pxf_gpupgrade_pre.html.md.erb
@@ -15,18 +15,18 @@ Before you run `gpupgrade`, perform the following steps:
 
 1. Install the Greenplum Database 6-specific PXF package of the same version on every segment host in the cluster. You need only install the PXF package; you do not need to run the `pxf cluster prepare` or `pxf cluster register` commands.
 
-1. Log in to the master host of your Greenplum Database 5.x cluster:
+1. Log in to the coordinator host of your Greenplum Database 5.x cluster:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
-    gpadmin@gpmaster$ 
+    $ ssh gpadmin@<coordinator>
+    gpadmin@coordinator$ 
     ```
 
 1. Run the following commands to set up your environment; substitute the file system path to your Greenplum 5.x install directory:
 
     ``` shell
-    gpadmin@gpmaster$ export GPHOME=<greenplum5-install-dir>
-    gpadmin@gpmaster$ /usr/local/pxf-gp5/bin/pxf-pre-gpupgrade
+    gpadmin@coordinator$ export GPHOME=<greenplum5-install-dir>
+    gpadmin@coordinator$ /usr/local/pxf-gp5/bin/pxf-pre-gpupgrade
     ```
 
     **Note:** The `pxf-pre-gpupgrade` script must connect to your running Greenplum Database 5.x cluster. By default, it attempts to connect to the `gpadmin` database on `localhost` on port `5432` as the `gpadmin` user (no password). If you need to customize these settings, refer to [Customizing the Greenplum Connection Parameters](#env) for instructions on setting environment variables for this purpose.
@@ -34,7 +34,7 @@ Before you run `gpupgrade`, perform the following steps:
 1. Stop PXF; note that PXF external tables will be inaccessible during the Greenplum Database upgrade process.
 
     ``` shell
-    gpadmin@gpmaster$ /usr/local/pxf-gp5/bin/pxf cluster stop
+    gpadmin@coordinator$ /usr/local/pxf-gp5/bin/pxf cluster stop
     ```
 
 1. PXF is ready for upgrading by `gpupgrade`; return to the `gpupgrade` documentation to upgrade from Greenplum Database 5.x to Greenplum Database 6.x.
@@ -46,8 +46,8 @@ The PXF scripts that you run before and after `gpupgrade` must connect to your r
 
 | Environment Variable | Default Value | Description                                           |
 |----------------------|---------------|-------------------------------------------------------|
-| `$PGHOST`            | localhost     | The host name or IP address of the Greenplum Database master host. |
-| `$PGPORT`            | 5432          | The port number to connect to on the master host.     |
+| `$PGHOST`            | localhost     | The host name or IP address of the Greenplum Database coordinator host. |
+| `$PGPORT`            | 5432          | The port number to connect to on the coordinator host.     |
 | `$PGDATABASE`        | gpadmin       | The name of the database. |
 | `$PGUSER`            | gpadmin       | The Greenplum Database user name.     |
 | `$PGPASSWORD`        | _none_        | The password for the user. |

--- a/docs/content/pxf_kerbhdfs.html.md.erb
+++ b/docs/content/pxf_kerbhdfs.html.md.erb
@@ -149,7 +149,7 @@ There are different procedures for configuring PXF for secure HDFS with a [Micro
 
 ### <a id="proc_ad"></a>Configuring PXF with a Microsoft Active Directory Kerberos KDC Server
 
-When you configure PXF for secure HDFS using an AD Kerberos KDC server, you will perform tasks on both the KDC server host and the Greenplum Database master host.
+When you configure PXF for secure HDFS using an AD Kerberos KDC server, you will perform tasks on both the KDC server host and the Greenplum Database coordinator host.
 
 **Perform the following steps to configure the Active Directory domain controller**:
 
@@ -167,26 +167,26 @@ When you configure PXF for secure HDFS using an AD Kerberos KDC server, you will
 
     With Active Directory, the principal and the keytab file are shared by all Greenplum Database hosts. 
 	
-8. Copy the `pxf.service.keytab` file to the Greenplum master host.
+8. Copy the `pxf.service.keytab` file to the Greenplum coordinator host.
 
-**Perform the following procedure on the Greenplum Database master host**:
+**Perform the following procedure on the Greenplum Database coordinator host**:
 
-1. Log in to the Greenplum Database master host. For example:
+1. Log in to the Greenplum Database coordinator host. For example:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
     
 2. Identify the name of the PXF Hadoop server configuration, and navigate to the server configuration directory. For example, if the server is named `hdp3`:
 
     ```shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/hdp3
+    gpadmin@coordinator$ cd $PXF_BASE/servers/hdp3
     ```
 
 3. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 4. Open the `pxf-site.xml` file in the editor of your choice, and update the keytab and principal property settings, if required. Specify the location of the keytab file and the Kerberos principal, substituting your realm. For example:
@@ -207,15 +207,15 @@ When you configure PXF for secure HDFS using an AD Kerberos KDC server, you will
 5. Synchronize the keytabs in `$PXF_BASE`. You must distribute the keytab file to `$PXF_BASE/keytabs/`. Locate the keytab file, copy the file to the `$PXF_BASE` runtime configuration directory, and set required permissions. For example:
 	
     ``` shell
-    gpadmin@gpmaster$ gpscp -f hostfile_all pxf.service.keytab =:$PXF_BASE/keytabs/
-    gpadmin@gpmaster$ gpssh -f hostfile_all chmod 400 $PXF_BASE/keytabs/pxf.service.keytab
+    gpadmin@coordinator$ gpscp -f hostfile_all pxf.service.keytab =:$PXF_BASE/keytabs/
+    gpadmin@coordinator$ gpssh -f hostfile_all chmod 400 $PXF_BASE/keytabs/pxf.service.keytab
     ```
 
 6. [Complete the PXF Configuration](#proc_complete) based on your chosen Hadoop access scenario.
 
 ### <a id="proc_mit"></a>Configuring PXF with an MIT Kerberos KDC Server
 
-When you configure PXF for secure HDFS using an MIT Kerberos KDC server, you will perform tasks on both the KDC server host and the Greenplum Database master host.
+When you configure PXF for secure HDFS using an MIT Kerberos KDC server, you will perform tasks on both the KDC server host and the Greenplum Database coordinator host.
 
 **Perform the following steps on the MIT Kerberos KDC server host**:
 
@@ -279,12 +279,12 @@ When you configure PXF for secure HDFS using an MIT Kerberos KDC server, you wil
     root@kdc-server$ ssh host3.example.com chmod 400 /usr/local/pxf-gp6/keytabs/pxf.service.keytab
     ```
 
-**Perform the following steps on the Greenplum Database master host**:
+**Perform the following steps on the Greenplum Database coordinator host**:
 
-1. Log in to the master host. For example:
+1. Log in to the coordinator host. For example:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Identify the name of the PXF Hadoop server configuration that requires Kerberos access.
@@ -292,13 +292,13 @@ When you configure PXF for secure HDFS using an MIT Kerberos KDC server, you wil
 3. Navigate to the server configuration directory. For example, if the server is named `hdp3`:
 
     ```shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/hdp3
+    gpadmin@coordinator$ cd $PXF_BASE/servers/hdp3
     ```
 
 4. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 5. Open the `pxf-site.xml` file in the editor of your choice, and update the keytab and principal property settings, if required. Specify the location of the keytab file and the Kerberos principal, substituting your realm. *The default values for these settings are identified below*:
@@ -320,7 +320,7 @@ When you configure PXF for secure HDFS using an MIT Kerberos KDC server, you wil
 
 ### <a id="proc_complete"></a>Completing the PXF Configuration
 
-On the Greenplum Database master host, complete the configuration of the PXF server based on your chosen Hadoop access scenario. Choose one, as *these are mutually exclusive*:
+On the Greenplum Database coordinator host, complete the configuration of the PXF server based on your chosen Hadoop access scenario. Choose one, as *these are mutually exclusive*:
 
 1. If you want to access Hadoop as the Greenplum Database user:
 
@@ -340,17 +340,17 @@ On the Greenplum Database master host, complete the configuration of the PXF ser
 1. Synchronize the PXF configuration to your Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 ### <a id="enable_kcd"></a>Activating Kerberos Constrained Delegation
 
 By default, Kerberos constrained delegation is deactivated for PXF. Perform the following procedure to configure Kerberos constrained delegation for a PXF server:
 
-1. Log in to your Greenplum Database master host as the administrative user:
+1. Log in to your Greenplum Database coordinator host as the administrative user:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 1. Identify the name of the Hadoop PXF server configuration that you want to update.
@@ -358,13 +358,13 @@ By default, Kerberos constrained delegation is deactivated for PXF. Perform the 
 1. Navigate to the server configuration directory. For example, if the server is named `hdp3`:
 
     ```shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/hdp3
+    gpadmin@coordinator$ cd $PXF_BASE/servers/hdp3
     ```
 
 1. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 1. Open the `pxf-site.xml` file in the editor of your choice, locate the `pxf.service.kerberos-constrained.delegation` property, and set it as follows:
@@ -381,6 +381,6 @@ By default, Kerberos constrained delegation is deactivated for PXF. Perform the 
 1. Use the `pxf cluster sync` command to synchronize the PXF Hadoop server configuration to your Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 

--- a/docs/content/pxfuserimpers.html.md.erb
+++ b/docs/content/pxfuserimpers.html.md.erb
@@ -86,10 +86,10 @@ By default, PXF accesses Hadoop using the identity of the Greenplum Database use
 
 Perform the following procedure to configure the Hadoop user:
 
-1. Log in to your Greenplum Database master host as the administrative user:
+1. Log in to your Greenplum Database coordinator host as the administrative user:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Identify the name of the Hadoop PXF server configuration that you want to update.
@@ -97,13 +97,13 @@ Perform the following procedure to configure the Hadoop user:
 3. Navigate to the server configuration directory. For example, if the server is named `hdp3`:
 
     ```shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/hdp3
+    gpadmin@coordinator$ cd $PXF_BASE/servers/hdp3
     ```
 
 4. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 5. Open the `pxf-site.xml` file in the editor of your choice, and configure the Hadoop user name. When impersonation is deactivated, this name identifies the Hadoop user identity that PXF will use to access the Hadoop system. When user impersonation is activated for a non-secure Hadoop cluster, this name identifies the PXF proxy Hadoop user. For example, if you want to access Hadoop as the user `hdfsuser1`, uncomment the property and set it as follows:
@@ -122,7 +122,7 @@ Perform the following procedure to configure the Hadoop user:
 8. Use the `pxf cluster sync` command to synchronize the PXF Hadoop server configuration to your Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 
@@ -133,13 +133,13 @@ PXF user impersonation is activated by default for Hadoop servers. You can confi
 1. Navigate to the server configuration directory. For example, if the server is named `hdp3`:
 
     ```shell
-    gpadmin@gpmaster$ cd $PXF_BASE/servers/hdp3
+    gpadmin@coordinator$ cd $PXF_BASE/servers/hdp3
     ```
 
 2. If the server configuration does not yet include a `pxf-site.xml` file, copy the template file to the directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/pxf-site.xml .
     ```
 
 3. Open the `pxf-site.xml` file in the editor of your choice, and update the user impersonation property setting. For example, if you do not require user impersonation for this server configuration, set the `pxf.service.user.impersonation` property to `false`:
@@ -167,7 +167,7 @@ PXF user impersonation is activated by default for Hadoop servers. You can confi
 5. Use the `pxf cluster sync` command to synchronize the PXF Hadoop server configuration to your Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 
@@ -197,7 +197,7 @@ When PXF user impersonation is activated for a Hadoop server configuration and K
 
 4. You must restart Hadoop for your `core-site.xml` changes to take effect.
 
-5. Copy the updated `core-site.xml` file to the PXF Hadoop server configuration directory `$PXF_BASE/servers/<server_name>` on the Greenplum Database master host and synchronize the configuration to the standby master host and each Greenplum Database segment host.
+5. Copy the updated `core-site.xml` file to the PXF Hadoop server configuration directory `$PXF_BASE/servers/<server_name>` on the Greenplum Database coordinator host and synchronize the configuration to the standby coordinator host and each Greenplum Database segment host.
 
 ## <a id="hive"></a>Hive User Impersonation
 

--- a/docs/content/ref/pxf-cluster.html.md.erb
+++ b/docs/content/ref/pxf-cluster.html.md.erb
@@ -28,16 +28,16 @@ sync
 
 ## <a id="topic1__section3"></a>Description
 
-The `pxf cluster` utility command manages PXF on the master host, standby master host, and on all Greenplum Database segment hosts. You can use the utility to:
+The `pxf cluster` utility command manages PXF on the coordinator host, standby coordinator host, and on all Greenplum Database segment hosts. You can use the utility to:
 
-- Start, stop, and restart the PXF Service instance on the master host, standby master host, and all segment hosts.
-- Display the status of the PXF Service instance on the master host, standby master host, and all segment hosts.
-- Synchronize the PXF configuration from the Greenplum Database master host to the standby master and to all segment hosts.
+- Start, stop, and restart the PXF Service instance on the coordinator host, standby coordinator host, and all segment hosts.
+- Display the status of the PXF Service instance on the coordinator host, standby coordinator host, and all segment hosts.
+- Synchronize the PXF configuration from the Greenplum Database coordinator host to the standby coordinator and to all segment hosts.
 - Copy the PXF extension control file from the PXF installation on each host to the Greenplum installation on the host after a Greenplum upgrade.
 - Prepare a new `$PXF_BASE` runtime configuration directory.
 - Migrate PXF 5 `$PXF_CONF` configuration to `$PXF_BASE`.
 
-`pxf cluster` requires a running Greenplum Database cluster. You must run the utility on the Greenplum Database master host.
+`pxf cluster` requires a running Greenplum Database cluster. You must run the utility on the Greenplum Database coordinator host.
 
 If you want to manage the PXF Service instance on a specific segment host, use the `pxf` utility. See [`pxf`](pxf.html#topic1).
 
@@ -62,19 +62,19 @@ If you want to manage the PXF Service instance on a specific segment host, use t
 <dd>The command is a no-op.</dd>
 
 <dt>restart</dt>
-<dd>Stop, and then start, the PXF Service instance on the master host, standby master host, and all segment hosts.</dd>
+<dd>Stop, and then start, the PXF Service instance on the coordinator host, standby coordinator host, and all segment hosts.</dd>
 
 <dt>start</dt>
-<dd>Start the PXF Service instance on the master host, standby master host, and all segment hosts.</dd>
+<dd>Start the PXF Service instance on the coordinator host, standby coordinator host, and all segment hosts.</dd>
 
 <dt>status  </dt>
-<dd>Display the status of the PXF Service instance on the master host, standby master host, and all segment hosts.</dd>
+<dd>Display the status of the PXF Service instance on the coordinator host, standby coordinator host, and all segment hosts.</dd>
 
 <dt>stop  </dt>
-<dd>Stop the PXF Service instance on the master host, standby master host, and all segment hosts.</dd>
+<dd>Stop the PXF Service instance on the coordinator host, standby coordinator host, and all segment hosts.</dd>
 
 <dt>sync  </dt>
-<dd>Synchronize the PXF configuration (<code>$PXF_BASE</code>) from the master host to the standby master host and to all Greenplum Database segment hosts. By default, this command updates files on and copies files to the remote. You can instruct PXF to also delete files during the synchronization; see Options below.</dd>
+<dd>Synchronize the PXF configuration (<code>$PXF_BASE</code>) from the coordinator host to the standby coordinator host and to all Greenplum Database segment hosts. By default, this command updates files on and copies files to the remote. You can instruct PXF to also delete files during the synchronization; see Options below.</dd>
 <dd>If you have updated the PXF user configuration or add new JAR or native library dependencies, you must also restart PXF after you synchronize the PXF configuration.</dd>
 
 ## <a id="options"></a>Options
@@ -82,17 +82,17 @@ If you want to manage the PXF Service instance on a specific segment host, use t
 The `pxf cluster sync` command takes the following option:
 
 <dt>&#8211;d | &#8211;&#8211;delete </dt>
-<dd>Delete any files in the PXF user configuration on the standby master host and segment hosts that are not also present on the master host.</dd>
+<dd>Delete any files in the PXF user configuration on the standby coordinator host and segment hosts that are not also present on the coordinator host.</dd>
 
 ## <a id="topic1__section5"></a>Examples
 
-Stop the PXF Service instance on the master host, standby master host, and all segment hosts:
+Stop the PXF Service instance on the coordinator host, standby coordinator host, and all segment hosts:
 
 ``` shell
 $ pxf cluster stop
 ```
 
-Synchronize the PXF configuration to the standby master host and all segment hosts, deleting files that do not exist on the master host:
+Synchronize the PXF configuration to the standby coordinator host and all segment hosts, deleting files that do not exist on the coordinator host:
 
 ``` shell
 $ pxf cluster sync --delete

--- a/docs/content/ref/pxf.html.md.erb
+++ b/docs/content/ref/pxf.html.md.erb
@@ -32,8 +32,8 @@ version
 
 The `pxf` utility manages the PXF configuration and the PXF Service instance on the local Greenplum Database host. You can use the utility to:
 
-- Synchronize the PXF configuration from the master host to the standby master host or to a segment host.
-- Start, stop, or restart the PXF Service instance on the master host, standby master host, or a specific segment host, or display the status of the PXF Service instance running on the master, standby master, or a segment host.
+- Synchronize the PXF configuration from the coordinator host to the standby coordinator host or to a segment host.
+- Start, stop, or restart the PXF Service instance on the coordinator host, standby coordinator host, or a specific segment host, or display the status of the PXF Service instance running on the coordinator, standby coordinator, or a segment host.
 - Copy the PXF extension control file from a PXF installation on the host to the Greenplum installation on the host after a Greenplum upgrade.
 - Prepare a new `$PXF_BASE` runtime configuration directory on the host.
 
@@ -63,32 +63,32 @@ The `pxf` utility manages the PXF configuration and the PXF Service instance on 
 <dd>The command is a no-op.</dd>
 
 <dt>restart</dt>
-<dd>Restart the PXF Service instance running on the local master host, standby master host, or segment host.</dd>
+<dd>Restart the PXF Service instance running on the local coordinator host, standby coordinator host, or segment host.</dd>
 
 <dt>start</dt>
-<dd>Start the PXF Service instance on the local master host, standby master host, or segment host.</dd>
+<dd>Start the PXF Service instance on the local coordinator host, standby coordinator host, or segment host.</dd>
 
 <dt>status</dt>
-<dd>Display the status of the PXF Service instance running on the local master host, standby master host, or segment host.</dd>
+<dd>Display the status of the PXF Service instance running on the local coordinator host, standby coordinator host, or segment host.</dd>
 
 <dt>stop  </dt>
-<dd>Stop the PXF Service instance running on the local master host, standby master host, or segment host.</dd>
+<dd>Stop the PXF Service instance running on the local coordinator host, standby coordinator host, or segment host.</dd>
 
 <dt>sync  </dt>
-<dd>Synchronize the PXF configuration (<code>$PXF_BASE</code>) from the master host to a specific Greenplum Database standby master host or segment host. You must run <code>pxf sync</code> on the master host. By default, this command updates files on and copies files to the remote. You can instruct PXF to also delete files during the synchronization; see Options below.</dd>
+<dd>Synchronize the PXF configuration (<code>$PXF_BASE</code>) from the coordinator host to a specific Greenplum Database standby coordinator host or segment host. You must run <code>pxf sync</code> on the coordinator host. By default, this command updates files on and copies files to the remote. You can instruct PXF to also delete files during the synchronization; see Options below.</dd>
 
 <dt>version  </dt>
 <dd>Display the PXF version and then exit.</dd>
 
 ## <a id="options"></a>Options
 
-The `pxf sync` command, which you must run on the Greenplum Database master host, takes the following option and argument:
+The `pxf sync` command, which you must run on the Greenplum Database coordinator host, takes the following option and argument:
 
 <dt>&#8211;d | &#8211;&#8211;delete </dt>
-<dd>Delete any files in the PXF user configuration on <code>&lt;gphost></code> that are not also present on the master host. If you specify this option, you must provide it on the command line before <code>&lt;gphost></code>.</dd>
+<dd>Delete any files in the PXF user configuration on <code>&lt;gphost></code> that are not also present on the coordinator host. If you specify this option, you must provide it on the command line before <code>&lt;gphost></code>.</dd>
 
 <dt>&lt;gphost> </dt>
-<dd>The Greenplum Database host to which to synchronize the PXF configuration. Required. <code>&lt;gphost></code> must identify the standby master host or a segment host.</dd>
+<dd>The Greenplum Database host to which to synchronize the PXF configuration. Required. <code>&lt;gphost></code> must identify the standby coordinator host or a segment host.</dd>
 
 ## <a id="topic1__section5"></a>Examples
 

--- a/docs/content/reg_jar_depend.html.md.erb
+++ b/docs/content/reg_jar_depend.html.md.erb
@@ -43,16 +43,16 @@ PXF loads JAR dependencies from the following directories, in this order:
 
 2. The default PXF JAR directory `$PXF_BASE/lib`.
 
-To add a JAR dependency for PXF, for example a MySQL driver JAR file, you must log in to the Greenplum Database master host, copy the JAR file to the PXF user configuration runtime library directory (`$PXF_BASE/lib`), sync the PXF configuration to the Greenplum Database cluster, and then restart PXF on each host. For example:
+To add a JAR dependency for PXF, for example a MySQL driver JAR file, you must log in to the Greenplum Database coordinator host, copy the JAR file to the PXF user configuration runtime library directory (`$PXF_BASE/lib`), sync the PXF configuration to the Greenplum Database cluster, and then restart PXF on each host. For example:
 
 ``` shell
-$ ssh gpadmin@<gpmaster>
-gpadmin@gpmaster$ cp new_dependent_jar.jar $PXF_BASE/lib/
-gpadmin@gpmaster$ pxf cluster sync
-gpadmin@gpmaster$ pxf cluster restart
+$ ssh gpadmin@<coordinator>
+gpadmin@coordinator$ cp new_dependent_jar.jar $PXF_BASE/lib/
+gpadmin@coordinator$ pxf cluster sync
+gpadmin@coordinator$ pxf cluster restart
 ```
 
-Alternatively, you could have identified the file system location of the JAR in the `pxf-env.sh` `PXF_LOADER_PATH` environment variable. If you choose this registration option, you must ensure that you copy the JAR file to the same location on the Greenplum Database standby master host and segment hosts before you synchronize and restart PXF.
+Alternatively, you could have identified the file system location of the JAR in the `pxf-env.sh` `PXF_LOADER_PATH` environment variable. If you choose this registration option, you must ensure that you copy the JAR file to the same location on the Greenplum Database standby coordinator host and segment hosts before you synchronize and restart PXF.
 
 
 ## <a id="reg_native"></a> Registering a Native Library Dependency
@@ -73,15 +73,15 @@ PXF loads native libraries from the following directories, in this order:
 
 As such, you have three file location options when you register a native library with PXF:
 
-- Copy the library to the default PXF native library directory, `$PXF_BASE/lib/native`, on only the Greenplum Database master host. When you next synchronize PXF, PXF copies the native library to all hosts in the Greenplum cluster.
-- Copy the library to the default Hadoop native library directory, `/usr/lib/hadoop/lib/native`, on the Greenplum master host, standby master host, and each segment host.
-- Copy the library to the same custom location on the Greenplum master host, standby master host, and each segment host, and uncomment and add the directory path to the `pxf-env.sh` `LD_LIBRARY_PATH` environment variable.
+- Copy the library to the default PXF native library directory, `$PXF_BASE/lib/native`, on only the Greenplum Database coordinator host. When you next synchronize PXF, PXF copies the native library to all hosts in the Greenplum cluster.
+- Copy the library to the default Hadoop native library directory, `/usr/lib/hadoop/lib/native`, on the Greenplum coordinator host, standby coordinator host, and each segment host.
+- Copy the library to the same custom location on the Greenplum coordinator host, standby coordinator host, and each segment host, and uncomment and add the directory path to the `pxf-env.sh` `LD_LIBRARY_PATH` environment variable.
 
 
 ### <a id="reg_native_proc"></a> Procedure
 
 1. Copy the native library file to one of the following:
-    - The `$PXF_BASE/lib/native` directory on the Greenplum Database master host. (You may need to create this directory.)
+    - The `$PXF_BASE/lib/native` directory on the Greenplum Database coordinator host. (You may need to create this directory.)
     - The `/usr/lib/hadoop/lib/native` directory on all Greenplum Database hosts.
     - A user-defined location on all Greenplum Database hosts; note the file system location of the native library.
 
@@ -102,19 +102,19 @@ As such, you have three file location options when you register a native library
 
     3. Save the file and exit the editor.
 
-3. Synchronize the PXF configuration from the Greenplum Database master host to the standby master host and segment hosts.
+3. Synchronize the PXF configuration from the Greenplum Database coordinator host to the standby coordinator host and segment hosts.
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
-    If you copied the native library to the `$PXF_BASE/lib/native` directory, this command copies the library to the same location on the Greenplum Database standby master host and segment hosts.
+    If you copied the native library to the `$PXF_BASE/lib/native` directory, this command copies the library to the same location on the Greenplum Database standby coordinator host and segment hosts.
 
-    If you updated the `pxf-env.sh` `LD_LIBRARY_PATH` environment variable, this command copies the configuration change to the Greenplum Database standby master host and segment hosts.
+    If you updated the `pxf-env.sh` `LD_LIBRARY_PATH` environment variable, this command copies the configuration change to the Greenplum Database standby coordinator host and segment hosts.
 
 4. Restart PXF on all Greenplum hosts:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster restart
     ```
 

--- a/docs/content/s3_objstore_cfg.html.md.erb
+++ b/docs/content/s3_objstore_cfg.html.md.erb
@@ -145,12 +145,12 @@ To enable SSE-C for a specific S3 bucket, use the property name variants that in
 
 ## <a id="cfg_proc"></a>Example Server Configuration Procedure
 
-In this procedure, you name and add a PXF server configuration in the `$PXF_BASE/servers` directory on the Greenplum Database master host for the S3 Cloud Storage connector. You then use the `pxf cluster sync` command to sync the server configuration(s) to the Greenplum Database cluster.
+In this procedure, you name and add a PXF server configuration in the `$PXF_BASE/servers` directory on the Greenplum Database coordinator host for the S3 Cloud Storage connector. You then use the `pxf cluster sync` command to sync the server configuration(s) to the Greenplum Database cluster.
 
-1. Log in to your Greenplum Database master host:
+1. Log in to your Greenplum Database coordinator host:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 2. Choose a name for the server. You will provide the name to end users that need to reference files in the object store.
@@ -158,13 +158,13 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_BASE
 3. Create the `$PXF_BASE/servers/<server_name>` directory. For example, use the following command to create a server configuration for an S3 server named `s3srvcfg`:
 
     ``` shell
-    gpadmin@gpmaster$ mkdir $PXF_BASE/servers/s3srvcfg
+    gpadmin@coordinator$ mkdir $PXF_BASE/servers/s3srvcfg
     ````
 
 3. Copy the PXF template file for S3 to the server configuration directory. For example:
 
     ``` shell
-    gpadmin@gpmaster$ cp <PXF_INSTALL_DIR>/templates/s3-site.xml $PXF_BASE/servers/s3srvcfg/
+    gpadmin@coordinator$ cp <PXF_INSTALL_DIR>/templates/s3-site.xml $PXF_BASE/servers/s3srvcfg/
     ```
         
 4. Open the template server configuration file in the editor of your choice, and provide appropriate property values for your environment. For example:
@@ -191,7 +191,7 @@ In this procedure, you name and add a PXF server configuration in the `$PXF_BASE
 4. Use the `pxf cluster sync` command to copy the new server configuration to the Greenplum Database cluster:
     
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 ## <a id="ecs_cfg"></a>Dell ECS Server Configuration

--- a/docs/content/troubleshooting_pxf.html.md.erb
+++ b/docs/content/troubleshooting_pxf.html.md.erb
@@ -96,7 +96,7 @@ PXF uses the `hive-site.xml` `hive.metastore.failure.retries` property setting t
 
 Perform the following procedure to configure the number of Hive MetaStore connection retries that PXF will attempt; you may be required to add the `hive.metastore.failure.retries` property to the `hive-site.xml` file:
 
-1. Log in to the Greenplum Database master host.
+1. Log in to the Greenplum Database coordinator host.
 
 1. Identify the name of your Hive PXF server.
 
@@ -114,7 +114,7 @@ Perform the following procedure to configure the number of Hive MetaStore connec
 1. Synchronize the PXF configuration to all hosts in your Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 1. Re-run the failing SQL external table command.
@@ -125,19 +125,19 @@ By default, PXF does not bundle the LZO compression library. If the Hadoop clust
 
 1. Locate the LZO library in the Hadoop installation directory on the Hadoop NameNode. For example, the file system location of the library may be `/usr/lib/hadoop-lzo/lib/hadoop-lzo.jar`.
 
-1. Log in to the Greenplum Database master host.
+1. Log in to the Greenplum Database coordinator host.
 
-1. Copy `hadoop-lzo.jar` from the Hadoop NameNode to the PXF configuration directory on the Greenplum Database master host. For example, if `$PXF_BASE` is `/usr/local/pxf-gp6`:
+1. Copy `hadoop-lzo.jar` from the Hadoop NameNode to the PXF configuration directory on the Greenplum Database coordinator host. For example, if `$PXF_BASE` is `/usr/local/pxf-gp6`:
 
     ``` shell
-    gpadmin@gpmaster$ scp <hadoop-user>@<namenode-host>:/usr/lib/hadoop-lzo/lib/hadoop-lzo.jar /usr/local/pxf-gp6/lib/
+    gpadmin@coordinator$ scp <hadoop-user>@<namenode-host>:/usr/lib/hadoop-lzo/lib/hadoop-lzo.jar /usr/local/pxf-gp6/lib/
     ```
 
 1. Synchronize the PXF configuration and restart PXF:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
-    gpadmin@gpmaster$ pxf cluster restart
+    gpadmin@coordinator$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster restart
     ```
 
 1. Re-run the query.
@@ -163,12 +163,12 @@ To remedy this situation, specify an executable directory for the Snappy `tempdi
 
     If the `mount` command output for `/tmp` includes `noexec`, continue.
 
-1. Log in to the Greenplum Database master host.
+1. Log in to the Greenplum Database coordinator host.
 
 1. Stop PXF on the Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster stop
+    gpadmin@coordinator$ pxf cluster stop
     ```
 
 1.  Locate the `pxf-env.sh` file in your PXF installation. If you did not relocate `$PXF_BASE`, the file is located here:
@@ -189,8 +189,8 @@ To remedy this situation, specify an executable directory for the Snappy `tempdi
 1.  Synchronize the PXF configuration and then restart PXF:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
-    gpadmin@gpmaster$ pxf cluster start
+    gpadmin@coordinator$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster start
     ```
 
 ## <a id="hiveorcnulls"></a>Reading from a Hive table STORED AS ORC Returns NULLs
@@ -218,7 +218,7 @@ The workaround described in this section applies when all of the following hold 
 
 *To remedy this situation, perform the following procedure*:
 
-1. Log in to the Greenplum Database master host.
+1. Log in to the Greenplum Database coordinator host.
 
 1. Identify the name of your Hadoop PXF server configuration.
 
@@ -241,7 +241,7 @@ The workaround described in this section applies when all of the following hold 
 1. Synchronize the PXF server configuration to your Greenplum Database cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ````
 
 1. Try the query again.

--- a/docs/content/upgrade_5_to_6.html.md.erb
+++ b/docs/content/upgrade_5_to_6.html.md.erb
@@ -17,16 +17,16 @@ The PXF upgrade procedure has three steps. You perform one pre-install procedure
 
 Perform this procedure before you upgrade to a new version of PXF:
 
-1. Log in to the Greenplum Database master host. For example:
+1. Log in to the Greenplum Database coordinator host. For example:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 1. Identify and note the version of PXF currently running in your Greenplum cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf version
+    gpadmin@coordinator$ pxf version
     ```
 
 
@@ -44,16 +44,16 @@ Perform this procedure before you upgrade to a new version of PXF:
 
 After you install the new version of PXF, perform the following procedure:
 
-1. Log in to the Greenplum Database master host. For example:
+1. Log in to the Greenplum Database coordinator host. For example:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 1. You must run the `pxf` commands specified in subsequent steps using the binaries from your PXF 6.x installation. Ensure that the PXF 6.x installation `bin/` directory is in your `$PATH`, or provide the full path to the `pxf` command. You can run the following command to check the `pxf` version:
 
     ``` shell
-    gpadmin@gpmaster$ pxf version
+    gpadmin@coordinator$ pxf version
     ```
 
 1. (Optional, Advanced) If you want to relocate `$PXF_BASE` outside of `<PXF_INSTALL_DIR>`, perform the procedure described in [Relocating $PXF_BASE](about_pxf_dir.html#movebase).
@@ -64,13 +64,13 @@ After you install the new version of PXF, perform the following procedure:
     2. Run the `migrate` command (see [pxf cluster migrate](ref/pxf-cluster.html)). You must provide `PXF_CONF`. If you relocated `$PXF_BASE`, provide that setting as well.
 
         ``` shell
-        gpadmin@gpmaster$ PXF_CONF=/path/to/dir pxf cluster migrate
+        gpadmin@coordinator$ PXF_CONF=/path/to/dir pxf cluster migrate
         ```
 
         Or:
 
         ``` shell
-        gpadmin@gpmaster$ PXF_CONF=/path/to/dir PXF_BASE=/new/dir pxf cluster migrate
+        gpadmin@coordinator$ PXF_CONF=/path/to/dir PXF_BASE=/new/dir pxf cluster migrate
         ```
 
         The command copies PXF 5.x `conf/pxf-profiles.xml`, `servers/*`, `lib/*`, and `keytabs/*` to the PXF 6.x `$PXF_BASE` directory. The command also merges configuration changes in the PXF 5.x `conf/pxf-env.sh` into the PXF 6.x file of the same name and into `pxf-application.properties`.
@@ -135,14 +135,14 @@ After you install the new version of PXF, perform the following procedure:
 1. Register the PXF 6.x extension files with Greenplum Database (see [pxf cluster register](ref/pxf-cluster.html)). `$GPHOME` must be set when you run this command.
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster register
+    gpadmin@coordinator$ pxf cluster register
     ```
 
-    The `register` command copies only the `pxf.control` extension file to the Greenplum cluster. In PXF 6.x, the PXF extension `.sql` file and library `pxf.so` reside in `<PXF_INSTALL_DIR>/gpextable`. You may choose to remove these now-unused files from the Greenplum Database installation *on the Greenplum Database master host, the standby master host, and all segment hosts*. For example, to remove the files on the master host:
+    The `register` command copies only the `pxf.control` extension file to the Greenplum cluster. In PXF 6.x, the PXF extension `.sql` file and library `pxf.so` reside in `<PXF_INSTALL_DIR>/gpextable`. You may choose to remove these now-unused files from the Greenplum Database installation *on the Greenplum Database coordinator host, the standby coordinator host, and all segment hosts*. For example, to remove the files on the coordinator host:
 
     ``` shell
-    gpadmin@gpmaster$ rm $GPHOME/share/postgresql/extension/pxf--1.0.sql
-    gpadmin@gpmaster$ rm $GPHOME/lib/postgresql/pxf.so
+    gpadmin@coordinator$ rm $GPHOME/share/postgresql/extension/pxf--1.0.sql
+    gpadmin@coordinator$ rm $GPHOME/lib/postgresql/pxf.so
     ```
 
 1. PXF 6.x includes a new version of the `pxf` extension. You must update the extension in every Greenplum database in which you are using PXF. A database superuser or the database owner must run this SQL command in the `psql` subsystem or in an SQL script:
@@ -167,18 +167,18 @@ After you install the new version of PXF, perform the following procedure:
     1. Add the location of this JAR to `$HBASE_CLASSPATH` on each HBase node.
     1. Restart HBase on each node.
 
-1. In PXF 6.x, the PXF Service runs on all Greenplum Database hosts. If you used PXF 5.x to access Kerberos-secured HDFS, you must now generate principals and keytabs for the Greenplum master and standby master hosts, and distribute these to the hosts as described in [Configuring PXF for Secure HDFS](pxf_kerbhdfs.html#procedure).
+1. In PXF 6.x, the PXF Service runs on all Greenplum Database hosts. If you used PXF 5.x to access Kerberos-secured HDFS, you must now generate principals and keytabs for the Greenplum coordinator and standby coordinator hosts, and distribute these to the hosts as described in [Configuring PXF for Secure HDFS](pxf_kerbhdfs.html#procedure).
 
-4. Synchronize the PXF 6.x configuration from the master host to the standby master host and each Greenplum Database segment host. For example:
+4. Synchronize the PXF 6.x configuration from the coordinator host to the standby coordinator host and each Greenplum Database segment host. For example:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
  
 5. Start PXF on each Greenplum host. For example:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster start
+    gpadmin@coordinator$ pxf cluster start
     ```
 
 1. Verify that PXF can access each external data source by querying external tables that specify each PXF server configuration.

--- a/docs/content/upgrade_6.html.md.erb
+++ b/docs/content/upgrade_6.html.md.erb
@@ -15,28 +15,28 @@ The PXF upgrade procedure has three steps. You perform one pre-install procedure
 
 Perform this procedure before you upgrade to a new version of PXF 6.x:
 
-1. Log in to the Greenplum Database master host. For example:
+1. Log in to the Greenplum Database coordinator host. For example:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 1. Identify and note the version of PXF currently running in your Greenplum cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf version
+    gpadmin@coordinator$ pxf version
     ```
 
 1. Stop PXF on each Greenplum host as described in [Stopping PXF](cfginitstart_pxf.html#stop_pxf):
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster stop
+    gpadmin@coordinator$ pxf cluster stop
     ```
 
 1. (Optional, Recommended) Back up the PXF user configuration files; for example, if `PXF_BASE=/usr/local/pxf-gp6`:
 
     ``` shell
-    gpadmin@gpmaster$ cp -avi /usr/local/pxf-gp6 pxf_base.bak
+    gpadmin@coordinator$ cp -avi /usr/local/pxf-gp6 pxf_base.bak
     ```
 
 
@@ -49,16 +49,16 @@ Install PXF 6.x and identify and note the new PXF version number.
 
 After you install the new version of PXF, perform the following procedure:
 
-1. Log in to the Greenplum Database master host. For example:
+1. Log in to the Greenplum Database coordinator host. For example:
 
     ``` shell
-    $ ssh gpadmin@<gpmaster>
+    $ ssh gpadmin@<coordinator>
     ```
 
 1. PXF 6.x includes a new version of the `pxf` extension. Register the extension files with Greenplum Database (see [pxf cluster register](ref/pxf-cluster.html)). `$GPHOME` must be set when you run this command:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster register
+    gpadmin@coordinator$ pxf cluster register
     ```
 
 1. You must update the `pxf` extension in every Greenplum database in which you are using PXF. A database superuser or the database owner must run this SQL command in the `psql` subsystem or in an SQL script:
@@ -127,15 +127,15 @@ After you install the new version of PXF, perform the following procedure:
 
     Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_parquet.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters a numeric overflow while writing to a Parquet file.
 
-1. Synchronize the PXF configuration from the master host to the standby master host and each Greenplum Database segment host. For example:
+1. Synchronize the PXF configuration from the coordinator host to the standby coordinator host and each Greenplum Database segment host. For example:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
  
 1. Start PXF on each Greenplum host as described in [Starting PXF](cfginitstart_pxf.html#start_pxf):
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster start
+    gpadmin@coordinator$ pxf cluster start
     ```
  

--- a/docs/content/upgrade_os.html.md.erb
+++ b/docs/content/upgrade_os.html.md.erb
@@ -23,18 +23,18 @@ After you upgrade the operating system and install, configure, and verify Greenp
 
 1. Install PXF for RHEL 8 on all Greenplum Database hosts.
 
-1. Copy the PXF configuration files from the original cluster to `/user/local/pxf-gp6` on the RHEL 8 Greenplum Database master host. If you choose to [relocate $PXF_BASE](about_pxf_dir.html#movebase), copy the configuration to that directory instead.
+1. Copy the PXF configuration files from the original cluster to `/user/local/pxf-gp6` on the RHEL 8 Greenplum Database coordinator host. If you choose to [relocate $PXF_BASE](about_pxf_dir.html#movebase), copy the configuration to that directory instead.
 
 1. Synchronize the PXF configuration to all hosts in the Greenplum cluster:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster sync
+    gpadmin@coordinator$ pxf cluster sync
     ```
 
 1. Start PXF on each Greenplum host:
 
     ``` shell
-    gpadmin@gpmaster$ pxf cluster start
+    gpadmin@coordinator$ pxf cluster start
     ```
 
 1. Verify that PXF can access each external data source by querying external tables that specify each PXF server configuration.

--- a/docs/content/using_pxf.html.md.erb
+++ b/docs/content/using_pxf.html.md.erb
@@ -34,7 +34,7 @@ Perform the following procedure for **_each_** database in which you want to use
 1. Connect to the database as the `gpadmin` user:
 
     ``` shell
-    gpadmin@gpmaster$ psql -d <dbname> -U gpadmin
+    gpadmin@coordinator$ psql -d <dbname> -U gpadmin
     ```
 
 2. Create the PXF extension. You must have Greenplum Database administrator privileges to create an extension. For example:
@@ -53,7 +53,7 @@ When you no longer want to use PXF on a specific database, you must explicitly d
 1. Connect to the database as the `gpadmin` user:
 
     ``` shell
-    gpadmin@gpmaster$ psql -d <dbname> -U gpadmin
+    gpadmin@coordinator$ psql -d <dbname> -U gpadmin
     ```
 
 2. Drop the PXF extension:


### PR DESCRIPTION
per the title.  there were no literals or command output to account for.

changed gpmaster to coordinator in command prompts.
skipped the file named upgrade_pxf_rpm.html.md.erb, it is not used in the pxf 6.x docs.
