### PR TITLE
fix rpmrebuild-rocky8 container image

### DIFF
--- a/concourse/docker/README.md
+++ b/concourse/docker/README.md
@@ -46,21 +46,14 @@ flowchart TD
   classDef latestStyle fill:#6c71c4,color:white,stroke:none
   classDef plainStyle fill:none,stroke:black
 
-  subgraph dockerhub [Official DockerHub]
-    centos7[centos:7]
-    rocky8[rockylinux:8]
-    class centos7 dockerhubStyle
-    class rocky8 dockerhubStyle
-
-  end
-  class dockerhub subgraphStyle
-
   subgraph gcr_images ["GP RelEng Images (gcr.io/data-gpdb-public-images)"]
     gp5_centos7_latest[centos-gpdb-dev:7-gcc6.2-llvm3.7]
     gp6_centos7_latest[gpdb6-centos7-test:latest]
+    gp6_centos7_build[gpdb6-centos7-build:latest]
     gp6_ubuntu18_latest[gpdb6-ubuntu18.04-test:latest]
     gp6_oel7_latest[gpdb6-oel7-test:latest]
     gp6_rocky8_latest[gpdb6-rocky8-test:latest]
+    gp6_rocky8_build[gpdb6-rocky8-build:latest]
     gp7_rocky8_latest[gpdb7-rocky8-test:latest]
 
     class gp5_centos7_latest gcrPublicStyle
@@ -210,9 +203,9 @@ flowchart TD
   gp7_rocky8_dockerfile -- CloudBuild --> gp7_rocky8_pxf_sha
   gp7_rocky8_pxf_sha -- "tag (concourse pipeline)" --> gp7_rocky8_pxf_latest
 
-  centos7 --> rpm_docker_centos7
+  gp6_centos7_build --> rpm_docker_centos7
   rpm_docker_centos7 --> rpm_centos7_latest
-  rocky8 --> rpm_docker_rocky8
+  gp6_rocky8_build --> rpm_docker_rocky8
   rpm_docker_rocky8 --> rpm_rocky8_latest
 
   gp5_centos7_pxf_latest --> mapr_dockerfile

--- a/concourse/docker/rpmrebuild/centos/Dockerfile
+++ b/concourse/docker/rpmrebuild/centos/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=centos:7
+ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-centos7-build
 
 FROM ${BASE_IMAGE}
 

--- a/concourse/docker/rpmrebuild/cloudbuild.yaml
+++ b/concourse/docker/rpmrebuild/cloudbuild.yaml
@@ -8,7 +8,7 @@ steps:
   id: rpmrebuild-centos7-image
   args:
     - 'build'
-    - '--build-arg=BASE_IMAGE=centos:7'
+    - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-centos7-build:latest'
     - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
     - '-f'
     - 'concourse/docker/rpmrebuild/centos/Dockerfile'
@@ -20,7 +20,7 @@ steps:
   id: rpmrebuild-rocky8-image
   args:
     - 'build'
-    - '--build-arg=BASE_IMAGE=rockylinux:8'
+    - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-rocky8-build:latest'
     - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-rocky8:latest'
     - '-f'
     - 'concourse/docker/rpmrebuild/rocky/Dockerfile'

--- a/concourse/docker/rpmrebuild/rocky/Dockerfile
+++ b/concourse/docker/rpmrebuild/rocky/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rockylinux:8
+ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-rocky8-build:latest
 
 FROM ${BASE_IMAGE}
 

--- a/concourse/pipelines/cloudbuild_pipeline.yml
+++ b/concourse/pipelines/cloudbuild_pipeline.yml
@@ -56,10 +56,12 @@ resources:
       private_key: ((ud/pxf/secrets/gp-image-baking-repo-key))
       paths:
         - images/docker/gpdb5/gpdb5-centos7-build-test
+        - images/docker/gpdb6/gpdb6-centos7-build
         - images/docker/gpdb6/gpdb6-centos7-test
         - images/docker/gpdb6/gpdb6-ubuntu18.04-test
         - images/docker/gpdb6/gpdb6-oel7-test
         - images/docker/gpdb6/gpdb6-rhel8-test
+        - images/docker/gpdb6/gpdb6-rocky8-build
         - images/docker/gpdb7/gpdb7-centos7-test
         - images/docker/gpdb7/gpdb7-rhel8-test
         - images/docker/gpdb7/gpdb7-rocky8-test


### PR DESCRIPTION
There is a compatibility issue between the version of coreutils (v8.30-15) included in rockylinux:8 and the version of Concourse (v5.7.1) used for PXF's CI. This causes the command `ls <some-dir>` to fail with the error message

```sh
ls: cannot access '<some-dir>': Operation not permitted
```

The same comand in the same container image running on Concourse 7.8.3 works successfully.

The Greenplum release engineering team previsouly encountered this same issue and resolved it by downgrading coreutils-single to v8.30-8. This version is no longer available from upstream repos for downgrading in the rpmrebuild images. Instead, this commit switches the base image from upstream rockylinux:8 to gpdb6-rocky8-build which is maintained by the Greenplum release engineering team and includes the older version of coreutils-single. For consistency, this commit also changes upstream centos:7 to gpdb6-centos7-build.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>