### PR TITLE
Ensured Consistent Ordering in GP6 and GP7 for JdbcHiveTest

### DIFF
--- a/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query02.ans
@@ -34,8 +34,8 @@ SELECT s1, n1 FROM pxf_jdbc_hive_non_secure_types_table WHERE tn < 11 ORDER BY n
 SELECT s1, n1 FROM pxf_jdbc_hive_types_table WHERE tn < 11 UNION ALL
 SELECT s1, n1 FROM pxf_jdbc_hive_non_secure_types_table WHERE tn < 11
 ORDER BY n1, s1;
-        s1         | n1
--------------------+----
+        s1        | n1
+------------------+----
  row1             |  1
  third_hive_row1  |  1
  row2             |  2

--- a/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query02.ans
@@ -33,28 +33,28 @@ SELECT s1, n1 FROM pxf_jdbc_hive_non_secure_types_table WHERE tn < 11 ORDER BY n
 
 SELECT s1, n1 FROM pxf_jdbc_hive_types_table WHERE tn < 11 UNION ALL
 SELECT s1, n1 FROM pxf_jdbc_hive_non_secure_types_table WHERE tn < 11
-ORDER BY n1;
-        s1         | n1 
+ORDER BY n1, s1;
+        s1         | n1
 -------------------+----
+ row1             |  1
  third_hive_row1  |  1
- row1              |  1
+ row2             |  2
  third_hive_row2  |  2
- row2              |  2
+ row3             |  3
  third_hive_row3  |  3
- row3              |  3
- row4              |  4
+ row4             |  4
  third_hive_row4  |  4
+ row5             |  5
  third_hive_row5  |  5
- row5              |  5
- row6              |  6
+ row6             |  6
  third_hive_row6  |  6
+ row7             |  7
  third_hive_row7  |  7
- row7              |  7
+ row8             |  8
  third_hive_row8  |  8
- row8              |  8
- row9              |  9
+ row9             |  9
  third_hive_row9  |  9
+ row10            | 10
  third_hive_row10 | 10
- row10             | 10
 (20 rows)
 

--- a/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query03.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query03.ans
@@ -20,8 +20,8 @@ SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01
 (13 rows)
 
 SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1, s1;
-               s1                | n1 |         tm          
----------------------------------+----+---------------------
+               s1               | n1 |         tm
+--------------------------------+----+---------------------
  third_hive_row11               | 11 | 2013-07-23 21:00:05
  third_hive_row12_text_null     | 11 | 2013-07-23 21:00:05
  third_hive_row14_double_null   | 11 | 2013-07-23 21:00:05
@@ -40,8 +40,8 @@ SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-
 SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' UNION ALL
 SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-23 21:00:01'
 ORDER BY n1, s1;
-               s1                | n1 |         tm          
----------------------------------+----+---------------------
+               s1               | n1 |         tm
+--------------------------------+----+---------------------
  row11                          | 11 | 2013-07-23 21:00:05
  row12_text_null                | 11 | 2013-07-23 21:00:05
  row14_double_null              | 11 | 2013-07-23 21:00:05

--- a/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query03.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query03.ans
@@ -1,12 +1,11 @@
 -- start_ignore
 -- end_ignore
 -- @description query03 for Multiple JDBC Hive Server queries with timestamp filter
-SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1;
+SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1, s1;
          s1          | n1 |         tm          
 ---------------------+----+---------------------
+ row11               | 11 | 2013-07-23 21:00:05
  row12_text_null     | 11 | 2013-07-23 21:00:05
- row24_char_null     | 11 | 2013-07-23 21:00:05
- row23_varchar_null  | 11 | 2013-07-23 21:00:05
  row14_double_null   | 11 | 2013-07-23 21:00:05
  row17_real_null     | 11 | 2013-07-23 21:00:05
  row18_bigint_null   | 11 | 2013-07-23 21:00:05
@@ -14,17 +13,17 @@ SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01
  row20_tinyint_null  | 11 | 2013-07-23 21:00:05
  row21_smallint_null | 11 | 2013-07-23 21:00:05
  row22_date_null     | 11 | 2013-07-23 21:00:05
- row11               | 11 | 2013-07-23 21:00:05
+ row23_varchar_null  | 11 | 2013-07-23 21:00:05
+ row24_char_null     | 11 | 2013-07-23 21:00:05
  row15_decimal_null  | 12 | 2013-07-24 21:00:05
  row13_int_null      |    | 2013-07-23 21:00:05
 (13 rows)
 
-SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1;
+SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1, s1;
                s1                | n1 |         tm          
 ---------------------------------+----+---------------------
+ third_hive_row11               | 11 | 2013-07-23 21:00:05
  third_hive_row12_text_null     | 11 | 2013-07-23 21:00:05
- third_hive_row24_char_null     | 11 | 2013-07-23 21:00:05
- third_hive_row23_varchar_null  | 11 | 2013-07-23 21:00:05
  third_hive_row14_double_null   | 11 | 2013-07-23 21:00:05
  third_hive_row17_real_null     | 11 | 2013-07-23 21:00:05
  third_hive_row18_bigint_null   | 11 | 2013-07-23 21:00:05
@@ -32,30 +31,28 @@ SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-
  third_hive_row20_tinyint_null  | 11 | 2013-07-23 21:00:05
  third_hive_row21_smallint_null | 11 | 2013-07-23 21:00:05
  third_hive_row22_date_null     | 11 | 2013-07-23 21:00:05
- third_hive_row11               | 11 | 2013-07-23 21:00:05
+ third_hive_row23_varchar_null  | 11 | 2013-07-23 21:00:05
+ third_hive_row24_char_null     | 11 | 2013-07-23 21:00:05
  third_hive_row15_decimal_null  | 12 | 2013-07-24 21:00:05
  third_hive_row13_int_null      |    | 2013-07-23 21:00:05
 (13 rows)
 
 SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' UNION ALL
 SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-23 21:00:01'
-ORDER BY n1;
+ORDER BY n1, s1;
                s1                | n1 |         tm          
 ---------------------------------+----+---------------------
- row12_text_null                 | 11 | 2013-07-23 21:00:05
- third_hive_row24_char_null     | 11 | 2013-07-23 21:00:05
- third_hive_row23_varchar_null  | 11 | 2013-07-23 21:00:05
- third_hive_row22_date_null     | 11 | 2013-07-23 21:00:05
- third_hive_row21_smallint_null | 11 | 2013-07-23 21:00:05
- row14_double_null               | 11 | 2013-07-23 21:00:05
- row17_real_null                 | 11 | 2013-07-23 21:00:05
- row18_bigint_null               | 11 | 2013-07-23 21:00:05
- row19_bool_null                 | 11 | 2013-07-23 21:00:05
- row20_tinyint_null              | 11 | 2013-07-23 21:00:05
- row21_smallint_null             | 11 | 2013-07-23 21:00:05
- row22_date_null                 | 11 | 2013-07-23 21:00:05
- row23_varchar_null              | 11 | 2013-07-23 21:00:05
- row24_char_null                 | 11 | 2013-07-23 21:00:05
+ row11                          | 11 | 2013-07-23 21:00:05
+ row12_text_null                | 11 | 2013-07-23 21:00:05
+ row14_double_null              | 11 | 2013-07-23 21:00:05
+ row17_real_null                | 11 | 2013-07-23 21:00:05
+ row18_bigint_null              | 11 | 2013-07-23 21:00:05
+ row19_bool_null                | 11 | 2013-07-23 21:00:05
+ row20_tinyint_null             | 11 | 2013-07-23 21:00:05
+ row21_smallint_null            | 11 | 2013-07-23 21:00:05
+ row22_date_null                | 11 | 2013-07-23 21:00:05
+ row23_varchar_null             | 11 | 2013-07-23 21:00:05
+ row24_char_null                | 11 | 2013-07-23 21:00:05
  third_hive_row11               | 11 | 2013-07-23 21:00:05
  third_hive_row12_text_null     | 11 | 2013-07-23 21:00:05
  third_hive_row14_double_null   | 11 | 2013-07-23 21:00:05
@@ -63,10 +60,13 @@ ORDER BY n1;
  third_hive_row18_bigint_null   | 11 | 2013-07-23 21:00:05
  third_hive_row19_bool_null     | 11 | 2013-07-23 21:00:05
  third_hive_row20_tinyint_null  | 11 | 2013-07-23 21:00:05
- row11                           | 11 | 2013-07-23 21:00:05
- row15_decimal_null              | 12 | 2013-07-24 21:00:05
+ third_hive_row21_smallint_null | 11 | 2013-07-23 21:00:05
+ third_hive_row22_date_null     | 11 | 2013-07-23 21:00:05
+ third_hive_row23_varchar_null  | 11 | 2013-07-23 21:00:05
+ third_hive_row24_char_null     | 11 | 2013-07-23 21:00:05
+ row15_decimal_null             | 12 | 2013-07-24 21:00:05
  third_hive_row15_decimal_null  | 12 | 2013-07-24 21:00:05
