### PR TITLE
Updated certification pipeline to include GPDB 7 certification job

### DIFF
--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -314,36 +314,36 @@ jobs:
 
 - name: Certify GPDB-7 with PXF-GP7 on RHEL8
   plan:
-    - in_parallel:
-        - get: pxf_src
-        - get: bin_gpdb
-          resource: gpdb7_tarball_rhel8
-          trigger: true
-        - get: pxf_package
-          resource: pxf_gp7_rpm_rhel8
-          trigger: true
-        - get: gpdb7-pxf-dev-rocky8-image
-        - get: ccp-7-image
-        - get: pxf-automation-dependencies
-        - get: gp6-python-libs
-        - get: singlecluster
-          resource: singlecluster-hdp2
-    - task: Test GPDB-7 with PXF-GP7-HDP2 on RHEL8
-      <<: *slack_alert
-      file: pxf_src/concourse/tasks/test_certification.yml
-      image: gpdb7-pxf-dev-rocky8-image
-      params:
-        ACCESS_KEY_ID: ((tf-machine-access-key-id))
-        GP_VER: 7
-        GROUP: gpdb,proxy,profile
-        SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-    - task: Upload certification for GPDB-7 with PXF-GP7-HDP2 on RHEL8
-      file: pxf_src/concourse/tasks/certification_upload.yml
-      image: ccp-7-image
-      params:
-        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
-        GP_VER: 7
-        PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
+  - in_parallel:
+    - get: pxf_src
+    - get: bin_gpdb
+      resource: gpdb7_tarball_rhel8
+      trigger: true
+    - get: pxf_package
+      resource: pxf_gp7_rpm_rhel8
+      trigger: true
+    - get: gpdb7-pxf-dev-rocky8-image
+    - get: ccp-7-image
+    - get: pxf-automation-dependencies
+    - get: gp6-python-libs
+    - get: singlecluster
+      resource: singlecluster-hdp2
+  - task: Test GPDB-7 with PXF-GP7-HDP2 on RHEL8
+    <<: *slack_alert
+    file: pxf_src/concourse/tasks/test_certification.yml
+    image: gpdb7-pxf-dev-rocky8-image
+    params:
+      ACCESS_KEY_ID: ((tf-machine-access-key-id))
+      GP_VER: 7
+      GROUP: gpdb,proxy,profile
+      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+  - task: Upload certification for GPDB-7 with PXF-GP7-HDP2 on RHEL8
+    file: pxf_src/concourse/tasks/certification_upload.yml
+    image: ccp-7-image
+    params:
+      GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
+      GP_VER: 7
+      PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
 ## ---------- Ubuntu 18 Swimlane ----------
 - name: Certify GPDB-6 with PXF-GP6 on Ubuntu 18.04
@@ -431,18 +431,18 @@ jobs:
 
 - name: Reporting Gate for PXF-GP7
   plan:
-    - in_parallel:
-        - get: pxf_src
-        # gpdb release candidate tarballs and PXF RPMs used in testing jobs
-        - get: gpdb7_tarball_rhel8
-          passed:
-            - Certify GPDB-7 with PXF-GP7 on RHEL8
-          trigger: true
-        - get: pxf_gp7_rpm_rhel8
-          passed:
-            - Certify GPDB-7 with PXF-GP7 on RHEL8
-          trigger: true
-        - get: ccp-7-image
+  - in_parallel:
+    - get: pxf_src
+    # gpdb release candidate tarballs and PXF RPMs used in testing jobs
+    - get: gpdb7_tarball_rhel8
+      passed:
+      - Certify GPDB-7 with PXF-GP7 on RHEL8
+      trigger: true
+    - get: pxf_gp7_rpm_rhel8
+      passed:
+      - Certify GPDB-7 with PXF-GP7 on RHEL8
+      trigger: true
+    - get: ccp-7-image
     - task: Print Report for GPDB-7 with PXF-GP7 Artifacts
       file: pxf_src/concourse/tasks/certification_list.yml
       image: ccp-7-image

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -8,7 +8,7 @@ anchors:
     put: slack-alert
     params:
       text: |
-        :ci-fail: <((ud/pxf/secrets/ud-concourse-url))/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (<((ud/pxf/common/slack-em-id.id1))>, <((ud/pxf/common/slack-em-id.id2))>)
+        :ci-fail: <${ATC_EXTERNAL_URL}/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (((ud/common/slack-em-ids)))
 
 ## ======================================================================
 ## RESOURCE TYPES

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -7,8 +7,8 @@ anchors:
   on_failure:
     put: slack-alert
     params:
