### PR TITLE
docs - new filter pushdown capabilities

### DIFF
--- a/docs/content/filter_push.html.md.erb
+++ b/docs/content/filter_push.html.md.erb
@@ -37,7 +37,7 @@ PXF filter pushdown can be used with these data types (connector- and profile-sp
 - `INT2`, `INT4`, `INT8`
 - `CHAR`, `TEXT`, `VARCHAR`
 - `FLOAT`
-- `NUMERIC` (not available with the S3 connector when using S3 Select, nor with the `hive` profile when accessing `STORED AS Parquet`)
+- `NUMERIC` (not available with the `hive` profile when accessing `STORED AS Parquet`)
 - `BOOL`
 - `DATE`, `TIMESTAMP` (available only with the JDBC connector, the S3 connector when using S3 Select, the `hive:rc` and `hive:orc` profiles, and the `hive` profile when accessing `STORED AS` `RCFile` or `ORC`)
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pxf/pull/1019

current situation:  we generally discuss pushdown on https://docs.vmware.com/en/VMware-Greenplum-Platform-Extension-Framework/6.7/greenplum-platform-extension-framework/filter_push.html.  we do not identify, per profile/connector, the data types on which the profile supports pushdown.  so the doc updates involved only remove s3 select from current NUMERIC statement.  (the release notes will contain more specifics.)

question:  is the list of data types for which pxf supports pushdown identified on the page correct?

let me know if we want to revisit how we document filter pushdown support, i can tackle that in a separate PR.