### PR TITLE
Bumped Azure Storage dependency to 5.5.0

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -287,7 +287,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>5.4.0</version>
+            <version>5.5.0</version>
         </dependency>
 
         <!-- HADOOP Dependencies -->

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -75,7 +75,7 @@ configure(javaProjects) {
             dependency("com.google.guava:guava:20.0")
             dependency("com.google.protobuf:protobuf-java:2.5.0")
             dependency("com.google.cloud.bigdataoss:gcs-connector:hadoop2-1.9.17")
-            dependency("com.microsoft.azure:azure-storage:5.4.0")
+            dependency("com.microsoft.azure:azure-storage:5.5.0")
             dependency("com.microsoft.azure:azure-data-lake-store-sdk:2.3.9")
             dependency("com.univocity:univocity-parsers:2.9.1")
             dependency("com.yammer.metrics:metrics-core:2.2.0")


### PR DESCRIPTION
Users encountered intermittent errors when writing to WASBS storage where an Authorization header was declared invalid. Upgrading to Azure Storage library 5.5.0 brings in a fix related to SAS tokens during delete directory requests that a library will do when PXF writes data to WASBS (it will delete a temporary directory).