### PR TITLE
Added MultiNode and CLI Test job for GP7 on RHEL8

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -1536,12 +1536,14 @@ jobs:
 {% set gp_ver = None %}
 
 ## ---------- Multi-node test for GP7 ----------
+{% set gp_ver = 7 %}
 {% set job_dependency='[Testing Gate for PXF-GP]' %}
 {% include 'jobs/multinode-tpl.yml'%}
 
 ## ---------- GP7 PXF CLI tests ----------
 {% include 'jobs/cli-tpl.yml' %}
 {% set job_dependency=None %}
+{% set gp_ver = None %}
 
 ## ---------- Compatibility Gate ----------
 {% set gp_ver = 6 %}

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -48,6 +48,10 @@ groups:
   - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
   - Test PXF-GP[[gp_ver]]-HDP2-Upgrade-Extension on RHEL7
 {% set gp_ver = None %}
+{% set gp_ver = 7 %}
+  - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+  - Test PXF-GP[[gp_ver]]-CLI on RHEL8
+{% set gp_ver = None %}
   - Compatibility Gate for PXF-GP
   - Promote PXF for GP5_GP6_GP7 Artifacts
   - Publish_PXF-GP5_GP6_GP7_Artifacts_to_GP-RelEng
@@ -94,6 +98,12 @@ groups:
   - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
   - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
   - Test PXF-GP[[gp_ver]]-HDP2-Upgrade-Extension on RHEL7