-      text: |
-        :ci-fail: <${ATC_EXTERNAL_URL}/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (((ud/common/slack-em-ids)))
+      # yamllint disable-line rule:line-length
+      text: ":ci-fail: <${ATC_EXTERNAL_URL}/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (((ud/common/slack-em-ids)))"
 
 ## ======================================================================
 ## RESOURCE TYPES

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -448,5 +448,5 @@ jobs:
       image: ccp-7-image
       params:
         GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
-        GP_VER: 6
+        GP_VER: 7
         PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -8,7 +8,7 @@ anchors:
     put: slack-alert
     params:
       text: |
-        :ci-fail: <((ud/pxf/secrets/ud-concourse-url))/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (<((ud/pxf/common/slack-em-id.id1))>, <((ud/pxf/common/slack-em-id.id1))>)
+        :ci-fail: <((ud/pxf/secrets/ud-concourse-url))/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (<((ud/pxf/common/slack-em-id.id1))>, <((ud/pxf/common/slack-em-id.id2))>)
 
 ## ======================================================================
 ## RESOURCE TYPES

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -44,6 +44,14 @@ resources:
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     versioned_file: automation-dependencies/pxf-automation-dependencies.tar.gz
 
+- name: gp6-python-libs
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: ((ud/pxf/common/build-resources-bucket-name))
+    json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
+    versioned_file: automation-dependencies/gp6-python-libs.tar.gz
+
 - name: singlecluster-hdp2
   type: gcs
   icon: google-drive
@@ -57,7 +65,6 @@ resources:
   type: git
   icon: git
   source:
-    tag_filter: release-*
     branch: ((pxf-git-branch))
     uri: ((ud/pxf/common/git-remote))
 
@@ -147,9 +154,7 @@ resources:
   source:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: s/server/published/main/server-rc-7.(.*)-el8_x86_64.tar.gz
-
-
+    regexp: server/published/main/server-rc-7.(.*)-el8_x86_64.tar.gz
 
 - name: gpdb6_ubuntu18_tarball
   type: gcs
@@ -340,7 +345,7 @@ jobs:
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
 
-- name: Certify GPDB-7 with PXF-GP6 on RHEL8
+- name: Certify GPDB-7 with PXF-GP7 on RHEL8
   plan:
     - in_parallel:
         - get: pxf_src
@@ -353,6 +358,7 @@ jobs:
         - get: gpdb7-pxf-dev-rocky8-image
         - get: ccp-7-image
         - get: pxf-automation-dependencies
+        - get: gp6-python-libs
         - get: singlecluster
           resource: singlecluster-hdp2
     - task: Test GPDB-7 with PXF-GP7-HDP2 on RHEL8
@@ -360,7 +366,7 @@ jobs:
       image: gpdb7-pxf-dev-rocky8-image
       params:
         ACCESS_KEY_ID: ((tf-machine-access-key-id))
-        GP_VER: 6
+        GP_VER: 7
         GROUP: gpdb,proxy,profile
         SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
     - task: Upload certification for GPDB-7 with PXF-GP7-HDP2 on RHEL8
@@ -423,3 +429,26 @@ jobs:
       GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
       GP_VER: 6
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
+
+- name: Reporting Gate for PXF-GP7
+  plan:
+    - in_parallel:
+        - get: pxf_src
+        # gpdb release candidate tarballs and PXF RPMs used in testing jobs
+        - get: gpdb7_tarball_rhel8
+          passed:
+            - Certify GPDB-7 with PXF-GP7 on RHEL8
+          trigger: true
+        - get: pxf_gp7_rpm_rhel8
+          passed:
+            - Certify GPDB-7 with PXF-GP7 on RHEL8
+          trigger: true
+        - get: ccp-7-image
+    - task: Print Report for GPDB-7 with PXF-GP7 Artifacts
+      <<: *slack_alert
+      file: pxf_src/concourse/tasks/certification_list.yml
+      image: ccp-7-image
+      params:
+        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
+        GP_VER: 6
+        PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -8,7 +8,7 @@ anchors:
     put: slack-alert
     params:
       text: |