+ row13_int_null                 |    | 2013-07-23 21:00:05
  third_hive_row13_int_null      |    | 2013-07-23 21:00:05
- row13_int_null                  |    | 2013-07-23 21:00:05
 (26 rows)
 

--- a/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query04.ans
@@ -30,8 +30,8 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER B
 (23 rows)
 
 SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-06' ORDER BY n1, s1;
-                s1                | n1 |     dt     
-----------------------------------+----+------------
+               s1                | n1 |     dt
+---------------------------------+----+------------
  third_hive_row1                 |  1 | 2015-03-06
  third_hive_row2                 |  2 | 2015-03-06
  third_hive_row3                 |  3 | 2015-03-06
@@ -60,8 +60,8 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-
 SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' UNION ALL
 SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-06'
 ORDER BY n1, s1;
-                s1                | n1 |     dt     
-----------------------------------+----+------------
+               s1                | n1 |     dt
+---------------------------------+----+------------
  row1                            |  1 | 2015-03-06
  third_hive_row1                 |  1 | 2015-03-06
  row2                            |  2 | 2015-03-06

--- a/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/expected/query04.ans
@@ -1,7 +1,7 @@
 -- start_ignore
 -- end_ignore
 -- @description query04 for Multiple JDBC Hive Server queries with date filter
-SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER BY n1;
+SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER BY n1, s1;
           s1          | n1 |     dt     
 ----------------------+----+------------
  row1                 |  1 | 2015-03-06
@@ -15,8 +15,7 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER B
  row9                 |  9 | 2015-03-06
  row10                | 10 | 2015-03-06
  row11                | 11 | 2015-03-06
- row24_char_null      | 11 | 2015-03-06
- row23_varchar_null   | 11 | 2015-03-06
+ row12_text_null      | 11 | 2015-03-06
  row14_double_null    | 11 | 2015-03-06
  row16_timestamp_null | 11 | 2015-03-06
  row17_real_null      | 11 | 2015-03-06
@@ -24,12 +23,13 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER B
  row19_bool_null      | 11 | 2015-03-06
  row20_tinyint_null   | 11 | 2015-03-06
  row21_smallint_null  | 11 | 2015-03-06
- row12_text_null      | 11 | 2015-03-06
+ row23_varchar_null   | 11 | 2015-03-06
+ row24_char_null      | 11 | 2015-03-06
  row15_decimal_null   | 12 | 2015-03-06
  row13_int_null       |    | 2015-03-06
 (23 rows)
 
-SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-06' ORDER BY n1;
+SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-06' ORDER BY n1, s1;
                 s1                | n1 |     dt     
 ----------------------------------+----+------------
  third_hive_row1                 |  1 | 2015-03-06
@@ -43,8 +43,7 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-
  third_hive_row9                 |  9 | 2015-03-06
  third_hive_row10                | 10 | 2015-03-06
  third_hive_row11                | 11 | 2015-03-06
- third_hive_row24_char_null      | 11 | 2015-03-06
- third_hive_row23_varchar_null   | 11 | 2015-03-06
+ third_hive_row12_text_null      | 11 | 2015-03-06
  third_hive_row14_double_null    | 11 | 2015-03-06
  third_hive_row16_timestamp_null | 11 | 2015-03-06
  third_hive_row17_real_null      | 11 | 2015-03-06
@@ -52,50 +51,48 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-
  third_hive_row19_bool_null      | 11 | 2015-03-06
  third_hive_row20_tinyint_null   | 11 | 2015-03-06
  third_hive_row21_smallint_null  | 11 | 2015-03-06
- third_hive_row12_text_null      | 11 | 2015-03-06
+ third_hive_row23_varchar_null   | 11 | 2015-03-06
+ third_hive_row24_char_null      | 11 | 2015-03-06
  third_hive_row15_decimal_null   | 12 | 2015-03-06
  third_hive_row13_int_null       |    | 2015-03-06
 (23 rows)
 
 SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' UNION ALL
 SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-06'
-ORDER BY n1;
+ORDER BY n1, s1;
                 s1                | n1 |     dt     
 ----------------------------------+----+------------
- row1                             |  1 | 2015-03-06
+ row1                            |  1 | 2015-03-06
  third_hive_row1                 |  1 | 2015-03-06
- row2                             |  2 | 2015-03-06
+ row2                            |  2 | 2015-03-06
  third_hive_row2                 |  2 | 2015-03-06
