### PR TITLE
Use `go run` to run cli tests that use ginkgo for PXF 5

### DIFF
--- a/cli/go/src/pxf-cli/Makefile
+++ b/cli/go/src/pxf-cli/Makefile
@@ -44,7 +44,9 @@ install: build
 	cp $(GOPATH)/bin/pxf-cli $(PXF_HOME)/bin
 
 test: build
-	ginkgo cmd end_to_end
+	# as the docker images no longer have ginkgo,
+	# fetch and run ginkgo but don't actually install it
+	go run github.com/onsi/ginkgo/ginkgo cmd end_to_end
 
 clean:
 	rm -rf ${PXF_CLI_DIR}/build


### PR DESCRIPTION
As the PXF docker images no longer install ginkgo, and we are using go version greater than 1.17, we can use `go run` to run ginkgo for tests without actually installing it [1]

[1] https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module