### PR TITLE
docs - enhanced processing for orc numeric overflow conditions

### DIFF
--- a/docs/content/cfg_server.html.md.erb
+++ b/docs/content/cfg_server.html.md.erb
@@ -92,7 +92,7 @@ PXF includes a template file named `pxf-site.xml` for PXF-specific configuration
 
 - Kerberos and/or user impersonation settings for server configurations
 - a base directory for file access
-- the action of PXF when it detects an overflow condition while writing numeric Parquet data
+- the action of PXF when it detects an overflow condition while writing numeric ORC or Parquet data
 
 <div class="note"><b>Note:</b> The Kerberos and user impersonation settings in this file may apply only to Hadoop and JDBC server configurations; they do not apply to file system or object store server configurations.</div>
 
@@ -116,6 +116,7 @@ You configure properties in the `pxf-site.xml` file for a PXF server when one or
 | pxf.fs.basePath | Identifies the base path or share point on the remote file system. This property is applicable when the server configuration is used with a profile that accesses a file. | None; this property is commented out by default. |
 | pxf.ppd.hive<sup>1</sup> | Specifies whether or not predicate pushdown is enabled for queries on external tables that specify the `hive`, `hive:rc`, or `hive:orc` profiles. | True; predicate pushdown is enabled. |
 | pxf.sasl.connection.retries | Specifies the maximum number of times that PXF retries a SASL connection request after a refused connection returns a `GSS initiate failed` error. | 5 |
