### PR TITLE
Adding CLI Test Job for GP7 for dev pipeline

### DIFF
--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -37,6 +37,7 @@ GS                          ?= false
 MINIO                       ?= false
 OEL7                        ?= false
 FILE                        ?= false
+GP7_CLI                     ?= false
 
 SET_PIPELINE := set-pipeline
 ifeq ($(CHECK_CREDS), true)
@@ -116,6 +117,7 @@ set-dev-build-pipeline:
 		gs=$(GS) \
 		minio=$(MINIO) \
 		oel7=$(OEL7) \
+		gp7_cli=$(GP7_CLI) \
 		dev_pipeline=true \
 		user=$(USER) \
 		branch=$(BRANCH) \

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -83,7 +83,7 @@ resource_types:
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
 {% endif %}
 
-{% if multinode or gp7_cli %}
+{% if multinode %}
 - name: terraform-0.14.10
   type: registry-image
   source:
@@ -617,7 +617,7 @@ jobs:
 {% endfor %}
 {% set gp_ver = None %}
 
-## ----------GP7 CLI tests ----------\
+## ----------GP7 PXF CLI tests START-----------
 
 {% if gp7_cli %}
 {% set gp_ver = 7 %}
@@ -647,7 +647,7 @@ jobs:
           generate_random_name: true
           terraform_source: ccp_src/google/
           vars:
-            PLATFORM: rocky8-gpdb7
+            PLATFORM: rocky8-gpdb[[gp_ver]]
             number_of_nodes: ((number_of_gpdb_nodes))
             extra_nodes: 1
             segments_per_host: 4
@@ -666,7 +666,7 @@ jobs:
           AWS_DEFAULT_REGION: ((ud/common/aws-region))
           BUCKET_PATH: ((tf-bucket-path))
           BUCKET_NAME: ((ud/pxf/common/tf-bucket-name))
-          PLATFORM: rocky8-gpdb7
+          PLATFORM: rocky8-gpdb[[gp_ver]]
           CLOUD_PROVIDER: google
           GPDB_RPM: true
   - task: Initialize Greenplum
@@ -683,15 +683,14 @@ jobs:
       PXF_JVM_OPTS: ((pxf-jvm-opts))
   - task: Test PXF CLI
     on_success:
-      in_parallel:
-        steps:
-        - *destroy_gpdb_cluster
+      <<: *destroy_gpdb_cluster
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     file: pxf_src/concourse/tasks/test_pxf_cli.yml
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}
 {% endif %}
+## ----------GP7 PXF CLI tests END ----------
 
 ## ---------- Extended Tests ----------
 {% set gp_ver = 6 %}

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -617,7 +617,7 @@ jobs:
 {% endfor %}
 {% set gp_ver = None %}
 
-## ----------GP7 PXF CLI tests START-----------
+## ---------- GP7 PXF tests ----------
 
 {% if gp7_cli %}
 {% set gp_ver = 7 %}
@@ -689,8 +689,8 @@ jobs:
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}
-{% endif %}
-## ----------GP7 PXF CLI tests END ----------
+{% endif %} # if gp7_cli ends here
+{% set gp_ver = None %}
 
 ## ---------- Extended Tests ----------
 {% set gp_ver = 6 %}

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -617,7 +617,7 @@ jobs:
 {% endfor %}
 {% set gp_ver = None %}
 
-## ---------- GP7 PXF tests ----------
+## ---------- GP7 PXF CLI tests ----------
 
 {% if gp7_cli %}
 {% set gp_ver = 7 %}

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -73,7 +73,7 @@ anchors:
 ## ======================================================================
 resource_types:
 
-{% if multinode or multinode_no_impersonation or file %}
+{% if multinode or multinode_no_impersonation or file or gp7_cli %}
 - name: terraform
   type: registry-image
   source:
@@ -83,7 +83,7 @@ resource_types:
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
 {% endif %}
 
-{% if multinode %}
+{% if multinode or gp7_cli %}
 - name: terraform-0.14.10
   type: registry-image
   source:
@@ -169,7 +169,7 @@ resources:
     branch: ((pxf-git-branch))
     uri: ((ud/pxf/common/git-remote))
 
-{% if multinode or multinode_no_impersonation or file %}
+{% if multinode or multinode_no_impersonation or file or gp7_cli %}
 - name: ccp_src
   type: git
   source:
@@ -202,7 +202,6 @@ resources:
     username: _json_key
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
 {% endfor %}
-{% set gp_ver = None %}
 
 {% if oel7 %}
 - name: gpdb6-pxf-dev-oel7-image
@@ -237,7 +236,7 @@ resources:
 {% endif %}
 {% set gp_ver = None %}
 