+ row3                            |  3 | 2015-03-06
  third_hive_row3                 |  3 | 2015-03-06
- row3                             |  3 | 2015-03-06
+ row4                            |  4 | 2015-03-06
  third_hive_row4                 |  4 | 2015-03-06
- row4                             |  4 | 2015-03-06
+ row5                            |  5 | 2015-03-06
  third_hive_row5                 |  5 | 2015-03-06
- row5                             |  5 | 2015-03-06
+ row6                            |  6 | 2015-03-06
  third_hive_row6                 |  6 | 2015-03-06
- row6                             |  6 | 2015-03-06
+ row7                            |  7 | 2015-03-06
  third_hive_row7                 |  7 | 2015-03-06
- row7                             |  7 | 2015-03-06
- row8                             |  8 | 2015-03-06
+ row8                            |  8 | 2015-03-06
  third_hive_row8                 |  8 | 2015-03-06
- row9                             |  9 | 2015-03-06
+ row9                            |  9 | 2015-03-06
  third_hive_row9                 |  9 | 2015-03-06
+ row10                           | 10 | 2015-03-06
  third_hive_row10                | 10 | 2015-03-06
- row10                            | 10 | 2015-03-06
- row11                            | 11 | 2015-03-06
- third_hive_row24_char_null      | 11 | 2015-03-06
- row23_varchar_null               | 11 | 2015-03-06
- row21_smallint_null              | 11 | 2015-03-06
- row20_tinyint_null               | 11 | 2015-03-06
- row19_bool_null                  | 11 | 2015-03-06
- row18_bigint_null                | 11 | 2015-03-06
- row17_real_null                  | 11 | 2015-03-06
- row16_timestamp_null             | 11 | 2015-03-06
- row14_double_null                | 11 | 2015-03-06
- row12_text_null                  | 11 | 2015-03-06
- third_hive_row23_varchar_null   | 11 | 2015-03-06
- third_hive_row21_smallint_null  | 11 | 2015-03-06
- third_hive_row20_tinyint_null   | 11 | 2015-03-06
+ row11                           | 11 | 2015-03-06
+ row12_text_null                 | 11 | 2015-03-06
+ row14_double_null               | 11 | 2015-03-06
+ row16_timestamp_null            | 11 | 2015-03-06
+ row17_real_null                 | 11 | 2015-03-06
+ row18_bigint_null               | 11 | 2015-03-06
+ row19_bool_null                 | 11 | 2015-03-06
+ row20_tinyint_null              | 11 | 2015-03-06
+ row21_smallint_null             | 11 | 2015-03-06
+ row23_varchar_null              | 11 | 2015-03-06
+ row24_char_null                 | 11 | 2015-03-06
  third_hive_row11                | 11 | 2015-03-06
  third_hive_row12_text_null      | 11 | 2015-03-06
  third_hive_row14_double_null    | 11 | 2015-03-06
@@ -103,10 +100,13 @@ ORDER BY n1;
  third_hive_row17_real_null      | 11 | 2015-03-06
  third_hive_row18_bigint_null    | 11 | 2015-03-06
  third_hive_row19_bool_null      | 11 | 2015-03-06
- row24_char_null                  | 11 | 2015-03-06
+ third_hive_row20_tinyint_null   | 11 | 2015-03-06
+ third_hive_row21_smallint_null  | 11 | 2015-03-06
+ third_hive_row23_varchar_null   | 11 | 2015-03-06
+ third_hive_row24_char_null      | 11 | 2015-03-06
+ row15_decimal_null              | 12 | 2015-03-06
  third_hive_row15_decimal_null   | 12 | 2015-03-06
- row15_decimal_null               | 12 | 2015-03-06
+ row13_int_null                  |    | 2015-03-06
  third_hive_row13_int_null       |    | 2015-03-06
- row13_int_null                   |    | 2015-03-06
 (46 rows)
 

--- a/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/sql/query02.sql
@@ -5,4 +5,4 @@ SELECT s1, n1 FROM pxf_jdbc_hive_non_secure_types_table WHERE tn < 11 ORDER BY n
 
 SELECT s1, n1 FROM pxf_jdbc_hive_types_table WHERE tn < 11 UNION ALL
 SELECT s1, n1 FROM pxf_jdbc_hive_non_secure_types_table WHERE tn < 11
-ORDER BY n1;
+ORDER BY n1, s1;

