### PR TITLE
Add MultiNode Test Job for GP7 for dev pipeline

### DIFF
--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -38,6 +38,7 @@ MINIO                       ?= false
 OEL7                        ?= false
 FILE                        ?= false
 GP7_CLI                     ?= false
+GP7_MULTINODE               ?= false
 
 SET_PIPELINE := set-pipeline
 ifeq ($(CHECK_CREDS), true)
@@ -104,6 +105,7 @@ set-dev-build-pipeline:
 	$(TEMPLATE_CMD) --template dev_build_pipeline-tpl.yml --vars \
 		slack_notification=$(SLACK) \
 		multinode=$(MULTINODE) \
+		gp7_multinode=$(GP7_MULTINODE) \
 		multinode_no_impersonation=$(MULTINODE_NO_IMPERSONATION) \
 		jdk11=$(JDK11) \
 		cdh=$(CDH) \

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -73,7 +73,7 @@ anchors:
 ## ======================================================================
 resource_types:
 
-{% if multinode or multinode_no_impersonation or file or gp7_cli %}
+{% if multinode or multinode_no_impersonation or file or gp7_cli or gp7_multinode %}
 - name: terraform
   type: registry-image
   source:
@@ -83,7 +83,7 @@ resource_types:
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
 {% endif %}
 
-{% if multinode %}
+{% if multinode or gp7_multinode %}
 - name: terraform-0.14.10
   type: registry-image
   source:
@@ -169,7 +169,7 @@ resources:
     branch: ((pxf-git-branch))
     uri: ((ud/pxf/common/git-remote))
 
-{% if multinode or multinode_no_impersonation or file or gp7_cli %}
+{% if multinode or multinode_no_impersonation or file or gp7_cli or gp7_multinode %}
 - name: ccp_src
   type: git
   source:
@@ -236,7 +236,7 @@ resources:
 {% endif %}
 {% set gp_ver = None %}
 
-{% if multinode or multinode_no_impersonation or ambari or file or gp7_cli %}
+{% if multinode or multinode_no_impersonation or ambari or file or gp7_cli or gp7_multinode %}
 - name: ccp-7-image
   type: registry-image
   icon: docker
@@ -350,7 +350,7 @@ resources:
 {% endfor %}
 
 ## ---------- Auxiliary Resources ----------
-{% if multinode or multinode_no_impersonation or file or gp7_cli %}
+{% if multinode or multinode_no_impersonation or file or gp7_cli or gp7_multinode %}
 - name: terraform
   type: terraform
   source:
@@ -368,7 +368,7 @@ resources:
       bucket_path: ((tf-bucket-path))
 {% endif %}
 
-{% if multinode %}
+{% if multinode or gp7_multinode %}
 - name: terraform_ipa_hadoop
   type: terraform-0.14.10
   source:
@@ -1431,3 +1431,150 @@ jobs:
     <<: *slack_alert
 {% endif %}
 {% endif %}