+{% set gp_ver = None %}
+{% set gp_ver = 7 %}
+- name: PXF Tests - GP[[gp_ver]] on RHEL8
+  jobs:
+  - Test PXF-GP[[ gp_ver ]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+  - Test PXF-GP[[ gp_ver ]]-CLI on RHEL8
 {% set gp_ver = None %}
 - name: Backwards Compatibility
   jobs:
@@ -235,6 +245,7 @@ resources:
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     versioned_file: automation-dependencies/pxf-automation-dependencies.tar.gz
 
+## TODO Remove gp6-python-libs resource once Tinc is replaced.
 - name: gp6-python-libs
   type: gcs
   icon: google-drive
@@ -1524,6 +1535,14 @@ jobs:
     file: pxf_src/concourse/tasks/test_pxf_cli.yml
 {% set gp_ver = None %}
 
+## ---------- Multi-node test for GP7 ----------
+{% set job_dependency='[Testing Gate for PXF-GP]' %}
+{% include 'jobs/multinode-tpl.yml'%}
+
+## ---------- GP7 PXF CLI tests ----------
+{% include 'jobs/cli-tpl.yml' %}
+{% set job_dependency=None %}
+
 ## ---------- Compatibility Gate ----------
 {% set gp_ver = 6 %}
 - name: Compatibility Gate for PXF-GP
@@ -1545,8 +1564,11 @@ jobs:
       - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
       - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
       - Test PXF-GP[[gp_ver]]-HDP2-Upgrade-Extension on RHEL7
-      trigger: true
+{% set gp_ver = 7 %}
+      - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+      - Test PXF-GP[[gp_ver]]-CLI on RHEL8
 {% set gp_ver = None %}
+      trigger: true
 {% set gp_ver = 5 %}
     - get: pxf_gp[[gp_ver]]_tarball_rhel7
       passed:
@@ -1577,7 +1599,8 @@ jobs:
 {% set gp_ver = 7 %}
     - get: pxf_gp[[gp_ver]]_tarball_rhel8
       passed:
-      - Testing Gate for PXF-GP
+      - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+      - Test PXF-GP[[gp_ver]]-CLI on RHEL8
 {% set gp_ver = None %}
 
 ## ---------- Compatibility Testing ----------

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -102,8 +102,8 @@ groups:
 {% set gp_ver = 7 %}
 - name: PXF Tests - GP[[gp_ver]] on RHEL8
   jobs:
-  - Test PXF-GP[[ gp_ver ]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
-  - Test PXF-GP[[ gp_ver ]]-CLI on RHEL8
+  - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+  - Test PXF-GP[[gp_ver]]-CLI on RHEL8
 {% set gp_ver = None %}
 - name: Backwards Compatibility
   jobs:
@@ -1537,12 +1537,12 @@ jobs:
 
 ## ---------- Multi-node test for GP7 ----------
 {% set gp_ver = 7 %}
-{% set job_dependency='[Testing Gate for PXF-GP]' %}
+{% set passed = '[Testing Gate for PXF-GP]' %}
 {% include 'jobs/multinode-tpl.yml'%}
 
 ## ---------- GP7 PXF CLI tests ----------
 {% include 'jobs/cli-tpl.yml' %}
-{% set job_dependency=None %}
+{% set passed = None %}
 {% set gp_ver = None %}
 
 ## ---------- Compatibility Gate ----------

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -621,9 +621,9 @@ jobs:
 
 {% if gp7_cli %}
 {% set gp_ver = 7 %}
-{% set job_dependency='[Build PXF-GP7 on RHEL8]' %}
+{% set passed = '[Build PXF-GP7 on RHEL8]' %}
 {% include 'jobs/cli-tpl.yml' %}
-{% set job_dependency=None %}
+{% set passed = None %}
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}
@@ -1373,9 +1373,9 @@ jobs:
 ## ---------- Multi-node test for GP7 ----------
 {% if gp7_multinode %}
 {% set gp_ver = 7 %}
-{% set job_dependency='[Build PXF-GP7 on RHEL8]' %}
+{% set passed = '[Build PXF-GP7 on RHEL8]' %}
 {% include 'jobs/multinode-tpl.yml'%}
-{% set job_dependency=None %}
+{% set passed = None %}
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -620,77 +620,13 @@ jobs:
 ## ---------- GP7 PXF CLI tests ----------
 
 {% if gp7_cli %}
-{% set gp_ver = 7 %}
-- name: Test PXF-GP[[gp_ver]]-CLI on RHEL8
-  max_in_flight: 2
-  plan:
-  - in_parallel:
-    - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
-      trigger: true
-    - get: pxf_tarball
-      resource: pxf_gp[[gp_ver]]_tarball_rhel8
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
-    - get: gpdb_package
-      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
-    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-    - get: ccp_src
-    - get: ccp-7-image
-  - in_parallel:
-    - do:
-      - put: terraform_gpdb
-        resource: terraform
-        params:
-          action: create
-          delete_on_failure: true
-          generate_random_name: true
-          terraform_source: ccp_src/google/
-          vars:
-            PLATFORM: rocky8-gpdb[[gp_ver]]
-            number_of_nodes: ((number_of_gpdb_nodes))
-            extra_nodes: 1
-            segments_per_host: 4
-            instance_type: n1-standard-4
-            ccp_reap_minutes: 120
-            standby_master: true
-      - task: Generate Greenplum Cluster
-        input_mapping:
-          gpdb_rpm: gpdb_package
-          terraform: terraform_gpdb
-        file: ccp_src/ci/tasks/gen_cluster.yml
-        image: ccp-7-image
-        params:
-          AWS_ACCESS_KEY_ID: ((tf-machine-access-key-id))
-          AWS_SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-          AWS_DEFAULT_REGION: ((ud/common/aws-region))
-          BUCKET_PATH: ((tf-bucket-path))
-          BUCKET_NAME: ((ud/pxf/common/tf-bucket-name))
-          PLATFORM: rocky8-gpdb[[gp_ver]]
-          CLOUD_PROVIDER: google
-          GPDB_RPM: true
-  - task: Initialize Greenplum
-    file: ccp_src/ci/tasks/gpinitsystem.yml
-  - task: Setup PXF
-    input_mapping:
-      terraform: terraform_gpdb
-    file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
-    image: ccp-7-image
-    params:
-      IMPERSONATION: false
-      INSTALL_GPHDFS: false
-      GP_VER: [[gp_ver]]
-      PXF_JVM_OPTS: ((pxf-jvm-opts))
-  - task: Test PXF CLI
-    on_success:
-      <<: *destroy_gpdb_cluster
-    image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-    file: pxf_src/concourse/tasks/test_pxf_cli.yml
+{% set job_dependency='[Build PXF-GP7 on RHEL8]' %}
+{% include 'jobs/cli-tpl.yml' %}
+{% set job_dependency=None %}
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}
 {% endif %} # if gp7_cli ends here