-{% if multinode or multinode_no_impersonation or ambari or file %}
+{% if multinode or multinode_no_impersonation or ambari or file or gp7_cli %}
 - name: ccp-7-image
   type: registry-image
   icon: docker
@@ -351,7 +350,7 @@ resources:
 {% endfor %}
 
 ## ---------- Auxiliary Resources ----------
-{% if multinode or multinode_no_impersonation or file %}
+{% if multinode or multinode_no_impersonation or file or gp7_cli %}
 - name: terraform
   type: terraform
   source:
@@ -617,6 +616,82 @@ jobs:
       USE_FDW: true
 {% endfor %}
 {% set gp_ver = None %}
+
+## ----------GP7 CLI tests ----------\
+
+{% if gp7_cli %}
+{% set gp_ver = 7 %}
+- name: Test PXF-GP[[gp_ver]]-CLI on RHEL8
+  max_in_flight: 2
+  plan:
+  - in_parallel:
+    - get: pxf_src
+      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+      trigger: true
+    - get: pxf_tarball
+      resource: pxf_gp[[gp_ver]]_tarball_rhel8
+      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+    - get: gpdb_package
+      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
+      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+    - get: ccp_src
+    - get: ccp-7-image
+  - in_parallel:
+    - do:
+      - put: terraform_gpdb
+        resource: terraform
+        params:
+          action: create
+          delete_on_failure: true
+          generate_random_name: true
+          terraform_source: ccp_src/google/
+          vars:
+            PLATFORM: rocky8-gpdb7
+            number_of_nodes: ((number_of_gpdb_nodes))
+            extra_nodes: 1
+            segments_per_host: 4
+            instance_type: n1-standard-4
+            ccp_reap_minutes: 120
+            standby_master: true
+      - task: Generate Greenplum Cluster
+        input_mapping:
+          gpdb_rpm: gpdb_package
+          terraform: terraform_gpdb
+        file: ccp_src/ci/tasks/gen_cluster.yml
+        image: ccp-7-image
+        params:
+          AWS_ACCESS_KEY_ID: ((tf-machine-access-key-id))
+          AWS_SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+          AWS_DEFAULT_REGION: ((ud/common/aws-region))
+          BUCKET_PATH: ((tf-bucket-path))
+          BUCKET_NAME: ((ud/pxf/common/tf-bucket-name))
+          PLATFORM: rocky8-gpdb7
+          CLOUD_PROVIDER: google
+          GPDB_RPM: true
+  - task: Initialize Greenplum
+    file: ccp_src/ci/tasks/gpinitsystem.yml
+  - task: Setup PXF
+    input_mapping:
+      terraform: terraform_gpdb
+    file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
+    image: ccp-7-image
+    params:
+      IMPERSONATION: false
+      INSTALL_GPHDFS: false
+      GP_VER: [[gp_ver]]
+      PXF_JVM_OPTS: ((pxf-jvm-opts))
+  - task: Test PXF CLI
+    on_success:
+      in_parallel:
+        steps:
+        - *destroy_gpdb_cluster
+    image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+    file: pxf_src/concourse/tasks/test_pxf_cli.yml
+{% if slack_notification %}
+    <<: *slack_alert
+{% endif %}
+{% endif %}
 
 ## ---------- Extended Tests ----------
 {% set gp_ver = 6 %}

--- a/concourse/scripts/cli/test_reset_init.sh
+++ b/concourse/scripts/cli/test_reset_init.sh
@@ -93,10 +93,10 @@ Initializing PXF on ${cluster_description}
 PXF initialized successfully on ${num_hosts} out of ${num_hosts} hosts"
 
 control_file_content=\
-"directory = '/usr/local/pxf-gp6/gpextable/'
+"directory = '${PXF_HOME}/gpextable/'
 default_version = '2.1'
 comment = 'Extension which allows to access unmanaged data'
-module_pathname = '/usr/local/pxf-gp6/gpextable/pxf'
+module_pathname = '${PXF_HOME}/gpextable/pxf'
 superuser = true
 relocatable = false
 schema = public"


### PR DESCRIPTION
- In GP7, gpscp is replaced by gpsync. Introduced a variable (GP_SCP_CMD) to specify the appropriate command based on GP version.
- Replaced the hardcoded pxf home (/usr/local/pxf-gp6) with the variable PXF_HOME.
- Added variables to the Makefile (GP7_CLI) and dev pipeline template (gp7_cli), when set to true, this will introduce PXF_CLI tests for GP7.
- Ran yamllint and shellcheck to confirm there are no issues with the new changes.
- For ccp, use PLATFORM value (rocky8-gpdb7) as the corresponding VM Image comes preinstalled with all GPDB7 runtime dependencies.

Note: See Jira details for dev-pipeline supporting this PR. 