+
+## ---------- Multi-node test for GP7 ----------
+{% if gp7_multinode %}
+{% set gp_ver = 7 %}
+- name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+  max_in_flight: 2
+  plan:
+  - in_parallel:
+    - get: pxf_src
+      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+      trigger: true
+    - get: pxf_tarball
+      resource: pxf_gp[[gp_ver]]_tarball_rhel8
+      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+    - get: gpdb_package
+      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
+      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+    - get: ccp_src
+    - get: ccp-7-image
+    - get: pxf-automation-dependencies
+    - get: singlecluster
+      resource: singlecluster-hdp2
+    - get: gp6-python-libs
+  - in_parallel:
+    - do:
+      - put: terraform_gpdb
+        resource: terraform
+        params:
+          action: create
+          delete_on_failure: true
+          generate_random_name: true
+          terraform_source: ccp_src/google/
+          vars:
+            PLATFORM: rocky8-gpdb[[gp_ver]]
+            number_of_nodes: ((number_of_gpdb_nodes))
+            extra_nodes: 1
+            segments_per_host: 4
+            instance_type: n1-standard-4
+            ccp_reap_minutes: 120
+            standby_master: true
+      - task: Generate Greenplum Cluster
+        input_mapping:
+          gpdb_rpm: gpdb_package
+          terraform: terraform_gpdb
+        file: ccp_src/ci/tasks/gen_cluster.yml
+        image: ccp-7-image
+        params:
+          AWS_ACCESS_KEY_ID: ((tf-machine-access-key-id))
+          AWS_SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+          AWS_DEFAULT_REGION: ((ud/common/aws-region))
+          BUCKET_PATH: ((tf-bucket-path))
+          BUCKET_NAME: ((ud/pxf/common/tf-bucket-name))
+          PLATFORM: rocky8-gpdb[[gp_ver]]
+          CLOUD_PROVIDER: google
+          GPDB_RPM: true
+      - in_parallel:
+        - task: Initialize Greenplum
+          file: ccp_src/ci/tasks/gpinitsystem.yml
+        - task: Install Hadoop
+          file: pxf_src/concourse/tasks/install_hadoop.yml
+          image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+          params:
+            ACCESS_KEY_ID: ((tf-machine-access-key-id))
+            SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+            IMPERSONATION: ((enable-impersonation-multinode))
+    - task: Generate Hadoop Cluster 1
+      file: pxf_src/concourse/tasks/install_dataproc.yml
+      params:
+        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
+        GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
+        GOOGLE_ZONE: ((ud/pxf/common/google-zone))
+        IMAGE_VERSION: ((dataproc-image-version))
+        KERBEROS: ((kerberos-enabled))
+        ccp_reap_minutes: 120
+    - task: Generate Hadoop Cluster 2
+      file: pxf_src/concourse/tasks/install_dataproc.yml
+      output_mapping:
+        dataproc_env_files: dataproc_2_env_files
+      params:
+        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/kerberos-ccp-ci-service-account-key))
+        GOOGLE_PROJECT_ID: ((ud/pxf/common/kerberos-google-project-id))
+        GOOGLE_ZONE: ((ud/pxf/common/kerberos-google-zone))
+        HADOOP_USER: gpuser
+        IMAGE_VERSION: ((dataproc-image-version))
+        INITIALIZATION_SCRIPT: gs://data-gpdb-ud-kerberos-scripts/scripts/initialization-for-kerberos.sh
+        INSTANCE_TAGS: bosh-network,data-gpdb-ud-access
+        KERBEROS: ((kerberos-enabled))
+        KEY: dataproc-kerberos-key
+        KEYRING: dataproc-kerberos
+        ccp_reap_minutes: 120
+        NO_ADDRESS: false
+        PROXY_USER: gpuser
+        SECRETS_BUCKET: ((ud/pxf/secrets/kerberos-pxf-secrets-bucket-name))
+  - do: # Generate IPA Hadoop cluster
+    - put: terraform_ipa_hadoop
+      params:
+        action: create
+        generate_random_name: true
+        terraform_source: pxf_src/concourse/terraform/ipa-multinode-hadoop
+        vars:
+          gcp_project: ((ud/pxf/common/ipa-google-project-id))
+    - task: Generate Multinode Hadoop Cluster
+      file: pxf_src/concourse/tasks/install_multinode_hadoop.yml
+      image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+      params:
+        ANSIBLE_VAR_gcp_storage_bucket: ((ud/pxf/common/build-resources-bucket-name))
+        ANSIBLE_VAR_ipa_password: ((ud/pxf/secrets/ipa-password))
+        ANSIBLE_VAR_ssl_store_password: ((ud/pxf/secrets/ssl-store-password))
+  - task: Setup PXF
+    input_mapping:
+      terraform: terraform_gpdb
+    file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
+    image: ccp-7-image
+    params:
+      IMPERSONATION: true
+      INSTALL_GPHDFS: false
+      GP_VER: [[gp_ver]]
+      KERBEROS: ((kerberos-enabled))
+      PXF_JVM_OPTS: ((pxf-jvm-opts))
+      PXF_BASE_DIR: /home/gpadmin/pxf-boot
+  - task: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+    image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+    file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
+    attempts: 2
+    params:
+      ACCESS_KEY_ID: ((tf-machine-access-key-id))
+      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+      HIVE_VERSION: 2
+      IMPERSONATION: true
+      KERBEROS: ((kerberos-enabled))
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
+      GP_VER: [[gp_ver]]
+      GROUP: security,proxySecurity,proxySecurityIpa,multiClusterSecurity
+      PXF_JVM_OPTS: ((pxf-jvm-opts))
+      PXF_BASE_DIR: /home/gpadmin/pxf-boot
+    on_success:
+      in_parallel:
+        steps:
+        - *destroy_dataproc_1
+        - *destroy_dataproc_2
+        - *destroy_gpdb_cluster
+        - *destroy_hadoop_cluster
+{% if slack_notification %}
+    <<: *slack_alert
+{% endif %}
+{% endif %} # if gp7_multinode ends here