-        :fail: <((ud/pxf/secrets/ud-concourse-url))/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (<((ud/pxf/common/slack-em-id.id1))>, <((ud/pxf/common/slack-em-id.id1))>)
+        :ci-fail: <((ud/pxf/secrets/ud-concourse-url))/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (<((ud/pxf/common/slack-em-id.id1))>, <((ud/pxf/common/slack-em-id.id1))>)
 
 ## ======================================================================
 ## RESOURCE TYPES

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -39,6 +39,7 @@ resources:
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     versioned_file: automation-dependencies/pxf-automation-dependencies.tar.gz
 
+## TODO Remove this resource block once Tinc is replaced with pg_regress.
 - name: gp6-python-libs
   type: gcs
   icon: google-drive
@@ -341,7 +342,7 @@ jobs:
       image: ccp-7-image
       params:
         GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
-        GP_VER: 6
+        GP_VER: 7
         PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
 ## ---------- Ubuntu 18 Swimlane ----------

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -8,12 +8,7 @@ anchors:
     put: slack-alert
     params:
       text: |
-        <((ud/pxf/secrets/ud-concourse-url))/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> went red :blob_slightly_frowning_face:
-  on_success:
-    put: slack-alert
-    params:
-      text: |
-        <((ud/pxf/secrets/ud-concourse-url))/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> went green! :smile:
+        :fail: <((ud/pxf/secrets/ud-concourse-url))/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (<((ud/pxf/common/slack-em-id.id1))>, <((ud/pxf/common/slack-em-id.id1))>)
 
 ## ======================================================================
 ## RESOURCE TYPES
@@ -65,6 +60,7 @@ resources:
   type: git
   icon: git
   source:
+    tag_filter: release-*
     branch: ((pxf-git-branch))
     uri: ((ud/pxf/common/git-remote))
 
@@ -234,6 +230,7 @@ jobs:
     - get: singlecluster
       resource: singlecluster-hdp2
   - task: Test GPDB-5 with PXF-GP5-HDP2 on RHEL7
+    <<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb5-pxf-dev-centos7-image
     params:
@@ -265,6 +262,7 @@ jobs:
     - get: singlecluster
       resource: singlecluster-hdp2
   - task: Test GPDB-6 with PXF-GP6-HDP2 on RHEL7
+    <<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb6-pxf-dev-centos7-image
     params:
@@ -297,6 +295,7 @@ jobs:
     - get: singlecluster
       resource: singlecluster-hdp2
   - task: Test GPDB-6 with PXF-GP6-HDP2 on RHEL8
+    <<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb6-pxf-dev-rocky8-image
     params:
@@ -311,39 +310,6 @@ jobs:
       GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
       GP_VER: 6
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
-
-## ---------- Ubuntu 18 Swimlane ----------
-- name: Certify GPDB-6 with PXF-GP6 on Ubuntu 18.04
-  plan:
-  - in_parallel:
-    - get: pxf_src
-    - get: bin_gpdb
-      resource: gpdb6_ubuntu18_tarball
-      trigger: true
-    - get: pxf_package
-      resource: pxf_gp6_deb_ubuntu18
-      trigger: true
-    - get: gpdb6-pxf-dev-ubuntu18-image
-    - get: ccp-7-image
-    - get: pxf-automation-dependencies
-    - get: singlecluster
-      resource: singlecluster-hdp2
-  - task: Test GPDB-6 with PXF-GP6-HDP2 on Ubuntu 18.04
-    file: pxf_src/concourse/tasks/test_certification.yml
-    image: gpdb6-pxf-dev-ubuntu18-image
-    params:
-      ACCESS_KEY_ID: ((tf-machine-access-key-id))
-      GP_VER: 6
-      GROUP: gpdb,proxy,profile
-      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-  - task: Upload certification for GPDB-6 with PXF-GP6-HDP2 on Ubuntu 18.04
-    file: pxf_src/concourse/tasks/certification_upload.yml
-    image: ccp-7-image
-    params:
-      GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
-      GP_VER: 6
-      PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
-
 
 - name: Certify GPDB-7 with PXF-GP7 on RHEL8
   plan:
@@ -362,6 +328,7 @@ jobs:
         - get: singlecluster
           resource: singlecluster-hdp2
     - task: Test GPDB-7 with PXF-GP7-HDP2 on RHEL8
+      <<: *slack_alert
       file: pxf_src/concourse/tasks/test_certification.yml
       image: gpdb7-pxf-dev-rocky8-image
       params:
@@ -376,6 +343,39 @@ jobs:
         GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
         GP_VER: 6
         PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
+
+## ---------- Ubuntu 18 Swimlane ----------
+- name: Certify GPDB-6 with PXF-GP6 on Ubuntu 18.04
+  plan:
+  - in_parallel:
+    - get: pxf_src
+    - get: bin_gpdb
+      resource: gpdb6_ubuntu18_tarball
+      trigger: true
+    - get: pxf_package
+      resource: pxf_gp6_deb_ubuntu18
+      trigger: true
+    - get: gpdb6-pxf-dev-ubuntu18-image
+    - get: ccp-7-image
+    - get: pxf-automation-dependencies
+    - get: singlecluster
+      resource: singlecluster-hdp2
+  - task: Test GPDB-6 with PXF-GP6-HDP2 on Ubuntu 18.04
+    <<: *slack_alert
+    file: pxf_src/concourse/tasks/test_certification.yml
+    image: gpdb6-pxf-dev-ubuntu18-image
+    params:
+      ACCESS_KEY_ID: ((tf-machine-access-key-id))
+      GP_VER: 6
+      GROUP: gpdb,proxy,profile
+      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+  - task: Upload certification for GPDB-6 with PXF-GP6-HDP2 on Ubuntu 18.04
+    file: pxf_src/concourse/tasks/certification_upload.yml
+    image: ccp-7-image
+    params:
+      GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
+      GP_VER: 6
+      PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
 ## ---------- Reporting Gates ----------
 - name: Reporting Gate for PXF-GP5
@@ -393,7 +393,6 @@ jobs:
       trigger: true
     - get: ccp-7-image
   - task: Print Report for GPDB-5 with PXF-GP5 Artifacts
-    <<: *slack_alert
     file: pxf_src/concourse/tasks/certification_list.yml
     image: ccp-7-image
     params:
@@ -422,7 +421,6 @@ jobs:
       - Certify GPDB-6 with PXF-GP6 on Ubuntu 18.04
     - get: ccp-7-image
   - task: Print Report for GPDB-6 with PXF-GP6 Artifacts
-    <<: *slack_alert
     file: pxf_src/concourse/tasks/certification_list.yml
     image: ccp-7-image
     params:
@@ -445,7 +443,6 @@ jobs:
           trigger: true
         - get: ccp-7-image
     - task: Print Report for GPDB-7 with PXF-GP7 Artifacts
-      <<: *slack_alert
       file: pxf_src/concourse/tasks/certification_list.yml
       image: ccp-7-image
       params:

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -98,6 +98,15 @@ resources:
     username: _json_key
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
 
+- name: gpdb7-pxf-dev-rocky8-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: gcr.io/data-gpdb-ud/gpdb-pxf-dev/gpdb7-rocky8-test-pxf
+    tag: latest
+    username: _json_key
+    password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
+
 - name: ccp-7-image
   type: registry-image
   icon: docker
@@ -131,6 +140,16 @@ resources:
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.tar.gz
+
+- name: gpdb7_tarball_rhel8
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: s/server/published/main/server-rc-7.(.*)-el8_x86_64.tar.gz
+
+
 
 - name: gpdb6_ubuntu18_tarball
   type: gcs