--- a/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/sql/query03.sql
+++ b/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/sql/query03.sql
@@ -1,8 +1,8 @@
 -- @description query03 for Multiple JDBC Hive Server queries with timestamp filter
-SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1;
+SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1, s1;
 
-SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1;
+SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1, s1;
 
 SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' UNION ALL
 SELECT s1, n1, tm FROM pxf_jdbc_hive_non_secure_types_table WHERE tm > '2013-07-23 21:00:01'
-ORDER BY n1;
+ORDER BY n1, s1;

--- a/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/sql/query04.sql
+++ b/automation/tincrepo/main/pxf/features/jdbc/secured_and_non_secured_hive/sql/query04.sql
@@ -1,8 +1,8 @@
 -- @description query04 for Multiple JDBC Hive Server queries with date filter
-SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER BY n1;
+SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER BY n1, s1;
 
-SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-06' ORDER BY n1;
+SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-06' ORDER BY n1, s1;
 
 SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' UNION ALL
 SELECT s1, n1, dt FROM pxf_jdbc_hive_non_secure_types_table WHERE dt = '2015-03-06'
-ORDER BY n1;
+ORDER BY n1, s1;

--- a/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/expected/query02.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/expected/query02.ans
@@ -33,28 +33,28 @@ SELECT s1, n1 FROM pxf_jdbc_hive_2_types_table WHERE tn < 11 ORDER BY n1;
 
 SELECT s1, n1 FROM pxf_jdbc_hive_types_table WHERE tn < 11 UNION ALL
 SELECT s1, n1 FROM pxf_jdbc_hive_2_types_table WHERE tn < 11
-ORDER BY n1;
+ORDER BY n1, s1;
         s1         | n1 
 -------------------+----
- second_hive_row1  |  1
  row1              |  1
- second_hive_row2  |  2
+ second_hive_row1  |  1
  row2              |  2
- second_hive_row3  |  3
+ second_hive_row2  |  2
  row3              |  3
+ second_hive_row3  |  3
  row4              |  4
  second_hive_row4  |  4
- second_hive_row5  |  5
  row5              |  5
+ second_hive_row5  |  5
  row6              |  6
  second_hive_row6  |  6
- second_hive_row7  |  7
  row7              |  7
- second_hive_row8  |  8
+ second_hive_row7  |  7
  row8              |  8
+ second_hive_row8  |  8
  row9              |  9
  second_hive_row9  |  9
- second_hive_row10 | 10
  row10             | 10
+ second_hive_row10 | 10
 (20 rows)
 

--- a/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/expected/query03.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/expected/query03.ans
@@ -1,12 +1,11 @@
 -- start_ignore
 -- end_ignore
 -- @description query03 for Multiple JDBC Hive Server queries with timestamp filter
-SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1;
+SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1, s1;
          s1          | n1 |         tm          
 ---------------------+----+---------------------
+ row11               | 11 | 2013-07-23 21:00:05
  row12_text_null     | 11 | 2013-07-23 21:00:05
- row24_char_null     | 11 | 2013-07-23 21:00:05
- row23_varchar_null  | 11 | 2013-07-23 21:00:05
  row14_double_null   | 11 | 2013-07-23 21:00:05
  row17_real_null     | 11 | 2013-07-23 21:00:05
  row18_bigint_null   | 11 | 2013-07-23 21:00:05
@@ -14,17 +13,17 @@ SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01
  row20_tinyint_null  | 11 | 2013-07-23 21:00:05
  row21_smallint_null | 11 | 2013-07-23 21:00:05
  row22_date_null     | 11 | 2013-07-23 21:00:05
- row11               | 11 | 2013-07-23 21:00:05
+ row23_varchar_null  | 11 | 2013-07-23 21:00:05
+ row24_char_null     | 11 | 2013-07-23 21:00:05
  row15_decimal_null  | 12 | 2013-07-24 21:00:05
  row13_int_null      |    | 2013-07-23 21:00:05
 (13 rows)
 
-SELECT s1, n1, tm FROM pxf_jdbc_hive_2_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1;
+SELECT s1, n1, tm FROM pxf_jdbc_hive_2_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1, s1;
                s1                | n1 |         tm          
 ---------------------------------+----+---------------------
+ second_hive_row11               | 11 | 2013-07-23 21:00:05
  second_hive_row12_text_null     | 11 | 2013-07-23 21:00:05
- second_hive_row24_char_null     | 11 | 2013-07-23 21:00:05
- second_hive_row23_varchar_null  | 11 | 2013-07-23 21:00:05
  second_hive_row14_double_null   | 11 | 2013-07-23 21:00:05
  second_hive_row17_real_null     | 11 | 2013-07-23 21:00:05
  second_hive_row18_bigint_null   | 11 | 2013-07-23 21:00:05