--- a/concourse/scripts/install_hadoop.bash
+++ b/concourse/scripts/install_hadoop.bash
@@ -5,10 +5,11 @@ set -exuo pipefail
 CWDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${CWDIR}/pxf_common.bash"
 
+set_default_ccp_user
 SSH_OPTS=(-i cluster_env_files/private_key.pem)
 LOCAL_GPHD_ROOT=/singlecluster
 inflate_singlecluster
-REMOTE_GPHD_ROOT=~centos/singlecluster
+REMOTE_GPHD_ROOT=~"${DEFAULT_CCP_USER}"/singlecluster
 
 function install_hadoop_single_cluster() {
 	local hadoop_ip=${1}
@@ -38,16 +39,16 @@ function install_hadoop_single_cluster() {
 		groupadd supergroup &&
 		usermod -aG supergroup gpadmin &&
 
-		source ~centos/pxf_common.bash &&
+		source ~${DEFAULT_CCP_USER}/pxf_common.bash &&
 		export IMPERSONATION=${IMPERSONATION} &&
 		setup_impersonation ${REMOTE_GPHD_ROOT} &&
 		start_hadoop_services ${REMOTE_GPHD_ROOT}
 	EOF
 
 	local FILES_TO_SCP=(~/setup_hadoop.sh pxf_src/concourse/scripts/pxf_common.bash "${LOCAL_GPHD_ROOT}")
-	scp "${SSH_OPTS[@]}" -rq "${FILES_TO_SCP[@]}" centos@edw0:
+	scp "${SSH_OPTS[@]}" -rq "${FILES_TO_SCP[@]}" "${DEFAULT_CCP_USER}"@edw0:
 
-	ssh "${SSH_OPTS[@]}" centos@edw0 '
+	ssh "${SSH_OPTS[@]}" "${DEFAULT_CCP_USER}"@edw0 '
 		sudo chmod +x ~/setup_hadoop.sh &&
 		sudo ~/setup_hadoop.sh
 	'

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -9,6 +9,7 @@ PROXY_USER=${PROXY_USER:-pxfuser}
 PROTOCOL=${PROTOCOL:-}
 GOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID:-data-gpdb-ud}
 PXF_SRC=$(find /tmp/build -name pxf_src -type d)
+DEFAULT_CCP_USER=""
 
 # on purpose do not call this PXF_CONF|PXF_BASE so that it is not set during pxf operations
 if [[ ${PXF_VERSION} == 5 ]]; then
@@ -22,7 +23,8 @@ else
 fi
 
 if [[ -f ~/.pxfrc ]]; then
-	source <(grep JAVA_HOME ~/.pxfrc)
+	# shellcheck disable=SC1090
+	source <(grep "export JAVA_HOME" ~/.pxfrc)
 	echo "JAVA_HOME found in ${HOME}/.pxfrc, set to ${JAVA_HOME}..."
 else
 	JAVA_HOME=$(find /usr/lib/jvm -name 'java-1.8.0-openjdk*' | head -1)
@@ -267,7 +269,7 @@ function remote_access_to_gpdb() {
 	cp cluster_env_files/.ssh/* /home/gpadmin/.ssh
 	cp cluster_env_files/.ssh/*.pem /home/gpadmin/.ssh/id_rsa
 	cp cluster_env_files/public_key.openssh /home/gpadmin/.ssh/authorized_keys
-	{ ssh-keyscan localhost; ssh-keyscan 0.0.0.0; } >> /home/gpadmin/.ssh/known_hosts
+	awk '{print "localhost", $1, $2; print "0.0.0.0", $1, $2}' /etc/ssh/ssh_host_rsa_key.pub >> /home/gpadmin/.ssh/known_hosts
 	ssh "${SSH_OPTS[@]}" gpadmin@cdw "
 		source ${GPHOME}/greenplum_path.sh &&
 		export MASTER_DATA_DIRECTORY=${CDD_VALUE} &&
@@ -312,7 +314,7 @@ function setup_gpadmin_user() {
 		ssh-keygen -t rsa -N "" -f ~gpadmin/.ssh/id_rsa
 		cat /home/gpadmin/.ssh/id_rsa.pub >> ~gpadmin/.ssh/authorized_keys
 		chmod 0600 /home/gpadmin/.ssh/authorized_keys
-		{ ssh-keyscan localhost; ssh-keyscan 0.0.0.0; } >> ~gpadmin/.ssh/known_hosts
+		awk '{print "localhost", $1, $2; print "0.0.0.0", $1, $2}' /etc/ssh/ssh_host_rsa_key.pub >> ~gpadmin/.ssh/known_hosts
 		chown -R gpadmin:gpadmin ${GPHOME} ~gpadmin/.ssh # don't chown cached dirs ~/.m2, etc.
 		echo -e "password\npassword" | passwd gpadmin 2> /dev/null
 	fi
@@ -863,4 +865,23 @@ function setup_minio() {
 
 	# export minio credentials as access environment variables
 	export ACCESS_KEY_ID=${MINIO_ACCESS_KEY} SECRET_ACCESS_KEY=${MINIO_SECRET_KEY}
+}
+
+function set_default_ccp_user() {
+    metadata_file="cluster_env_files/terraform/metadata"
+
+    # Check if jq is installed
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is not installed. Installing jq..."
+        sudo yum install -y jq
+    fi
+
+    # Check if the metadata file exists
+    if [ -e "$metadata_file" ]; then
+        # shellcheck disable=SC2034
+        DEFAULT_CCP_USER=$(jq -r '.ami_default_user' "$metadata_file")
+    else
+        echo "The $metadata_file file does not exist."
+        exit 2
+    fi
 }

--- a/concourse/scripts/test_pxf_multinode.bash
+++ b/concourse/scripts/test_pxf_multinode.bash
@@ -14,8 +14,16 @@ else
 fi
 export PXF_HOME
 
+# gpscp command is replaced with gpsync in GP7
+if [ "${GP_VER}" -lt 7 ]; then
+  GP_SCP_CMD=gpscp
+else
+  GP_SCP_CMD=gpsync
+fi
+
 # shellcheck source=/dev/null
 source "${CWDIR}/pxf_common.bash"
+set_default_ccp_user
 
 SSH_OPTS=(-i cluster_env_files/private_key.pem -o 'StrictHostKeyChecking=no')
 HADOOP_SSH_OPTS=(-o 'StrictHostKeyChecking=no')
@@ -80,7 +88,7 @@ function add_testing_encoding() {
 	# install new encoding and restart Greenplum so that the new encoding is picked up by Greenplum
 	ssh "${SSH_OPTS[@]}" gpadmin@cdw "
 		source ${GPHOME}/greenplum_path.sh &&
-		gpssh -f ~gpadmin/hostfile_all -v -u centos -s -e 'sudo localedef -c -i ru_RU -f CP1251 ru_RU.CP1251' &&
+		gpssh -f ~gpadmin/hostfile_all -v -u ${DEFAULT_CCP_USER} -s -e 'if ! rpm -q glibc-locale-source >/dev/null 2>&1; then sudo yum install -y glibc-locale-source; fi; sudo localedef -c -i ru_RU -f CP1251 ru_RU.CP1251' &&
 		export MASTER_DATA_DIRECTORY=/data/gpdata/coordinator/gpseg-1 &&
 		gpstop -air
 	"
@@ -209,7 +217,7 @@ function setup_pxf_kerberos_on_cluster() {
 	sudo mkdir -p /etc/security/keytabs
 	sudo cp "${DATAPROC_DIR}/pxf.service.keytab" /etc/security/keytabs/gpadmin.headless.keytab
 	sudo chown gpadmin:gpadmin /etc/security/keytabs/gpadmin.headless.keytab
-	scp centos@cdw:/etc/krb5.conf /tmp/krb5.conf
+	scp "${DEFAULT_CCP_USER}"@cdw:/etc/krb5.conf /tmp/krb5.conf
 	sudo cp /tmp/krb5.conf /etc/krb5.conf
 
 	# Add foreign dataproc hostfile to /etc/hosts
@@ -284,11 +292,11 @@ function setup_pxf_kerberos_on_cluster() {
 		# Add foreign dataproc hostfile to /etc/hosts on all nodes and copy keytab
 		ssh gpadmin@cdw "
 			source ${GPHOME}/greenplum_path.sh &&
-			gpscp -f ~gpadmin/hostfile_all -v -r -u centos ~/dataproc_2_env_files/etc_hostfile =:/tmp/etc_hostfile &&
-			gpssh -f ~gpadmin/hostfile_all -v -u centos -s -e 'sudo tee --append /etc/hosts < /tmp/etc_hostfile' &&
-			gpscp -h cdw -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-cdw.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab &&
-			gpscp -h sdw1 -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-sdw1.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab &&
-			gpscp -h sdw2 -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-sdw2.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab
+			${GP_SCP_CMD} -f ~gpadmin/hostfile_all -v -r -u ${DEFAULT_CCP_USER} ~/dataproc_2_env_files/etc_hostfile =:/tmp/etc_hostfile &&
+			gpssh -f ~gpadmin/hostfile_all -v -u ${DEFAULT_CCP_USER} -s -e 'sudo tee --append /etc/hosts < /tmp/etc_hostfile' &&
+			${GP_SCP_CMD} -h cdw -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-cdw.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab &&
+			${GP_SCP_CMD} -h sdw1 -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-sdw1.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab &&
+			${GP_SCP_CMD} -h sdw2 -v -r -u gpadmin ~/dataproc_2_env_files/pxf.service-sdw2.keytab =:${BASE_DIR}/keytabs/pxf.service.2.keytab
 		"
 		sudo cp "${DATAPROC_2_DIR}/pxf.service.keytab" /etc/security/keytabs/gpuser.headless.keytab
 		sudo chown gpadmin:gpadmin /etc/security/keytabs/gpuser.headless.keytab
@@ -355,10 +363,10 @@ function setup_pxf_kerberos_on_cluster() {
 		# add foreign Hadoop and IPA KDC hostfile to /etc/hosts on all nodes
 		ssh gpadmin@cdw "
 			source ${GPHOME}/greenplum_path.sh &&
-			gpscp -f ~gpadmin/hostfile_all -v -r -u centos ~/ipa_env_files/etc_hostfile =:/tmp/etc_hostfile &&
-			gpssh -f ~gpadmin/hostfile_all -v -u centos -s -e 'sudo tee --append /etc/hosts < /tmp/etc_hostfile' &&
-			gpscp -f ~gpadmin/hostfile_all -v -r -u gpadmin ~/ipa_env_files/pxf.service.keytab =:${BASE_DIR}/keytabs/pxf.service.3.keytab
-			gpscp -f ~gpadmin/hostfile_all -v -r -u gpadmin ~/ipa_env_files/hadoop.user.keytab =:${BASE_DIR}/keytabs/hadoop.user.3.keytab
+			${GP_SCP_CMD} -f ~gpadmin/hostfile_all -v -r -u ${DEFAULT_CCP_USER} ~/ipa_env_files/etc_hostfile =:/tmp/etc_hostfile &&
+			gpssh -f ~gpadmin/hostfile_all -v -u ${DEFAULT_CCP_USER} -s -e 'sudo tee --append /etc/hosts < /tmp/etc_hostfile' &&
+			${GP_SCP_CMD} -f ~gpadmin/hostfile_all -v -r -u gpadmin ~/ipa_env_files/pxf.service.keytab =:${BASE_DIR}/keytabs/pxf.service.3.keytab
+			${GP_SCP_CMD} -f ~gpadmin/hostfile_all -v -r -u gpadmin ~/ipa_env_files/hadoop.user.keytab =:${BASE_DIR}/keytabs/hadoop.user.3.keytab
 		"
 
 		sudo cp "${HADOOP_3_DIR}/hadoop.user.keytab" "/etc/security/keytabs/${HADOOP_3_USER}.headless.keytab"
@@ -531,8 +539,8 @@ function _main() {
 		HDFS_BIN=/usr/bin
 	elif grep "edw0" cluster_env_files/etc_hostfile; then
 		HADOOP_HOSTNAME=hadoop
-		HADOOP_USER=centos
-		HDFS_BIN=~centos/singlecluster/bin
+		HADOOP_USER="${DEFAULT_CCP_USER}"
+		HDFS_BIN=~"${DEFAULT_CCP_USER}"/singlecluster/bin
 		hadoop_ip=$(grep < cluster_env_files/etc_hostfile edw0 | awk '{print $1}')
 		# tell hbase where to find zookeeper
 		sed -i "/<name>hbase.zookeeper.quorum<\/name>/ {n; s/127.0.0.1/${hadoop_ip}/}" \
@@ -571,6 +579,18 @@ function _main() {
 	if [[ "$PROTOCOL" != "file" ]] && [[ $KERBEROS != true ]]; then
 		run_multinode_smoke_test 1000
 	fi
+
+  #TODO Remove this "if" block once Tinc is replaced with pg_regress.
+  # To run Tinc against GP7 we need to modify PYTHONPATH in $GPHOME/greenplum_path.sh since Tinc calls that script
+  # we will set PYTHONPATH to point to the set of python libs compiled with Python2 for GP6
+  if [[ ${GP_VER} == 7 ]]; then
+    local gp6_python_libs=~gpadmin/python
+    {
+      echo "# Added by test.bash - Overriding PYTHONPATH to run the Tinc Tests in GP7" >> ${GPHOME}/greenplum_path.sh
+      echo "# Comment the following line out if you need to run GP utilities" >> ${GPHOME}/greenplum_path.sh
+      echo "export PYTHONPATH=${gp6_python_libs}"
+    } >> ${GPHOME}/greenplum_path.sh
+  fi
 
 	inflate_dependencies
 	run_pxf_automation

--- a/concourse/tasks/test_pxf_on_ccp.yml
+++ b/concourse/tasks/test_pxf_on_ccp.yml
@@ -16,6 +16,9 @@ inputs:
   optional: true
 - name: singlecluster
   optional: true
+# TODO Remove gp6-python-libs input once Tinc is replaced with pg_regress.
+- name: gp6-python-libs
+  optional: true
 
 params:
   ACCEPTANCE:


### PR DESCRIPTION
- Added variables to the Makefile (GP7_MULTINODE) and dev pipeline template (gp7_multinode), when set to true, this will introduce MultiNode tests for GP7.
- In pxf_common.bash, `grep "JAVA_HOME"` command returs two occurrences of JAVA_HOME (for Rocky8) and the script to fails. To address this issue, I have modified the script to grep for a single occurrence of JAVA_HOME: `grep "export JAVA_HOME"`
- Replaced the hard coded `centos` user with the variable (DEFAULT_CCP_USER) which contains the user based on the OS.
- `ssh-keyscan` doesn't work in Rocky8. Replaced it with awk command to set the localhost in `/home/gpadmin/.ssh/known_hosts`.
- In GP7, `gpscp` is replaced by `gpsync`. Introduced a variable (GP_SCP_CMD) to specify the appropriate command based on GP version.
- Added `gp6_python_libs` to set the `PYTHONPATH` in test_pxf_multinode.bash (same as test.bash). This is needed to run the Tinc Test.
- The command used in the script to set the locale `sudo localedef -c -i ru_RU -f CP1251 ru_RU.CP1251` fails for Rocky8. The package `glibc-locale-source` is needed to successfully set the locale and was missing from ccp image for Rocky8. Added the `yum install` command in the script to install this package if missing from the vms.
- Ran `yamllint` and `shellcheck` to confirm there are no issues with the new changes.