@@ -174,6 +193,14 @@ resources:
     bucket: ((ud/pxf/common/releases-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     regexp: prod/releases/gp6/pxf-gp6-(.*)-1-ubuntu18.04-amd64.deb
+
+- name: pxf_gp7_rpm_rhel8
+  type: gcs
+  icon: google-drive
+  source:
+    bucket: ((ud/pxf/common/releases-bucket-name))
+    json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
+    regexp: prod/releases/gp7/pxf-gp7-(.*)-1.el8.x86_64.rpm
 
 - name: slack-alert
   type: slack-notification
@@ -311,6 +338,38 @@ jobs:
       GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
       GP_VER: 6
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
+
+
+- name: Certify GPDB-7 with PXF-GP6 on RHEL8
+  plan:
+    - in_parallel:
+        - get: pxf_src
+        - get: bin_gpdb
+          resource: gpdb7_tarball_rhel8
+          trigger: true
+        - get: pxf_package
+          resource: pxf_gp7_rpm_rhel8
+          trigger: true
+        - get: gpdb7-pxf-dev-rocky8-image
+        - get: ccp-7-image
+        - get: pxf-automation-dependencies
+        - get: singlecluster
+          resource: singlecluster-hdp2
+    - task: Test GPDB-7 with PXF-GP7-HDP2 on RHEL8
+      file: pxf_src/concourse/tasks/test_certification.yml
+      image: gpdb7-pxf-dev-rocky8-image
+      params:
+        ACCESS_KEY_ID: ((tf-machine-access-key-id))
+        GP_VER: 6
+        GROUP: gpdb,proxy,profile
+        SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+    - task: Upload certification for GPDB-7 with PXF-GP7-HDP2 on RHEL8
+      file: pxf_src/concourse/tasks/certification_upload.yml
+      image: ccp-7-image
+      params:
+        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
+        GP_VER: 6
+        PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
 ## ---------- Reporting Gates ----------
 - name: Reporting Gate for PXF-GP5

--- a/concourse/scripts/test.bash
+++ b/concourse/scripts/test.bash
@@ -257,7 +257,7 @@ function _main() {
 	# we will set PYTHONPATH to point to the set of python libs compiled with Python2 for GP6
 	if [[ ${GP_VER} == 7 ]]; then
 	  local gp6_python_libs=~gpadmin/python
-	  echo "export PYTHONPATH=${gp6_python_libs}" >> /usr/local/greenplum-db/greenplum_path.sh
+	  echo "export PYTHONPATH=${gp6_python_libs}" >> ${GPHOME}/greenplum_path.sh
 	fi
 
 	ln -s "${PWD}/pxf_src" ~gpadmin/pxf_src

--- a/concourse/scripts/test.bash
+++ b/concourse/scripts/test.bash
@@ -253,7 +253,7 @@ function _main() {
 
 	inflate_dependencies
 
-	#TODO Revisit this code once the Tinc is removed and pg_regress is implemented. We then no longer need this extra PYTHONPATH setting.
+	#TODO Remove this "if" block once Tinc is replaced with pg_regress.
 	# To run Tinc against GP7 we need to modify PYTHONPATH in $GPHOME/greenplum_path.sh since Tinc calls that script
 	# we will set PYTHONPATH to point to the set of python libs compiled with Python2 for GP6
 	if [[ ${GP_VER} == 7 ]]; then

--- a/concourse/scripts/test.bash
+++ b/concourse/scripts/test.bash
@@ -253,10 +253,13 @@ function _main() {
 
 	inflate_dependencies
 
+	#TODO Revisit this code once the Tinc is removed and pg_regress is implemented. We then no longer need this extra PYTHONPATH setting.
 	# To run Tinc against GP7 we need to modify PYTHONPATH in $GPHOME/greenplum_path.sh since Tinc calls that script
 	# we will set PYTHONPATH to point to the set of python libs compiled with Python2 for GP6
 	if [[ ${GP_VER} == 7 ]]; then
 	  local gp6_python_libs=~gpadmin/python
+	  echo "# Added by test.bash - Overriding PYTHONPATH to run the Tinc Tests in GP7" >> ${GPHOME}/greenplum_path.sh
+	  echo "# Comment the following line out if you need to run GP utilities" >> ${GPHOME}/greenplum_path.sh
 	  echo "export PYTHONPATH=${gp6_python_libs}" >> ${GPHOME}/greenplum_path.sh
 	fi
 

--- a/concourse/tasks/test_certification.yml
+++ b/concourse/tasks/test_certification.yml
@@ -9,6 +9,8 @@ inputs:
 - name: pxf_package
 - name: singlecluster
 - name: pxf-automation-dependencies
+- name: gp6-python-libs
+  optional: true
 
 outputs:
 - name: certification

--- a/concourse/tasks/test_certification.yml
+++ b/concourse/tasks/test_certification.yml
@@ -9,6 +9,7 @@ inputs:
 - name: pxf_package
 - name: singlecluster
 - name: pxf-automation-dependencies
+# TODO Remove gp6-python-libs input once Tinc is replaced with pg_regress.
 - name: gp6-python-libs
   optional: true
 


### PR DESCRIPTION
This PR includes following changes to the certification pipeline:  

- Added GP7 certification 
- Slack Alerts Update: 
Previously, Slack alerts were sent when the pipeline ran successfully. With this change, Slack alerts will now be triggered on individual job failures. With the new format, in addition to the team notification, EM and PM will be mentioned as well in the Slack message.