@@ -32,21 +31,19 @@ SELECT s1, n1, tm FROM pxf_jdbc_hive_2_types_table WHERE tm > '2013-07-23 21:00:
  second_hive_row20_tinyint_null  | 11 | 2013-07-23 21:00:05
  second_hive_row21_smallint_null | 11 | 2013-07-23 21:00:05
  second_hive_row22_date_null     | 11 | 2013-07-23 21:00:05
- second_hive_row11               | 11 | 2013-07-23 21:00:05
+ second_hive_row23_varchar_null  | 11 | 2013-07-23 21:00:05
+ second_hive_row24_char_null     | 11 | 2013-07-23 21:00:05
  second_hive_row15_decimal_null  | 12 | 2013-07-24 21:00:05
  second_hive_row13_int_null      |    | 2013-07-23 21:00:05
 (13 rows)
 
 SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' UNION ALL
 SELECT s1, n1, tm FROM pxf_jdbc_hive_2_types_table WHERE tm > '2013-07-23 21:00:01'
-ORDER BY n1;
+ORDER BY n1, s1;
                s1                | n1 |         tm          
 ---------------------------------+----+---------------------
+ row11                           | 11 | 2013-07-23 21:00:05
  row12_text_null                 | 11 | 2013-07-23 21:00:05
- second_hive_row24_char_null     | 11 | 2013-07-23 21:00:05
- second_hive_row23_varchar_null  | 11 | 2013-07-23 21:00:05
- second_hive_row22_date_null     | 11 | 2013-07-23 21:00:05
- second_hive_row21_smallint_null | 11 | 2013-07-23 21:00:05
  row14_double_null               | 11 | 2013-07-23 21:00:05
  row17_real_null                 | 11 | 2013-07-23 21:00:05
  row18_bigint_null               | 11 | 2013-07-23 21:00:05
@@ -63,10 +60,13 @@ ORDER BY n1;
  second_hive_row18_bigint_null   | 11 | 2013-07-23 21:00:05
  second_hive_row19_bool_null     | 11 | 2013-07-23 21:00:05
  second_hive_row20_tinyint_null  | 11 | 2013-07-23 21:00:05
- row11                           | 11 | 2013-07-23 21:00:05
+ second_hive_row21_smallint_null | 11 | 2013-07-23 21:00:05
+ second_hive_row22_date_null     | 11 | 2013-07-23 21:00:05
+ second_hive_row23_varchar_null  | 11 | 2013-07-23 21:00:05
+ second_hive_row24_char_null     | 11 | 2013-07-23 21:00:05
  row15_decimal_null              | 12 | 2013-07-24 21:00:05
  second_hive_row15_decimal_null  | 12 | 2013-07-24 21:00:05
- second_hive_row13_int_null      |    | 2013-07-23 21:00:05
  row13_int_null                  |    | 2013-07-23 21:00:05
+ second_hive_row13_int_null      |    | 2013-07-23 21:00:05
 (26 rows)
 

--- a/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/expected/query04.ans
+++ b/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/expected/query04.ans
@@ -1,7 +1,7 @@
 -- start_ignore
 -- end_ignore
 -- @description query04 for Multiple JDBC Hive Server queries with date filter
-SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER BY n1;
+SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER BY n1, s1;
           s1          | n1 |     dt     
 ----------------------+----+------------
  row1                 |  1 | 2015-03-06
@@ -15,8 +15,7 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER B
  row9                 |  9 | 2015-03-06
  row10                | 10 | 2015-03-06
  row11                | 11 | 2015-03-06
- row24_char_null      | 11 | 2015-03-06
- row23_varchar_null   | 11 | 2015-03-06
+ row12_text_null      | 11 | 2015-03-06
  row14_double_null    | 11 | 2015-03-06
  row16_timestamp_null | 11 | 2015-03-06
  row17_real_null      | 11 | 2015-03-06
@@ -24,13 +23,14 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER B
  row19_bool_null      | 11 | 2015-03-06
  row20_tinyint_null   | 11 | 2015-03-06
  row21_smallint_null  | 11 | 2015-03-06
- row12_text_null      | 11 | 2015-03-06
+ row23_varchar_null   | 11 | 2015-03-06
+ row24_char_null      | 11 | 2015-03-06
  row15_decimal_null   | 12 | 2015-03-06
  row13_int_null       |    | 2015-03-06
 (23 rows)
 
