### PR TITLE
ci: fix issue in automation Makefile

### DIFF
--- a/automation/Makefile
+++ b/automation/Makefile
@@ -166,8 +166,11 @@ sync_jdbc_config:
 sync_cloud_configs:
 ifneq "$(PROTOCOL)" ""
 	@mkdir -p $(PROTOCOL_HOME)
-	@if [ ! -f "$(PROTOCOL_HOME)/$(PROTOCOL)-site.xml" ]; then \
-		cp $(TEMPLATES_DIR)/$(PROTOCOL)-site.xml $(PROTOCOL_HOME)/; \
+	@ set -e; \
+	if [ ! -f "$(PROTOCOL_HOME)/$(PROTOCOL)-site.xml" ]; then \
+		if [ $(PROTOCOL) != file ]; then \
+			cp $(TEMPLATES_DIR)/$(PROTOCOL)-site.xml $(PROTOCOL_HOME)/; \
+		fi; \
 		cp $(TEMPLATES_DIR)/mapred-site.xml $(PROTOCOL_HOME)/; \
 		if [ $(PROTOCOL) = file ]; then \
 			if [ ! -d "$(BASE_PATH)" ]; then \
@@ -175,7 +178,7 @@ ifneq "$(PROTOCOL)" ""
 				rm -rf $(PROTOCOL_HOME); \
 				exit 1; \
 			fi; \
-			echo "Make sure your $PXF_BASE/conf/pxf-profiles.xml file configures the file:AvroSequenceFile and file:SequenceFile profiles"; \
+			echo "Make sure your $$PXF_BASE/conf/pxf-profiles.xml file configures the file:AvroSequenceFile and file:SequenceFile profiles"; \
 			cp $(TEMPLATES_DIR)/pxf-site.xml $(PROTOCOL_HOME)/; \
 			sed $(SED_OPTS) 's|</configuration>|<property><name>pxf.fs.basePath</name><value>$(BASE_PATH)</value></property></configuration>|g' $(PROTOCOL_HOME)/pxf-site.xml; \
 		fi; \


### PR DESCRIPTION
For all of the protocols other than file, PXF requires $(PROTOCOL)-site.xml to configure the particular protocol (e.g., AWS credentials for s3 protocol). Rather then repeating the copying of the required template from $PXF_HOME, the automation Makefile has the copy command at the start of the shell script for the sync_cloud_config target.The configuration for the file protocol is done via pxf-site.xml instead of file-site.xml. This causes the copy command to attempt to copy a non-existent file-site.xml. This commit adds a check for the protocl before attempting to copy.

The reason the failed copy doesn't fail the build in CI is that a multiline shell command is used in the recipe for sync_cloud_configs and this shell command does not include errexit. The shell keeps processing the multiline command despite the failing copy command and returns the last exist code which is 0 so make considers the command a success. This commit enables errexit to cause the shell to immediately exit if any command exits with a non-zero status.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>