### PR TITLE
Add pxf.service.kerberos.ticket-renew-window option to pxf-site.xml

### DIFF
--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
@@ -21,11 +21,13 @@ public class LoginSession {
     private String principalName;
     private String keytabPath;
     private long kerberosMinMillisBeforeRelogin;
+    private float kerberosTicketRenewWindow;
 
     // derived fields stored to be re-used for subsequent requests
     private UserGroupInformation loginUser;
     private Subject subject;
     private User user;
+
 
     /**
      * Creates a new session object with a config directory
@@ -33,7 +35,7 @@ public class LoginSession {
      * @param configDirectory server configuration directory
      */
     public LoginSession(String configDirectory) {
-        this(configDirectory, null, null, null, null, 0L);
+        this(configDirectory, null, null, null, null, 0L, 0f);
     }
 
     /**
@@ -43,7 +45,7 @@ public class LoginSession {
      * @param loginUser       UserGroupInformation for the given principal after login to Kerberos was performed
      */
     public LoginSession(String configDirectory, UserGroupInformation loginUser) {
-        this(configDirectory, null, null, loginUser, null, 0L);
+        this(configDirectory, null, null, loginUser, null, 0L, 0f);
     }
 
     /**
@@ -54,7 +56,7 @@ public class LoginSession {
      * @param keytabPath      full path to a keytab file for the principal
      */
     public LoginSession(String configDirectory, String principalName, String keytabPath, long kerberosMinMillisBeforeRelogin) {
-        this(configDirectory, principalName, keytabPath, null, null, kerberosMinMillisBeforeRelogin);
+        this(configDirectory, principalName, keytabPath, null, null, kerberosMinMillisBeforeRelogin, 0f);
     }
 
     /**
@@ -66,9 +68,10 @@ public class LoginSession {
      * @param loginUser                      UserGroupInformation for the given principal after login to Kerberos was performed
      * @param subject                        the subject
      * @param kerberosMinMillisBeforeRelogin the number of milliseconds before re-login
+     * @param kerberosTicketRenewWindow the percentage of the ticket lifespan
      */
     public LoginSession(String configDirectory, String principalName, String keytabPath, UserGroupInformation loginUser,
-                        Subject subject, long kerberosMinMillisBeforeRelogin) {
+                        Subject subject, long kerberosMinMillisBeforeRelogin, float kerberosTicketRenewWindow) {
         this.configDirectory = configDirectory;
         this.principalName = principalName;
         this.keytabPath = keytabPath;
@@ -78,6 +81,7 @@ public class LoginSession {
             this.user = subject.getPrincipals(User.class).iterator().next();
         }
         this.kerberosMinMillisBeforeRelogin = kerberosMinMillisBeforeRelogin;
+        this.kerberosTicketRenewWindow = kerberosTicketRenewWindow;
     }
 
     /**
@@ -134,6 +138,10 @@ public class LoginSession {
         return principalName;
     }
 
+    public float getKerberosTicketRenewWindow() {
+        return kerberosTicketRenewWindow;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -143,12 +151,13 @@ public class LoginSession {
         return Objects.equals(configDirectory, that.configDirectory) &&
                 Objects.equals(principalName, that.principalName) &&
                 Objects.equals(keytabPath, that.keytabPath) &&
-                kerberosMinMillisBeforeRelogin == that.kerberosMinMillisBeforeRelogin;
+                kerberosMinMillisBeforeRelogin == that.kerberosMinMillisBeforeRelogin &&
+                kerberosTicketRenewWindow == that.kerberosTicketRenewWindow;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(configDirectory, principalName, keytabPath, kerberosMinMillisBeforeRelogin);
+        return Objects.hash(configDirectory, principalName, keytabPath, kerberosMinMillisBeforeRelogin, kerberosTicketRenewWindow);
     }
 
     @Override
@@ -158,6 +167,7 @@ public class LoginSession {
                 .append("principal", principalName)
                 .append("keytab", keytabPath)
                 .append("kerberosMinMillisBeforeRelogin", kerberosMinMillisBeforeRelogin)
+                .append("kerberosTicketRenewWindow", kerberosTicketRenewWindow)
                 .toString();
     }
 }

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
@@ -50,9 +50,9 @@ public class LoginSession {
     /**
      * Creates a new session object.
      *
-     * @param configDirectory server configuration directory
-     * @param principalName   Kerberos principal name to use to obtain tokens
-     * @param keytabPath      full path to a keytab file for the principal
+     * @param configDirectory           server configuration directory
+     * @param principalName             Kerberos principal name to use to obtain tokens
+     * @param keytabPath                full path to a keytab file for the principal
      * @param kerberosTicketRenewWindow the percentage of the ticket lifespan
      */
     public LoginSession(String configDirectory, String principalName, String keytabPath, long kerberosMinMillisBeforeRelogin, float kerberosTicketRenewWindow) {
@@ -68,7 +68,7 @@ public class LoginSession {
      * @param loginUser                      UserGroupInformation for the given principal after login to Kerberos was performed
      * @param subject                        the subject
      * @param kerberosMinMillisBeforeRelogin the number of milliseconds before re-login
-     * @param kerberosTicketRenewWindow the percentage of the ticket lifespan
+     * @param kerberosTicketRenewWindow      the percentage of the ticket lifespan
      */
     public LoginSession(String configDirectory, String principalName, String keytabPath, UserGroupInformation loginUser,
                         Subject subject, long kerberosMinMillisBeforeRelogin, float kerberosTicketRenewWindow) {

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
@@ -28,7 +28,6 @@ public class LoginSession {
     private Subject subject;
     private User user;
 
-
     /**
      * Creates a new session object with a config directory
      *

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
@@ -53,6 +53,7 @@ public class LoginSession {
      * @param configDirectory server configuration directory
      * @param principalName   Kerberos principal name to use to obtain tokens
      * @param keytabPath      full path to a keytab file for the principal
+     * @param kerberosTicketRenewWindow the percentage of the ticket lifespan
      */
     public LoginSession(String configDirectory, String principalName, String keytabPath, long kerberosMinMillisBeforeRelogin, float kerberosTicketRenewWindow) {
         this(configDirectory, principalName, keytabPath, null, null, kerberosMinMillisBeforeRelogin, kerberosTicketRenewWindow);

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/LoginSession.java
@@ -55,8 +55,8 @@ public class LoginSession {
      * @param principalName   Kerberos principal name to use to obtain tokens
      * @param keytabPath      full path to a keytab file for the principal
      */
-    public LoginSession(String configDirectory, String principalName, String keytabPath, long kerberosMinMillisBeforeRelogin) {
-        this(configDirectory, principalName, keytabPath, null, null, kerberosMinMillisBeforeRelogin, 0f);
+    public LoginSession(String configDirectory, String principalName, String keytabPath, long kerberosMinMillisBeforeRelogin, float kerberosTicketRenewWindow) {
+        this(configDirectory, principalName, keytabPath, null, null, kerberosMinMillisBeforeRelogin, kerberosTicketRenewWindow);
     }
 
     /**

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
@@ -41,6 +41,9 @@ public class PxfUserGroupInformation {
     private static final String MUST_FIRST_LOGIN_FROM_KEYTAB = "loginUserFromKeyTab must be done first";
     private static final String OS_LOGIN_MODULE_NAME = getOSLoginModuleName();
 
+    /**
+     * Percentage of the ticket window to use before we renew ticket.
+     */
     public static final String CONFIG_KEY_TICKET_RENEW_WINDOW = "pxf.service.kerberos.ticket-renew-window";
     public static final float TICKET_RENEW_WINDOW_DEFAULT = 0.8f;
 
@@ -217,6 +220,7 @@ public class PxfUserGroupInformation {
         }
         return ticketRenewWindow;
     }
+
     // if the first kerberos ticket is not TGT, then remove and destroy it since
     // the kerberos library of jdk always use the first kerberos ticket as TGT.
     // See HADOOP-13433 for more details.

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_KERBEROS_MIN_SECONDS_BEFORE_RELOGIN;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_KERBEROS_MIN_SECONDS_BEFORE_RELOGIN_DEFAULT;
 
 /**
  * PXF-specific analog of <code>UserGroupInformation</code> class to support multiple concurrent Kerberos sessions
@@ -196,7 +197,7 @@ public class PxfUserGroupInformation {
 
     public long getKerberosMinMillisBeforeRelogin(String serverName, Configuration configuration) {
         try {
-            return 1000L * configuration.getLong(HADOOP_KERBEROS_MIN_SECONDS_BEFORE_RELOGIN, 60L);
+            return 1000L * configuration.getLong(HADOOP_KERBEROS_MIN_SECONDS_BEFORE_RELOGIN, HADOOP_KERBEROS_MIN_SECONDS_BEFORE_RELOGIN_DEFAULT);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException(String.format("Invalid attribute value for %s of %s for server %s",
                     HADOOP_KERBEROS_MIN_SECONDS_BEFORE_RELOGIN,

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
@@ -40,7 +40,7 @@ public class PxfUserGroupInformation {
     private static final String MUST_FIRST_LOGIN_FROM_KEYTAB = "loginUserFromKeyTab must be done first";
     private static final String OS_LOGIN_MODULE_NAME = getOSLoginModuleName();
 
-    private static final String PROPERTY_TICKET_RENEW_THRESHOLD = "pxf.service.kerberos.ticket-renew-threshold";
+    public static final String PROPERTY_TICKET_RENEW_THRESHOLD = "pxf.service.kerberos.ticket-renew-threshold";
 
     private static final boolean windows = System.getProperty("os.name").startsWith("Windows");
     private static final boolean is64Bit = System.getProperty("os.arch").contains("64") ||
@@ -79,9 +79,6 @@ public class PxfUserGroupInformation {
 
             // set the configuration on the HadoopKerberosName
             HadoopKerberosName.setConfiguration(configuration);
-
-            // the percentage of the ticket window to use before we renew ticket
-            float ticket_renew_threshold = configuration.getFloat(PROPERTY_TICKET_RENEW_THRESHOLD, 0.80f);
 
             long now = Time.now();
             // create login context with the given subject, using Kerberos principal and keytab filename; then login
@@ -129,7 +126,7 @@ public class PxfUserGroupInformation {
      * @throws IOException           when an IO error occurs
      * @throws KerberosAuthException on a failure
      */
-    public void reloginFromKeytab(String serverName, LoginSession loginSession, Configuration configuration) throws KerberosAuthException {
+    public void reloginFromKeytab(String serverName, LoginSession loginSession, float ticket_renew_threshold) throws KerberosAuthException {
 
         UserGroupInformation ugi = loginSession.getLoginUser();
 
@@ -144,8 +141,6 @@ public class PxfUserGroupInformation {
             if (!hasSufficientTimeElapsed(now, loginSession)) {
                 return;
             }
-
-            float ticket_renew_threshold = configuration.getFloat(PROPERTY_TICKET_RENEW_THRESHOLD, 0.80f);
 
             Subject subject = loginSession.getSubject();
             KerberosTicket tgt = getTGT(subject);

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
@@ -207,11 +207,11 @@ public class PxfUserGroupInformation {
 
     public float getKerberosTicketRenewWindow(String serverName, Configuration configuration) {
         float ticketRenewWindow = configuration.getFloat(CONFIG_KEY_TICKET_RENEW_WINDOW, TICKET_RENEW_WINDOW_DEFAULT);
-        if (ticketRenewWindow < 0 || ticketRenewWindow > 1.0) {
+        if (ticketRenewWindow < 0f || ticketRenewWindow > 1f) {
             throw new IllegalArgumentException(
                     String.format("Invalid value for %s of %f for server %s. Please choose a value between 0 and 1.",
-                            ticketRenewWindow,
                             CONFIG_KEY_TICKET_RENEW_WINDOW,
+                            ticketRenewWindow,
                             serverName));
         }
         return ticketRenewWindow;
@@ -247,10 +247,10 @@ public class PxfUserGroupInformation {
         LOG.warn("Warning, no kerberos tickets found while attempting to renew ticket");
     }
 
-    private long getRefreshTime(KerberosTicket tgt, float ticket_renew_threshold) {
+    private long getRefreshTime(KerberosTicket tgt, float ticketRenewWindow) {
         long start = tgt.getStartTime().getTime();
         long end = tgt.getEndTime().getTime();
-        return start + (long) ((end - start) * ticket_renew_threshold);
+        return start + (long) ((end - start) * ticketRenewWindow);
     }
 
     private static String getOSLoginModuleName() {

--- a/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
+++ b/server/pxf-api/src/main/java/org/apache/hadoop/security/PxfUserGroupInformation.java
@@ -45,7 +45,7 @@ public class PxfUserGroupInformation {
      * Percentage of the ticket window to use before we renew ticket.
      */
     public static final String CONFIG_KEY_TICKET_RENEW_WINDOW = "pxf.service.kerberos.ticket-renew-window";
-    public static final float TICKET_RENEW_WINDOW_DEFAULT = 0.8f;
+    public static final float DEFAULT_TICKET_RENEW_WINDOW = 0.8f;
 
     private static final boolean windows = System.getProperty("os.name").startsWith("Windows");
     private static final boolean is64Bit = System.getProperty("os.arch").contains("64") ||
@@ -210,7 +210,7 @@ public class PxfUserGroupInformation {
     }
 
     public float getKerberosTicketRenewWindow(String serverName, Configuration configuration) {
-        float ticketRenewWindow = configuration.getFloat(CONFIG_KEY_TICKET_RENEW_WINDOW, TICKET_RENEW_WINDOW_DEFAULT);
+        float ticketRenewWindow = configuration.getFloat(CONFIG_KEY_TICKET_RENEW_WINDOW, DEFAULT_TICKET_RENEW_WINDOW);
         if (ticketRenewWindow < 0f || ticketRenewWindow > 1f) {
             throw new IllegalArgumentException(
                     String.format("Invalid value for %s of %f for server %s. Please choose a value between 0 and 1.",

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
@@ -38,6 +38,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.hadoop.security.PxfUserGroupInformation.PROPERTY_TICKET_RENEW_THRESHOLD;
+
 /**
  * This class relies heavily on Hadoop API to
  * <ul>
@@ -64,6 +66,8 @@ public class SecureLogin {
     public static final String CONFIG_KEY_SERVICE_CONSTRAINED_DELEGATION = "pxf.service.kerberos.constrained-delegation";
     public static final String CONFIG_KEY_SERVICE_USER_IMPERSONATION = "pxf.service.user.impersonation";
     public static final String CONFIG_KEY_SERVICE_USER_NAME = "pxf.service.user.name";
+
+    public static final float DEFAULT_TICKET_RENEW_THRESHOLD = 0.8f;
 
     private static final Map<String, LoginSession> loginMap = new HashMap<>();
 
@@ -130,7 +134,11 @@ public class SecureLogin {
 
         // try to relogin to keep the TGT token from expiring, if it still has a long validity, it will be a no-op
         if (Utilities.isSecurityEnabled(configuration)) {
-            pxfUserGroupInformation.reloginFromKeytab(serverName, loginSession, configuration);
+
+            // the percentage of the ticket window to use before we renew ticket
+            float ticket_renew_threshold = configuration.getFloat(PROPERTY_TICKET_RENEW_THRESHOLD, DEFAULT_TICKET_RENEW_THRESHOLD);
+
+            pxfUserGroupInformation.reloginFromKeytab(serverName, loginSession, ticket_renew_threshold);
         }
 
         return loginSession.getLoginUser();

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
@@ -130,7 +130,6 @@ public class SecureLogin {
 
         // try to relogin to keep the TGT token from expiring, if it still has a long validity, it will be a no-op
         if (Utilities.isSecurityEnabled(configuration)) {
-
             pxfUserGroupInformation.reloginFromKeytab(serverName, loginSession);
         }
 

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
@@ -130,7 +130,7 @@ public class SecureLogin {
 
         // try to relogin to keep the TGT token from expiring, if it still has a long validity, it will be a no-op
         if (Utilities.isSecurityEnabled(configuration)) {
-            pxfUserGroupInformation.reloginFromKeytab(serverName, loginSession);
+            pxfUserGroupInformation.reloginFromKeytab(serverName, loginSession, configuration);
         }
 
         return loginSession.getLoginUser();

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
@@ -38,8 +38,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.hadoop.security.PxfUserGroupInformation.PROPERTY_TICKET_RENEW_THRESHOLD;
-
 /**
  * This class relies heavily on Hadoop API to
  * <ul>
@@ -66,8 +64,6 @@ public class SecureLogin {
     public static final String CONFIG_KEY_SERVICE_CONSTRAINED_DELEGATION = "pxf.service.kerberos.constrained-delegation";
     public static final String CONFIG_KEY_SERVICE_USER_IMPERSONATION = "pxf.service.user.impersonation";
     public static final String CONFIG_KEY_SERVICE_USER_NAME = "pxf.service.user.name";
-
-    public static final float DEFAULT_TICKET_RENEW_THRESHOLD = 0.8f;
 
     private static final Map<String, LoginSession> loginMap = new HashMap<>();
 
@@ -135,10 +131,7 @@ public class SecureLogin {
         // try to relogin to keep the TGT token from expiring, if it still has a long validity, it will be a no-op
         if (Utilities.isSecurityEnabled(configuration)) {
 
-            // the percentage of the ticket window to use before we renew ticket
-            float ticket_renew_threshold = configuration.getFloat(PROPERTY_TICKET_RENEW_THRESHOLD, DEFAULT_TICKET_RENEW_THRESHOLD);
-
-            pxfUserGroupInformation.reloginFromKeytab(serverName, loginSession, ticket_renew_threshold);
+            pxfUserGroupInformation.reloginFromKeytab(serverName, loginSession);
         }
 
         return loginSession.getLoginUser();
@@ -226,6 +219,7 @@ public class SecureLogin {
         LoginSession expectedLoginSession;
         if (Utilities.isSecurityEnabled(configuration)) {
             long kerberosMinMillisBeforeRelogin = pxfUserGroupInformation.getKerberosMinMillisBeforeRelogin(serverName, configuration);
+            float kerberosTicketRenewWindow = pxfUserGroupInformation.getKerberosTicketRenewWindow(serverName, configuration);
             expectedLoginSession = new LoginSession(
                     configDirectory,
                     getServicePrincipal(serverName, configuration),

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/security/SecureLogin.java
@@ -224,7 +224,8 @@ public class SecureLogin {
                     configDirectory,
                     getServicePrincipal(serverName, configuration),
                     getServiceKeytab(serverName, configuration),
-                    kerberosMinMillisBeforeRelogin);
+                    kerberosMinMillisBeforeRelogin,
+                    kerberosTicketRenewWindow);
         } else {
             expectedLoginSession = new LoginSession(configDirectory);
         }

--- a/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
+++ b/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
@@ -54,30 +54,33 @@ public class LoginSessionTest {
     public void testLoginSessionConfigurationConstructor() {
         session = new LoginSession("config");
         assertEquals(0, session.getKerberosMinMillisBeforeRelogin());
+        assertEquals(0, session.getKerberosTicketRenewWindow());
         assertNull(session.getKeytabPath());
         assertNull(session.getPrincipalName());
         assertNull(session.getLoginUser());
         assertNull(session.getSubject());
         assertNull(session.getUser());
-        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0]", session.toString());
+        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0,kerberosTicketRenewWindow=0.8]", session.toString());
     }
 
     @Test
     public void testLoginSessionConfigurationAndLoginUserConstructor() {
         session = new LoginSession("config", ugiFoo);
         assertEquals(0, session.getKerberosMinMillisBeforeRelogin());
+        assertEquals(0, session.getKerberosTicketRenewWindow());
         assertSame(ugiFoo, session.getLoginUser());
         assertNull(session.getKeytabPath());
         assertNull(session.getPrincipalName());
         assertNull(session.getSubject());
         assertNull(session.getUser());
-        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0]", session.toString());
+        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0,kerberosTicketRenewWindow=0.8]", session.toString());
     }
 
     @Test
     public void testLoginSessionShortConstructor() {
         session = new LoginSession("config", "principal", "keytab", 0);
         assertEquals(0, session.getKerberosMinMillisBeforeRelogin());
+        assertEquals(0, session.getKerberosTicketRenewWindow());
         assertEquals("keytab", session.getKeytabPath());
         assertEquals("principal", session.getPrincipalName());
         assertNull(session.getLoginUser());
@@ -87,8 +90,9 @@ public class LoginSessionTest {
 
     @Test
     public void testLoginSessionFullConstructor() {
-        session = new LoginSession("config", "principal", "keytab", ugiFoo, subjectFoo, 1);
+        session = new LoginSession("config", "principal", "keytab", ugiFoo, subjectFoo, 1, 0.8f);
         assertEquals(1, session.getKerberosMinMillisBeforeRelogin());
+        assertEquals(0.8f, session.getKerberosTicketRenewWindow());
         assertEquals("keytab", session.getKeytabPath());
         assertEquals("principal", session.getPrincipalName());
         assertSame(ugiFoo, session.getLoginUser());
@@ -98,35 +102,39 @@ public class LoginSessionTest {
 
     @Test
     public void testEquality() {
-        sessionFoo = new LoginSession("config", "principal", "keytab", ugiFoo, subjectFoo, 1);
+        sessionFoo = new LoginSession("config", "principal", "keytab", ugiFoo, subjectFoo, 1, 0.8f);
 
-        sessionBar = new LoginSession("config", "principal", "keytab", ugiBar, subjectBar, 1);
+        sessionBar = new LoginSession("config", "principal", "keytab", ugiBar, subjectBar, 1, 0.8f);
         assertEquals(sessionFoo, sessionBar);
         assertEquals(sessionFoo.hashCode(), sessionBar.hashCode());
 
 
-        sessionBar = new LoginSession("DIFFERENT", "principal", "keytab", ugiBar, subjectBar, 1);
+        sessionBar = new LoginSession("DIFFERENT", "principal", "keytab", ugiBar, subjectBar, 1, 0.8f);
         assertNotEquals(sessionFoo, sessionBar);
         assertNotEquals(sessionFoo.hashCode(), sessionBar.hashCode());
 
-        sessionBar = new LoginSession("config", "DIFFERENT", "keytab", ugiBar, subjectBar, 1);
+        sessionBar = new LoginSession("config", "DIFFERENT", "keytab", ugiBar, subjectBar, 1, 0.8f);
         assertNotEquals(sessionFoo, sessionBar);
         assertNotEquals(sessionFoo.hashCode(), sessionBar.hashCode());
 
 
-        sessionBar = new LoginSession("config", "principal", "DIFFERENT", ugiBar, subjectBar, 1);
+        sessionBar = new LoginSession("config", "principal", "DIFFERENT", ugiBar, subjectBar, 1, 0.8f);
         assertNotEquals(sessionFoo, sessionBar);
         assertNotEquals(sessionFoo.hashCode(), sessionBar.hashCode());
 
-        sessionBar = new LoginSession("config", "principal", "keytab", ugiBar, subjectBar, 999);
+        sessionBar = new LoginSession("config", "principal", "keytab", ugiBar, subjectBar, 999, 0.8f);
+        assertNotEquals(sessionFoo, sessionBar);
+        assertNotEquals(sessionFoo.hashCode(), sessionBar.hashCode());
+
+        sessionBar = new LoginSession("config", "principal", "keytab", ugiBar, subjectBar, 1, 0.4f);
         assertNotEquals(sessionFoo, sessionBar);
         assertNotEquals(sessionFoo.hashCode(), sessionBar.hashCode());
     }
 
     @Test
     public void testToString() {
-        session = new LoginSession("config", "principal", "keytab", ugiFoo, subjectFoo, 1);
-        assertEquals("LoginSession[config=config,principal=principal,keytab=keytab,kerberosMinMillisBeforeRelogin=1]", session.toString());
+        session = new LoginSession("config", "principal", "keytab", ugiFoo, subjectFoo, 1, 0.8f);
+        assertEquals("LoginSession[config=config,principal=principal,keytab=keytab,kerberosMinMillisBeforeRelogin=1,kerberosTicketRenewWindow=0.8]", session.toString());
     }
 
     private static void resetProperty(String key, String val) {

--- a/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
+++ b/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
@@ -78,9 +78,9 @@ public class LoginSessionTest {
 
     @Test
     public void testLoginSessionShortConstructor() {
-        session = new LoginSession("config", "principal", "keytab", 0);
+        session = new LoginSession("config", "principal", "keytab", 0, 0.8f);
         assertEquals(0, session.getKerberosMinMillisBeforeRelogin());
-        assertEquals(0, session.getKerberosTicketRenewWindow());
+        assertEquals(0.8f, session.getKerberosTicketRenewWindow());
         assertEquals("keytab", session.getKeytabPath());
         assertEquals("principal", session.getPrincipalName());
         assertNull(session.getLoginUser());

--- a/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
+++ b/server/pxf-api/src/test/java/org/apache/hadoop/security/LoginSessionTest.java
@@ -60,7 +60,7 @@ public class LoginSessionTest {
         assertNull(session.getLoginUser());
         assertNull(session.getSubject());
         assertNull(session.getUser());
-        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0,kerberosTicketRenewWindow=0.8]", session.toString());
+        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0,kerberosTicketRenewWindow=0.0]", session.toString());
     }
 
     @Test
@@ -73,7 +73,7 @@ public class LoginSessionTest {
         assertNull(session.getPrincipalName());
         assertNull(session.getSubject());
         assertNull(session.getUser());
-        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0,kerberosTicketRenewWindow=0.8]", session.toString());
+        assertEquals("LoginSession[config=config,principal=<null>,keytab=<null>,kerberosMinMillisBeforeRelogin=0,kerberosTicketRenewWindow=0.0]", session.toString());
     }
 
     @Test

--- a/server/pxf-api/src/test/java/org/apache/hadoop/security/PxfUserGroupInformationTest.java
+++ b/server/pxf-api/src/test/java/org/apache/hadoop/security/PxfUserGroupInformationTest.java
@@ -111,14 +111,7 @@ public class PxfUserGroupInformationTest {
 
         // assert that the login session was created with properly wired up ugi/subject/user/loginContext
         assertEquals(33000, session.getKerberosMinMillisBeforeRelogin()); // will pick from configuration
-        assertEquals("/path/to/keytab", session.getKeytabPath());
-        assertEquals("principal/some.host.com@EXAMPLE.COM", session.getPrincipalName());
-        assertEquals(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
-        assertNotSame(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
-        assertSame(subject, session.getSubject());
-        assertSame(user, session.getUser());
-        assertSame(mockLoginContext, session.getUser().getLogin());
-        assertEquals(UserGroupInformation.AuthenticationMethod.KERBEROS, session.getLoginUser().getAuthenticationMethod());
+        assertSessionInfo(session, mockLoginContext, ugi, subject, user);
 
         // verify that login() was called
         verify(mockLoginContext).login();
@@ -132,14 +125,7 @@ public class PxfUserGroupInformationTest {
 
         // assert that the login session was created with properly wired up ugi/subject/user/loginContext
         assertEquals(60000, session.getKerberosMinMillisBeforeRelogin()); // will pick from default
-        assertEquals("/path/to/keytab", session.getKeytabPath());
-        assertEquals("principal/some.host.com@EXAMPLE.COM", session.getPrincipalName());
-        assertEquals(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
-        assertNotSame(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
-        assertSame(subject, session.getSubject());
-        assertSame(user, session.getUser());
-        assertSame(mockLoginContext, session.getUser().getLogin());
-        assertEquals(UserGroupInformation.AuthenticationMethod.KERBEROS, session.getLoginUser().getAuthenticationMethod());
+        assertSessionInfo(session, mockLoginContext, ugi, subject, user);
 
         // verify that login() was called
         verify(mockLoginContext).login();
@@ -154,14 +140,7 @@ public class PxfUserGroupInformationTest {
 
         // assert that the login session was created with properly wired up ugi/subject/user/loginContext
         assertEquals(0.2f, session.getKerberosTicketRenewWindow()); // will pick from configuration
-        assertEquals("/path/to/keytab", session.getKeytabPath());
-        assertEquals("principal/some.host.com@EXAMPLE.COM", session.getPrincipalName());
-        assertEquals(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
-        assertNotSame(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
-        assertSame(subject, session.getSubject());
-        assertSame(user, session.getUser());
-        assertSame(mockLoginContext, session.getUser().getLogin());
-        assertEquals(UserGroupInformation.AuthenticationMethod.KERBEROS, session.getLoginUser().getAuthenticationMethod());
+        assertSessionInfo(session, mockLoginContext, ugi, subject, user);
 
         // verify that login() was called
         verify(mockLoginContext).login();
@@ -175,14 +154,7 @@ public class PxfUserGroupInformationTest {
 
         // assert that the login session was created with properly wired up ugi/subject/user/loginContext
         assertEquals(0.8f, session.getKerberosTicketRenewWindow()); // will pick from default
-        assertEquals("/path/to/keytab", session.getKeytabPath());
-        assertEquals("principal/some.host.com@EXAMPLE.COM", session.getPrincipalName());
-        assertEquals(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
-        assertNotSame(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
-        assertSame(subject, session.getSubject());
-        assertSame(user, session.getUser());
-        assertSame(mockLoginContext, session.getUser().getLogin());
-        assertEquals(UserGroupInformation.AuthenticationMethod.KERBEROS, session.getLoginUser().getAuthenticationMethod());
+        assertSessionInfo(session, mockLoginContext, ugi, subject, user);
 
         // verify that login() was called
         verify(mockLoginContext).login();
@@ -405,6 +377,17 @@ public class PxfUserGroupInformationTest {
         Exception e = assertThrows(KerberosAuthException.class,
                 () -> pxfUserGroupInformation.reloginFromKeytab(serverName, session));
         assertEquals("Login failure for principal: principal from keytab keytab javax.security.auth.login.LoginException: foo", e.getMessage());
+    }
+
+    private static void assertSessionInfo(LoginSession session, LoginContext loginContext, UserGroupInformation ugi, Subject subject, User user) {
+        assertEquals("/path/to/keytab", session.getKeytabPath());
+        assertEquals("principal/some.host.com@EXAMPLE.COM", session.getPrincipalName());
+        assertEquals(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
+        assertNotSame(ugi, session.getLoginUser()); // UGI equality only compares enclosed subjects
+        assertSame(subject, session.getSubject());
+        assertSame(user, session.getUser());
+        assertSame(loginContext, session.getUser().getLogin());
+        assertEquals(UserGroupInformation.AuthenticationMethod.KERBEROS, session.getLoginUser().getAuthenticationMethod());
     }
 
     private static void resetProperty(String key, String val) {

--- a/server/pxf-api/src/test/java/org/apache/hadoop/security/PxfUserGroupInformationTest.java
+++ b/server/pxf-api/src/test/java/org/apache/hadoop/security/PxfUserGroupInformationTest.java
@@ -154,7 +154,7 @@ public class PxfUserGroupInformationTest {
         // do NOT set authentication method of UGI to KERBEROS, will cause NOOP for relogin
         session = new LoginSession("config", "principal", "keytab", ugi, subjectWithKerberosKeyTab, 1);
 
-        pxfUserGroupInformation.reloginFromKeytab(serverName, session);
+        pxfUserGroupInformation.reloginFromKeytab(serverName, session, configuration);
 
         verifyNoInteractions(mockLoginContext); // proves noop
     }
@@ -166,7 +166,7 @@ public class PxfUserGroupInformationTest {
         ugi.setAuthenticationMethod(UserGroupInformation.AuthenticationMethod.KERBEROS);
         session = new LoginSession("config", "principal", "keytab", ugi, subject, 1);
 
-        pxfUserGroupInformation.reloginFromKeytab(serverName, session);
+        pxfUserGroupInformation.reloginFromKeytab(serverName, session, configuration);
 
         verifyNoInteractions(mockLoginContext); // proves noop
     }
@@ -180,7 +180,7 @@ public class PxfUserGroupInformationTest {
         // set 33 secs between re-login attempts
         session = new LoginSession("config", "principal", "keytab", ugi, subjectWithKerberosKeyTab, 55000L);
 
-        pxfUserGroupInformation.reloginFromKeytab(serverName, session);
+        pxfUserGroupInformation.reloginFromKeytab(serverName, session, configuration);
 
         verifyNoInteractions(mockLoginContext); // proves noop
     }
@@ -199,7 +199,7 @@ public class PxfUserGroupInformationTest {
         // leave user.lastLogin at 0 to simulate old login
         session = new LoginSession("config", "principal", "keytab", ugi, subjectWithKerberosKeyTab, 1);
 
-        pxfUserGroupInformation.reloginFromKeytab(serverName, session);
+        pxfUserGroupInformation.reloginFromKeytab(serverName, session, configuration);
 
         verifyNoInteractions(mockLoginContext);
     }
@@ -213,7 +213,7 @@ public class PxfUserGroupInformationTest {
         session = new LoginSession("config", "principal", "keytab", ugi, subjectWithKerberosKeyTab, 1);
 
         Exception e = assertThrows(KerberosAuthException.class,
-                () -> pxfUserGroupInformation.reloginFromKeytab(serverName, session));
+                () -> pxfUserGroupInformation.reloginFromKeytab(serverName, session, configuration));
         assertEquals(" loginUserFromKeyTab must be done first", e.getMessage());
     }
 
@@ -226,7 +226,7 @@ public class PxfUserGroupInformationTest {
         session = new LoginSession("config", "principal", null, ugi, subjectWithKerberosKeyTab, 1);
 
         Exception e = assertThrows(KerberosAuthException.class,
-                () -> pxfUserGroupInformation.reloginFromKeytab(serverName, session));
+                () -> pxfUserGroupInformation.reloginFromKeytab(serverName, session, configuration));
         assertEquals(" loginUserFromKeyTab must be done first", e.getMessage());
     }
 
@@ -249,7 +249,7 @@ public class PxfUserGroupInformationTest {
         mockAnotherLoginContext = mock(LoginContext.class);
         when(mockLoginContextProvider.newLoginContext(anyString(), any(), any())).thenReturn(mockAnotherLoginContext);
 
-        pxfUserGroupInformation.reloginFromKeytab(serverName, session);
+        pxfUserGroupInformation.reloginFromKeytab(serverName, session, configuration);
 
         assertNotSame(mockLoginContext, user.getLogin());
         assertSame(mockAnotherLoginContext, user.getLogin());
@@ -283,7 +283,7 @@ public class PxfUserGroupInformationTest {
         mockAnotherLoginContext = mock(LoginContext.class);
         when(mockLoginContextProvider.newLoginContext(anyString(), any(), any())).thenReturn(mockAnotherLoginContext);
 
-        pxfUserGroupInformation.reloginFromKeytab(serverName, session);
+        pxfUserGroupInformation.reloginFromKeytab(serverName, session, configuration);
 
         assertNotSame(mockLoginContext, user.getLogin());
         assertSame(mockAnotherLoginContext, user.getLogin());
@@ -310,7 +310,7 @@ public class PxfUserGroupInformationTest {
         doThrow(new LoginException("foo")).when(mockAnotherLoginContext).login(); // simulate login failure
 
         Exception e = assertThrows(KerberosAuthException.class,
-                () -> pxfUserGroupInformation.reloginFromKeytab(serverName, session));
+                () -> pxfUserGroupInformation.reloginFromKeytab(serverName, session, configuration));
         assertEquals("Login failure for principal: principal from keytab keytab javax.security.auth.login.LoginException: foo", e.getMessage());
     }
 

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/security/SecureLoginTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/security/SecureLoginTest.java
@@ -190,7 +190,7 @@ public class SecureLoginTest {
         assertSame(expectedUGI, loginUGI); // since actual login was mocked, we should get back whatever we mocked
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab");
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession, configuration);
 
         verifyNoMoreInteractions(pxfUserGroupInformationMock);
     }
@@ -227,7 +227,7 @@ public class SecureLoginTest {
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab");
         verify(pxfUserGroupInformationMock).getKerberosMinMillisBeforeRelogin("server", configuration);
         // 1 extra relogin call
-        verify(pxfUserGroupInformationMock, times(2)).reloginFromKeytab("server", expectedLoginSession);
+        verify(pxfUserGroupInformationMock, times(2)).reloginFromKeytab("server", expectedLoginSession, configuration);
 
         verifyNoMoreInteractions(pxfUserGroupInformationMock);
     }
@@ -271,10 +271,10 @@ public class SecureLoginTest {
         assertNotSame(loginSession, diffLoginSession); // should be different object
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab");
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession, configuration);
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(diffConfiguration, "diff-server", "diff-config", "principal", "/path/to/keytab");
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("diff-server", expectedDiffLoginSession);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("diff-server", expectedDiffLoginSession, diffConfiguration);
 
         verifyNoMoreInteractions(pxfUserGroupInformationMock);
     }
@@ -321,11 +321,11 @@ public class SecureLoginTest {
         assertNotSame(loginSession, diffLoginSession); // should be different object
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab");
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession, configuration);
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(diffConfiguration, "server", "config", "diff-principal", "/path/to/keytab");
         verify(pxfUserGroupInformationMock, times(2)).getKerberosMinMillisBeforeRelogin("server", diffConfiguration);
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedDiffLoginSession);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedDiffLoginSession, diffConfiguration);
 
         verifyNoMoreInteractions(pxfUserGroupInformationMock);
     }
@@ -353,7 +353,7 @@ public class SecureLoginTest {
         assertSame(expectedUGI, loginUGI); // since actual login was mocked, we should get back whatever we mocked
 
         // login should be never called, only re-login
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", loginSession);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", loginSession, configuration);
         verify(pxfUserGroupInformationMock, never()).loginUserFromKeytab(any(), any(), any(), any(), any());
     }
 

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/security/SecureLoginTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/security/SecureLoginTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.InetAddress;
 
+import static org.greenplum.pxf.api.security.SecureLogin.DEFAULT_TICKET_RENEW_THRESHOLD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -190,7 +191,7 @@ public class SecureLoginTest {
         assertSame(expectedUGI, loginUGI); // since actual login was mocked, we should get back whatever we mocked
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab");
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession, configuration);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession, DEFAULT_TICKET_RENEW_THRESHOLD);
 
         verifyNoMoreInteractions(pxfUserGroupInformationMock);
     }
@@ -227,7 +228,7 @@ public class SecureLoginTest {
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab");
         verify(pxfUserGroupInformationMock).getKerberosMinMillisBeforeRelogin("server", configuration);
         // 1 extra relogin call
-        verify(pxfUserGroupInformationMock, times(2)).reloginFromKeytab("server", expectedLoginSession, configuration);
+        verify(pxfUserGroupInformationMock, times(2)).reloginFromKeytab("server", expectedLoginSession, DEFAULT_TICKET_RENEW_THRESHOLD);
 
         verifyNoMoreInteractions(pxfUserGroupInformationMock);
     }
@@ -271,10 +272,10 @@ public class SecureLoginTest {
         assertNotSame(loginSession, diffLoginSession); // should be different object
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab");
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession, configuration);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession, DEFAULT_TICKET_RENEW_THRESHOLD);
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(diffConfiguration, "diff-server", "diff-config", "principal", "/path/to/keytab");
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("diff-server", expectedDiffLoginSession, diffConfiguration);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("diff-server", expectedDiffLoginSession, DEFAULT_TICKET_RENEW_THRESHOLD);
 
         verifyNoMoreInteractions(pxfUserGroupInformationMock);
     }
@@ -321,11 +322,11 @@ public class SecureLoginTest {
         assertNotSame(loginSession, diffLoginSession); // should be different object
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab");
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession, configuration);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedLoginSession, DEFAULT_TICKET_RENEW_THRESHOLD);
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(diffConfiguration, "server", "config", "diff-principal", "/path/to/keytab");
         verify(pxfUserGroupInformationMock, times(2)).getKerberosMinMillisBeforeRelogin("server", diffConfiguration);
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedDiffLoginSession, diffConfiguration);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedDiffLoginSession, DEFAULT_TICKET_RENEW_THRESHOLD);
 
         verifyNoMoreInteractions(pxfUserGroupInformationMock);
     }
@@ -353,7 +354,7 @@ public class SecureLoginTest {
         assertSame(expectedUGI, loginUGI); // since actual login was mocked, we should get back whatever we mocked
 
         // login should be never called, only re-login
-        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", loginSession, configuration);
+        verify(pxfUserGroupInformationMock).reloginFromKeytab("server", loginSession, DEFAULT_TICKET_RENEW_THRESHOLD);
         verify(pxfUserGroupInformationMock, never()).loginUserFromKeytab(any(), any(), any(), any(), any());
     }
 

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/security/SecureLoginTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/security/SecureLoginTest.java
@@ -205,6 +205,7 @@ public class SecureLoginTest {
         configuration.set("hadoop.kerberos.min.seconds.before.relogin", "90");
         when(pxfUserGroupInformationMock.loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab")).thenReturn(expectedLoginSession);
         when(pxfUserGroupInformationMock.getKerberosMinMillisBeforeRelogin("server", configuration)).thenReturn(90000L);
+        when(pxfUserGroupInformationMock.getKerberosTicketRenewWindow("server", configuration)).thenReturn(0.8f);
 
         UserGroupInformation loginUGI = secureLogin.getLoginUser("server", "config", configuration);
 
@@ -226,6 +227,7 @@ public class SecureLoginTest {
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab");
         verify(pxfUserGroupInformationMock).getKerberosMinMillisBeforeRelogin("server", configuration);
+        verify(pxfUserGroupInformationMock).getKerberosTicketRenewWindow("server", configuration);
         // 1 extra relogin call
         verify(pxfUserGroupInformationMock, times(2)).reloginFromKeytab("server", expectedLoginSession);
 
@@ -290,6 +292,7 @@ public class SecureLoginTest {
         configuration.set(PROPERTY_KEY_SERVICE_KEYTAB, "/path/to/keytab");
         configuration.set("hadoop.kerberos.min.seconds.before.relogin", "90");
         when(pxfUserGroupInformationMock.loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab")).thenReturn(expectedLoginSession);
+        when(pxfUserGroupInformationMock.getKerberosTicketRenewWindow("server", configuration)).thenReturn(0.8f);
 
         UserGroupInformation loginUGI = secureLogin.getLoginUser("server", "config", configuration);
 
@@ -310,6 +313,7 @@ public class SecureLoginTest {
         when(pxfUserGroupInformationMock.loginUserFromKeytab(configuration, "server", "config", "principal", "/path/to/keytab")).thenReturn(expectedLoginSession);
         when(pxfUserGroupInformationMock.loginUserFromKeytab(diffConfiguration, "server", "config", "diff-principal", "/path/to/keytab")).thenReturn(expectedDiffLoginSession);
         when(pxfUserGroupInformationMock.getKerberosMinMillisBeforeRelogin("server", diffConfiguration)).thenReturn(180000L);
+        when(pxfUserGroupInformationMock.getKerberosTicketRenewWindow("server", diffConfiguration)).thenReturn(0.8f);
 
         UserGroupInformation diffLoginUGI = secureLogin.getLoginUser("server", "config", diffConfiguration);
 
@@ -325,6 +329,7 @@ public class SecureLoginTest {
 
         verify(pxfUserGroupInformationMock).loginUserFromKeytab(diffConfiguration, "server", "config", "diff-principal", "/path/to/keytab");
         verify(pxfUserGroupInformationMock, times(2)).getKerberosMinMillisBeforeRelogin("server", diffConfiguration);
+        verify(pxfUserGroupInformationMock, times(2)).getKerberosTicketRenewWindow("server", diffConfiguration);
         verify(pxfUserGroupInformationMock).reloginFromKeytab("server", expectedDiffLoginSession);
 
         verifyNoMoreInteractions(pxfUserGroupInformationMock);
@@ -333,6 +338,7 @@ public class SecureLoginTest {
     @Test
     public void testLoginKerberosReuseExistingLoginSessionWithResolvedHostnameInPrincipal() throws IOException {
         when(pxfUserGroupInformationMock.getKerberosMinMillisBeforeRelogin("server", configuration)).thenReturn(90L);
+        when(pxfUserGroupInformationMock.getKerberosTicketRenewWindow("server", configuration)).thenReturn(0.8f);
 
         expectedUGI = UserGroupInformation.createUserForTesting("some", new String[]{});
 

--- a/server/pxf-service/src/templates/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/templates/pxf-site.xml
@@ -26,6 +26,16 @@
             Set to true to enable, false to disable.
         </description>
     </property>
+    <!--
+    <property>
+        <name>pxf.service.kerberos.ticket-renew-threshold</name>
+        <value>0.8</value>
+        <description>
+            By default, PXF refreshes the Kerberos ticket when 80% (0.8) of its lifespan has elapsed.
+            Specifies the threshold, as a float, at which PXF will actively refresh the ticket.
+        </description>
+    </property>
+    -->
 
     <!--
     <property>

--- a/server/pxf-service/src/templates/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/templates/pxf-site.xml
@@ -32,7 +32,7 @@
         <value>0.8</value>
         <description>
             By default, PXF refreshes the Kerberos ticket when 80% (0.8) of its lifespan has elapsed.
-            Specifies the threshold, as a float, at which PXF will actively refresh the ticket.
+            Specifies the window, as a float, at which PXF will actively refresh the ticket.
         </description>
     </property>
     -->

--- a/server/pxf-service/src/templates/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/templates/pxf-site.xml
@@ -31,7 +31,9 @@
         <value>0.8</value>
         <description>
             By default, PXF refreshes the Kerberos ticket when 80% (0.8) of its lifespan has elapsed.
-            Specifies the window, as a float, at which PXF will actively refresh the ticket.
+            Specifies the window, as a float, at which PXF will actively refresh the ticket. This value
+            must be between 0 and 1. Setting this value to 0 means that every PXF request will get a new
+            ticket.
         </description>
     </property>
 

--- a/server/pxf-service/src/templates/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/templates/pxf-site.xml
@@ -28,7 +28,7 @@
     </property>
     <!--
     <property>
-        <name>pxf.service.kerberos.ticket-renew-threshold</name>
+        <name>pxf.service.kerberos.ticket-renew-window</name>
         <value>0.8</value>
         <description>
             By default, PXF refreshes the Kerberos ticket when 80% (0.8) of its lifespan has elapsed.

--- a/server/pxf-service/src/templates/templates/pxf-site.xml
+++ b/server/pxf-service/src/templates/templates/pxf-site.xml
@@ -26,7 +26,6 @@
             Set to true to enable, false to disable.
         </description>
     </property>
-    <!--
     <property>
         <name>pxf.service.kerberos.ticket-renew-window</name>
         <value>0.8</value>
@@ -35,7 +34,6 @@
             Specifies the window, as a float, at which PXF will actively refresh the ticket.
         </description>
     </property>
-    -->
 
     <!--
     <property>


### PR DESCRIPTION
PXF currently renews the kerberos ticket only when at least 80% of the ticket lifespan has passed. 

This PR introduces a new property `pxf.service.kerberos.ticket-renew-window` that allows users to change the threshold at which we renew the ticket. The default value is 0.8f to maintain backwards compatibility. This value can be changed by adding the property into the pxf-site.xml file and can be different for each server config. For example, to renew the ticket after 30% of the ticket lifespan has passed, set the following: 
```
    <property>
        <name>pxf.service.kerberos.ticket-renew-window</name>
        <value>0.3</value>
    </property>
```