-SELECT s1, n1, dt FROM pxf_jdbc_hive_2_types_table WHERE dt = '2015-03-06' ORDER BY n1;
-                s1                | n1 |     dt     
+SELECT s1, n1, dt FROM pxf_jdbc_hive_2_types_table WHERE dt = '2015-03-06' ORDER BY n1, s1;
+                s1                | n1 |     dt
 ----------------------------------+----+------------
  second_hive_row1                 |  1 | 2015-03-06
  second_hive_row2                 |  2 | 2015-03-06
@@ -43,8 +43,7 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_2_types_table WHERE dt = '2015-03-06' ORDER
  second_hive_row9                 |  9 | 2015-03-06
  second_hive_row10                | 10 | 2015-03-06
  second_hive_row11                | 11 | 2015-03-06
- second_hive_row24_char_null      | 11 | 2015-03-06
- second_hive_row23_varchar_null   | 11 | 2015-03-06
+ second_hive_row12_text_null      | 11 | 2015-03-06
  second_hive_row14_double_null    | 11 | 2015-03-06
  second_hive_row16_timestamp_null | 11 | 2015-03-06
  second_hive_row17_real_null      | 11 | 2015-03-06
@@ -52,50 +51,48 @@ SELECT s1, n1, dt FROM pxf_jdbc_hive_2_types_table WHERE dt = '2015-03-06' ORDER
  second_hive_row19_bool_null      | 11 | 2015-03-06
  second_hive_row20_tinyint_null   | 11 | 2015-03-06
  second_hive_row21_smallint_null  | 11 | 2015-03-06
- second_hive_row12_text_null      | 11 | 2015-03-06
+ second_hive_row23_varchar_null   | 11 | 2015-03-06
+ second_hive_row24_char_null      | 11 | 2015-03-06
  second_hive_row15_decimal_null   | 12 | 2015-03-06
  second_hive_row13_int_null       |    | 2015-03-06
 (23 rows)
 
 SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' UNION ALL
 SELECT s1, n1, dt FROM pxf_jdbc_hive_2_types_table WHERE dt = '2015-03-06'
-ORDER BY n1;
-                s1                | n1 |     dt     
+ORDER BY n1, s1;
+                s1                | n1 |     dt
 ----------------------------------+----+------------
  row1                             |  1 | 2015-03-06
  second_hive_row1                 |  1 | 2015-03-06
  row2                             |  2 | 2015-03-06
  second_hive_row2                 |  2 | 2015-03-06
- second_hive_row3                 |  3 | 2015-03-06
  row3                             |  3 | 2015-03-06
- second_hive_row4                 |  4 | 2015-03-06
+ second_hive_row3                 |  3 | 2015-03-06
  row4                             |  4 | 2015-03-06
- second_hive_row5                 |  5 | 2015-03-06
+ second_hive_row4                 |  4 | 2015-03-06
  row5                             |  5 | 2015-03-06
- second_hive_row6                 |  6 | 2015-03-06
+ second_hive_row5                 |  5 | 2015-03-06
  row6                             |  6 | 2015-03-06
- second_hive_row7                 |  7 | 2015-03-06
+ second_hive_row6                 |  6 | 2015-03-06
  row7                             |  7 | 2015-03-06
+ second_hive_row7                 |  7 | 2015-03-06
  row8                             |  8 | 2015-03-06
  second_hive_row8                 |  8 | 2015-03-06
  row9                             |  9 | 2015-03-06
  second_hive_row9                 |  9 | 2015-03-06
- second_hive_row10                | 10 | 2015-03-06
  row10                            | 10 | 2015-03-06
+ second_hive_row10                | 10 | 2015-03-06
  row11                            | 11 | 2015-03-06
- second_hive_row24_char_null      | 11 | 2015-03-06
- row23_varchar_null               | 11 | 2015-03-06
- row21_smallint_null              | 11 | 2015-03-06
- row20_tinyint_null               | 11 | 2015-03-06
- row19_bool_null                  | 11 | 2015-03-06
- row18_bigint_null                | 11 | 2015-03-06
- row17_real_null                  | 11 | 2015-03-06
- row16_timestamp_null             | 11 | 2015-03-06
- row14_double_null                | 11 | 2015-03-06
  row12_text_null                  | 11 | 2015-03-06