-{% set gp_ver = None %}
 
 ## ---------- Extended Tests ----------
 {% set gp_ver = 6 %}
@@ -1434,148 +1370,11 @@ jobs:
 
 ## ---------- Multi-node test for GP7 ----------
 {% if gp7_multinode %}
-{% set gp_ver = 7 %}
-- name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
-  max_in_flight: 2
-  plan:
-  - in_parallel:
-    - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
-      trigger: true
-    - get: pxf_tarball
-      resource: pxf_gp[[gp_ver]]_tarball_rhel8
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
-    - get: gpdb_package
-      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
-    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-    - get: ccp_src
-    - get: ccp-7-image
-    - get: pxf-automation-dependencies
-    - get: singlecluster
-      resource: singlecluster-hdp2
-    - get: gp6-python-libs
-  - in_parallel:
-    - do:
-      - put: terraform_gpdb
-        resource: terraform
-        params:
-          action: create
-          delete_on_failure: true
-          generate_random_name: true
-          terraform_source: ccp_src/google/
-          vars:
-            PLATFORM: rocky8-gpdb[[gp_ver]]
-            number_of_nodes: ((number_of_gpdb_nodes))
-            extra_nodes: 1
-            segments_per_host: 4
-            instance_type: n1-standard-4
-            ccp_reap_minutes: 120
-            standby_master: true
-      - task: Generate Greenplum Cluster
-        input_mapping:
-          gpdb_rpm: gpdb_package
-          terraform: terraform_gpdb
-        file: ccp_src/ci/tasks/gen_cluster.yml
-        image: ccp-7-image
-        params:
-          AWS_ACCESS_KEY_ID: ((tf-machine-access-key-id))
-          AWS_SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-          AWS_DEFAULT_REGION: ((ud/common/aws-region))
-          BUCKET_PATH: ((tf-bucket-path))
-          BUCKET_NAME: ((ud/pxf/common/tf-bucket-name))
-          PLATFORM: rocky8-gpdb[[gp_ver]]
-          CLOUD_PROVIDER: google
-          GPDB_RPM: true
-      - in_parallel:
-        - task: Initialize Greenplum
-          file: ccp_src/ci/tasks/gpinitsystem.yml
-        - task: Install Hadoop
-          file: pxf_src/concourse/tasks/install_hadoop.yml
-          image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-          params:
-            ACCESS_KEY_ID: ((tf-machine-access-key-id))
-            SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-            IMPERSONATION: ((enable-impersonation-multinode))
-    - task: Generate Hadoop Cluster 1
-      file: pxf_src/concourse/tasks/install_dataproc.yml
-      params:
-        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
-        GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
-        GOOGLE_ZONE: ((ud/pxf/common/google-zone))
-        IMAGE_VERSION: ((dataproc-image-version))
-        KERBEROS: ((kerberos-enabled))
-        ccp_reap_minutes: 120
-    - task: Generate Hadoop Cluster 2
-      file: pxf_src/concourse/tasks/install_dataproc.yml
-      output_mapping:
-        dataproc_env_files: dataproc_2_env_files
-      params:
-        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/kerberos-ccp-ci-service-account-key))
-        GOOGLE_PROJECT_ID: ((ud/pxf/common/kerberos-google-project-id))
-        GOOGLE_ZONE: ((ud/pxf/common/kerberos-google-zone))
-        HADOOP_USER: gpuser
-        IMAGE_VERSION: ((dataproc-image-version))
-        INITIALIZATION_SCRIPT: gs://data-gpdb-ud-kerberos-scripts/scripts/initialization-for-kerberos.sh
-        INSTANCE_TAGS: bosh-network,data-gpdb-ud-access
-        KERBEROS: ((kerberos-enabled))
-        KEY: dataproc-kerberos-key
-        KEYRING: dataproc-kerberos
-        ccp_reap_minutes: 120
-        NO_ADDRESS: false
-        PROXY_USER: gpuser
-        SECRETS_BUCKET: ((ud/pxf/secrets/kerberos-pxf-secrets-bucket-name))
-  - do: # Generate IPA Hadoop cluster
-    - put: terraform_ipa_hadoop
-      params:
-        action: create
-        generate_random_name: true
-        terraform_source: pxf_src/concourse/terraform/ipa-multinode-hadoop
-        vars:
-          gcp_project: ((ud/pxf/common/ipa-google-project-id))
-    - task: Generate Multinode Hadoop Cluster
-      file: pxf_src/concourse/tasks/install_multinode_hadoop.yml
-      image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-      params:
-        ANSIBLE_VAR_gcp_storage_bucket: ((ud/pxf/common/build-resources-bucket-name))
-        ANSIBLE_VAR_ipa_password: ((ud/pxf/secrets/ipa-password))
-        ANSIBLE_VAR_ssl_store_password: ((ud/pxf/secrets/ssl-store-password))
-  - task: Setup PXF
-    input_mapping:
-      terraform: terraform_gpdb
-    file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
-    image: ccp-7-image
-    params:
-      IMPERSONATION: true
-      INSTALL_GPHDFS: false
-      GP_VER: [[gp_ver]]
-      KERBEROS: ((kerberos-enabled))
-      PXF_JVM_OPTS: ((pxf-jvm-opts))
-      PXF_BASE_DIR: /home/gpadmin/pxf-boot
-  - task: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
-    image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-    file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
-    attempts: 2
-    params:
-      ACCESS_KEY_ID: ((tf-machine-access-key-id))
-      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-      HIVE_VERSION: 2
-      IMPERSONATION: true
-      KERBEROS: ((kerberos-enabled))
-      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
-      GP_VER: [[gp_ver]]
-      GROUP: security,proxySecurity,proxySecurityIpa,multiClusterSecurity
-      PXF_JVM_OPTS: ((pxf-jvm-opts))
-      PXF_BASE_DIR: /home/gpadmin/pxf-boot
-    on_success:
-      in_parallel:
-        steps:
-        - *destroy_dataproc_1
-        - *destroy_dataproc_2
-        - *destroy_gpdb_cluster
-        - *destroy_hadoop_cluster
+{% set job_dependency='[Build PXF-GP7 on RHEL8]' %}
+{% include 'jobs/multinode-tpl.yml'%}
+{% set job_dependency=None %}
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}
 {% endif %} # if gp7_multinode ends here