+| pxf.orc.write.decimal.overflow | Specifies how PXF handles numeric data that exceeds the maximum precision of 38 and [overflows](hdfs_orc.html#overflow) when writing to an ORC file. Valid values are: round, error, or ignore | round |
 | pxf.parquet.write.decimal.overflow | Specifies how PXF handles numeric data that exceeds the maximum precision of 38 and [overflows](hdfs_parquet.html#overflow) when writing to a Parquet file. Valid values are: round, error, or ignore | round |
 
 </br><sup>1</sup>&nbsp;Should you need to, you can override this setting on a per-table basis by specifying the `&PPD=<boolean>` option in the `LOCATION` clause when you create the external table.

--- a/docs/content/hdfs_orc.html.md.erb
+++ b/docs/content/hdfs_orc.html.md.erb
@@ -301,3 +301,25 @@ In this example, you create a writable external table to write some data to the 
     postgres=# SELECT * FROM sample_orc ORDER BY num_orders;
     ```
 
+## <a id="overflow"></a>Understanding Overflow Conditions When Writing Numeric Data
+
+PXF uses the `HiveDecimal` class to write numeric ORC data. `HiveDecimal` limits both the precision and the scale of a numeric type to a maximum of 38.
+
+When you define a `NUMERIC` column in an external table without specifying a precision or scale, PXF internally maps the column to a `DECIMAL(38, 10)`.
+
+A precision overflow condition can result when:
+
+- You define a `NUMERIC` column in the external table, and the integer digit count of a value exceeds the maximum supported precision of 38. For example, `1234567890123456789012345678901234567890.12345`, which has an integer digit count of 45.
+- You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38. For example, `NUMERIC(55)`.
+- You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`, which has an integer digit count of 19, which is greater than 20-4=16.
+
+PXF can take one of three actions when it detects an overflow while writing numeric data to an ORC file: round the value (the default), return an error, or ignore the overflow. The `pxf.orc.write.decimal.overflow` property in the `pxf-site.xml` server configuration governs PXF's action in this circumstance; valid values for this property follow:
+
+| Value  | PXF Action |
+|-------|-------------------------------------|
+| `round` | When PXF encounters an overflow, it attempts to round the value to meet both precision and scale requirements before writing and logs a warning. PXF reports an error if rounding fails. This may potentially leave an incomplete data set in the external system.  `round` is the default. |
+| `error` | PXF reports an error when it encounters an overflow, and the transaction fails. |
+| `ignore` | PXF attempts to round the value to meet only the precision requirement; otherwise PXF writes a NULL value. (This was PXF's behavior prior to version 6.7.0.) |
+
+PXF always logs a warning when it detects an overflow, regardless of the `pxf.orc.write.decimal.overflow` property setting.
+

--- a/docs/content/hdfs_orc.html.md.erb
+++ b/docs/content/hdfs_orc.html.md.erb
@@ -303,7 +303,7 @@ In this example, you create a writable external table to write some data to the 
 
 ## <a id="overflow"></a>Understanding Overflow Conditions When Writing Numeric Data
 
-PXF uses the `HiveDecimal` class to write numeric ORC data. In versions prior to 6.7.0, PXF limited only the precision of a numeric type to a maximum of 38. In versions 6.7.0 and later, PXF limits both the precision and the scale of a numeric type to a maximum of 38.
+PXF uses the `HiveDecimal` class to write numeric ORC data. In versions prior to 6.7.0, PXF limited only the precision of a numeric type to a maximum of 38. In versions 6.7.0 and later, PXF must meet both precision and scale requirements before writing numeric ORC data.
 
 When you define a `NUMERIC` column in an external table without specifying a precision or scale, PXF internally maps the column to a `DECIMAL(38, 10)`.
 

--- a/docs/content/hdfs_orc.html.md.erb
+++ b/docs/content/hdfs_orc.html.md.erb
@@ -303,23 +303,25 @@ In this example, you create a writable external table to write some data to the 
 
 ## <a id="overflow"></a>Understanding Overflow Conditions When Writing Numeric Data
 
-PXF uses the `HiveDecimal` class to write numeric ORC data. `HiveDecimal` limits both the precision and the scale of a numeric type to a maximum of 38.
+PXF uses the `HiveDecimal` class to write numeric ORC data. In versions prior to 6.7.0, PXF limited only the precision of a numeric type to a maximum of 38. In versions 6.7.0 and later, PXF limits both the precision and the scale of a numeric type to a maximum of 38.
 
 When you define a `NUMERIC` column in an external table without specifying a precision or scale, PXF internally maps the column to a `DECIMAL(38, 10)`.
 
-A precision overflow condition can result when:
+PXF handles the following precision overflow conditions:
 
 - You define a `NUMERIC` column in the external table, and the integer digit count of a value exceeds the maximum supported precision of 38. For example, `1234567890123456789012345678901234567890.12345`, which has an integer digit count of 45.
 - You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38. For example, `NUMERIC(55)`.
-- You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`, which has an integer digit count of 19, which is greater than 20-4=16.
+- You define a `NUMERIC` column in the external table, and the integer digit count of a value is greater than 28 (38-10). For example, `123456789012345678901234567890.12345`, which has an integer digit count of 30.
+
+If you define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`, PXF returns an error. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`, which has an integer digit count of 19, which is greater than 20-4=16.
 
 PXF can take one of three actions when it detects an overflow while writing numeric data to an ORC file: round the value (the default), return an error, or ignore the overflow. The `pxf.orc.write.decimal.overflow` property in the `pxf-site.xml` server configuration governs PXF's action in this circumstance; valid values for this property follow:
 
 | Value  | PXF Action |
 |-------|-------------------------------------|
-| `round` | When PXF encounters an overflow, it attempts to round the value to meet both precision and scale requirements before writing and logs a warning. PXF reports an error if rounding fails. This may potentially leave an incomplete data set in the external system.  `round` is the default. |
+| `round` | When PXF encounters an overflow, it attempts to round the value to meet both precision and scale requirements before writing. PXF reports an error if rounding fails. This may potentially leave an incomplete data set in the external system.  `round` is the default. |
 | `error` | PXF reports an error when it encounters an overflow, and the transaction fails. |
-| `ignore` | PXF attempts to round the value to meet only the precision requirement; otherwise PXF writes a NULL value. (This was PXF's behavior prior to version 6.7.0.) |
+| `ignore` | PXF attempts to round the value to meet only the precision requirement and ignore validation of precision and scale; otherwise PXF writes a NULL value. (This was PXF's behavior prior to version 6.7.0.) |
 
-PXF always logs a warning when it detects an overflow, regardless of the `pxf.orc.write.decimal.overflow` property setting.
+PXF logs a warning when it detects an overflow and the `pxf.orc.write.decimal.overflow` property is set to `ignore`.
 

--- a/docs/content/hdfs_orc.html.md.erb
+++ b/docs/content/hdfs_orc.html.md.erb
@@ -321,7 +321,7 @@ PXF can take one of three actions when it detects an overflow while writing nume
 |-------|-------------------------------------|
 | `round` | When PXF encounters an overflow, it attempts to round the value to meet both precision and scale requirements before writing. PXF reports an error if rounding fails. This may potentially leave an incomplete data set in the external system.  `round` is the default. |
 | `error` | PXF reports an error when it encounters an overflow, and the transaction fails. |
-| `ignore` | PXF attempts to round the value to meet only the precision requirement and ignore validation of precision and scale; otherwise PXF writes a NULL value. (This was PXF's behavior prior to version 6.7.0.) |
+| `ignore` | PXF attempts to round the value to meet only the precision requirement and ignores validation of precision and scale; otherwise PXF writes a NULL value. (This was PXF's behavior prior to version 6.7.0.) |
 
 PXF logs a warning when it detects an overflow and the `pxf.orc.write.decimal.overflow` property is set to `ignore`.
 

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -251,19 +251,21 @@ PXF uses the `HiveDecimal` class to write numeric Parquet data. `HiveDecimal` li
 
 When you define a `NUMERIC` column in an external table without specifying a precision or scale, PXF internally maps the column to a `DECIMAL(38, 18)`.
 
-A precision overflow condition can result when:
+PXF handles the following precision overflow conditions:
 
 - You define a `NUMERIC` column in the external table, and the integer digit count of a value exceeds the maximum supported precision of 38. For example, `1234567890123456789012345678901234567890.12345`, which has an integer digit count of 45.
 - You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38. For example, `NUMERIC(55)`.
-- You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`, which has an integer digit count of 19, which is greater than 20-4=16.
+- You define a `NUMERIC` column in the external table, and the integer digit count of a value is greater than 20 (38-18). For example, `123456789012345678901234567890.12345`, which has an integer digit count of 30.
+
+If define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`, PXF returns an error. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`, which has an integer digit count of 19, which is greater than 20-4=16.
 
 PXF can take one of three actions when it detects an overflow while writing numeric data to a Parquet file: round the value (the default), return an error, or ignore the overflow. The `pxf.parquet.write.decimal.overflow` property in the `pxf-site.xml` server configuration governs PXF's action in this circumstance; valid values for this property follow:
 
 | Value  | PXF Action |
 |-------|-------------------------------------|
-| `round` | When PXF encounters an overflow, it attempts to round the value to meet both precision and scale requirements before writing and logs a warning. PXF reports an error if rounding fails. This may potentially leave an incomplete data set in the external system.  `round` is the default. |
+| `round` | When PXF encounters an overflow, it attempts to round the value to meet both precision and scale requirements before writing. PXF reports an error if rounding fails. This may potentially leave an incomplete data set in the external system.  `round` is the default. |
 | `error` | PXF reports an error when it encounters an overflow, and the transaction fails. |
 | `ignore` | PXF attempts to round the value to meet both precision and scale requirements; otherwise PXF writes a NULL value. (This was PXF's behavior prior to version 6.6.0.) |
 
-PXF always logs a warning when it detects an overflow, regardless of the `pxf.parquet.write.decimal.overflow` property setting.
+PXF logs a warning when it detects an overflow and the `pxf.parquet.write.decimal.overflow` property is set to `ignore`.
 

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -253,7 +253,7 @@ When you define a `NUMERIC` column in an external table without specifying a pre
 
 A precision overflow condition can result when:
 
-- You define a `NUMERIC` column in the external table, and the integer digit count of a value exceeds maximum precision 38. For example, `1234567890123456789012345678901234567890.12345`, which has an integer digit count of 45.
+- You define a `NUMERIC` column in the external table, and the integer digit count of a value exceeds the maximum supported precision of 38. For example, `1234567890123456789012345678901234567890.12345`, which has an integer digit count of 45.
 - You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38. For example, `NUMERIC(55)`.
 - You define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`, which has an integer digit count of 19, which is greater than 20-4=16.
 
@@ -261,9 +261,9 @@ PXF can take one of three actions when it detects an overflow while writing nume
 
 | Value  | PXF Action |
 |-------|-------------------------------------|
-| `round` | When PXF encounters an overflow, it attempts to round the value before writing and logs a warning. PXF reports an error if rounding fails. This may potentially leave an incomplete data set in the external system.  `round` is the default. |
+| `round` | When PXF encounters an overflow, it attempts to round the value to meet both precision and scale requirements before writing and logs a warning. PXF reports an error if rounding fails. This may potentially leave an incomplete data set in the external system.  `round` is the default. |
 | `error` | PXF reports an error when it encounters an overflow, and the transaction fails. |
-| `ignore` | PXF writes a NULL value. (This was PXF's behavior prior to version 6.6.0.) |
+| `ignore` | PXF attempts to round the value to meet both precision and scale requirements; otherwise PXF writes a NULL value. (This was PXF's behavior prior to version 6.6.0.) |
 
-PXF always logs an warning when it detects an overflow, regardless of the `pxf.parquet.write.decimal.overflow` property setting.
+PXF always logs a warning when it detects an overflow, regardless of the `pxf.parquet.write.decimal.overflow` property setting.
 

--- a/docs/content/hdfs_parquet.html.md.erb
+++ b/docs/content/hdfs_parquet.html.md.erb
@@ -257,7 +257,7 @@ PXF handles the following precision overflow conditions:
 - You define a `NUMERIC(<precision>)` column with a `<precision>` greater than 38. For example, `NUMERIC(55)`.
 - You define a `NUMERIC` column in the external table, and the integer digit count of a value is greater than 20 (38-18). For example, `123456789012345678901234567890.12345`, which has an integer digit count of 30.
 
-If define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`, PXF returns an error. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`, which has an integer digit count of 19, which is greater than 20-4=16.
+If you define a `NUMERIC(<precision>, <scale>)` column and the integer digit count of a value is greater than `<precision> - <scale>`, PXF returns an error. For example, you define a `NUMERIC(20,4)` column and the value is `12345678901234567.12`, which has an integer digit count of 19, which is greater than 20-4=16.
 
 PXF can take one of three actions when it detects an overflow while writing numeric data to a Parquet file: round the value (the default), return an error, or ignore the overflow. The `pxf.parquet.write.decimal.overflow` property in the `pxf-site.xml` server configuration governs PXF's action in this circumstance; valid values for this property follow:
 

--- a/docs/content/upgrade_6.html.md.erb
+++ b/docs/content/upgrade_6.html.md.erb
@@ -123,7 +123,7 @@ After you install the new version of PXF, perform the following procedure:
     </property>
     ```
 
-    where `NEW_VALUE` is `error` or `ignore`.
+    where `NEW_VALUE` is `round`, `error`, or `ignore`. The default value is `round`.
 
     Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_parquet.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters a numeric overflow while writing to a Parquet file.
 
@@ -136,7 +136,7 @@ After you install the new version of PXF, perform the following procedure:
     </property>
     ```
 
-    where `NEW_VALUE` is `error` or `ignore`.
+    where `NEW_VALUE` is `round`, `error`, or `ignore`. The default value is `round`.
 
     Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_orc.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters a numeric overflow while writing to an ORC file.
 

--- a/docs/content/upgrade_6.html.md.erb
+++ b/docs/content/upgrade_6.html.md.erb
@@ -127,6 +127,19 @@ After you install the new version of PXF, perform the following procedure:
 
     Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_parquet.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters a numeric overflow while writing to a Parquet file.
 
+1. **If you are upgrading <i>from</i> PXF version 6.6.x or earlier <i>to</i> PXF version 6.7.0 or later**, and you want to change the value of the new `pxf.orc.write.decimal.overflow` property from the default of `round`, add the following to the `pxf-site.xml` file for your PXF server:
+
+    ``` pre
+    <property>
+      <name>pxf.orc.write.decimal.overflow</name>
+      <value>NEW_VALUE</value>
+    </property>
+    ```
+
+    where `NEW_VALUE` is `error` or `ignore`.
+
+    Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_orc.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters a numeric overflow while writing to an ORC file.
+
 1. Synchronize the PXF configuration from the master host to the standby master host and each Greenplum Database segment host. For example:
 
     ``` shell

--- a/docs/content/upgrade_6.html.md.erb
+++ b/docs/content/upgrade_6.html.md.erb
@@ -123,7 +123,7 @@ After you install the new version of PXF, perform the following procedure:
     </property>
     ```
 
-    where `NEW_VALUE` is `round`, `error`, or `ignore`. The default value is `round`.
+    where `NEW_VALUE` is `error` or `ignore`.
 
     Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_parquet.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters a numeric overflow while writing to a Parquet file.
 
@@ -136,7 +136,7 @@ After you install the new version of PXF, perform the following procedure:
     </property>
     ```
 
-    where `NEW_VALUE` is `round`, `error`, or `ignore`. The default value is `round`.
+    where `NEW_VALUE` is `error` or `ignore`.
 
     Refer to [Understanding Overflow Conditions When Writing Numeric Data](hdfs_orc.html#overflow) for more information about how PXF uses this property to direct its actions when it encounters a numeric overflow while writing to an ORC file.
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/978 - PXF provides enhanced processing for numeric overflow conditions when writing ORC data.  similar, but not quite the same, as the parquet numeric overflow processing.  

in this PR:
- add description of new pxf-site.xml pxf.orc.write.decimal.overflow property
- add new section "Understanding Overflow Conditions When Writing Numeric Data" in the ORC topic
- minor updates to parquet overflow topic
- add an upgrade step that describes how to change the default value of the new property

question:  did we change the behaviour of parquet numeric overflow processing at all?

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/VMware-Greenplum-Platform-Extension-Framework/orcoverflow/greenplum-platform-extension-framework/GUID-hdfs_orc.html#understanding-overflow-conditions-when-writing-numeric-data-9