- second_hive_row23_varchar_null   | 11 | 2015-03-06
- second_hive_row21_smallint_null  | 11 | 2015-03-06
- second_hive_row20_tinyint_null   | 11 | 2015-03-06
+ row14_double_null                | 11 | 2015-03-06
+ row16_timestamp_null             | 11 | 2015-03-06
+ row17_real_null                  | 11 | 2015-03-06
+ row18_bigint_null                | 11 | 2015-03-06
+ row19_bool_null                  | 11 | 2015-03-06
+ row20_tinyint_null               | 11 | 2015-03-06
+ row21_smallint_null              | 11 | 2015-03-06
+ row23_varchar_null               | 11 | 2015-03-06
+ row24_char_null                  | 11 | 2015-03-06
  second_hive_row11                | 11 | 2015-03-06
  second_hive_row12_text_null      | 11 | 2015-03-06
  second_hive_row14_double_null    | 11 | 2015-03-06
@@ -103,10 +100,13 @@ ORDER BY n1;
  second_hive_row17_real_null      | 11 | 2015-03-06
  second_hive_row18_bigint_null    | 11 | 2015-03-06
  second_hive_row19_bool_null      | 11 | 2015-03-06
- row24_char_null                  | 11 | 2015-03-06
- second_hive_row15_decimal_null   | 12 | 2015-03-06
+ second_hive_row20_tinyint_null   | 11 | 2015-03-06
+ second_hive_row21_smallint_null  | 11 | 2015-03-06
+ second_hive_row23_varchar_null   | 11 | 2015-03-06
+ second_hive_row24_char_null      | 11 | 2015-03-06
  row15_decimal_null               | 12 | 2015-03-06
- second_hive_row13_int_null       |    | 2015-03-06
+ second_hive_row15_decimal_null   | 12 | 2015-03-06
  row13_int_null                   |    | 2015-03-06
+ second_hive_row13_int_null       |    | 2015-03-06
 (46 rows)
 

--- a/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/sql/query02.sql
+++ b/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/sql/query02.sql
@@ -5,4 +5,4 @@ SELECT s1, n1 FROM pxf_jdbc_hive_2_types_table WHERE tn < 11 ORDER BY n1;
 
 SELECT s1, n1 FROM pxf_jdbc_hive_types_table WHERE tn < 11 UNION ALL
 SELECT s1, n1 FROM pxf_jdbc_hive_2_types_table WHERE tn < 11
-ORDER BY n1;
+ORDER BY n1, s1;

--- a/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/sql/query03.sql
+++ b/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/sql/query03.sql
@@ -1,8 +1,8 @@
 -- @description query03 for Multiple JDBC Hive Server queries with timestamp filter
-SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1;
+SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1, s1;
 
-SELECT s1, n1, tm FROM pxf_jdbc_hive_2_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1;
+SELECT s1, n1, tm FROM pxf_jdbc_hive_2_types_table WHERE tm > '2013-07-23 21:00:01' ORDER BY n1, s1;
 
 SELECT s1, n1, tm FROM pxf_jdbc_hive_types_table WHERE tm > '2013-07-23 21:00:01' UNION ALL
 SELECT s1, n1, tm FROM pxf_jdbc_hive_2_types_table WHERE tm > '2013-07-23 21:00:01'
-ORDER BY n1;
+ORDER BY n1, s1;

--- a/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/sql/query04.sql
+++ b/automation/tincrepo/main/pxf/features/jdbc/two_secured_hive/sql/query04.sql
@@ -1,8 +1,8 @@
 -- @description query04 for Multiple JDBC Hive Server queries with date filter
-SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER BY n1;
+SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' ORDER BY n1, s1;
 
-SELECT s1, n1, dt FROM pxf_jdbc_hive_2_types_table WHERE dt = '2015-03-06' ORDER BY n1;
+SELECT s1, n1, dt FROM pxf_jdbc_hive_2_types_table WHERE dt = '2015-03-06' ORDER BY n1, s1;
 
 SELECT s1, n1, dt FROM pxf_jdbc_hive_types_table WHERE dt = '2015-03-06' UNION ALL
 SELECT s1, n1, dt FROM pxf_jdbc_hive_2_types_table WHERE dt = '2015-03-06'
-ORDER BY n1;
+ORDER BY n1, s1;


### PR DESCRIPTION
Addressed query result ordering inconsistencies observed between Greenplum 6 (GP6)and Greenplum 7 (GP7) for JdbcHiveTest. Modified test queries and answer files to enhance result ordering consistency. Added an extra column "s1" to the ORDER BY clause in test queries, ensuring predictable and stable ordering across both GP6 and GP7 environments.