-{% set gp_ver = None %}
+

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -620,6 +620,7 @@ jobs:
 ## ---------- GP7 PXF CLI tests ----------
 
 {% if gp7_cli %}
+{% set gp_ver = 7 %}
 {% set job_dependency='[Build PXF-GP7 on RHEL8]' %}
 {% include 'jobs/cli-tpl.yml' %}
 {% set job_dependency=None %}
@@ -627,6 +628,7 @@ jobs:
     <<: *slack_alert
 {% endif %}
 {% endif %} # if gp7_cli ends here
+{% set gp_ver = None %}
 
 ## ---------- Extended Tests ----------
 {% set gp_ver = 6 %}
@@ -1370,6 +1372,7 @@ jobs:
 
 ## ---------- Multi-node test for GP7 ----------
 {% if gp7_multinode %}
+{% set gp_ver = 7 %}
 {% set job_dependency='[Build PXF-GP7 on RHEL8]' %}
 {% include 'jobs/multinode-tpl.yml'%}
 {% set job_dependency=None %}
@@ -1377,4 +1380,5 @@ jobs:
     <<: *slack_alert
 {% endif %}
 {% endif %} # if gp7_multinode ends here
+{% set gp_ver = None %}
 

--- a/concourse/pipelines/templates/jobs/cli-tpl.yml
+++ b/concourse/pipelines/templates/jobs/cli-tpl.yml
@@ -1,4 +1,7 @@
-{% set gp_ver = 7 %}
+## Variables that need to be set for this job:
+## - gp_ver = Greenplum Major Version
+## - job_dependency: Set this to [Testing Gate for PXF-GP] for pxf-build or [Build PXF-GP7 on RHEL8] for dev
+
 - name: Test PXF-GP[[gp_ver]]-CLI on RHEL8
   max_in_flight: 2
   plan:
