### PR TITLE
Update pipelines for Concourse 7.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-**PXF Build** [![Concourse Build Status](http://ud.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/pxf-build/badge)](https://ud.ci.gpdb.pivotal.io/teams/main/pipelines/pxf-build) |
-**PXF Certification** [![Concourse Build Status](http://ud.ci.gpdb.pivotal.io/api/v1/teams/main/pipelines/pxf-certification/badge)](https://ud.ci.gpdb.pivotal.io/teams/main/pipelines/pxf-certification)
+**PXF Build** [![Concourse Build Status](http://ci.ud.gpdb.pivotal.io/api/v1/teams/main/pipelines/pxf-build/badge)](https://ci.ud.gpdb.pivotal.io/teams/main/pipelines/pxf-build) |
+**PXF Certification** [![Concourse Build Status](http://ci.ud.gpdb.pivotal.io/api/v1/teams/main/pipelines/pxf-certification/badge)](https://ci.ud.gpdb.pivotal.io/teams/main/pipelines/pxf-certification)
 
 ----------------------------------------------------------------------
 

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -13,6 +13,7 @@ DEV_BUILD_PIPELINE_NAME     ?= dev-$(USER)-$(BRANCH)
 PR_BUILD_PIPELINE_NAME      ?= pxf_pr_pipeline
 CERTIFICATION_PIPELINE_NAME ?= pxf-certification
 CLOUDBUILD_PIPELINE_NAME    ?= cloudbuild
+DEV_CLOUDBUILD_PIPELINE_NAME ?= dev-cloudbuild
 PERF_PIPELINE_NAME          ?= pxf_perf-$(SCALE)g-RHEL$(REDHAT_MAJOR_VERSION)
 PIVNET_PIPELINE_NAME        ?= pivnet_artifacts
 NUM_GPDB5_VERSIONS          ?= 10
@@ -56,6 +57,7 @@ dev-release: set-dev-release-pipeline
 dev: set-dev-build-pipeline
 pr: set-pr-build-pipeline
 cloudbuild: set-cloudbuild-pipeline
+dev-cloudbuild: set-dev-cloudbuild-pipeline
 longevity: set-longevity-pipeline
 
 # ============================= BUILD PIPELINE TARGETS =============================
@@ -196,8 +198,19 @@ set-cloudbuild-pipeline:
 	$(FLY_CMD) --target=$(CONCOURSE) \
 		$(SET_PIPELINE) \
 		--config $(HOME)/workspace/pxf/concourse/pipelines/cloudbuild_pipeline.yml \
-		--var pxf-git-branch=$(BRANCH) \
+		--var pxf-git-branch=main \
+		--var gcp-image-tag=latest \
 		--pipeline $(CLOUDBUILD_PIPELINE_NAME) \
+		${FLY_OPTION_NON-INTERACTIVE} || echo "pipelines/cloudbuild_pipeline.yml has errors"
+
+.PHONY: set-dev-cloudbuild-pipeline
+set-dev-cloudbuild-pipeline:
+	$(FLY_CMD) --target=$(CONCOURSE) \
+		$(SET_PIPELINE) \
+		--config $(HOME)/workspace/pxf/concourse/pipelines/cloudbuild_pipeline.yml \
+		--var pxf-git-branch=$(BRANCH) \
+		--var gcp-image-tag=$(PXF_DEV_IMAGE_TAG) \
+		--pipeline $(DEV_CLOUDBUILD_PIPELINE_NAME) \
 		${FLY_OPTION_NON-INTERACTIVE} || echo "pipelines/cloudbuild_pipeline.yml has errors"
 
 .PHONY: pivnet

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -9,7 +9,7 @@ YOUR_TAG ?= $(shell git describe --tags --abbrev=0)
 
 SHELL                        = /bin/bash
 BUILD_PIPELINE_NAME         ?= pxf-build
-DEV_BUILD_PIPELINE_NAME     ?= dev:$(USER)-$(BRANCH)
+DEV_BUILD_PIPELINE_NAME     ?= dev-$(USER)-$(BRANCH)
 PR_BUILD_PIPELINE_NAME      ?= pxf_pr_pipeline
 CERTIFICATION_PIPELINE_NAME ?= pxf-certification
 CLOUDBUILD_PIPELINE_NAME    ?= cloudbuild

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -237,8 +237,8 @@ set-pivnet-pipeline:
 .PHONY: singlecluster
 singlecluster:
 	$(FLY_CMD) --target=$(CONCOURSE) \
-	    $(SET_PIPELINE) \
-	    --pipeline=pxf-singlecluster \
+		$(SET_PIPELINE) \
+		--pipeline=pxf-singlecluster \
 		--config ~/workspace/pxf/concourse/pipelines/singlecluster-pipeline.yml \
 		--var pxf-git-branch=main \
 		${FLY_OPTIONS_NON-INTERACTIVE} || echo "pipelines/singlecluster-pipeline.yml has errors"

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -13,7 +13,7 @@ DEV_BUILD_PIPELINE_NAME     ?= dev-$(USER)-$(BRANCH)
 PR_BUILD_PIPELINE_NAME      ?= pxf_pr_pipeline
 CERTIFICATION_PIPELINE_NAME ?= pxf-certification
 CLOUDBUILD_PIPELINE_NAME    ?= cloudbuild
-DEV_CLOUDBUILD_PIPELINE_NAME ?= dev-cloudbuild
+DEV_CLOUDBUILD_PIPELINE_NAME ?= dev-cloudbuild-$(USER)-$(BRANCH)
 PERF_PIPELINE_NAME          ?= pxf_perf-$(SCALE)g-RHEL$(REDHAT_MAJOR_VERSION)
 PIVNET_PIPELINE_NAME        ?= pivnet_artifacts
 NUM_GPDB5_VERSIONS          ?= 10
@@ -50,7 +50,7 @@ ifeq ($(CHECK_CREDS), true)
 SET_PIPELINE += --check-creds
 endif
 
-.PHONY: build certification dev pr cloudbuild longevity
+.PHONY: build certification dev-release dev pr cloudbuild dev-cloudbuild longevity
 build: set-build-pipeline
 certification: set-certification-pipeline
 dev-release: set-dev-release-pipeline
@@ -194,23 +194,25 @@ set-certification-pipeline:
 # ============================= HELPER PIPELINE TARGETS =============================
 
 .PHONY: set-cloudbuild-pipeline
-set-cloudbuild-pipeline:
-	$(FLY_CMD) --target=$(CONCOURSE) \
-		$(SET_PIPELINE) \
-		--config $(HOME)/workspace/pxf/concourse/pipelines/cloudbuild_pipeline.yml \
-		--var pxf-git-branch=main \
-		--var gcp-image-tag=latest \
-		--pipeline $(CLOUDBUILD_PIPELINE_NAME) \
-		${FLY_OPTION_NON-INTERACTIVE} || echo "pipelines/cloudbuild_pipeline.yml has errors"
+set-cloudbuild-pipeline: PXF_GIT_BRANCH=main
+set-cloudbuild-pipeline: GCP_IMAGE_TAG=latest
+set-cloudbuild-pipeline: PIPELINE_NAME=$(CLOUDBUILD_PIPELINE_NAME)
+set-cloudbuild-pipeline: set-cloudbuild-pipeline-base
 
 .PHONY: set-dev-cloudbuild-pipeline
-set-dev-cloudbuild-pipeline:
+set-dev-cloudbuild-pipeline: PXF_GIT_BRANCH=$(BRANCH)
+set-dev-cloudbuild-pipeline: GCP_IMAGE_TAG=$(PXF_DEV_IMAGE_TAG)
+set-dev-cloudbuild-pipeline: PIPELINE_NAME=$(DEV_CLOUDBUILD_PIPELINE_NAME)
+set-dev-cloudbuild-pipeline: set-cloudbuild-pipeline-base
+
+.PHONY: set-cloudbuild-pipeline-base
+set-cloudbuild-pipeline-base:
 	$(FLY_CMD) --target=$(CONCOURSE) \
 		$(SET_PIPELINE) \
 		--config $(HOME)/workspace/pxf/concourse/pipelines/cloudbuild_pipeline.yml \
-		--var pxf-git-branch=$(BRANCH) \
-		--var gcp-image-tag=$(PXF_DEV_IMAGE_TAG) \
-		--pipeline $(DEV_CLOUDBUILD_PIPELINE_NAME) \
+		--var pxf-git-branch=$(PXF_GIT_BRANCH) \
+		--var gcp-image-tag=$(GCP_IMAGE_TAG) \
+		--pipeline $(PIPELINE_NAME) \
 		${FLY_OPTION_NON-INTERACTIVE} || echo "pipelines/cloudbuild_pipeline.yml has errors"
 
 .PHONY: pivnet

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -234,9 +234,15 @@ set-pivnet-pipeline:
 
 .PHONY: singlecluster
 singlecluster:
-	$(FLY_CMD) -t ud set-pipeline \
-		-c ~/workspace/pxf/concourse/pipelines/singlecluster-pipeline.yml \
-		-v pxf-git-branch=main -p pxf-singlecluster
+	$(FLY_CMD) --target=$(CONCOURSE) \
+	    $(SET_PIPELINE) \
+	    --pipeline=pxf-singlecluster \
+		--config ~/workspace/pxf/concourse/pipelines/singlecluster-pipeline.yml \
+		--var pxf-git-branch=main \
+		${FLY_OPTIONS_NON-INTERACTIVE} || echo "pipelines/singlecluster-pipeline.yml has errors"
+
+	@echo "using the following command to unpause the pipeline"
+	@echo -e "\t$(FLY_CMD) -t $(CONCOURSE) unpause-pipeline --pipeline pxf-singlecluster"
 
 # ============================= PERFORMANCE PIPELINE TARGETS =============================
 

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -2,13 +2,13 @@
 ## ======================================================================
 ## ANCHORS
 ## ======================================================================
-#anchors:
-#- &slack_alert
-#  on_failure:
-#    put: slack-alert
-#    params:
-#      # yamllint disable-line rule:line-length
-#      text: ":ci-fail: <${ATC_EXTERNAL_URL}/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (((ud/common/slack-em-ids)))"
+anchors:
+- &slack_alert
+  on_failure:
+    put: slack-alert
+    params:
+      # yamllint disable-line rule:line-length
+      text: ":ci-fail: <${ATC_EXTERNAL_URL}/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (((ud/common/slack-em-ids)))"
 
 ## ======================================================================
 ## RESOURCE TYPES
@@ -20,11 +20,11 @@ resource_types:
   source:
     repository: frodenas/gcs-resource
 
-#- name: slack-notification
-#  type: registry-image
-#  source:
-#    repository: cfcommunity/slack-notification-resource
-#    tag: latest
+- name: slack-notification
+  type: registry-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
 
 ## ======================================================================
 ## RESOURCES
@@ -213,10 +213,10 @@ resources:
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     regexp: prod/releases/gp7/pxf-gp7-(.*)-1.el8.x86_64.rpm
 
-#- name: slack-alert
-#  type: slack-notification
-#  source:
-#    url: ((ud/pxf/secrets/ud-pipeline-bot-ud-dev-webhook))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: ((ud/pxf/secrets/ud-pipeline-bot-ud-dev-webhook))
 
 ## ======================================================================
 ## JOBS
@@ -240,7 +240,7 @@ jobs:
     - get: singlecluster
       resource: singlecluster-hdp2
   - task: test_gpdb-5_with_pxf-gp5-hdp2_on_rhel7
-    #<<: *slack_alert
+    <<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb5-pxf-dev-centos7-image
     params:
@@ -272,7 +272,7 @@ jobs:
     - get: singlecluster
       resource: singlecluster-hdp2
   - task: test_gpdb-6_with_pxf-gp6-hdp2_on_rhel7
-    #<<: *slack_alert
+    <<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb6-pxf-dev-centos7-image
     params:
@@ -305,7 +305,7 @@ jobs:
     - get: singlecluster
       resource: singlecluster-hdp2
   - task: test_gpdb-6_with_pxf-gp6-hdp2_on_rhel8
-    #<<: *slack_alert
+    <<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb6-pxf-dev-rocky8-image
     params:
@@ -338,7 +338,7 @@ jobs:
     - get: singlecluster
       resource: singlecluster-hdp2
   - task: test_gpdb-7_with_pxf-gp7-hdp2_on_rhel8
-    #<<: *slack_alert
+    <<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb7-pxf-dev-rocky8-image
     params:
@@ -371,7 +371,7 @@ jobs:
     - get: singlecluster
       resource: singlecluster-hdp2
   - task: test_gpdb-6_with_pxf-gp6-hdp2_on_ubuntu_18.04
-    #<<: *slack_alert
+    <<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb6-pxf-dev-ubuntu18-image
     params:

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -172,7 +172,7 @@ resources:
     # TODO: swap out for non-debug builds of ubuntu20 when upstream gpdb start creating release candidates
     regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.debug.tar.gz
 
-## ---------- PXF Released RPM_artifacts ----------
+## ---------- PXF Released RPM Artifacts ----------
 - name: pxf_gp5_rpm_rhel7
   type: gcs
   icon: google-drive

--- a/concourse/pipelines/certification_pipeline.yml
+++ b/concourse/pipelines/certification_pipeline.yml
@@ -2,13 +2,13 @@
 ## ======================================================================
 ## ANCHORS
 ## ======================================================================
-anchors:
-- &slack_alert
-  on_failure:
-    put: slack-alert
-    params:
-      # yamllint disable-line rule:line-length
-      text: ":ci-fail: <${ATC_EXTERNAL_URL}/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (((ud/common/slack-em-ids)))"
+#anchors:
+#- &slack_alert
+#  on_failure:
+#    put: slack-alert
+#    params:
+#      # yamllint disable-line rule:line-length
+#      text: ":ci-fail: <${ATC_EXTERNAL_URL}/builds/$BUILD_ID|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME> has failed (((ud/common/slack-em-ids)))"
 
 ## ======================================================================
 ## RESOURCE TYPES
@@ -20,11 +20,11 @@ resource_types:
   source:
     repository: frodenas/gcs-resource
 
-- name: slack-notification
-  type: registry-image
-  source:
-    repository: cfcommunity/slack-notification-resource
-    tag: latest
+#- name: slack-notification
+#  type: registry-image
+#  source:
+#    repository: cfcommunity/slack-notification-resource
+#    tag: latest
 
 ## ======================================================================
 ## RESOURCES
@@ -61,7 +61,16 @@ resources:
   type: git
   icon: git
   source:
-    tag_filter: release-*
+    # This pipeline should be using a release tag for running
+    # the certification tests, but the build jobs are red on the latest release
+    # of PXF (currently 6.8.0) because of a change in concourse 7.8.x behavior
+    # where gpadmin doesn't own /home/gpadmin. The change only impacts PXF CI code
+    # and not the product's functionality. Until the next release of PXF is tagged
+    # this pipeline should be pointed at the main branch and have the pxf_src
+    # resource pinned to the commit with the fixed CI code. After the next
+    # release, this should be reverted back to using a tag_filter.
+    # TODO: revert this change and unpin resouce in UI.
+    #tag_filter: release-*
     branch: ((pxf-git-branch))
     uri: ((ud/pxf/common/git-remote))
 
@@ -163,7 +172,7 @@ resources:
     # TODO: swap out for non-debug builds of ubuntu20 when upstream gpdb start creating release candidates
     regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.debug.tar.gz
 
-## ---------- PXF Released RPM Artifacts ----------
+## ---------- PXF Released RPM_artifacts ----------
 - name: pxf_gp5_rpm_rhel7
   type: gcs
   icon: google-drive
@@ -204,10 +213,10 @@ resources:
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     regexp: prod/releases/gp7/pxf-gp7-(.*)-1.el8.x86_64.rpm
 
-- name: slack-alert
-  type: slack-notification
-  source:
-    url: ((ud/pxf/secrets/ud-pipeline-bot-ud-dev-webhook))
+#- name: slack-alert
+#  type: slack-notification
+#  source:
+#    url: ((ud/pxf/secrets/ud-pipeline-bot-ud-dev-webhook))
 
 ## ======================================================================
 ## JOBS
@@ -215,7 +224,7 @@ resources:
 jobs:
 
 ## ---------- Centos 7 Swimlane ----------
-- name: Certify GPDB-5 with PXF-GP5 on RHEL7
+- name: certify_gpdb-5_with_pxf-gp5_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
@@ -230,8 +239,8 @@ jobs:
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test GPDB-5 with PXF-GP5-HDP2 on RHEL7
-    <<: *slack_alert
+  - task: test_gpdb-5_with_pxf-gp5-hdp2_on_rhel7
+    #<<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb5-pxf-dev-centos7-image
     params:
@@ -239,7 +248,7 @@ jobs:
       GP_VER: 5
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-  - task: Upload certification for GPDB-5 with PXF-GP5-HDP2 on RHEL7
+  - task: upload_certification_for_gpdb-5_with_pxf-gp5-hdp2_on_rhel7
     file: pxf_src/concourse/tasks/certification_upload.yml
     image: ccp-7-image
     params:
@@ -247,7 +256,7 @@ jobs:
       GP_VER: 5
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
-- name: Certify GPDB-6 with PXF-GP6 on RHEL7
+- name: certify_gpdb-6_with_pxf-gp6_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
@@ -262,8 +271,8 @@ jobs:
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test GPDB-6 with PXF-GP6-HDP2 on RHEL7
-    <<: *slack_alert
+  - task: test_gpdb-6_with_pxf-gp6-hdp2_on_rhel7
+    #<<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb6-pxf-dev-centos7-image
     params:
@@ -271,7 +280,7 @@ jobs:
       GP_VER: 6
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-  - task: Upload certification for GPDB-6 with PXF-GP6-HDP2 on RHEL7
+  - task: upload_certification_for_gpdb-6_with_pxf-gp6-hdp2_on_rhel7
     file: pxf_src/concourse/tasks/certification_upload.yml
     image: ccp-7-image
     params:
@@ -280,7 +289,7 @@ jobs:
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
 ## ---------- RHEL 8 Swimlane ----------
-- name: Certify GPDB-6 with PXF-GP6 on RHEL8
+- name: certify_gpdb-6_with_pxf-gp6_on_rhel8
   plan:
   - in_parallel:
     - get: pxf_src
@@ -295,8 +304,8 @@ jobs:
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test GPDB-6 with PXF-GP6-HDP2 on RHEL8
-    <<: *slack_alert
+  - task: test_gpdb-6_with_pxf-gp6-hdp2_on_rhel8
+    #<<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb6-pxf-dev-rocky8-image
     params:
@@ -304,7 +313,7 @@ jobs:
       GP_VER: 6
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-  - task: Upload certification for GPDB-6 with PXF-GP6-HDP2 on RHEL8
+  - task: upload_certification_for_gpdb-6_with_pxf-gp6-hdp2_on_rhel8
     file: pxf_src/concourse/tasks/certification_upload.yml
     image: ccp-7-image
     params:
@@ -312,7 +321,7 @@ jobs:
       GP_VER: 6
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
-- name: Certify GPDB-7 with PXF-GP7 on RHEL8
+- name: certify_gpdb-7_with_pxf-gp7_on_rhel8
   plan:
   - in_parallel:
     - get: pxf_src
@@ -328,8 +337,8 @@ jobs:
     - get: gp6-python-libs
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test GPDB-7 with PXF-GP7-HDP2 on RHEL8
-    <<: *slack_alert
+  - task: test_gpdb-7_with_pxf-gp7-hdp2_on_rhel8
+    #<<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb7-pxf-dev-rocky8-image
     params:
@@ -337,7 +346,7 @@ jobs:
       GP_VER: 7
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-  - task: Upload certification for GPDB-7 with PXF-GP7-HDP2 on RHEL8
+  - task: upload_certification_for_gpdb-7_with_pxf-gp7-hdp2_on_rhel8
     file: pxf_src/concourse/tasks/certification_upload.yml
     image: ccp-7-image
     params:
@@ -346,7 +355,7 @@ jobs:
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
 ## ---------- Ubuntu 18 Swimlane ----------
-- name: Certify GPDB-6 with PXF-GP6 on Ubuntu 18.04
+- name: certify_gpdb-6_with_pxf-gp6_on_ubuntu_18.04
   plan:
   - in_parallel:
     - get: pxf_src
@@ -361,8 +370,8 @@ jobs:
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test GPDB-6 with PXF-GP6-HDP2 on Ubuntu 18.04
-    <<: *slack_alert
+  - task: test_gpdb-6_with_pxf-gp6-hdp2_on_ubuntu_18.04
+    #<<: *slack_alert
     file: pxf_src/concourse/tasks/test_certification.yml
     image: gpdb6-pxf-dev-ubuntu18-image
     params:
@@ -370,7 +379,7 @@ jobs:
       GP_VER: 6
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-  - task: Upload certification for GPDB-6 with PXF-GP6-HDP2 on Ubuntu 18.04
+  - task: upload_certification_for_gpdb-6_with_pxf-gp6-hdp2_on_ubuntu_18.04
     file: pxf_src/concourse/tasks/certification_upload.yml
     image: ccp-7-image
     params:
@@ -379,21 +388,21 @@ jobs:
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
 ## ---------- Reporting Gates ----------
-- name: Reporting Gate for PXF-GP5
+- name: reporting_gate_for_pxf-gp5
   plan:
   - in_parallel:
     - get: pxf_src
     # gpdb release candidate tarballs and PXF RPMs used in testing jobs
     - get: gpdb5_tarball_rhel7
       passed:
-      - Certify GPDB-5 with PXF-GP5 on RHEL7
+      - certify_gpdb-5_with_pxf-gp5_on_rhel7
       trigger: true
     - get: pxf_gp5_rpm_rhel7
       passed:
-      - Certify GPDB-5 with PXF-GP5 on RHEL7
+      - certify_gpdb-5_with_pxf-gp5_on_rhel7
       trigger: true
     - get: ccp-7-image
-  - task: Print Report for GPDB-5 with PXF-GP5 Artifacts
+  - task: print_report_for_gpdb-5_with_pxf-gp5_artifacts
     file: pxf_src/concourse/tasks/certification_list.yml
     image: ccp-7-image
     params:
@@ -401,27 +410,27 @@ jobs:
       GP_VER: 5
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
-- name: Reporting Gate for PXF-GP6
+- name: reporting_gate_for_pxf-gp6
   plan:
   - in_parallel:
     - get: pxf_src
     # gpdb release candidate tarballs and PXF RPMs used in testing jobs
     - get: gpdb6_tarball_rhel7
       passed:
-      - Certify GPDB-6 with PXF-GP6 on RHEL7
+      - certify_gpdb-6_with_pxf-gp6_on_rhel7
       trigger: true
     - get: pxf_gp6_rpm_rhel7
       passed:
-      - Certify GPDB-6 with PXF-GP6 on RHEL7
+      - certify_gpdb-6_with_pxf-gp6_on_rhel7
       trigger: true
     - get: pxf_gp6_rpm_rhel8
       passed:
-      - Certify GPDB-6 with PXF-GP6 on RHEL8
+      - certify_gpdb-6_with_pxf-gp6_on_rhel8
     - get: pxf_gp6_deb_ubuntu18
       passed:
-      - Certify GPDB-6 with PXF-GP6 on Ubuntu 18.04
+      - certify_gpdb-6_with_pxf-gp6_on_ubuntu_18.04
     - get: ccp-7-image
-  - task: Print Report for GPDB-6 with PXF-GP6 Artifacts
+  - task: print_report_for_gpdb-6_with_pxf-gp6_artifacts
     file: pxf_src/concourse/tasks/certification_list.yml
     image: ccp-7-image
     params:
@@ -429,21 +438,21 @@ jobs:
       GP_VER: 6
       PXF_CERTIFICATION_FOLDER: data-gpdb-ud-pxf-build/prod/certifications
 
-- name: Reporting Gate for PXF-GP7
+- name: reporting_gate_for_pxf-gp7
   plan:
   - in_parallel:
     - get: pxf_src
     # gpdb release candidate tarballs and PXF RPMs used in testing jobs
     - get: gpdb7_tarball_rhel8
       passed:
-      - Certify GPDB-7 with PXF-GP7 on RHEL8
+      - certify_gpdb-7_with_pxf-gp7_on_rhel8
       trigger: true
     - get: pxf_gp7_rpm_rhel8
       passed:
-      - Certify GPDB-7 with PXF-GP7 on RHEL8
+      - certify_gpdb-7_with_pxf-gp7_on_rhel8
       trigger: true
     - get: ccp-7-image
-  - task: Print Report for GPDB-7 with PXF-GP7 Artifacts
+  - task: print_report_for_gpdb-7_with_pxf-gp7_artifacts
     file: pxf_src/concourse/tasks/certification_list.yml
     image: ccp-7-image
     params:

--- a/concourse/pipelines/cloudbuild_pipeline.yml
+++ b/concourse/pipelines/cloudbuild_pipeline.yml
@@ -84,6 +84,7 @@ jobs:
       GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
       GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GOOGLE_ZONE: ((ud/pxf/common/google-zone))
+      # yamllint disable rule:line-length
       IMAGE_LIST: "gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-rocky8-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf gpdb7-rocky8-test-pxf"
       IMAGE_TAG: ((gcp-image-tag))
     config:

--- a/concourse/pipelines/cloudbuild_pipeline.yml
+++ b/concourse/pipelines/cloudbuild_pipeline.yml
@@ -1,106 +1,107 @@
+---
 ## ======================================================================
 ## RESOURCES
 ## ======================================================================
 resources:
-  - name: gcloud
-    type: registry-image
-    icon: docker
-    source:
-      repository: google/cloud-sdk
-      tag: slim
+- name: gcloud
+  type: registry-image
+  icon: docker
+  source:
+    repository: google/cloud-sdk
+    tag: slim
 
-  - name: pxf-dev-base-cloudbuild-trigger
-    type: git
-    icon: git
-    source:
-      branch: ((pxf-git-branch))
-      uri: ((ud/pxf/common/git-remote))
-      paths:
-        - concourse/docker/pxf-dev-base
-        - concourse/scripts/check_docker_images_and_tag.bash
+- name: pxf-dev-base-cloudbuild-trigger
+  type: git
+  icon: git
+  source:
+    branch: ((pxf-git-branch))
+    uri: ((ud/pxf/common/git-remote))
+    paths:
+    - concourse/docker/pxf-dev-base
+    - concourse/scripts/check_docker_images_and_tag.bash
 
-  - name: base-images-trigger
-    type: git
-    icon: git
-    source:
-      uri: ((ud/pxf/common/gp-image-baking-repo-uri))
-      branch: ((ud/pxf/common/gp-image-baking-repo-branch))
-      private_key: ((ud/pxf/secrets/gp-image-baking-repo-key))
-      paths:
-        - images/docker/gpdb5/gpdb5-centos7-build-test
-        - images/docker/gpdb6/gpdb6-centos7-build
-        - images/docker/gpdb6/gpdb6-centos7-test
-        - images/docker/gpdb6/gpdb6-ubuntu18.04-test
-        - images/docker/gpdb6/gpdb6-oel7-test
-        - images/docker/gpdb6/gpdb6-rhel8-test
-        - images/docker/gpdb6/gpdb6-rocky8-build
-        - images/docker/gpdb7/gpdb7-centos7-test
-        - images/docker/gpdb7/gpdb7-rhel8-test
-        - images/docker/gpdb7/gpdb7-rocky8-test
+- name: base-images-trigger
+  type: git
+  icon: git
+  source:
+    uri: ((ud/pxf/common/gp-image-baking-repo-uri))
+    branch: ((ud/pxf/common/gp-image-baking-repo-branch))
+    private_key: ((ud/pxf/secrets/gp-image-baking-repo-key))
+    paths:
+    - images/docker/gpdb5/gpdb5-centos7-build-test
+    - images/docker/gpdb6/gpdb6-centos7-build
+    - images/docker/gpdb6/gpdb6-centos7-test
+    - images/docker/gpdb6/gpdb6-ubuntu18.04-test
+    - images/docker/gpdb6/gpdb6-oel7-test
+    - images/docker/gpdb6/gpdb6-rhel8-test
+    - images/docker/gpdb6/gpdb6-rocky8-build
+    - images/docker/gpdb7/gpdb7-centos7-test
+    - images/docker/gpdb7/gpdb7-rhel8-test
+    - images/docker/gpdb7/gpdb7-rocky8-test
 
 ## ======================================================================
 ## JOBS
 ## ======================================================================
 jobs:
-  - name: check_upstream_base_images
-    max_in_flight: 1
-    plan:
-    - in_parallel:
-      - get: gcloud
-      - get: pxf_src
-        resource: pxf-dev-base-cloudbuild-trigger
-      - get: base-images-trigger
-        trigger: true
-    - task: trigger_builds
-      image: gcloud
-      params:
-        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
-        GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
-        GOOGLE_ZONE: ((ud/pxf/common/google-zone))
-        TRIGGER_LIST: "pxf-dev-base rpmrebuild"
-      config:
-        platform: linux
-        inputs:
-          - name: pxf_src
-        run:
-          path: pxf_src/concourse/scripts/trigger_cloudbuild.bash
+- name: check_upstream_base_images
+  max_in_flight: 1
+  plan:
+  - in_parallel:
+    - get: gcloud
+    - get: pxf_src
+      resource: pxf-dev-base-cloudbuild-trigger
+    - get: base-images-trigger
+      trigger: true
+  - task: trigger_builds
+    image: gcloud
+    params:
+      GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
+      GOOGLE_ZONE: ((ud/pxf/common/google-zone))
+      TRIGGER_LIST: "pxf-dev-base rpmrebuild"
+    config:
+      platform: linux
+      inputs:
+      - name: pxf_src
+      run:
+        path: pxf_src/concourse/scripts/trigger_cloudbuild.bash
 
-  - name: check_pxf-dev-base_images
-    max_in_flight: 1
-    plan:
-    - in_parallel:
-      - get: gcloud
-      - get: pxf_src
-        resource: pxf-dev-base-cloudbuild-trigger
-        trigger: true
-      - get: base-images-trigger
-        passed: [check_upstream_base_images]
-        trigger: true
-    - task: check_docker_images_and_tag
-      timeout: 30m
-      image: gcloud
-      params:
-        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
-        GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
-        GOOGLE_ZONE: ((ud/pxf/common/google-zone))
-        IMAGE_LIST: "gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-rocky8-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf gpdb7-rocky8-test-pxf"
-        IMAGE_TAG: ((gcp-image-tag))
-      config:
-        platform: linux
-        inputs:
-          - name: pxf_src
-        run:
-          path: pxf_src/concourse/scripts/check_docker_images_and_tag.bash
-    - task: trigger_builds
-      image: gcloud
-      params:
-        GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
-        GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
-        GOOGLE_ZONE: ((ud/pxf/common/google-zone))
-        TRIGGER_LIST: "pxf-dev-server"
-      config:
-        platform: linux
-        inputs:
-          - name: pxf_src
-        run:
-          path: pxf_src/concourse/scripts/trigger_cloudbuild.bash
+- name: check_pxf-dev-base_images
+  max_in_flight: 1
+  plan:
+  - in_parallel:
+    - get: gcloud
+    - get: pxf_src
+      resource: pxf-dev-base-cloudbuild-trigger
+      trigger: true
+    - get: base-images-trigger
+      passed: [check_upstream_base_images]
+      trigger: true
+  - task: check_docker_images_and_tag
+    timeout: 30m
+    image: gcloud
+    params:
+      GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
+      GOOGLE_ZONE: ((ud/pxf/common/google-zone))
+      IMAGE_LIST: "gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-rocky8-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf gpdb7-rocky8-test-pxf"
+      IMAGE_TAG: ((gcp-image-tag))
+    config:
+      platform: linux
+      inputs:
+      - name: pxf_src
+      run:
+        path: pxf_src/concourse/scripts/check_docker_images_and_tag.bash
+  - task: trigger_builds
+    image: gcloud
+    params:
+      GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
+      GOOGLE_ZONE: ((ud/pxf/common/google-zone))
+      TRIGGER_LIST: "pxf-dev-server"
+    config:
+      platform: linux
+      inputs:
+      - name: pxf_src
+      run:
+        path: pxf_src/concourse/scripts/trigger_cloudbuild.bash

--- a/concourse/pipelines/cloudbuild_pipeline.yml
+++ b/concourse/pipelines/cloudbuild_pipeline.yml
@@ -17,6 +17,7 @@ resources:
       uri: ((ud/pxf/common/git-remote))
       paths:
         - concourse/docker/pxf-dev-base
+        - concourse/scripts/check_docker_images_and_tag.bash
 
   - name: base-images-trigger
     type: git
@@ -41,7 +42,7 @@ resources:
 ## JOBS
 ## ======================================================================
 jobs:
-  - name: Check upstream base images
+  - name: check_upstream_base_images
     max_in_flight: 1
     plan:
     - in_parallel:
@@ -64,7 +65,7 @@ jobs:
         run:
           path: pxf_src/concourse/scripts/trigger_cloudbuild.bash
 
-  - name: Check pxf-dev-base images
+  - name: check_pxf-dev-base_images
     max_in_flight: 1
     plan:
     - in_parallel:
@@ -73,7 +74,7 @@ jobs:
         resource: pxf-dev-base-cloudbuild-trigger
         trigger: true
       - get: base-images-trigger
-        passed: [Check upstream base images]
+        passed: [check_upstream_base_images]
         trigger: true
     - task: check_docker_images_and_tag
       timeout: 30m
@@ -83,6 +84,7 @@ jobs:
         GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
         GOOGLE_ZONE: ((ud/pxf/common/google-zone))
         IMAGE_LIST: "gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-rocky8-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf gpdb7-rocky8-test-pxf"
+        IMAGE_TAG: ((gcp-image-tag))
       config:
         platform: linux
         inputs:

--- a/concourse/pipelines/hadoop-cluster-cleaner.yml
+++ b/concourse/pipelines/hadoop-cluster-cleaner.yml
@@ -1,3 +1,4 @@
+---
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/concourse/pipelines/singlecluster-pipeline.yml
+++ b/concourse/pipelines/singlecluster-pipeline.yml
@@ -1,3 +1,4 @@
+---
 ## ======================================================================
 ## RESOURCE TYPES
 ## ======================================================================
@@ -11,138 +12,138 @@ resource_types:
 ## RESOURCES
 ## ======================================================================
 resources:
-  - name: hdp2_tars_tarball
-    type: s3
-    icon: s3
-    source:
-      access_key_id: ((ud/pxf/secrets/aws-bucket-access-key-id))
-      secret_access_key: ((ud/pxf/secrets/aws-bucket-secret-access-key))
-      bucket: ((ud/pxf/common/aws-bucket-name))
-      region_name: ((ud/common/aws-region))
-      versioned_file: hortonworks/HDP-2.5.3.0-centos6-tars-tarball.tar.gz
+- name: hdp2_tars_tarball
+  type: s3
+  icon: s3
+  source:
+    access_key_id: ((ud/pxf/secrets/aws-bucket-access-key-id))
+    secret_access_key: ((ud/pxf/secrets/aws-bucket-secret-access-key))
+    bucket: ((ud/pxf/common/aws-bucket-name))
+    region_name: ((ud/common/aws-region))
+    versioned_file: hortonworks/HDP-2.5.3.0-centos6-tars-tarball.tar.gz
 
-  - name: hdp3_tars_tarball
-    type: s3
-    icon: s3
-    source:
-      access_key_id: ((ud/pxf/secrets/aws-bucket-access-key-id))
-      secret_access_key: ((ud/pxf/secrets/aws-bucket-secret-access-key))
-      bucket: ((ud/pxf/common/aws-bucket-name))
-      region_name: ((ud/common/aws-region))
-      versioned_file: hortonworks/HDP-3.1.4.0-centos7-tars-tarball.tar.gz
+- name: hdp3_tars_tarball
+  type: s3
+  icon: s3
+  source:
+    access_key_id: ((ud/pxf/secrets/aws-bucket-access-key-id))
+    secret_access_key: ((ud/pxf/secrets/aws-bucket-secret-access-key))
+    bucket: ((ud/pxf/common/aws-bucket-name))
+    region_name: ((ud/common/aws-region))
+    versioned_file: hortonworks/HDP-3.1.4.0-centos7-tars-tarball.tar.gz
 
-  - name: cdh_tars_tarball
-    type: s3
-    icon: s3
-    source:
-      access_key_id: ((ud/pxf/secrets/aws-bucket-access-key-id))
-      secret_access_key: ((ud/pxf/secrets/aws-bucket-secret-access-key))
-      bucket: ((ud/pxf/common/aws-bucket-name))
-      region_name: ((ud/common/aws-region))
-      versioned_file: cloudera/CDH-5.12.2.tar.gz
+- name: cdh_tars_tarball
+  type: s3
+  icon: s3
+  source:
+    access_key_id: ((ud/pxf/secrets/aws-bucket-access-key-id))
+    secret_access_key: ((ud/pxf/secrets/aws-bucket-secret-access-key))
+    bucket: ((ud/pxf/common/aws-bucket-name))
+    region_name: ((ud/common/aws-region))
+    versioned_file: cloudera/CDH-5.12.2.tar.gz
 
-  - name: jdbc
-    type: s3
-    icon: s3
-    source:
-      access_key_id: ((ud/pxf/secrets/aws-bucket-access-key-id))
-      secret_access_key: ((ud/pxf/secrets/aws-bucket-secret-access-key))
-      bucket: ((ud/pxf/common/aws-bucket-name))
-      region_name: ((ud/common/aws-region))
-      versioned_file: jdbc/postgresql-jdbc-8.4.704.jar
+- name: jdbc
+  type: s3
+  icon: s3
+  source:
+    access_key_id: ((ud/pxf/secrets/aws-bucket-access-key-id))
+    secret_access_key: ((ud/pxf/secrets/aws-bucket-secret-access-key))
+    bucket: ((ud/pxf/common/aws-bucket-name))
+    region_name: ((ud/common/aws-region))
+    versioned_file: jdbc/postgresql-jdbc-8.4.704.jar
 
-  - name: singlecluster-hdp2-gcs
-    type: google-cloud-storage
-    icon: google-drive
-    source:
-      bucket: ((ud/pxf/common/build-resources-bucket-name))
-      json_key: ((ud/pxf/secrets/gsc-ci-service-account-key))
-      versioned_file: singlecluster/HDP2/singlecluster-HDP2.tar.gz
+- name: singlecluster-hdp2-gcs
+  type: google-cloud-storage
+  icon: google-drive
+  source:
+    bucket: ((ud/pxf/common/build-resources-bucket-name))
+    json_key: ((ud/pxf/secrets/gsc-ci-service-account-key))
+    versioned_file: singlecluster/HDP2/singlecluster-HDP2.tar.gz
 
-  - name: singlecluster-hdp3-gcs
-    type: google-cloud-storage
-    icon: google-drive
-    source:
-      bucket: ((ud/pxf/common/build-resources-bucket-name))
-      json_key: ((ud/pxf/secrets/gsc-ci-service-account-key))
-      versioned_file: singlecluster/HDP3/singlecluster-HDP3.tar.gz
+- name: singlecluster-hdp3-gcs
+  type: google-cloud-storage
+  icon: google-drive
+  source:
+    bucket: ((ud/pxf/common/build-resources-bucket-name))
+    json_key: ((ud/pxf/secrets/gsc-ci-service-account-key))
+    versioned_file: singlecluster/HDP3/singlecluster-HDP3.tar.gz
 
-  - name: singlecluster-cdh-gcs
-    type: google-cloud-storage
-    icon: google-drive
-    source:
-      bucket: ((ud/pxf/common/build-resources-bucket-name))
-      json_key: ((ud/pxf/secrets/gsc-ci-service-account-key))
-      versioned_file: singlecluster/CDH/singlecluster-CDH.tar.gz
+- name: singlecluster-cdh-gcs
+  type: google-cloud-storage
+  icon: google-drive
+  source:
+    bucket: ((ud/pxf/common/build-resources-bucket-name))
+    json_key: ((ud/pxf/secrets/gsc-ci-service-account-key))
+    versioned_file: singlecluster/CDH/singlecluster-CDH.tar.gz
 
-  - name: pxf_singlecluster
-    type: git
-    icon: git
-    source:
-      branch: ((pxf-git-branch))
-      uri: ((ud/pxf/common/git-remote))
-      paths: [singlecluster/*]
+- name: pxf_singlecluster
+  type: git
+  icon: git
+  source:
+    branch: ((pxf-git-branch))
+    uri: ((ud/pxf/common/git-remote))
+    paths: [singlecluster/*]
 
-  - name: gpdb6-centos7
-    type: registry-image
-    icon: docker
-    source:
-      repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
-      tag: latest
+- name: gpdb6-centos7
+  type: registry-image
+  icon: docker
+  source:
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
+    tag: latest
 
 ## ======================================================================
 ## JOBS
 ## ======================================================================
 jobs:
-  - name: singlecluster_noarch_cdh
-    plan:
-    - in_parallel:
-      - get: cdh_tars_tarball
-        trigger: true
-      - get: jdbc
-      - get: gpdb6-centos7
-      - get: pxf_src
-        resource: pxf_singlecluster
-        trigger: true
-    - task: package_singlecluster
-      file: pxf_src/singlecluster/package_singlecluster_cdh.yml
-      image: gpdb6-centos7
-    - put: singlecluster-cdh-gcs
-      params:
-        file: artifacts/singlecluster-CDH.tar.gz
+- name: singlecluster_noarch_cdh
+  plan:
+  - in_parallel:
+    - get: cdh_tars_tarball
+      trigger: true
+    - get: jdbc
+    - get: gpdb6-centos7
+    - get: pxf_src
+      resource: pxf_singlecluster
+      trigger: true
+  - task: package_singlecluster
+    file: pxf_src/singlecluster/package_singlecluster_cdh.yml
+    image: gpdb6-centos7
+  - put: singlecluster-cdh-gcs
+    params:
+      file: artifacts/singlecluster-CDH.tar.gz
 
-  - name: singlecluster_noarch_hdp2
-    plan:
-    - in_parallel:
-      - get: hdp_tars_tarball
-        resource: hdp2_tars_tarball
-        trigger: true
-      - get: jdbc
-      - get: gpdb6-centos7
-      - get: pxf_src
-        resource: pxf_singlecluster
-        trigger: true
-    - task: package_singlecluster
-      file: pxf_src/singlecluster/package_singlecluster_hdp2.yml
-      image: gpdb6-centos7
-    - put: singlecluster-hdp2-gcs
-      params:
-        file: artifacts/singlecluster-HDP.tar.gz
+- name: singlecluster_noarch_hdp2
+  plan:
+  - in_parallel:
+    - get: hdp_tars_tarball
+      resource: hdp2_tars_tarball
+      trigger: true
+    - get: jdbc
+    - get: gpdb6-centos7
+    - get: pxf_src
+      resource: pxf_singlecluster
+      trigger: true
+  - task: package_singlecluster
+    file: pxf_src/singlecluster/package_singlecluster_hdp2.yml
+    image: gpdb6-centos7
+  - put: singlecluster-hdp2-gcs
+    params:
+      file: artifacts/singlecluster-HDP.tar.gz
 
-  - name: singlecluster_noarch_hdp3
-    plan:
-    - in_parallel:
-      - get: hdp_tars_tarball
-        resource: hdp3_tars_tarball
-        trigger: true
-      - get: jdbc
-      - get: gpdb6-centos7
-      - get: pxf_src
-        resource: pxf_singlecluster
-        trigger: true
-    - task: package_singlecluster
-      file: pxf_src/singlecluster/package_singlecluster_hdp3.yml
-      image: gpdb6-centos7
-    - put: singlecluster-hdp3-gcs
-      params:
-        file: artifacts/singlecluster-HDP.tar.gz
+- name: singlecluster_noarch_hdp3
+  plan:
+  - in_parallel:
+    - get: hdp_tars_tarball
+      resource: hdp3_tars_tarball
+      trigger: true
+    - get: jdbc
+    - get: gpdb6-centos7
+    - get: pxf_src
+      resource: pxf_singlecluster
+      trigger: true
+  - task: package_singlecluster
+    file: pxf_src/singlecluster/package_singlecluster_hdp3.yml
+    image: gpdb6-centos7
+  - put: singlecluster-hdp3-gcs
+    params:
+      file: artifacts/singlecluster-HDP.tar.gz

--- a/concourse/pipelines/singlecluster-pipeline.yml
+++ b/concourse/pipelines/singlecluster-pipeline.yml
@@ -51,7 +51,7 @@ resources:
       region_name: ((ud/common/aws-region))
       versioned_file: jdbc/postgresql-jdbc-8.4.704.jar
 
-  - name: singlecluster-HDP2-gcs
+  - name: singlecluster-hdp2-gcs
     type: google-cloud-storage
     icon: google-drive
     source:
@@ -59,7 +59,7 @@ resources:
       json_key: ((ud/pxf/secrets/gsc-ci-service-account-key))
       versioned_file: singlecluster/HDP2/singlecluster-HDP2.tar.gz
 
-  - name: singlecluster-HDP3-gcs
+  - name: singlecluster-hdp3-gcs
     type: google-cloud-storage
     icon: google-drive
     source:
@@ -67,7 +67,7 @@ resources:
       json_key: ((ud/pxf/secrets/gsc-ci-service-account-key))
       versioned_file: singlecluster/HDP3/singlecluster-HDP3.tar.gz
 
-  - name: singlecluster-CDH-gcs
+  - name: singlecluster-cdh-gcs
     type: google-cloud-storage
     icon: google-drive
     source:
@@ -107,7 +107,7 @@ jobs:
     - task: package_singlecluster
       file: pxf_src/singlecluster/package_singlecluster_cdh.yml
       image: gpdb6-centos7
-    - put: singlecluster-CDH-gcs
+    - put: singlecluster-cdh-gcs
       params:
         file: artifacts/singlecluster-CDH.tar.gz
 
@@ -125,7 +125,7 @@ jobs:
     - task: package_singlecluster
       file: pxf_src/singlecluster/package_singlecluster_hdp2.yml
       image: gpdb6-centos7
-    - put: singlecluster-HDP2-gcs
+    - put: singlecluster-hdp2-gcs
       params:
         file: artifacts/singlecluster-HDP.tar.gz
 
@@ -143,6 +143,6 @@ jobs:
     - task: package_singlecluster
       file: pxf_src/singlecluster/package_singlecluster_hdp3.yml
       image: gpdb6-centos7
-    - put: singlecluster-HDP3-gcs
+    - put: singlecluster-hdp3-gcs
       params:
         file: artifacts/singlecluster-HDP.tar.gz

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -6,127 +6,127 @@
 ## GROUPS
 ## ======================================================================
 groups:
-- name: All
+- name: all
   jobs:
-  - Testing Gate for PXF-GP
+  - testing_gate_for_pxf-gp
 {% set gp_ver = None %}
 {% for gp_ver in range(5, 7) %}
-  - Build PXF-GP[[gp_ver]] on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
+  - build_pxf-gp[[gp_ver]]_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
 {% endfor %}
 {% set gp_ver = 6 %}
-  - Test PXF-GP[[gp_ver]]-HDP2 on OEL7
-  - Build PXF-GP[[gp_ver]] on Ubuntu18
-  - Test PXF-GP[[gp_ver]]-HDP2 on Ubuntu18
+  - test_pxf-gp[[gp_ver]]-hdp2_on_oel7
+  - build_pxf-gp[[gp_ver]]_on_ubuntu18
+  - test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18
 {% for gp_ver in range(6, 8) %}
-  - Build PXF-GP[[gp_ver]] on RHEL8
-  - Test PXF-GP[[gp_ver]]-HDP2 on RHEL8
+  - build_pxf-gp[[gp_ver]]_on_rhel8
+  - test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
 {% endfor %}
 {% set gp_ver = None %}
 {% for gp_ver in range(5, 7) %}
-  - Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL7
+  - test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel7
 {% endfor %}
 {% set gp_ver = 7 %}
-  - Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL8
+  - test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel8
 {% set gp_ver = None %}
 {% set gp_ver = 6 %}
-  - Test PXF-GP[[gp_ver]] Backward Compatibility on Ubuntu18
-  - Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL8
-  - Test PXF-GP[[gp_ver]]-HDP2-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP3 on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP3-SECURE AMBARI (MANUAL) on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2-JDK11 on RHEL7
-  - Test PXF-GP[[gp_ver]]-CDH on RHEL7
-  - Test PXF-GP[[gp_ver]]-FILE-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-S3 on RHEL7
-  - Test PXF-GP[[gp_ver]]-S3-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-ADL-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-GS-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-MINIO-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2-Upgrade-Extension on RHEL7
+  - test_pxf-gp[[gp_ver]]_backward_compatibility_on_ubuntu18
+  - test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel8
+  - test_pxf-gp[[gp_ver]]-hdp2-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp3_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp3-secure_ambari_manual_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2-jdk11_on_rhel7
+  - test_pxf-gp[[gp_ver]]-cdh_on_rhel7
+  - test_pxf-gp[[gp_ver]]-file-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-s3_on_rhel7
+  - test_pxf-gp[[gp_ver]]-s3-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-adl-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-gs-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-minio-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2-upgrade-extension_on_rhel7
 {% set gp_ver = None %}
 {% set gp_ver = 7 %}
-  - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
-  - Test PXF-GP[[gp_ver]]-CLI on RHEL8
+  - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel8
+  - test_pxf-gp[[gp_ver]]-cli_on_rhel8
 {% set gp_ver = None %}
-  - Compatibility Gate for PXF-GP
-  - Promote PXF for GP5_GP6_GP7 Artifacts
-  - Publish_PXF-GP5_GP6_GP7_Artifacts_to_GP-RelEng
+  - compatibility_gate_for_pxf-gp
+  - promote_pxf_for_gp5_gp6_gp7_artifacts
+  - publish_pxf-gp5_gp6_gp7_artifacts_to_gp-releng
 
 {% set gp_ver = None %}
 {% for gp_ver in range(5, 7) %}
-- name: GP[[gp_ver]] on RHEL7
+- name: gp[[gp_ver]]_on_rhel7
   jobs:
-  - Build PXF-GP[[gp_ver]] on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
+  - build_pxf-gp[[gp_ver]]_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
 {% endfor %}
-- name: GP6 on OEL7
+- name: gp6_on_oel7
   jobs:
-  - Build PXF-GP6 on RHEL7
-  - Test PXF-GP6-HDP2 on OEL7
+  - build_pxf-gp6_on_rhel7
+  - test_pxf-gp6-hdp2_on_oel7
 {% set gp_ver = 6 %}
-- name: GP[[gp_ver]] on Ubuntu18
+- name: gp[[gp_ver]]_on_ubuntu18
   jobs:
-  - Test PXF-GP[[gp_ver]]-HDP2 on Ubuntu18
-  - Build PXF-GP[[gp_ver]] on Ubuntu18
+  - test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18
+  - build_pxf-gp[[gp_ver]]_on_ubuntu18
 {% set gp_ver = None %}
 {% for gp_ver in range(6, 8) %}
-- name: GP[[gp_ver]] on RHEL8
+- name: gp[[gp_ver]]_on_rhel8
   jobs:
-  - Test PXF-GP[[gp_ver]]-HDP2 on RHEL8
-  - Build PXF-GP[[gp_ver]] on RHEL8
+  - test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
+  - build_pxf-gp[[gp_ver]]_on_rhel8
 {% endfor %}
 {% set gp_ver = None %}
 {% set gp_ver = 6 %}
-- name: PXF Tests - GP[[gp_ver]] on RHEL7
+- name: pxf_test-gp[[gp_ver]]_on_rhel7
   jobs:
-  - Test PXF-GP[[gp_ver]]-HDP2-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP3 on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP3-SECURE AMBARI (MANUAL) on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2-JDK11 on RHEL7
-  - Test PXF-GP[[gp_ver]]-CDH on RHEL7
-  - Test PXF-GP[[gp_ver]]-FILE-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-S3 on RHEL7
-  - Test PXF-GP[[gp_ver]]-S3-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-ADL-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-GS-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-MINIO-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
-  - Test PXF-GP[[gp_ver]]-HDP2-Upgrade-Extension on RHEL7
+  - test_pxf-gp[[gp_ver]]-hdp2-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp3_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp3-secure_ambari_manual_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2-jdk11_on_rhel7
+  - test_pxf-gp[[gp_ver]]-cdh_on_rhel7
+  - test_pxf-gp[[gp_ver]]-file-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-s3_on_rhel7
+  - test_pxf-gp[[gp_ver]]-s3-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-adl-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-gs-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-minio-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-no-impers_on_rhel7
+  - test_pxf-gp[[gp_ver]]-hdp2-upgrade-extension_on_rhel7
 {% set gp_ver = None %}
 {% set gp_ver = 7 %}
-- name: PXF Tests - GP[[gp_ver]] on RHEL8
+- name: pxf_test-gp[[gp_ver]]_on_rhel8
   jobs:
-  - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
-  - Test PXF-GP[[gp_ver]]-CLI on RHEL8
+  - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel8
+  - test_pxf-gp[[gp_ver]]-cli_on_rhel8
 {% set gp_ver = None %}
-- name: Backwards Compatibility
+- name: backwards_compatibility
   jobs:
 {% set gp_ver = None %}
 {% for gp_ver in range(5, 7) %}
-  - Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL7
+  - test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel7
 {% endfor %}
 {% set gp_ver = None %}
 {% for gp_ver in range(6, 8) %}
-  - Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL8
+  - test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel8
 {% endfor %}
 {% set gp_ver = 6 %}
-  - Test PXF-GP[[gp_ver]] Backward Compatibility on Ubuntu18
+  - test_pxf-gp[[gp_ver]]_backward_compatibility_on_ubuntu18
 {% set gp_ver = None %}
-- name: Promote and Publish
+- name: promote_and_publish
   jobs:
-  - Promote PXF for GP5_GP6_GP7 Artifacts
-  - Publish_PXF-GP5_GP6_GP7_Artifacts_to_GP-RelEng
+  - promote_pxf_for_gp5_gp6_gp7_artifacts
+  - publish_pxf-gp5_gp6_gp7_artifacts_to_gp-releng
 
 ## ======================================================================
 ## ANCHORS
 ## ======================================================================
 anchors:
 - &destroy_dataproc_1
-  task: Cleanup Dataproc 1
+  task: cleanup_dataproc_1
   config:
     run:
       path: pxf_src/concourse/scripts/cleanup_dataproc_cluster.bash
@@ -141,7 +141,7 @@ anchors:
     GOOGLE_ZONE: ((ud/pxf/common/google-zone))
 
 - &destroy_dataproc_2
-  task: Cleanup Dataproc 2
+  task: cleanup_dataproc_2
   input_mapping:
     dataproc_env_files: dataproc_2_env_files
   config:
@@ -610,7 +610,7 @@ resources:
 jobs:
 ## ---------- Centos 7 Swimlane ----------
 {% for gp_ver in range(5, 7) %}
-- name: Build PXF-GP[[gp_ver]] on RHEL7
+- name: build_pxf-gp[[gp_ver]]_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
@@ -619,7 +619,7 @@ jobs:
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-build-dependencies
-  - task: Build PXF-GP[[gp_ver]] on RHEL7
+  - task: build_pxf-gp[[gp_ver]]_on_rhel7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/build.yml
     params:
@@ -629,24 +629,24 @@ jobs:
     params:
       file: dist/pxf-gp[[gp_ver]]-*.el7.tar.gz
 
-- name: Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -656,23 +656,23 @@ jobs:
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
 {% endfor %} {# gp_ver 5 and 6 #}
 
-- name: Test PXF-GP6-HDP2 on OEL7
+- name: test_pxf-gp6-hdp2_on_oel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP6 on RHEL7]
+      passed: [build_pxf-gp6_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp6_tarball_rhel7
-      passed: [Build PXF-GP6 on RHEL7]
+      passed: [build_pxf-gp6_on_rhel7]
     - get: gpdb_package
       resource: gpdb6_rhel7_rpm_latest-0
-      passed: [Build PXF-GP6 on RHEL7]
+      passed: [build_pxf-gp6_on_rhel7]
     - get: gpdb6-pxf-dev-oel7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP6-HDP2 on OEL7
+  - task: test_pxf-gp6-hdp2_on_oel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb6-pxf-dev-oel7-image
     params:
@@ -683,7 +683,7 @@ jobs:
 
 ## ---------- Ubuntu 18 Swimlane ----------
 {% set gp_ver = 6 %}
-- name: Build PXF-GP[[gp_ver]] on Ubuntu18
+- name: build_pxf-gp[[gp_ver]]_on_ubuntu18
   plan:
   - in_parallel:
     - get: pxf_src
@@ -692,7 +692,7 @@ jobs:
       resource: gpdb[[gp_ver]]_ubuntu18_deb_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     - get: pxf-build-dependencies
-  - task: Build PXF-GP[[gp_ver]] on Ubuntu18
+  - task: build_pxf-gp[[gp_ver]]_on_ubuntu18
     image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     file: pxf_src/concourse/tasks/build.yml
     params:
@@ -702,24 +702,24 @@ jobs:
     params:
       file: dist/pxf-gp[[gp_ver]]-*-ubuntu18.04.tar.gz
 
-- name: Test PXF-GP[[gp_ver]]-HDP2 on Ubuntu18
+- name: test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on Ubuntu18]
+      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_ubuntu18
-      passed: [Build PXF-GP[[gp_ver]] on Ubuntu18]
+      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_ubuntu18_deb_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on Ubuntu18]
+      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
     - get: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
-      passed: [Build PXF-GP[[gp_ver]] on Ubuntu18]
+      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2 on Ubuntu18
+  - task: test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     params:
@@ -732,7 +732,7 @@ jobs:
 
 ## ---------- RHEL 8 / Rocky 8 Swimlane ----------
 {% for gp_ver in range(6, 8) %}
-- name: Build PXF-GP[[gp_ver]] on RHEL8
+- name: build_pxf-gp[[gp_ver]]_on_rhel8
   plan:
   - in_parallel:
     - get: pxf_src
@@ -741,7 +741,7 @@ jobs:
       resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     - get: pxf-build-dependencies
-  - task: Build PXF-GP[[gp_ver]] on RHEL8
+  - task: build_pxf-gp[[gp_ver]]_on_rhel8
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     file: pxf_src/concourse/tasks/build.yml
     params:
@@ -751,27 +751,27 @@ jobs:
     params:
       file: dist/pxf-gp[[gp_ver]]-*.el8.tar.gz
 
-- name: Test PXF-GP[[gp_ver]]-HDP2 on RHEL8
+- name: test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel8
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
     - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-      passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
     - get: pxf-automation-dependencies
 {% if gp_ver == 7 %}
     - get: gp6-python-libs
 {% endif %}
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2 on RHEL8
+  - task: test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     params:
@@ -783,91 +783,91 @@ jobs:
 {% set gp_ver = None %}
 
 ## ---------- Testing Gate ----------
-- name: Testing Gate for PXF-GP
+- name: testing_gate_for_pxf-gp
   plan:
   - in_parallel:
     - get: pxf_src
       trigger: true
       passed:
 {% for gp_ver in range(5, 7) %}
-      - Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
+      - test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
 {% endfor %}
-      - Test PXF-GP6-HDP2 on OEL7
+      - test_pxf-gp6-hdp2_on_oel7
 {% set gp_ver = None %}
-      - Test PXF-GP6-HDP2 on Ubuntu18
+      - test_pxf-gp6-hdp2_on_ubuntu18
 {% for gp_ver in range(6, 8) %}
-      - Test PXF-GP[[gp_ver]]-HDP2 on RHEL8
+      - test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
 {% endfor %}
     - get: pxf_gp5_tarball_rhel7
-      passed: [Test PXF-GP5-HDP2 on RHEL7]
+      passed: [test_pxf-gp5-hdp2_on_rhel7]
     - get: gpdb5_rhel7_rpm_latest-0
-      passed: [ Test PXF-GP5-HDP2 on RHEL7 ]
+      passed: [ test_pxf-gp5-hdp2_on_rhel7 ]
 {% set gp_ver = 6 %}
     - get: pxf_gp[[gp_ver]]_tarball_ubuntu18
-      passed: [Test PXF-GP[[gp_ver]]-HDP2 on Ubuntu18]
+      passed: [test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18]
     - get: pxf_gp[[gp_ver]]_tarball_rhel8
-      passed: [Test PXF-GP[[gp_ver]]-HDP2 on RHEL8]
+      passed: [test_pxf-gp[[gp_ver]]-hdp2_on_rhel8]
     - get: pxf_gp[[gp_ver]]_tarball_rhel7
       passed:
-      - Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP2 on OEL7
+      - test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp2_on_oel7
     - get: gpdb[[gp_ver]]_ubuntu18_deb_latest-0
-      passed: [Test PXF-GP[[gp_ver]]-HDP2 on Ubuntu18]
+      passed: [test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18]
     - get: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-      passed: [Test PXF-GP[[gp_ver]]-HDP2 on RHEL8]
+      passed: [test_pxf-gp[[gp_ver]]-hdp2_on_rhel8]
     - get: gpdb[[gp_ver]]_rhel7_rpm_latest-0
       passed:
-      - Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP2 on OEL7
+      - test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp2_on_oel7
 {% set gp_ver = 7 %}
     - get: pxf_gp[[gp_ver]]_tarball_rhel8
-      passed: [Test PXF-GP[[gp_ver]]-HDP2 on RHEL8]
+      passed: [test_pxf-gp[[gp_ver]]-hdp2_on_rhel8]
     - get: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-      passed: [Test PXF-GP[[gp_ver]]-HDP2 on RHEL8]
+      passed: [test_pxf-gp[[gp_ver]]-hdp2_on_rhel8]
 {% set gp_ver = None %}
 
 ## ---------- Extended Tests ----------
 {% set gp_ver = 6 %}
-- name: Test PXF-GP[[gp_ver]]-HDP2-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
       GP_VER: [[gp_ver]]
       IMPERSONATION: false
 
-- name: Test PXF-GP[[gp_ver]]-HDP3 on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp3_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp3
-  - task: Test PXF-GP[[gp_ver]]-HDP3 on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp3_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -876,17 +876,17 @@ jobs:
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
 
-- name: Test PXF-GP[[gp_ver]]-HDP3-SECURE AMBARI (MANUAL) on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp3-secure_ambari_manual_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: ccp-7-image
     - get: pxf-automation-dependencies
@@ -899,7 +899,7 @@ jobs:
       GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
       GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GOOGLE_ZONE: ((ud/pxf/common/google-zone))
-  - task: Test PXF-GP[[gp_ver]]-HDP3-SECURE AMBARI (MANUAL) on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp3-secure_ambari_manual_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -909,23 +909,23 @@ jobs:
       HADOOP_CLIENT: HDP_KERBEROS
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
 
-- name: Test PXF-GP[[gp_ver]]-HDP2-JDK11 on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2-jdk11_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2-JDK11 on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2-jdk11_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -935,23 +935,23 @@ jobs:
       RUN_JDK_VERSION: 11
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
 
-- name: Test PXF-GP[[gp_ver]]-CDH on RHEL7
+- name: test_pxf-gp[[gp_ver]]-cdh_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-cdh
-  - task: Test PXF-GP[[gp_ver]]-CDH on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-cdh_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     # CDH often fails on HBASE permission grant
@@ -963,25 +963,25 @@ jobs:
       HADOOP_CLIENT: CDH
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
 
-- name: Test PXF-GP[[gp_ver]]-HDP2-Upgrade-Extension on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2-upgrade-extension_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_package
       resource: pxf6_6_gp6_rhel7_released # for upgrade test
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2-New-Extension on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2-new-extension_on_rhel7
     file: pxf_src/concourse/tasks/upgrade_extension.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -993,19 +993,19 @@ jobs:
 
 ## ---------- FILE tests -----------------
 
-- name: Test PXF-GP[[gp_ver]]-FILE-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-file-no-impers_on_rhel7
   max_in_flight: 2
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: ccp_src
     - get: ccp-7-image
@@ -1025,7 +1025,7 @@ jobs:
         segments_per_host: 4
         instance_type: n1-standard-4
         ccp_reap_minutes: 60
-  - task: Generate Greenplum Cluster
+  - task: generate_greenplum_cluster
     input_mapping:
       gpdb_rpm: gpdb_package
       terraform: terraform_gpdb
@@ -1040,16 +1040,16 @@ jobs:
       PLATFORM: centos7
       CLOUD_PROVIDER: google
       GPDB_RPM: true
-  - task: Initialize Greenplum
+  - task: initialize_greenplum
     file: ccp_src/ci/tasks/gpinitsystem.yml
-  - task: Setup NFS
+  - task: setup_nfs
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/install_nfs_on_ccp.yml
     image: ccp-7-image
     params:
       BASE_PATH: /mnt/nfs/var/nfsshare
-  - task: Setup PXF
+  - task: setup_pxf
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
@@ -1060,7 +1060,7 @@ jobs:
       INSTALL_GPHDFS: false
       PXF_JVM_OPTS: ((pxf-jvm-opts))
       SKIP_HADOOP_SETUP: true
-  - task: Test PXF-GP[[gp_ver]]-FILE-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-file-no-impers_on_rhel7
     on_success:
       do:
       - put: terraform_gpdb
@@ -1083,23 +1083,23 @@ jobs:
 
 ## ---------- HCFS Cloud tests ----------
 
-- name: Test PXF-GP[[gp_ver]]-S3 on RHEL7
+- name: test_pxf-gp[[gp_ver]]-s3_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-S3 on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-s3_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -1109,23 +1109,23 @@ jobs:
       PROTOCOL: s3
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
 
-- name: Test PXF-GP[[gp_ver]]-S3-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-s3-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-S3-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-s3-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -1136,23 +1136,23 @@ jobs:
       PROTOCOL: s3
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
 
-- name: Test PXF-GP[[gp_ver]]-ADL-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-adl-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-ADL-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-adl-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -1165,23 +1165,23 @@ jobs:
       IMPERSONATION: false
       PROTOCOL: adl
 
-- name: Test PXF-GP[[gp_ver]]-GS-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-gs-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-GS-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-gs-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -1191,23 +1191,23 @@ jobs:
       IMPERSONATION: false
       PROTOCOL: gs
 
-- name: Test PXF-GP[[gp_ver]]-MINIO-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-minio-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-MINIO-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-minio-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -1218,21 +1218,21 @@ jobs:
 
 ## ---------- Multi-node tests ----------
 
-- name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel7
   max_in_flight: 2
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_artifact
       resource: pxf5_gp6_rhel7_released # for upgrade test
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: ccp_src
     - get: ccp-7-image
@@ -1256,7 +1256,7 @@ jobs:
             instance_type: n1-standard-4
             ccp_reap_minutes: 120
             standby_master: true
-      - task: Generate Greenplum Cluster
+      - task: generate_greenplum_cluster
         input_mapping:
           gpdb_rpm: gpdb_package
           terraform: terraform_gpdb
@@ -1272,16 +1272,16 @@ jobs:
           CLOUD_PROVIDER: google
           GPDB_RPM: true
       - in_parallel:
-        - task: Initialize Greenplum
+        - task: initialize_greenplum
           file: ccp_src/ci/tasks/gpinitsystem.yml
-        - task: Install Hadoop
+        - task: install_hadoop
           file: pxf_src/concourse/tasks/install_hadoop.yml
           image: gpdb[[gp_ver]]-pxf-dev-centos7-image
           params:
             ACCESS_KEY_ID: ((tf-machine-access-key-id))
             SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
             IMPERSONATION: ((enable-impersonation-multinode))
-    - task: Generate Hadoop Cluster 1
+    - task: generate_hadoop_cluster_1
       file: pxf_src/concourse/tasks/install_dataproc.yml
       params:
         GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
@@ -1290,7 +1290,7 @@ jobs:
         IMAGE_VERSION: ((dataproc-image-version))
         KERBEROS: ((kerberos-enabled))
         ccp_reap_minutes: 120
-    - task: Generate Hadoop Cluster 2
+    - task: generate_hadoop_cluster_2
       file: pxf_src/concourse/tasks/install_dataproc.yml
       output_mapping:
         dataproc_env_files: dataproc_2_env_files
@@ -1317,14 +1317,14 @@ jobs:
           terraform_source: pxf_src/concourse/terraform/ipa-multinode-hadoop
           vars:
             gcp_project: ((ud/pxf/common/ipa-google-project-id))
-      - task: Generate Multinode Hadoop Cluster
+      - task: generate_multinode_hadoop_cluster
         file: pxf_src/concourse/tasks/install_multinode_hadoop.yml
         image: gpdb[[gp_ver]]-pxf-dev-centos7-image
         params:
           ANSIBLE_VAR_gcp_storage_bucket: ((ud/pxf/common/build-resources-bucket-name))
           ANSIBLE_VAR_ipa_password: ((ud/pxf/secrets/ipa-password))
           ANSIBLE_VAR_ssl_store_password: ((ud/pxf/secrets/ssl-store-password))
-  - task: Setup PXF 5 Latest
+  - task: setup_pxf_5_latest
     input_mapping:
       terraform: terraform_gpdb
       pxf_tarball: pxf_tarball_ignore # do not install from the artifact
@@ -1337,7 +1337,7 @@ jobs:
       KERBEROS: ((kerberos-enabled))
       PXF_JVM_OPTS: ((pxf-jvm-opts))
       PXF_VERSION: 5
-  - task: Upgrade to PXF 6
+  - task: upgrade_to_pxf_6
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/upgrade_pxf_on_ccp.yml
@@ -1346,7 +1346,7 @@ jobs:
       GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GP_VER: [[gp_ver]]
       PXF_BASE_DIR: /home/gpadmin/pxf-boot
-  - task: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
     attempts: 2
@@ -1361,7 +1361,7 @@ jobs:
       GROUP: security,proxySecurity,proxySecurityIpa,multiClusterSecurity
       PXF_BASE_DIR: /home/gpadmin/pxf-boot
       PXF_JVM_OPTS: ((pxf-jvm-opts))
-  - task: Test PXF CLI
+  - task: test_pxf_cli
     on_success:
       in_parallel:
         steps:
@@ -1372,19 +1372,19 @@ jobs:
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/test_pxf_cli.yml
 
-- name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-no-impers_on_rhel7
   max_in_flight: 2
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Testing Gate for PXF-GP]
+      passed: [testing_gate_for_pxf-gp]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: ccp_src
     - get: ccp-7-image
@@ -1409,7 +1409,7 @@ jobs:
             instance_type: n1-standard-4
             ccp_reap_minutes: 120
             standby_master: false
-      - task: Generate Greenplum Cluster
+      - task: generate_greenplum_cluster
         input_mapping:
           gpdb_rpm: gpdb_package
           terraform: terraform_gpdb
@@ -1425,7 +1425,7 @@ jobs:
           CLOUD_PROVIDER: google
           GPDB_RPM: true
       - in_parallel:
-        - task: Initialize Greenplum
+        - task: initialize_greenplum
           file: ccp_src/ci/tasks/gpinitsystem.yml
           params:
             POSTGRES_CONF_ADDONS:
@@ -1434,14 +1434,14 @@ jobs:
             - gp_dispatch_keepalives_idle=30
             - gp_dispatch_keepalives_interval=10
             - gp_dispatch_keepalives_count=4
-        - task: Install Hadoop
+        - task: install_hadoop
           file: pxf_src/concourse/tasks/install_hadoop.yml
           image: gpdb[[gp_ver]]-pxf-dev-centos7-image
           params:
             ACCESS_KEY_ID: ((tf-machine-access-key-id))
             SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
             IMPERSONATION: ((enable-impersonation-multinode))
-    - task: Generate Hadoop Cluster 1
+    - task: generate_hadoop_cluster_1
       file: pxf_src/concourse/tasks/install_dataproc.yml
       params:
         GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
@@ -1450,7 +1450,7 @@ jobs:
         IMAGE_VERSION: ((dataproc-image-version))
         KERBEROS: ((kerberos-enabled))
         ccp_reap_minutes: 120
-    - task: Generate Hadoop Cluster 2
+    - task: generate_hadoop_cluster_2
       file: pxf_src/concourse/tasks/install_dataproc.yml
       output_mapping:
         dataproc_env_files: dataproc_2_env_files
@@ -1469,7 +1469,7 @@ jobs:
         NO_ADDRESS: false
         PROXY_USER: gpuser
         SECRETS_BUCKET: ((ud/pxf/secrets/kerberos-pxf-secrets-bucket-name))
-  - task: Setup PXF
+  - task: setup_pxf
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
@@ -1480,7 +1480,7 @@ jobs:
       GP_VER: [[gp_ver]]
       KERBEROS: ((kerberos-enabled))
       PXF_JVM_OPTS: ((pxf-jvm-opts))
-  - task: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-no-impers_on_rhel7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
     attempts: 2
@@ -1494,7 +1494,7 @@ jobs:
       GP_VER: [[gp_ver]]
       GROUP: security,multiClusterSecurity
       PXF_JVM_OPTS: ((pxf-jvm-opts))
-  - task: Test PXF CLI
+  - task: test_pxf_cli
     on_success:
       in_parallel:
         steps:
@@ -1507,7 +1507,7 @@ jobs:
 
 ## ---------- Multi-node test for GP7 ----------
 {% set gp_ver = 7 %}
-{% set passed = '[Testing Gate for PXF-GP]' %}
+{% set passed = '[testing_gate_for_pxf-gp]' %}
 {% include 'jobs/multinode-tpl.yml'%}
 
 ## ---------- GP7 PXF CLI tests ----------
@@ -1517,60 +1517,60 @@ jobs:
 
 ## ---------- Compatibility Gate ----------
 {% set gp_ver = 6 %}
-- name: Compatibility Gate for PXF-GP
+- name: compatibility_gate_for_pxf-gp
   plan:
   - in_parallel:
     - get: pxf_src
       passed:
-      - Test PXF-GP[[gp_ver]]-HDP2-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP3 on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP2-JDK11 on RHEL7
-      - Test PXF-GP[[gp_ver]]-CDH on RHEL7
-      - Test PXF-GP[[gp_ver]]-FILE-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-S3 on RHEL7
-      - Test PXF-GP[[gp_ver]]-S3-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-ADL-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-GS-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-MINIO-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP2-Upgrade-Extension on RHEL7
+      - test_pxf-gp[[gp_ver]]-hdp2-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp3_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp2-jdk11_on_rhel7
+      - test_pxf-gp[[gp_ver]]-cdh_on_rhel7
+      - test_pxf-gp[[gp_ver]]-file-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-s3_on_rhel7
+      - test_pxf-gp[[gp_ver]]-s3-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-adl-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-gs-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-minio-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp2-upgrade-extension_on_rhel7
 {% set gp_ver = 7 %}
-      - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
-      - Test PXF-GP[[gp_ver]]-CLI on RHEL8
+      - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel8
+      - test_pxf-gp[[gp_ver]]-cli_on_rhel8
 {% set gp_ver = None %}
       trigger: true
 {% set gp_ver = 5 %}
     - get: pxf_gp[[gp_ver]]_tarball_rhel7
       passed:
-      - Testing Gate for PXF-GP
+      - testing_gate_for_pxf-gp
 {% set gp_ver = None %}
 {% set gp_ver = 6 %}
     - get: pxf_gp[[gp_ver]]_tarball_ubuntu18
       passed:
-      - Testing Gate for PXF-GP
+      - testing_gate_for_pxf-gp
     - get: pxf_gp[[gp_ver]]_tarball_rhel8
       passed:
-      - Testing Gate for PXF-GP
+      - testing_gate_for_pxf-gp
     - get: pxf_gp[[gp_ver]]_tarball_rhel7
       passed:
-      - Test PXF-GP[[gp_ver]]-HDP2-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP3 on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP2-JDK11 on RHEL7
-      - Test PXF-GP[[gp_ver]]-CDH on RHEL7
-      - Test PXF-GP[[gp_ver]]-FILE-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-S3 on RHEL7
-      - Test PXF-GP[[gp_ver]]-S3-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-ADL-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-GS-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-MINIO-NO-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
-      - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
+      - test_pxf-gp[[gp_ver]]-hdp2-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp3_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp2-jdk11_on_rhel7
+      - test_pxf-gp[[gp_ver]]-cdh_on_rhel7
+      - test_pxf-gp[[gp_ver]]-file-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-s3_on_rhel7
+      - test_pxf-gp[[gp_ver]]-s3-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-adl-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-gs-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-minio-no-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel7
+      - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-no-impers_on_rhel7
 {% set gp_ver = 7 %}
     - get: pxf_gp[[gp_ver]]_tarball_rhel8
       passed:
-      - Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
-      - Test PXF-GP[[gp_ver]]-CLI on RHEL8
+      - test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel8
+      - test_pxf-gp[[gp_ver]]-cli_on_rhel8
 {% set gp_ver = None %}
 
 ## ---------- Compatibility Testing ----------
@@ -1579,14 +1579,14 @@ jobs:
 {% if gp_ver == 6 %}
   {% set num_versions = num_gpdb6_versions %}
 {% endif %}
-- name: Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL7
+- name: test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Compatibility Gate for PXF-GP]
+      passed: [compatibility_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
-      passed: [Compatibility Gate for PXF-GP]
+      passed: [compatibility_gate_for_pxf-gp]
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: singlecluster
@@ -1600,7 +1600,7 @@ jobs:
       fail_fast: false
       steps:
 {% for i in range(1, num_versions) %}
-      - task: Test Against Greenplum Latest - [[i]] RHEL7
+      - task: test_against_greenplum_latest-[[i]]_rhel7
         image: gpdb[[gp_ver]]-pxf-dev-centos7-image
         config:
           platform: linux
@@ -1624,14 +1624,14 @@ jobs:
 {% endfor %} {# both gp5 and gp6 #}
 
 {% set gp_ver = 6 %}
-- name: Test PXF-GP[[gp_ver]] Backward Compatibility on Ubuntu18
+- name: test_pxf-gp[[gp_ver]]_backward_compatibility_on_ubuntu18
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Compatibility Gate for PXF-GP]
+      passed: [compatibility_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
-      passed: [Compatibility Gate for PXF-GP]
+      passed: [compatibility_gate_for_pxf-gp]
       resource: pxf_gp[[gp_ver]]_tarball_ubuntu18
     - get: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     - get: singlecluster
@@ -1645,7 +1645,7 @@ jobs:
       fail_fast: false
       steps:
 {% for i in range(1, num_gpdb6_versions) %}
-      - task: Test Against Greenplum Latest - [[i]] Ubuntu18
+      - task: test_against_greenplum_latest-[[i]]_ubuntu18
         image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
         config:
           platform: linux
@@ -1668,14 +1668,14 @@ jobs:
 {% set gp_ver = None %}
 
 {% set gp_ver = 6 %}
-- name: Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL8
+- name: test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel8
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Compatibility Gate for PXF-GP]
+      passed: [compatibility_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
-      passed: [Compatibility Gate for PXF-GP]
+      passed: [compatibility_gate_for_pxf-gp]
       resource: pxf_gp[[gp_ver]]_tarball_rhel8
     - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     - get: singlecluster
@@ -1689,7 +1689,7 @@ jobs:
       fail_fast: false
       steps:
 {% for i in range(1, num_gpdb6_versions) %}
-      - task: Test Against Greenplum Latest - [[i]] RHEL8
+      - task: test_against_greenplum_latest-[[i]]_rhel8
         image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
         config:
           platform: linux
@@ -1714,53 +1714,53 @@ jobs:
 ## ---------- This is a No-Op job for GP7 and once the GP7 ----------
 ## ---------- is released this can be updated and like the GP6 job above ----------
 {% set gp_ver = 7 %}
-- name: Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL8
+- name: test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel8
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Compatibility Gate for PXF-GP]
+      passed: [compatibility_gate_for_pxf-gp]
       trigger: true
     - get: pxf_tarball
-      passed: [Compatibility Gate for PXF-GP]
+      passed: [compatibility_gate_for_pxf-gp]
       resource: pxf_gp[[gp_ver]]_tarball_rhel8
 {% set gp_ver = None %}
 
 ## ---------- Artifact Promotion Gate ----------
-- name: Promote PXF for GP5_GP6_GP7 Artifacts
-  old_name: Promote PXF-GP5 and PXF-GP6 Artifacts
+- name: promote_pxf_for_gp5_gp6_gp7_artifacts
+  old_name: Promote pxf-gp5 and pxf-gp6 Artifacts
   plan:
   - in_parallel:
     - get: pxf_src
       trigger: true
       passed:
 {% for gp_ver in range(5, 7) %}
-      - Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL7
+      - test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel7
 {% endfor %}
 {% set gp_ver = None %}
 {% for gp_ver in range(6, 8) %}
-      - Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL8
+      - test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel8
 {% endfor %}
 {% set gp_ver = 6 %}
-      - Test PXF-GP[[gp_ver]] Backward Compatibility on Ubuntu18
+      - test_pxf-gp[[gp_ver]]_backward_compatibility_on_ubuntu18
 {% set gp_ver = None %}
 {% for gp_ver in range(5, 7) %}
     - get: pxf_gp[[gp_ver]]_tarball_rhel7
       passed:
-      - Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL7
+      - test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel7
 {% endfor %}
 {% set gp_ver = None %}
 {% for gp_ver in range(6, 8) %}
     - get: pxf_gp[[gp_ver]]_tarball_rhel8
       passed:
-      - Test PXF-GP[[gp_ver]] Backward Compatibility on RHEL8
+      - test_pxf-gp[[gp_ver]]_backward_compatibility_on_rhel8
 {% endfor %}
 {% set gp_ver = 6 %}
     - get: pxf_gp[[gp_ver]]_tarball_ubuntu18
       passed:
-      - Test PXF-GP[[gp_ver]] Backward Compatibility on Ubuntu18
+      - test_pxf-gp[[gp_ver]]_backward_compatibility_on_ubuntu18
 {% set gp_ver = None %}
     - get: google-cloud-sdk-slim-image
-  - task: Promote PXF for GP5_GP6_GP7 Artifacts
+  - task: promote_pxf_for_gp5_gp6_gp7_artifacts
     image: google-cloud-sdk-slim-image
     file: pxf_src/concourse/tasks/promote_pxf_artifacts.yml
     params:
@@ -1777,20 +1777,20 @@ jobs:
     <<: *slack_alert
 {% endif %}
 
-- name: Publish_PXF-GP5_GP6_GP7_Artifacts_to_GP-RelEng
-  old_name: Publish_PXF-GP5_and_PXF-GP6_Artifacts_to_GP-RelEng
+- name: publish_pxf-gp5_gp6_gp7_artifacts_to_gp-releng
+  old_name: Publish_pxf-gp5_and_pxf-gp6_Artifacts_to_GP-RelEng
   plan:
   - in_parallel:
     - get: pxf_src
       passed:
-      - Promote PXF for GP5_GP6_GP7 Artifacts
+      - promote_pxf_for_gp5_gp6_gp7_artifacts
     - get: pxf_shipit_file
       trigger: true
     - get: google-cloud-sdk-slim-image
     - get: rpmrebuild-centos7-image
     - get: rpmrebuild-rocky8-image
     - get: gpdb6-pxf-dev-ubuntu18-image
-  - task: Get PXF-GP5 and PXF-GP6 Artifacts from Releases Directory
+  - task: get_pxf-gp5_and_pxf-gp6_artifacts_from_releases_directory
     image: google-cloud-sdk-slim-image
     file: pxf_src/concourse/tasks/get_pxf_release_artifacts.yml
     params:
@@ -1801,7 +1801,7 @@ jobs:
       GOOGLE_CREDENTIALS: ((ud/pxf/secrets/pxf-storage-service-account-key))
   #  - in_parallel: does not work since all tasks modify pxf_artifacts
 {% for gp_ver in range(5, 7) %}
-  - task: Add OSL file to PXF-GP[[gp_ver]] RPM on RHEL7
+  - task: add_osl_file_to_pxf-gp[[gp_ver]]_rpm_on_rhel7
     image: rpmrebuild-centos7-image
     file: pxf_src/concourse/tasks/add_osl_rpm.yml
     params:
@@ -1809,19 +1809,19 @@ jobs:
       REDHAT_MAJOR_VERSION: 7
 {% endfor %}
 {% set gp_ver = 6 %}
-  - task: Add OSL file to PXF-GP[[gp_ver]] RPM on RHEL8
+  - task: add_osl_file_to_pxf-gp[[gp_ver]]_rpm_on_rhel8
     image: rpmrebuild-rocky8-image
     file: pxf_src/concourse/tasks/add_osl_rpm.yml
     params:
       GP_VER: [[gp_ver]]
       REDHAT_MAJOR_VERSION: 8
-  - task: Add OSL file to PXF-GP[[gp_ver]] DEB on Ubuntu 18.04
+  - task: add_osl_file_to_pxf-gp[[gp_ver]]_deb_on_ubuntu18.04
     file: pxf_src/concourse/tasks/add_osl_deb.yml
     image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     params:
       GP_VER: [[gp_ver]]
 {% set gp_ver = 7 %}
-  - task: Add OSL file to PXF-GP[[gp_ver]] RPM on RHEL8
+  - task: add_osl_file_to_pxf-gp[[gp_ver]]_rpm_on_rhel8
     image: rpmrebuild-rocky8-image
     file: pxf_src/concourse/tasks/add_osl_rpm.yml
     params:
@@ -1829,13 +1829,13 @@ jobs:
       REDHAT_MAJOR_VERSION: 8
 {% set gp_ver = None %}
 {% for gp_ver in range(5, 7) %}
-  - task: Generate PXF binary tarball from PXF-GP[[gp_ver]] on RHEL7 RPM
+  - task: generate_pxf_binary_tarball_from_pxf-gp[[gp_ver]]_on_rhel7_rpm
     file: pxf_src/concourse/tasks/generate_tarball_from_rpm.yml
     image: rpmrebuild-centos7-image
     params:
       GP_VER: [[gp_ver]]
 {% endfor %}
-  - task: Generate Slack Message
+  - task: generate_slack_message
     image: google-cloud-sdk-slim-image
     file: pxf_src/concourse/tasks/generate_slack_message.yml
     params:

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -131,8 +131,8 @@ anchors:
     run:
       path: pxf_src/concourse/scripts/cleanup_dataproc_cluster.bash
     inputs:
-      - name: pxf_src
-      - name: dataproc_env_files
+    - name: pxf_src
+    - name: dataproc_env_files
     platform: linux
   image: ccp-7-image
   params:
@@ -148,8 +148,8 @@ anchors:
     run:
       path: pxf_src/concourse/scripts/cleanup_dataproc_cluster.bash
     inputs:
-      - name: pxf_src
-      - name: dataproc_env_files
+    - name: pxf_src
+    - name: dataproc_env_files
     platform: linux
   image: ccp-7-image
   params:
@@ -285,10 +285,10 @@ resources:
     branch: ((pxf-git-branch))
     uri: ((ud/pxf/common/git-remote))
     ignore_paths:
-      - docs/**
-      - singlecluster/**
-      - NOTICE
-      - README.md
+    - docs/**
+    - singlecluster/**
+    - NOTICE
+    - README.md
 
 - name: ccp_src
   type: git
@@ -388,7 +388,7 @@ resources:
     tag: latest
     username: _json_key
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
-{% endfor %} {# gp5, gp6 #}
+{% endfor %}{# gp5, gp6 #}
 
 {% for gp_ver in range(6, 8) %}
 - name: gpdb[[gp_ver]]-pxf-dev-rocky8-image
@@ -399,7 +399,7 @@ resources:
     tag: latest
     username: _json_key
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
-{% endfor %} {# gp6, gp7 #}
+{% endfor %}{# gp6, gp7 #}
 {% set gp_ver = None %}
 
 - name: gpdb6-pxf-dev-oel7-image
@@ -477,7 +477,7 @@ resources:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel7-x86_64.rpm
-{% endfor %} {# range(num_gpdb5_versions) #}
+{% endfor %}{# range(num_gpdb5_versions) #}
 {% set gp_ver = None %}
 
 {% set gp_ver = 6 %}
@@ -497,7 +497,7 @@ resources:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-ubuntu18.04-amd64.deb
-{% endfor %} {# range(num_gpdb6_versions) #}
+{% endfor %}{# range(num_gpdb6_versions) #}
 {% set gp_ver = None %}
 
 {% set gp_ver = 6 %}
@@ -509,7 +509,7 @@ resources:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-rhel8-x86_64.rpm
-{% endfor %} {# range(num_gpdb6_versions) #}
+{% endfor %}{# range(num_gpdb6_versions) #}
 {% set gp_ver = None %}
 
 {% set gp_ver = 7 %}
@@ -521,7 +521,7 @@ resources:
     bucket: ((ud/pxf/common/pivnet-artifacts-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     regexp: latest-[[i]]_gpdb[[gp_ver]]/greenplum-db-([[gp_ver]].*)-el8-x86_64.rpm
-{% endfor %} {# range(num_gpdb7_versions) #}
+{% endfor %}{# range(num_gpdb7_versions) #}
 {% set gp_ver = None %}
 
 ## ---------- PXF 5 (for GPDB 6) Artifact ---------------
@@ -654,7 +654,7 @@ jobs:
       GP_VER: [[gp_ver]]
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-{% endfor %} {# gp_ver 5 and 6 #}
+{% endfor %}{# gp_ver 5 and 6 #}
 
 - name: test_pxf-gp6-hdp2_on_oel7
   plan:
@@ -779,7 +779,7 @@ jobs:
       GP_VER: [[gp_ver]]
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-{% endfor %} {# gp_ver 6 and 7 #}
+{% endfor %}{# gp_ver 6 and 7 #}
 {% set gp_ver = None %}
 
 ## ---------- Testing Gate ----------
@@ -801,7 +801,7 @@ jobs:
     - get: pxf_gp5_tarball_rhel7
       passed: [test_pxf-gp5-hdp2_on_rhel7]
     - get: gpdb5_rhel7_rpm_latest-0
-      passed: [ test_pxf-gp5-hdp2_on_rhel7 ]
+      passed: [test_pxf-gp5-hdp2_on_rhel7]
 {% set gp_ver = 6 %}
     - get: pxf_gp[[gp_ver]]_tarball_ubuntu18
       passed: [test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18]
@@ -970,7 +970,7 @@ jobs:
       passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_package
-      resource: pxf6_6_gp6_rhel7_released # for upgrade test
+      resource: pxf6_6_gp6_rhel7_released   # for upgrade test
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
       passed: [testing_gate_for_pxf-gp]
@@ -1226,7 +1226,7 @@ jobs:
       passed: [testing_gate_for_pxf-gp]
       trigger: true
     - get: pxf_artifact
-      resource: pxf5_gp6_rhel7_released # for upgrade test
+      resource: pxf5_gp6_rhel7_released   # for upgrade test
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
       passed: [testing_gate_for_pxf-gp]
@@ -1309,7 +1309,7 @@ jobs:
         NO_ADDRESS: false
         PROXY_USER: gpuser
         SECRETS_BUCKET: ((ud/pxf/secrets/kerberos-pxf-secrets-bucket-name))
-    - do: # Generate IPA Hadoop cluster
+    - do:   # Generate IPA Hadoop cluster
       - put: terraform_ipa_hadoop
         params:
           action: create
@@ -1327,7 +1327,7 @@ jobs:
   - task: setup_pxf_5_latest
     input_mapping:
       terraform: terraform_gpdb
-      pxf_tarball: pxf_tarball_ignore # do not install from the artifact
+      pxf_tarball: pxf_tarball_ignore   # do not install from the artifact
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
     image: ccp-7-image
     params:
@@ -1621,7 +1621,7 @@ jobs:
             path: pxf_src/concourse/scripts/test.bash
 {% endfor %}
 {% set num_versions = None %}
-{% endfor %} {# both gp5 and gp6 #}
+{% endfor %}{# both gp5 and gp6 #}
 
 {% set gp_ver = 6 %}
 - name: test_pxf-gp[[gp_ver]]_backward_compatibility_on_ubuntu18

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -848,6 +848,7 @@ jobs:
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
     image: ccp-7-image
     params:
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GP_VER: [[gp_ver]]
       IMPERSONATION: true
       INSTALL_GPHDFS: false
@@ -868,6 +869,7 @@ jobs:
     file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       BASE_PATH: /mnt/nfs/var/nfsshare
       GP_VER: [[gp_ver]]
       GROUP: hcfs
@@ -1183,6 +1185,7 @@ jobs:
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
     image: ccp-7-image
     params:
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GP_VER: [[gp_ver]]
       IMPERSONATION: true
       INSTALL_GPHDFS: false
@@ -1195,7 +1198,6 @@ jobs:
     file: pxf_src/concourse/tasks/upgrade_pxf_on_ccp.yml
     image: ccp-7-image
     params:
-      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GP_VER: [[gp_ver]]
       PXF_BASE_DIR: /home/gpadmin/pxf-boot
   - task: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
@@ -1203,12 +1205,12 @@ jobs:
     file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
     attempts: 2
     params:
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       ACCESS_KEY_ID: ((tf-machine-access-key-id))
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
       HIVE_VERSION: 2
       IMPERSONATION: true
       KERBEROS: ((kerberos-enabled))
-      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GP_VER: [[gp_ver]]
       GROUP: security,proxySecurity,proxySecurityIpa,multiClusterSecurity
       PXF_BASE_DIR: /home/gpadmin/pxf-boot
@@ -1331,6 +1333,7 @@ jobs:
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
     image: ccp-7-image
     params:
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       IMPERSONATION: false
       INSTALL_GPHDFS: false
       GP_VER: [[gp_ver]]
@@ -1341,12 +1344,12 @@ jobs:
     file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
     attempts: 2
     params:
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       ACCESS_KEY_ID: ((tf-machine-access-key-id))
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
       HIVE_VERSION: 2
       IMPERSONATION: false
       KERBEROS: ((kerberos-enabled))
-      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GP_VER: [[gp_ver]]
       GROUP: security,multiClusterSecurity
       PXF_JVM_OPTS: ((pxf-jvm-opts))

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -9,8 +9,8 @@ anchors:
     run:
       path: pxf_src/concourse/scripts/cleanup_dataproc_cluster.bash
     inputs:
-      - name: pxf_src
-      - name: dataproc_env_files
+    - name: pxf_src
+    - name: dataproc_env_files
     platform: linux
   image: ccp-7-image
   params:
@@ -26,8 +26,8 @@ anchors:
     run:
       path: pxf_src/concourse/scripts/cleanup_dataproc_cluster.bash
     inputs:
-      - name: pxf_src
-      - name: dataproc_env_files
+    - name: pxf_src
+    - name: dataproc_env_files
     platform: linux
   image: ccp-7-image
   params:
@@ -190,7 +190,7 @@ resources:
     tag: ((pxf-dev-image-tag))
     username: _json_key
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
-{% endfor %} {# gp5, gp6, and gp7 #}
+{% endfor %}{# gp5, gp6, and gp7 #}
 
 {% for gp_ver in range(6, 8) %}
 - name: gpdb[[gp_ver]]-pxf-dev-rocky8-image
@@ -223,7 +223,6 @@ resources:
     tag: ((pxf-dev-image-tag))
     username: _json_key
     password: ((ud/pxf/secrets/pxf-cloudbuild-service-account-key))
-
 {% set gp_ver = None %}
 
 {% if multinode or multinode_no_impersonation or ambari or file or gp7_cli or gp7_multinode %}
@@ -541,23 +540,23 @@ jobs:
 - name: test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
   plan:
   - in_parallel:
-      - get: pxf_src
-        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-        trigger: true
-      - get: pxf_tarball
-        resource: pxf_gp[[gp_ver]]_tarball_rhel8
-        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-      - get: gpdb_package
-        resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-      - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-      - get: pxf-automation-dependencies
+    - get: pxf_src
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+      trigger: true
+    - get: pxf_tarball
+      resource: pxf_gp[[gp_ver]]_tarball_rhel8
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+    - get: gpdb_package
+      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+    - get: pxf-automation-dependencies
 {% if gp_ver == 7 %}
-      - get: gp6-python-libs
+    - get: gp6-python-libs
 {% endif %}
-      - get: singlecluster
-        resource: singlecluster-hdp2
+    - get: singlecluster
+      resource: singlecluster-hdp2
   - task: test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
@@ -574,28 +573,28 @@ jobs:
 - name: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_rhel8
   plan:
   - in_parallel:
-      - get: pxf_src
-        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-        trigger: true
-      - get: pxf_tarball
-        resource: pxf_gp[[gp_ver]]_tarball_rhel8
-        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+    - get: pxf_src
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+      trigger: true
+    - get: pxf_tarball
+      resource: pxf_gp[[gp_ver]]_tarball_rhel8
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
 {% if gp_ver == 6 %}
-      - get: pxf_fdw_tarball
-        resource: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
-        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+    - get: pxf_fdw_tarball
+      resource: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
 {% endif %}
-      - get: gpdb_package
-        resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+    - get: gpdb_package
+      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
 {% if gp_ver == 7 %}
-      - get: gp6-python-libs
+    - get: gp6-python-libs
 {% endif %}
-      - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-      - get: pxf-automation-dependencies
-      - get: singlecluster
-        resource: singlecluster-hdp2
+    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+    - get: pxf-automation-dependencies
+    - get: singlecluster
+      resource: singlecluster-hdp2
   - task: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_rhel8
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
@@ -618,7 +617,7 @@ jobs:
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}
-{% endif %} # if gp7_cli ends here
+{% endif %}   # if gp7_cli ends here
 {% set gp_ver = None %}
 
 ## ---------- Extended Tests ----------
@@ -1080,7 +1079,7 @@ jobs:
       passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_artifact
-      resource: pxf5_gp6_rhel7_released # for upgrade test
+      resource: pxf5_gp6_rhel7_released   # for upgrade test
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
       passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
@@ -1163,7 +1162,7 @@ jobs:
         NO_ADDRESS: false
         PROXY_USER: gpuser
         SECRETS_BUCKET: ((ud/pxf/secrets/kerberos-pxf-secrets-bucket-name))
-    - do: # Generate IPA Hadoop cluster
+    - do:   # Generate IPA Hadoop cluster
       - put: terraform_ipa_hadoop
         params:
           action: create
@@ -1181,7 +1180,7 @@ jobs:
   - task: setup_pxf_5_latest
     input_mapping:
       terraform: terraform_gpdb
-      pxf_tarball: pxf_tarball_ignore # do not install from the artifact
+      pxf_tarball: pxf_tarball_ignore   # do not install from the artifact
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
     image: ccp-7-image
     params:
@@ -1377,5 +1376,5 @@ jobs:
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}
-{% endif %} # if gp7_multinode ends here
+{% endif %}   # if gp7_multinode ends here
 {% set gp_ver = None %}

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -4,7 +4,7 @@
 ## ======================================================================
 anchors:
 - &destroy_dataproc_1
-  task: Cleanup Dataproc 1
+  task: cleanup_dataproc_1
   config:
     run:
       path: pxf_src/concourse/scripts/cleanup_dataproc_cluster.bash
@@ -19,7 +19,7 @@ anchors:
     GOOGLE_ZONE: ((ud/pxf/common/google-zone))
 
 - &destroy_dataproc_2
-  task: Cleanup Dataproc 2
+  task: cleanup_dataproc_2
   input_mapping:
     dataproc_env_files: dataproc_2_env_files
   config:
@@ -381,7 +381,7 @@ jobs:
 
 ## ---------- Centos 7 Swimlane ----------
 {% for gp_ver in range(5, 7) %}
-- name: Build PXF-GP[[gp_ver]] on RHEL7
+- name: build_pxf-gp[[gp_ver]]_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
@@ -390,7 +390,7 @@ jobs:
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-build-dependencies
-  - task: Build PXF-GP[[gp_ver]] on RHEL7
+  - task: build_pxf-gp[[gp_ver]]_on_rhel7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/build.yml
     params:
@@ -400,24 +400,24 @@ jobs:
     params:
       file: dist/pxf-gp[[gp_ver]]-*.el7.tar.gz
 
-- name: Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2 on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -431,23 +431,23 @@ jobs:
 {% endfor %}
 
 {% if oel7 %}
-- name: Test PXF-GP6-HDP2 on OEL7
+- name: test_pxf-gp6-hdp2_on_oel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP6 on RHEL7]
+      passed: [build_pxf-gp6_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp6_tarball_rhel7
-      passed: [Build PXF-GP6 on RHEL7]
+      passed: [build_pxf-gp6_on_rhel7]
     - get: gpdb_package
       resource: gpdb6_rhel7_rpm_latest-0
-      passed: [Build PXF-GP6 on RHEL7]
+      passed: [build_pxf-gp6_on_rhel7]
     - get: gpdb6-pxf-dev-oel7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP6-HDP2 on OEL7
+  - task: test_pxf-gp6-hdp2_on_oel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb6-pxf-dev-oel7-image
     params:
@@ -462,7 +462,7 @@ jobs:
 
 ## ---------- Ubuntu 18 Swimlane ----------
 {% set gp_ver = 6 %}
-- name: Build PXF-GP[[gp_ver]] on Ubuntu18
+- name: build_pxf-gp[[gp_ver]]_on_ubuntu18
   plan:
   - in_parallel:
     - get: pxf_src
@@ -471,7 +471,7 @@ jobs:
       resource: gpdb[[gp_ver]]_ubuntu18_deb_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     - get: pxf-build-dependencies
-  - task: Build PXF-GP[[gp_ver]] on Ubuntu18
+  - task: build_pxf-gp[[gp_ver]]_on_ubuntu18
     image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     file: pxf_src/concourse/tasks/build.yml
     params:
@@ -481,24 +481,24 @@ jobs:
     params:
       file: dist/pxf-gp[[gp_ver]]-*-ubuntu18.04.tar.gz
 
-- name: Test PXF-GP[[gp_ver]]-HDP2 on Ubuntu18
+- name: test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on Ubuntu18]
+      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_ubuntu18
-      passed: [Build PXF-GP[[gp_ver]] on Ubuntu18]
+      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_ubuntu18_deb_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on Ubuntu18]
+      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
     - get: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
-      passed: [Build PXF-GP[[gp_ver]] on Ubuntu18]
+      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2 on Ubuntu18
+  - task: test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     params:
@@ -514,7 +514,7 @@ jobs:
 
 ## ---------- RHEL 8 Swimlane (uses Rocky 8 images) ----------
 {% for gp_ver in range(6, 8) %}
-- name: Build PXF-GP[[gp_ver]] on RHEL8
+- name: build_pxf-gp[[gp_ver]]_on_rhel8
   plan:
   - in_parallel:
     - get: pxf_src
@@ -523,7 +523,7 @@ jobs:
       resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
     - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     - get: pxf-build-dependencies
-  - task: Build PXF-GP[[gp_ver]] on RHEL8
+  - task: build_pxf-gp[[gp_ver]]_on_rhel8
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     file: pxf_src/concourse/tasks/build.yml
     params:
@@ -538,27 +538,27 @@ jobs:
       file: dist/pxf-fdw-gp[[gp_ver]]-*.el8.tar.gz
 {% endif %}
 
-- name: Test PXF-GP[[gp_ver]]-HDP2 on RHEL8
+- name: test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
   plan:
   - in_parallel:
       - get: pxf_src
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
         trigger: true
       - get: pxf_tarball
         resource: pxf_gp[[gp_ver]]_tarball_rhel8
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
       - get: gpdb_package
         resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
       - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
       - get: pxf-automation-dependencies
 {% if gp_ver == 7 %}
       - get: gp6-python-libs
 {% endif %}
       - get: singlecluster
         resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2 on RHEL8
+  - task: test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     params:
@@ -571,32 +571,32 @@ jobs:
 
 ## ---------- FDW RHEL 8 Swimlane ----------
 {% for gp_ver in range(6, 8) %}
-- name: Test PXF-FDW-GP[[gp_ver]]-HDP2 on RHEL8
+- name: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_rhel8
   plan:
   - in_parallel:
       - get: pxf_src
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
         trigger: true
       - get: pxf_tarball
         resource: pxf_gp[[gp_ver]]_tarball_rhel8
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
 {% if gp_ver == 6 %}
       - get: pxf_fdw_tarball
         resource: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
 {% endif %}
       - get: gpdb_package
         resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
 {% if gp_ver == 7 %}
       - get: gp6-python-libs
 {% endif %}
       - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-        passed: [Build PXF-GP[[gp_ver]] on RHEL8]
+        passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
       - get: pxf-automation-dependencies
       - get: singlecluster
         resource: singlecluster-hdp2
-  - task: Test PXF-FDW-GP[[gp_ver]]-HDP2 on RHEL8
+  - task: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_rhel8
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     params:
@@ -612,7 +612,7 @@ jobs:
 
 {% if gp7_cli %}
 {% set gp_ver = 7 %}
-{% set passed = '[Build PXF-GP7 on RHEL8]' %}
+{% set passed = '[build_pxf-gp7_on_rhel8]' %}
 {% include 'jobs/cli-tpl.yml' %}
 {% set passed = None %}
 {% if slack_notification %}
@@ -624,23 +624,23 @@ jobs:
 ## ---------- Extended Tests ----------
 {% set gp_ver = 6 %}
 {% if hdp2 %}
-- name: Test PXF-GP[[gp_ver]]-HDP2-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -652,23 +652,23 @@ jobs:
 {% endif %}
 
 {% if hdp3 %}
-- name: Test PXF-GP[[gp_ver]]-HDP3 on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp3_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp3
-  - task: Test PXF-GP[[gp_ver]]-HDP3 on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp3_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -682,17 +682,17 @@ jobs:
 {% endif %}
 
 {% if ambari %}
-- name: Test PXF-GP[[gp_ver]]-HDP3-SECURE AMBARI (MANUAL) on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp3-secure_ambari_manual_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: ccp-7-image
     - get: pxf-automation-dependencies
@@ -705,7 +705,7 @@ jobs:
       GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
       GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GOOGLE_ZONE: ((ud/pxf/common/google-zone))
-  - task: Test PXF-GP[[gp_ver]]-HDP3-SECURE AMBARI (MANUAL) on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp3-secure_ambari_manual_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -720,23 +720,23 @@ jobs:
 {% endif %}
 
 {% if jdk11 %}
-- name: Test PXF-GP[[gp_ver]]-HDP2-JDK11 on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2-jdk11_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-HDP2-JDK11 on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2-jdk11_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -751,23 +751,23 @@ jobs:
 {% endif %}
 
 {% if cdh %}
-- name: Test PXF-GP[[gp_ver]]-CDH on RHEL7
+- name: test_pxf-gp[[gp_ver]]-cdh_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-cdh
-  - task: Test PXF-GP[[gp_ver]]-CDH on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-cdh_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     # CDH often fails on HBASE permission grant
@@ -786,19 +786,19 @@ jobs:
 ## ---------- FILE tests -----------------
 
 {% if file %}
-- name: Test PXF-GP[[gp_ver]]-FILE-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-file-no-impers_on_rhel7
   max_in_flight: 2
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: ccp_src
     - get: ccp-7-image
@@ -818,7 +818,7 @@ jobs:
         segments_per_host: 4
         instance_type: n1-standard-4
         ccp_reap_minutes: 60
-  - task: Generate Greenplum Cluster
+  - task: generate_greenplum_cluster
     input_mapping:
       gpdb_rpm: gpdb_package
       terraform: terraform_gpdb
@@ -833,16 +833,16 @@ jobs:
       PLATFORM: centos7
       CLOUD_PROVIDER: google
       GPDB_RPM: true
-  - task: Initialize Greenplum
+  - task: initialize_greenplum
     file: ccp_src/ci/tasks/gpinitsystem.yml
-  - task: Setup NFS
+  - task: setup-nfs
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/install_nfs_on_ccp.yml
     image: ccp-7-image
     params:
       BASE_PATH: /mnt/nfs/var/nfsshare
-  - task: Setup PXF
+  - task: setup_pxf
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
@@ -854,7 +854,7 @@ jobs:
       INSTALL_GPHDFS: false
       PXF_JVM_OPTS: ((pxf-jvm-opts))
       SKIP_HADOOP_SETUP: true
-  - task: Test PXF-GP[[gp_ver]]-FILE-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-file-no-impers_on_rhel7
     on_success:
       do:
       - put: terraform_gpdb
@@ -883,23 +883,23 @@ jobs:
 ## ---------- HCFS Cloud tests ----------
 
 {% if s3 %}
-- name: Test PXF-GP[[gp_ver]]-S3 on RHEL7
+- name: test_pxf-gp[[gp_ver]]-s3_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-S3 on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-s3_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -912,23 +912,23 @@ jobs:
     <<: *slack_alert
 {% endif %}
 
-- name: Test PXF-GP[[gp_ver]]-S3-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-s3-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-S3-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-s3-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -944,23 +944,23 @@ jobs:
 {% endif %}
 
 {% if adl %}
-- name: Test PXF-GP[[gp_ver]]-ADL-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-adl-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-ADL-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-adl-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -978,23 +978,23 @@ jobs:
 {% endif %}
 
 {% if wasb %}
-- name: Test PXF-GP[[gp_ver]]-WASB-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-wasb-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-WASB-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-wasb-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -1010,23 +1010,23 @@ jobs:
 {% endif %}
 
 {% if gs %}
-- name: Test PXF-GP[[gp_ver]]-GS-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-gs-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-GS-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-gs-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -1041,23 +1041,23 @@ jobs:
 {% endif %}
 
 {% if minio %}
-- name: Test PXF-GP[[gp_ver]]-MINIO-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-minio-no-impers_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Test PXF-GP[[gp_ver]]-MINIO-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-minio-no-impers_on_rhel7
     file: pxf_src/concourse/tasks/test.yml
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     params:
@@ -1072,21 +1072,21 @@ jobs:
 
 ## ---------- Multi-node tests ----------
 {% if multinode %}
-- name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel7
   max_in_flight: 2
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_artifact
       resource: pxf5_gp6_rhel7_released # for upgrade test
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: ccp_src
     - get: ccp-7-image
@@ -1110,7 +1110,7 @@ jobs:
             instance_type: n1-standard-4
             ccp_reap_minutes: 120
             standby_master: true
-      - task: Generate Greenplum Cluster
+      - task: generate_greenplum_cluster
         input_mapping:
           gpdb_rpm: gpdb_package
           terraform: terraform_gpdb
@@ -1126,16 +1126,16 @@ jobs:
           CLOUD_PROVIDER: google
           GPDB_RPM: true
       - in_parallel:
-        - task: Initialize Greenplum
+        - task: initialize_greenplum
           file: ccp_src/ci/tasks/gpinitsystem.yml
-        - task: Install Hadoop
+        - task: install_hadoop
           file: pxf_src/concourse/tasks/install_hadoop.yml
           image: gpdb[[gp_ver]]-pxf-dev-centos7-image
           params:
             ACCESS_KEY_ID: ((tf-machine-access-key-id))
             SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
             IMPERSONATION: ((enable-impersonation-multinode))
-    - task: Generate Hadoop Cluster 1
+    - task: generate_hadoop_cluster_1
       file: pxf_src/concourse/tasks/install_dataproc.yml
       params:
         GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
@@ -1144,7 +1144,7 @@ jobs:
         IMAGE_VERSION: ((dataproc-image-version))
         KERBEROS: ((kerberos-enabled))
         ccp_reap_minutes: 120
-    - task: Generate Hadoop Cluster 2
+    - task: generate_hadoop_cluster_2
       file: pxf_src/concourse/tasks/install_dataproc.yml
       output_mapping:
         dataproc_env_files: dataproc_2_env_files
@@ -1171,14 +1171,14 @@ jobs:
           terraform_source: pxf_src/concourse/terraform/ipa-multinode-hadoop
           vars:
             gcp_project: ((ud/pxf/common/ipa-google-project-id))
-      - task: Generate Multinode Hadoop Cluster
+      - task: generate_multinode_hadoop_cluster
         file: pxf_src/concourse/tasks/install_multinode_hadoop.yml
         image: gpdb[[gp_ver]]-pxf-dev-centos7-image
         params:
           ANSIBLE_VAR_gcp_storage_bucket: ((ud/pxf/common/build-resources-bucket-name))
           ANSIBLE_VAR_ipa_password: ((ud/pxf/secrets/ipa-password))
           ANSIBLE_VAR_ssl_store_password: ((ud/pxf/secrets/ssl-store-password))
-  - task: Setup PXF 5 Latest
+  - task: setup_pxf_5_latest
     input_mapping:
       terraform: terraform_gpdb
       pxf_tarball: pxf_tarball_ignore # do not install from the artifact
@@ -1192,7 +1192,7 @@ jobs:
       KERBEROS: ((kerberos-enabled))
       PXF_JVM_OPTS: ((pxf-jvm-opts))
       PXF_VERSION: 5
-  - task: Upgrade to PXF 6
+  - task: upgrade_to_pxf_6
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/upgrade_pxf_on_ccp.yml
@@ -1200,7 +1200,7 @@ jobs:
     params:
       GP_VER: [[gp_ver]]
       PXF_BASE_DIR: /home/gpadmin/pxf-boot
-  - task: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
     attempts: 2
@@ -1214,7 +1214,7 @@ jobs:
       GP_VER: [[gp_ver]]
       GROUP: security,proxySecurity,proxySecurityIpa,multiClusterSecurity
       PXF_BASE_DIR: /home/gpadmin/pxf-boot
-  - task: Test PXF CLI
+  - task: test_pxf_cli
     on_success:
       in_parallel:
         steps:
@@ -1230,19 +1230,19 @@ jobs:
 {% endif %}
 
 {% if multinode_no_impersonation %}
-- name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
+- name: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-no-impers_on_rhel7
   max_in_flight: 2
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
       trigger: true
     - get: pxf_tarball
       resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb_package
       resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [Build PXF-GP[[gp_ver]] on RHEL7]
+      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
     - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
     - get: ccp_src
     - get: ccp-7-image
@@ -1267,7 +1267,7 @@ jobs:
             instance_type: n1-standard-4
             ccp_reap_minutes: 120
             standby_master: false
-      - task: Generate Greenplum Cluster
+      - task: generate_greenplum_cluster
         input_mapping:
           gpdb_rpm: gpdb_package
           terraform: terraform_gpdb
@@ -1283,7 +1283,7 @@ jobs:
           CLOUD_PROVIDER: google
           GPDB_RPM: true
       - in_parallel:
-        - task: Initialize Greenplum
+        - task: initialize_greenplum
           file: ccp_src/ci/tasks/gpinitsystem.yml
           params:
             POSTGRES_CONF_ADDONS:
@@ -1292,14 +1292,14 @@ jobs:
             - gp_dispatch_keepalives_idle=30
             - gp_dispatch_keepalives_interval=10
             - gp_dispatch_keepalives_count=4
-        - task: Install Hadoop
+        - task: install_hadoop
           file: pxf_src/concourse/tasks/install_hadoop.yml
           image: gpdb[[gp_ver]]-pxf-dev-centos7-image
           params:
             ACCESS_KEY_ID: ((tf-machine-access-key-id))
             SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
             IMPERSONATION: ((enable-impersonation-multinode))
-    - task: Generate Hadoop Cluster 1
+    - task: generate_hadoop_cluster_1
       file: pxf_src/concourse/tasks/install_dataproc.yml
       params:
         GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
@@ -1308,7 +1308,7 @@ jobs:
         IMAGE_VERSION: ((dataproc-image-version))
         KERBEROS: ((kerberos-enabled))
         ccp_reap_minutes: 120
-    - task: Generate Hadoop Cluster 2
+    - task: generate_hadoop_cluster_2
       file: pxf_src/concourse/tasks/install_dataproc.yml
       output_mapping:
         dataproc_env_files: dataproc_2_env_files
@@ -1327,7 +1327,7 @@ jobs:
         NO_ADDRESS: false
         PROXY_USER: gpuser
         SECRETS_BUCKET: ((ud/pxf/secrets/kerberos-pxf-secrets-bucket-name))
-  - task: Setup PXF
+  - task: setup_pxf
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
@@ -1339,7 +1339,7 @@ jobs:
       GP_VER: [[gp_ver]]
       KERBEROS: ((kerberos-enabled))
       PXF_JVM_OPTS: ((pxf-jvm-opts))
-  - task: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-NO-IMPERS on RHEL7
+  - task: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-no-impers_on_rhel7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
     attempts: 2
@@ -1353,7 +1353,7 @@ jobs:
       GP_VER: [[gp_ver]]
       GROUP: security,multiClusterSecurity
       PXF_JVM_OPTS: ((pxf-jvm-opts))
-  - task: Test PXF CLI
+  - task: test_pxf_cli
     on_success:
       in_parallel:
         steps:
@@ -1371,7 +1371,7 @@ jobs:
 ## ---------- Multi-node test for GP7 ----------
 {% if gp7_multinode %}
 {% set gp_ver = 7 %}
-{% set passed = '[Build PXF-GP7 on RHEL8]' %}
+{% set passed = '[build_pxf-gp7_on_rhel8]' %}
 {% include 'jobs/multinode-tpl.yml'%}
 {% set passed = None %}
 {% if slack_notification %}

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:empty-lines
 ## ======================================================================
 ## ANCHORS
 ## ======================================================================
@@ -180,7 +181,6 @@ resources:
 
 ## ---------- Docker Images ----------
 {% set gp_ver = None %}
-
 {% for gp_ver in range(5, 7) %}
 - name: gpdb[[gp_ver]]-pxf-dev-centos7-image
   type: registry-image
@@ -300,7 +300,6 @@ resources:
 
 ## ---------- PXF Build Artifacts ----------
 {% set gp_ver = None %}
-
 {% for gp_ver in range(5, 7) %}
 - name: pxf_gp[[gp_ver]]_tarball_rhel7
   type: gcs
@@ -617,7 +616,7 @@ jobs:
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}
-{% endif %}   # if gp7_cli ends here
+{% endif %}{# if gp7_cli ends here #}
 {% set gp_ver = None %}
 
 ## ---------- Extended Tests ----------
@@ -1376,5 +1375,5 @@ jobs:
 {% if slack_notification %}
     <<: *slack_alert
 {% endif %}
-{% endif %}   # if gp7_multinode ends here
+{% endif %}{# if gp7_multinode ends here #}
 {% set gp_ver = None %}

--- a/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
+++ b/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
@@ -87,10 +87,10 @@ jobs:
     config:
       platform: linux
       inputs:
-        - name: pxf_src
-        - name: pivnet_cli
+      - name: pxf_src
+      - name: pivnet_cli
       outputs:
-        - name: pivnet_cli
+      - name: pivnet_cli
       params:
         PIVNET_CLI_DIR: pivnet_cli
       run:
@@ -119,15 +119,15 @@ jobs:
     config:
       platform: linux
       inputs:
-        - name: pxf_src
-        - name: pivnet_cli
-        - name: gpdb5_rhel7_rpm_latest-[[i]]
-        {% if i > 0 %}
-        # save a download from pivnet if not fetching latest
-        - name: gpdb5_rhel7_rpm_latest-[[i - 1]]
-        {% endif %}
+      - name: pxf_src
+      - name: pivnet_cli
+      - name: gpdb5_rhel7_rpm_latest-[[i]]
+      {% if i > 0 %}
+      # save a download from pivnet if not fetching latest
+      - name: gpdb5_rhel7_rpm_latest-[[i - 1]]
+      {% endif %}
       outputs:
-        - name: gpdb5_rhel7_rpm_latest-[[i]]
+      - name: gpdb5_rhel7_rpm_latest-[[i]]
       params:
         GPDB_VERSION: 5
         LIST_OF_DIRS: gpdb5_rhel7_rpm_latest-[[i]]
@@ -165,21 +165,21 @@ jobs:
     config:
       platform: linux
       inputs:
-        - name: pxf_src
-        - name: pivnet_cli
-        - name: gpdb6_rhel7_rpm_latest-[[i]]
-        - name: gpdb6_rhel8_rpm_latest-[[i]]
-        - name: gpdb6_ubuntu18_deb_latest-[[i]]
-        {% if i > 0 %}
-        # save a download from pivnet if not fetching latest
-        - name: gpdb6_rhel7_rpm_latest-[[i - 1]]
-        - name: gpdb6_rhel8_rpm_latest-[[i - 1]]
-        - name: gpdb6_ubuntu18_deb_latest-[[i - 1]]
-        {% endif %}
+      - name: pxf_src
+      - name: pivnet_cli
+      - name: gpdb6_rhel7_rpm_latest-[[i]]
+      - name: gpdb6_rhel8_rpm_latest-[[i]]
+      - name: gpdb6_ubuntu18_deb_latest-[[i]]
+      {% if i > 0 %}
+      # save a download from pivnet if not fetching latest
+      - name: gpdb6_rhel7_rpm_latest-[[i - 1]]
+      - name: gpdb6_rhel8_rpm_latest-[[i - 1]]
+      - name: gpdb6_ubuntu18_deb_latest-[[i - 1]]
+      {% endif %}
       outputs:
-        - name: gpdb6_rhel7_rpm_latest-[[i]]
-        - name: gpdb6_rhel8_rpm_latest-[[i]]
-        - name: gpdb6_ubuntu18_deb_latest-[[i]]
+      - name: gpdb6_rhel7_rpm_latest-[[i]]
+      - name: gpdb6_rhel8_rpm_latest-[[i]]
+      - name: gpdb6_ubuntu18_deb_latest-[[i]]
       params:
         GPDB_VERSION: 6
         LIST_OF_DIRS: gpdb6_rhel7_rpm_latest-[[i]],gpdb6_rhel8_rpm_latest-[[i]],gpdb6_ubuntu18_deb_latest-[[i]]

--- a/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
+++ b/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
@@ -73,7 +73,7 @@ resources:
 {% endfor %}
 
 jobs:
-- name: Download Latest PivNet CLI
+- name: download_latest_pivnet_cli
   plan:
   - in_parallel:
     - get: twice-a-day
@@ -81,7 +81,7 @@ jobs:
     - get: pxf_src
     - get: ubuntu18
     - get: pivnet_cli
-  - task: Get Latest PivNet CLI
+  - task: get_latest_pivnet_cli
     attempts: [[attempts]]
     image: ubuntu18
     config:
@@ -99,20 +99,20 @@ jobs:
     params:
       file: pivnet_cli/pivnet
 
-- name: Get Greenplum Product Files GP5
+- name: get_greenplum_product_files_gp5
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Download Latest PivNet CLI]
+      passed: [download_latest_pivnet_cli]
     - get: ubuntu18
     - get: pivnet_cli
-      passed: [Download Latest PivNet CLI]
+      passed: [download_latest_pivnet_cli]
       trigger: true
 {% for i in range(num_gpdb5_versions) %}
     - get: gpdb5_rhel7_rpm_latest-[[i]]
 {% endfor %}
 {% for i in range(num_gpdb5_versions - 1, -1, -1) %}
-  - task: Get Greenplum Product Files GP5 Latest - [[i]]
+  - task: get_greenplum_product_files_gp5_latest-[[i]]
     attempts: [[attempts]]
     # this task will fail on centos6
     image: ubuntu18
@@ -143,14 +143,14 @@ jobs:
       file: gpdb5_rhel7_rpm_latest-[[i]]/greenplum-db-5.*-rhel7-x86_64.rpm
 {% endfor %}
 
-- name: Get Greenplum Product Files GP6
+- name: get_greenplum_product_files_gp6
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [Download Latest PivNet CLI]
+      passed: [download_latest_pivnet_cli]
     - get: ubuntu18
     - get: pivnet_cli
-      passed: [Download Latest PivNet CLI]
+      passed: [download_latest_pivnet_cli]
       trigger: true
 {% for i in range(num_gpdb6_versions) %}
     - get: gpdb6_rhel7_rpm_latest-[[i]]
@@ -158,7 +158,7 @@ jobs:
     - get: gpdb6_ubuntu18_deb_latest-[[i]]
 {% endfor %}
 {% for i in range(num_gpdb6_versions - 1, -1, -1) %}
-  - task: Get Greenplum Product Files GP6 Latest - [[i]]
+  - task: get_greenplum_product_files_gp6_latest-[[i]]
     attempts: [[attempts]]
     # this task will fail on centos6
     image: ubuntu18

--- a/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
+++ b/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
@@ -183,6 +183,7 @@ jobs:
       params:
         GPDB_VERSION: 6
         LIST_OF_DIRS: gpdb6_rhel7_rpm_latest-[[i]],gpdb6_rhel8_rpm_latest-[[i]],gpdb6_ubuntu18_deb_latest-[[i]]
+        # yamllint disable rule:line-length
         LIST_OF_PRODUCTS: greenplum-db-GPDB_VERSION-rhel7-x86_64.rpm,greenplum-db-GPDB_VERSION-rhel8-x86_64.rpm,greenplum-db-GPDB_VERSION-ubuntu18.04-amd64.deb
         PIVNET_API_TOKEN: ((ud/pxf/secrets/pivnet-uaa-refresh-token))
         PIVNET_CLI_DIR: pivnet_cli

--- a/concourse/pipelines/templates/jobs/cli-tpl.yml
+++ b/concourse/pipelines/templates/jobs/cli-tpl.yml
@@ -58,6 +58,7 @@
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
     image: ccp-7-image
     params:
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       IMPERSONATION: false
       INSTALL_GPHDFS: false
       GP_VER: [[gp_ver]]

--- a/concourse/pipelines/templates/jobs/cli-tpl.yml
+++ b/concourse/pipelines/templates/jobs/cli-tpl.yml
@@ -2,7 +2,7 @@
 ## - gp_ver = Greenplum Major Version
 ## - passed = upstream job name that the artifacts need to pass before this job
 
-- name: Test PXF-GP[[gp_ver]]-CLI on RHEL8
+- name: test_pxf-gp[[gp_ver]]-cli_on_rhel8
   max_in_flight: 2
   plan:
   - in_parallel:
@@ -35,7 +35,7 @@
             instance_type: n1-standard-4
             ccp_reap_minutes: 120
             standby_master: true
-      - task: Generate Greenplum Cluster
+      - task: generate_greenplum_cluster
         input_mapping:
           gpdb_rpm: gpdb_package
           terraform: terraform_gpdb
@@ -50,9 +50,9 @@
           PLATFORM: rocky8-gpdb[[gp_ver]]
           CLOUD_PROVIDER: google
           GPDB_RPM: true
-  - task: Initialize Greenplum
+  - task: initialize_greenplum
     file: ccp_src/ci/tasks/gpinitsystem.yml
-  - task: Setup PXF
+  - task: setup_pxf
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
@@ -63,7 +63,7 @@
       INSTALL_GPHDFS: false
       GP_VER: [[gp_ver]]
       PXF_JVM_OPTS: ((pxf-jvm-opts))
-  - task: Test PXF CLI
+  - task: test_pxf_cli
     on_success:
       <<: *destroy_gpdb_cluster
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image

--- a/concourse/pipelines/templates/jobs/multinode-tpl.yml
+++ b/concourse/pipelines/templates/jobs/multinode-tpl.yml
@@ -2,7 +2,7 @@
 ## - gp_ver = Greenplum Major Version
 ## - passed = upstream job name that the artifacts need to pass before this job
 
-- name: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+- name: test_pxf-gp[[gp_ver]]_hdp2-secure-multi-impers_on_rhel8
   max_in_flight: 2
   plan:
   - in_parallel:
@@ -39,7 +39,7 @@
             instance_type: n1-standard-4
             ccp_reap_minutes: 120
             standby_master: true
-      - task: Generate Greenplum Cluster
+      - task: generate_greenplum_cluster
         input_mapping:
           gpdb_rpm: gpdb_package
           terraform: terraform_gpdb
@@ -55,16 +55,16 @@
           CLOUD_PROVIDER: google
           GPDB_RPM: true
       - in_parallel:
-        - task: Initialize Greenplum
+        - task: initialize_greenplum
           file: ccp_src/ci/tasks/gpinitsystem.yml
-        - task: Install Hadoop
+        - task: install_hadoop
           file: pxf_src/concourse/tasks/install_hadoop.yml
           image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
           params:
             ACCESS_KEY_ID: ((tf-machine-access-key-id))
             SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
             IMPERSONATION: ((enable-impersonation-multinode))
-    - task: Generate Hadoop Cluster 1
+    - task: generate_hadoop_cluster_1
       file: pxf_src/concourse/tasks/install_dataproc.yml
       params:
         GOOGLE_CREDENTIALS: ((ud/pxf/secrets/ccp-ci-service-account-key))
@@ -73,7 +73,7 @@
         IMAGE_VERSION: ((dataproc-image-version))
         KERBEROS: ((kerberos-enabled))
         ccp_reap_minutes: 120
-    - task: Generate Hadoop Cluster 2
+    - task: generate_hadoop_cluster_2
       file: pxf_src/concourse/tasks/install_dataproc.yml
       output_mapping:
         dataproc_env_files: dataproc_2_env_files
@@ -100,14 +100,14 @@
         terraform_source: pxf_src/concourse/terraform/ipa-multinode-hadoop
         vars:
           gcp_project: ((ud/pxf/common/ipa-google-project-id))
-    - task: Generate Multinode Hadoop Cluster
+    - task: generate_multinode_hadoop_cluster
       file: pxf_src/concourse/tasks/install_multinode_hadoop.yml
       image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
       params:
         ANSIBLE_VAR_gcp_storage_bucket: ((ud/pxf/common/build-resources-bucket-name))
         ANSIBLE_VAR_ipa_password: ((ud/pxf/secrets/ipa-password))
         ANSIBLE_VAR_ssl_store_password: ((ud/pxf/secrets/ssl-store-password))
-  - task: Setup PXF
+  - task: setup_pxf
     input_mapping:
       terraform: terraform_gpdb
     file: pxf_src/concourse/tasks/install_pxf_on_ccp.yml
@@ -119,7 +119,7 @@
       KERBEROS: ((kerberos-enabled))
       PXF_JVM_OPTS: ((pxf-jvm-opts))
       PXF_BASE_DIR: /home/gpadmin/pxf-boot
-  - task: Test PXF-GP[[gp_ver]]-HDP2-SECURE-MULTI-IMPERS on RHEL8
+  - task: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel8
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
     attempts: 2

--- a/concourse/pipelines/templates/jobs/multinode-tpl.yml
+++ b/concourse/pipelines/templates/jobs/multinode-tpl.yml
@@ -124,12 +124,12 @@
     file: pxf_src/concourse/tasks/test_pxf_on_ccp.yml
     attempts: 2
     params:
+      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       ACCESS_KEY_ID: ((tf-machine-access-key-id))
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
       HIVE_VERSION: 2
       IMPERSONATION: true
       KERBEROS: ((kerberos-enabled))
-      GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GP_VER: [[gp_ver]]
       GROUP: security,proxySecurity,proxySecurityIpa,multiClusterSecurity
       PXF_JVM_OPTS: ((pxf-jvm-opts))

--- a/concourse/pipelines/templates/jobs/multinode-tpl.yml
+++ b/concourse/pipelines/templates/jobs/multinode-tpl.yml
@@ -92,7 +92,7 @@
         NO_ADDRESS: false
         PROXY_USER: gpuser
         SECRETS_BUCKET: ((ud/pxf/secrets/kerberos-pxf-secrets-bucket-name))
-  - do: # Generate IPA Hadoop cluster
+  - do:   # Generate IPA Hadoop cluster
     - put: terraform_ipa_hadoop
       params:
         action: create

--- a/concourse/pipelines/templates/jobs/multinode-tpl.yml
+++ b/concourse/pipelines/templates/jobs/multinode-tpl.yml
@@ -2,7 +2,7 @@
 ## - gp_ver = Greenplum Major Version
 ## - passed = upstream job name that the artifacts need to pass before this job
 
-- name: test_pxf-gp[[gp_ver]]_hdp2-secure-multi-impers_on_rhel8
+- name: test_pxf-gp[[gp_ver]]-hdp2-secure-multi-impers_on_rhel8
   max_in_flight: 2
   plan:
   - in_parallel:

--- a/concourse/pipelines/templates/pr_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/pr_pipeline-tpl.yml
@@ -141,20 +141,20 @@ jobs:
 {% set gp_ver = None %}
 ## ---------- Centos 7 Swimlane ----------
 {% for gp_ver in range(5, 7) %}
-- name: Build and Test PXF-GP[[gp_ver]] on RHEL7
+- name: build_and_test_pxf-gp[[gp_ver]]_on_rhel7
   public: true
   on_failure:
     put: pxf_src
     params:
       path: pxf_src
       status: failure
-      context: Build and Test PXF-GP[[gp_ver]] on RHEL7
+      context: build_and_test_pxf-gp[[gp_ver]]_on_rhel7
   on_success:
     put: pxf_src
     params:
       path: pxf_src
       status: success
-      context: Build and Test PXF-GP[[gp_ver]] on RHEL7
+      context: build_and_test_pxf-gp[[gp_ver]]_on_rhel7
   plan:
   - in_parallel:
     - get: pxf_src
@@ -165,13 +165,13 @@ jobs:
     - get: pxf-build-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Build PXF-GP[[gp_ver]] on RHEL7
+  - task: build_pxf-gp[[gp_ver]]_on_rhel7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     file: pxf_src/concourse/tasks/build.yml
     params:
       LICENSE: ((ud/pxf/common/rpm-license))
       VENDOR: ((ud/pxf/common/rpm-vendor))
-  - task: Test Against Greenplum Latest RHEL7
+  - task: test_against_greenplum_latest_rhel7
     image: gpdb[[gp_ver]]-pxf-dev-centos7-image
     config:
       platform: linux
@@ -195,20 +195,20 @@ jobs:
 
 ## ---------- RHEL 8 / Rocky 8 Swimlane ----------
 {% for gp_ver in range(6, 8) %}
-- name: Build and Test PXF-GP[[gp_ver]] on RHEL8
+- name: build_and_test_pxf-gp[[gp_ver]]_on_rhel8
   public: true
   on_failure:
     put: pxf_src
     params:
       path: pxf_src
       status: failure
-      context: Build and Test PXF-GP[[gp_ver]] on RHEL8
+      context: build_and_test_pxf-gp[[gp_ver]]_on_rhel8
   on_success:
     put: pxf_src
     params:
       path: pxf_src
       status: success
-      context: Build and Test PXF-GP[[gp_ver]] on RHEL8
+      context: build_and_test_pxf-gp[[gp_ver]]_on_rhel8
   plan:
   - in_parallel:
     - get: pxf_src
@@ -219,13 +219,13 @@ jobs:
     - get: pxf-build-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Build PXF-GP[[gp_ver]] on RHEL8
+  - task: build_pxf-gp[[gp_ver]]_on_rhel8
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     file: pxf_src/concourse/tasks/build.yml
     params:
       LICENSE: ((ud/pxf/common/rpm-license))
       VENDOR: ((ud/pxf/common/rpm-vendor))
-  - task: Test Against Greenplum Latest RHEL8
+  - task: test_against_greenplum_latest_rhel8
     image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
     config:
       platform: linux
@@ -250,20 +250,20 @@ jobs:
 
 ## ---------- Ubuntu 18 Swimlane ----------
 {% set gp_ver = 6 %}
-- name: Build and Test PXF-GP[[gp_ver]] on Ubuntu18
+- name: build_and_test_pxf-gp[[gp_ver]]_on_ubuntu18
   public: true
   on_failure:
     put: pxf_src
     params:
       path: pxf_src
       status: failure
-      context: Build and Test PXF-GP[[gp_ver]] on Ubuntu18
+      context: build_and_test_pxf-gp[[gp_ver]]_on_ubuntu18
   on_success:
     put: pxf_src
     params:
       path: pxf_src
       status: success
-      context: Build and Test PXF-GP[[gp_ver]] on Ubuntu18
+      context: build_and_test_pxf-gp[[gp_ver]]_on_ubuntu18
   plan:
   - in_parallel:
     - get: pxf_src
@@ -274,13 +274,13 @@ jobs:
     - get: pxf-build-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: Build PXF-GP[[gp_ver]] on Ubuntu18
+  - task: build_pxf-gp[[gp_ver]]_on_ubuntu18
     image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     file: pxf_src/concourse/tasks/build.yml
     params:
       LICENSE: ((ud/pxf/common/rpm-license))
       VENDOR: ((ud/pxf/common/deb-maintainer))
-  - task: Test Against Greenplum Latest Ubuntu18
+  - task: test_against_greenplum_latest_ubuntu18
     image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
     config:
       platform: linux

--- a/concourse/scripts/check_docker_images_and_tag.bash
+++ b/concourse/scripts/check_docker_images_and_tag.bash
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+IMAGE_TAG="${IMAGE_TAG:-latest}"
 COMMIT_SHA=$(cat pxf_src/.git/ref)
 echo "Checking images for PXF SHA-1: ${COMMIT_SHA}"
 
@@ -39,13 +40,15 @@ do
 
     for image in "${IMAGE_NAMES[@]}"
     do
-      # we need to untag latest first
-      gcloud container images untag --quiet "gcr.io/${GOOGLE_PROJECT_ID}/gpdb-pxf-dev/${image}:latest" || true
-      # tag image with latest
-      echo "Tagging gcr.io/${GOOGLE_PROJECT_ID}/gpdb-pxf-dev/${image}:${COMMIT_SHA} with latest"
+      # we need to untag ${IMAGE_TAG} first
+      if [[ $IMAGE_TAG == "latest"]]; then
+        gcloud container images untag --quiet "gcr.io/${GOOGLE_PROJECT_ID}/gpdb-pxf-dev/${image}:${IMAGE_TAG}" || true
+      fi
+      # tag image with ${IMAGE_TAG}
+      echo "Tagging gcr.io/${GOOGLE_PROJECT_ID}/gpdb-pxf-dev/${image}:${COMMIT_SHA} with ${IMAGE_TAG}"
       gcloud container images add-tag --quiet \
         "gcr.io/${GOOGLE_PROJECT_ID}/gpdb-pxf-dev/${image}:${COMMIT_SHA}" \
-        "gcr.io/${GOOGLE_PROJECT_ID}/gpdb-pxf-dev/${image}:latest"
+        "gcr.io/${GOOGLE_PROJECT_ID}/gpdb-pxf-dev/${image}:${IMAGE_TAG}"
     done
 
     exit 0

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -184,6 +184,9 @@ function build_install_gpdb() {
 }
 
 function install_gpdb_binary() {
+	# Ensure gpadmin owns its home directory
+	chown -R gpadmin:gpadmin /home/gpadmin
+
 	if [[ -d bin_gpdb ]]; then
 		mkdir -p ${GPHOME}
 		tar -xzf bin_gpdb/*.tar.gz -C ${GPHOME}
@@ -208,6 +211,9 @@ function install_gpdb_binary() {
 }
 
 function install_gpdb_package() {
+	# Ensure gpadmin owns its home directory
+	chown -R gpadmin:gpadmin /home/gpadmin
+
 	local gphome python_dir python_version=2.7 export_pythonpath='export PYTHONPATH=$PYTHONPATH' pkg_file version
 	gpdb_package=${PWD}/${GPDB_PKG_DIR:-gpdb_package}
 

--- a/concourse/scripts/pxf_common.bash
+++ b/concourse/scripts/pxf_common.bash
@@ -184,7 +184,10 @@ function build_install_gpdb() {
 }
 
 function install_gpdb_binary() {
-	# Ensure gpadmin owns its home directory
+	# TODO Remove the chown once the ownership of /home/gpadmin is correctly set
+	# In concourse 7.8.x, even though the base pxf dev image correctly gave
+	# gpadmin permissions to /home/gpadmin, the change is not respected
+	# So we have added this chown here to ensure gpadmin owns its home directory
 	chown -R gpadmin:gpadmin /home/gpadmin
 
 	if [[ -d bin_gpdb ]]; then
@@ -211,7 +214,10 @@ function install_gpdb_binary() {
 }
 
 function install_gpdb_package() {
-	# Ensure gpadmin owns its home directory
+	# TODO Remove the chown once the ownership of /home/gpadmin is correctly set
+	# In concourse 7.8.x, even though the base pxf dev image correctly gave
+	# gpadmin permissions to /home/gpadmin, the change is not respected
+	# So we have added this chown here to ensure gpadmin owns its home directory
 	chown -R gpadmin:gpadmin /home/gpadmin
 
 	local gphome python_dir python_version=2.7 export_pythonpath='export PYTHONPATH=$PYTHONPATH' pkg_file version

--- a/concourse/tasks/install_pxf_on_ccp.yml
+++ b/concourse/tasks/install_pxf_on_ccp.yml
@@ -22,6 +22,7 @@ inputs:
   optional: true
 
 params:
+  GOOGLE_PROJECT_ID:
   GP_VER:
   IMPERSONATION: true
   INSTALL_GPHDFS: true

--- a/concourse/tasks/test_pxf_on_ccp.yml
+++ b/concourse/tasks/test_pxf_on_ccp.yml
@@ -35,5 +35,6 @@ params:
   PXF_JVM_OPTS:
   PXF_VERSION: 6
   SECRET_ACCESS_KEY:
+  GOOGLE_PROJECT_ID:
 run:
   path: pxf_src/concourse/scripts/test_pxf_multinode.bash

--- a/dev/multinode-ci-notes.md
+++ b/dev/multinode-ci-notes.md
@@ -1,6 +1,6 @@
 # PXF MultiNode CI Notes
 
-Based on the CI job [Test PXF-GP6-HDP2-SECURE-MULTI-IMPERS on RHEL7](https://ud.ci.gpdb.pivotal.io/teams/main/pipelines/pxf-build/jobs/Test%20PXF-GP6-HDP2-SECURE-MULTI-IMPERS%20on%20RHEL7)
+Based on the CI job [Test PXF-GP6-HDP2-SECURE-MULTI-IMPERS on RHEL7](https://ci.ud.gpdb.pivotal.io/teams/main/pipelines/pxf-build/jobs/Test%20PXF-GP6-HDP2-SECURE-MULTI-IMPERS%20on%20RHEL7)
 
 ## Infrastructure
 


### PR DESCRIPTION
This PR updates the PXF pipelines to remove deprecation warnings and ensure that pipelines can run without issues in a Concourse 7.8.x deployment. 

The changes made include: 
- Updating all group, job, task and resource names to be all lowercase
- Updating all spaces in said names to be underscores
- Removing parentheses
- Updating colon to dash in pipeline names

The pipeline states: 
| pipeline               | moved? | updated?   |
|------------------------|--------|------------|
| dev                    | yes    | yes        |
| pxf-build              | yes    | yes        |
| pr                     | yes    | yes        |
| certification          | yes    | yes        |
| cloudbuild             | yes    | yes        |
| pivnet                 | yes    | yes        |
| singlecluster          | yes    | yes        |
| hadoop-cluster-cleaner | yes    | not needed |
| perf pipelines         | no     | no         |
| pxf 5 pipelines        | no     | no         |