@@ -64,4 +67,3 @@
       <<: *destroy_gpdb_cluster
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     file: pxf_src/concourse/tasks/test_pxf_cli.yml
-{% set gp_ver = None %}

--- a/concourse/pipelines/templates/jobs/cli-tpl.yml
+++ b/concourse/pipelines/templates/jobs/cli-tpl.yml
@@ -1,0 +1,67 @@
+{% set gp_ver = 7 %}
+- name: Test PXF-GP[[gp_ver]]-CLI on RHEL8
+  max_in_flight: 2
+  plan:
+  - in_parallel:
+    - get: pxf_src
+      passed: [[job_dependency]]
+      trigger: true
+    - get: pxf_tarball
+      resource: pxf_gp[[gp_ver]]_tarball_rhel8
+      passed: [[job_dependency]]
+    - get: gpdb_package
+      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
+      passed: [[job_dependency]]
+    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+    - get: ccp_src
+    - get: ccp-7-image
+  - in_parallel:
+    - do:
+      - put: terraform_gpdb
+        resource: terraform
+        params:
+          action: create
+          delete_on_failure: true
+          generate_random_name: true
+          terraform_source: ccp_src/google/
+          vars:
+            PLATFORM: rocky8-gpdb[[gp_ver]]
+            number_of_nodes: ((number_of_gpdb_nodes))
+            extra_nodes: 1
+            segments_per_host: 4
+            instance_type: n1-standard-4
+            ccp_reap_minutes: 120
+            standby_master: true
+      - task: Generate Greenplum Cluster
+        input_mapping:
+          gpdb_rpm: gpdb_package
+          terraform: terraform_gpdb
+        file: ccp_src/ci/tasks/gen_cluster.yml
+        image: ccp-7-image
+        params:
+          AWS_ACCESS_KEY_ID: ((tf-machine-access-key-id))
+          AWS_SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+          AWS_DEFAULT_REGION: ((ud/common/aws-region))
+          BUCKET_PATH: ((tf-bucket-path))
+          BUCKET_NAME: ((ud/pxf/common/tf-bucket-name))
+          PLATFORM: rocky8-gpdb[[gp_ver]]
+          CLOUD_PROVIDER: google
+          GPDB_RPM: true
+  - task: Initialize Greenplum
+    file: ccp_src/ci/tasks/gpinitsystem.yml
+  - task: Setup PXF
+    input_mapping:
+      terraform: terraform_gpdb
+    file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
+    image: ccp-7-image
+    params:
+      IMPERSONATION: false
+      INSTALL_GPHDFS: false
+      GP_VER: [[gp_ver]]
+      PXF_JVM_OPTS: ((pxf-jvm-opts))
+  - task: Test PXF CLI
+    on_success:
+      <<: *destroy_gpdb_cluster
+    image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+    file: pxf_src/concourse/tasks/test_pxf_cli.yml
+{% set gp_ver = None %}

--- a/concourse/pipelines/templates/jobs/cli-tpl.yml
+++ b/concourse/pipelines/templates/jobs/cli-tpl.yml
@@ -1,20 +1,20 @@
 ## Variables that need to be set for this job:
 ## - gp_ver = Greenplum Major Version
-## - job_dependency: Set this to [Testing Gate for PXF-GP] for pxf-build or [Build PXF-GP7 on RHEL8] for dev
+## - passed = upstream job name that the artifacts need to pass before this job
 
 - name: Test PXF-GP[[gp_ver]]-CLI on RHEL8
   max_in_flight: 2
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [[job_dependency]]
+      passed: [[passed]]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel8
-      passed: [[job_dependency]]
+      passed: [[passed]]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-      passed: [[job_dependency]]
+      passed: [[passed]]
     - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     - get: ccp_src
     - get: ccp-7-image

--- a/concourse/pipelines/templates/jobs/multinode-tpl.yml
+++ b/concourse/pipelines/templates/jobs/multinode-tpl.yml
@@ -1,20 +1,20 @@
 ## Variables that need to be set for this job:
 ## - gp_ver = Greenplum Major Version
-## - job_dependency: Set this to [Testing Gate for PXF-GP] for pxf-build or [Build PXF-GP7 on RHEL8] for dev
+## - passed = upstream job name that the artifacts need to pass before this job
 
 - name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
   max_in_flight: 2
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [[job_dependency]]
+      passed: [[passed]]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel8
-      passed: [[job_dependency]]
+      passed: [[passed]]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-      passed: [[job_dependency]]
+      passed: [[passed]]
     - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     - get: ccp_src
     - get: ccp-7-image

--- a/concourse/pipelines/templates/jobs/multinode-tpl.yml
+++ b/concourse/pipelines/templates/jobs/multinode-tpl.yml
@@ -1,4 +1,7 @@
-{% set gp_ver = 7 %}
+## Variables that need to be set for this job:
+## - gp_ver = Greenplum Major Version
+## - job_dependency: Set this to [Testing Gate for PXF-GP] for pxf-build or [Build PXF-GP7 on RHEL8] for dev
+
 - name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
   max_in_flight: 2
   plan:
@@ -138,4 +141,3 @@
         - *destroy_dataproc_2
         - *destroy_gpdb_cluster
         - *destroy_hadoop_cluster
-{% set gp_ver = None %}

--- a/concourse/pipelines/templates/jobs/multinode-tpl.yml
+++ b/concourse/pipelines/templates/jobs/multinode-tpl.yml
@@ -1,0 +1,141 @@
+{% set gp_ver = 7 %}
+- name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+  max_in_flight: 2
+  plan:
+  - in_parallel:
+    - get: pxf_src
+      passed: [[job_dependency]]
+      trigger: true
+    - get: pxf_tarball
+      resource: pxf_gp[[gp_ver]]_tarball_rhel8
+      passed: [[job_dependency]]
+    - get: gpdb_package
+      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
+      passed: [[job_dependency]]
+    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+    - get: ccp_src
+    - get: ccp-7-image
+    - get: pxf-automation-dependencies
+    - get: singlecluster
+      resource: singlecluster-hdp2
+    - get: gp6-python-libs
+  - in_parallel:
+    - do:
+      - put: terraform_gpdb
+        resource: terraform
+        params:
+          action: create
+          delete_on_failure: true
+          generate_random_name: true
+          terraform_source: ccp_src/google/
+          vars:
+            PLATFORM: rocky8-gpdb[[gp_ver]]
+            number_of_nodes: ((number_of_gpdb_nodes))
+            extra_nodes: 1
+            segments_per_host: 4
+            instance_type: n1-standard-4
+            ccp_reap_minutes: 120
+            standby_master: true
+      - task: Generate Greenplum Cluster
+        input_mapping:
+          gpdb_rpm: gpdb_package
+          terraform: terraform_gpdb
+        file: ccp_src/ci/tasks/gen_cluster.yml
+        image: ccp-7-image
+        params:
+          AWS_ACCESS_KEY_ID: ((tf-machine-access-key-id))
+          AWS_SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+          AWS_DEFAULT_REGION: ((ud/common/aws-region))
+          BUCKET_PATH: ((tf-bucket-path))
+          BUCKET_NAME: ((ud/pxf/common/tf-bucket-name))
+          PLATFORM: rocky8-gpdb[[gp_ver]]
+          CLOUD_PROVIDER: google
+          GPDB_RPM: true
+      - in_parallel:
+        - task: Initialize Greenplum
+          file: ccp_src/ci/tasks/gpinitsystem.yml
+        - task: Install Hadoop
+          file: pxf_src/concourse/tasks/install_hadoop.yml
+          image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+          params:
+            ACCESS_KEY_ID: ((tf-machine-access-key-id))
+            SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+            IMPERSONATION: ((enable-impersonation-multinode))
+    - task: Generate Hadoop Cluster 1
+      file: pxf_src/concourse/tasks/install_dataproc.yml
+      params:
+        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
+        GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
+        GOOGLE_ZONE: ((ud/pxf/common/google-zone))
+        IMAGE_VERSION: ((dataproc-image-version))
+        KERBEROS: ((kerberos-enabled))
+        ccp_reap_minutes: 120
+    - task: Generate Hadoop Cluster 2
+      file: pxf_src/concourse/tasks/install_dataproc.yml
+      output_mapping:
+        dataproc_env_files: dataproc_2_env_files
+      params:
+        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/kerberos-ccp-ci-service-account-key))
+        GOOGLE_PROJECT_ID: ((ud/pxf/common/kerberos-google-project-id))
+        GOOGLE_ZONE: ((ud/pxf/common/kerberos-google-zone))
+        HADOOP_USER: gpuser
+        IMAGE_VERSION: ((dataproc-image-version))
+        INITIALIZATION_SCRIPT: gs://data-gpdb-ud-kerberos-scripts/scripts/initialization-for-kerberos.sh
+        INSTANCE_TAGS: bosh-network,data-gpdb-ud-access
+        KERBEROS: ((kerberos-enabled))
+        KEY: dataproc-kerberos-key
+        KEYRING: dataproc-kerberos
+        ccp_reap_minutes: 120
+        NO_ADDRESS: false
+        PROXY_USER: gpuser
+        SECRETS_BUCKET: ((ud/pxf/secrets/kerberos-pxf-secrets-bucket-name))
+  - do: # Generate IPA Hadoop cluster
+    - put: terraform_ipa_hadoop
+      params:
+        action: create
+        generate_random_name: true
+        terraform_source: pxf_src/concourse/terraform/ipa-multinode-hadoop
+        vars:
+          gcp_project: ((ud/pxf/common/ipa-google-project-id))
+    - task: Generate Multinode Hadoop Cluster
+      file: pxf_src/concourse/tasks/install_multinode_hadoop.yml
+      image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+      params:
+        ANSIBLE_VAR_gcp_storage_bucket: ((ud/pxf/common/build-resources-bucket-name))
+        ANSIBLE_VAR_ipa_password: ((ud/pxf/secrets/ipa-password))
+        ANSIBLE_VAR_ssl_store_password: ((ud/pxf/secrets/ssl-store-password))
+  - task: Setup PXF
+    input_mapping:
+      terraform: terraform_gpdb
+    file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
+    image: ccp-7-image
+    params:
+      IMPERSONATION: true
+      INSTALL_GPHDFS: false
+      GP_VER: [[gp_ver]]
+      KERBEROS: ((kerberos-enabled))
+      PXF_JVM_OPTS: ((pxf-jvm-opts))
+      PXF_BASE_DIR: /home/gpadmin/pxf-boot
+  - task: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+    image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+    file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
+    attempts: 2
+    params:
+      ACCESS_KEY_ID: ((tf-machine-access-key-id))
+      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+      HIVE_VERSION: 2
+      IMPERSONATION: true
+      KERBEROS: ((kerberos-enabled))
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
+      GP_VER: [[gp_ver]]
+      GROUP: security,proxySecurity,proxySecurityIpa,multiClusterSecurity
+      PXF_JVM_OPTS: ((pxf-jvm-opts))
+      PXF_BASE_DIR: /home/gpadmin/pxf-boot
+    on_success:
+      in_parallel:
+        steps:
+        - *destroy_dataproc_1
+        - *destroy_dataproc_2
+        - *destroy_gpdb_cluster
+        - *destroy_hadoop_cluster
+{% set gp_ver = None %}


### PR DESCRIPTION
- Added a new group `PXF Tests - GP7 on RHEL8`. The new jobs are part of the new group as well as `All`
- Refactored the Multinode and CLI jobs, moved them to separate template files (`jobs/multinode-tpl.yml` and `jobs/cli-tpl.yml`)
- These template files are referred in the build(`build_pipeline-tpl.yml`) and dev(`dev_build_pipeline-tpl.yml`) using the `include` tag.
- The `passed` condition for these jobs differ for build ( depends on `Testing Gate for PXF-GP`) and dev ( depends on `Build PXF-GP7 on RHEL8`). Setting a variable `job_dependency` to dynamically set the `passed` condition
- Tested locally, the generated pipeline for dev is same as non-refactored version
- Ran yamllint, added one new line in `dev_build_pipeline-tpl.yml` to resolve the yamllint error