### PR TITLE
Templating Pipeline Jobs

### DIFF
--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -377,43 +377,38 @@ jobs:
 ## the following platform_gp_combinations dictionary definition:
 ##
 ##   gp_ver: GPDB Major Version
-##   execution_os: OS platform in which build and test jobs are executed
-##   os_ver: OS Major version
 ##   build_os: OS Platform in which the build was performed
+##   test_os: OS platform in which test jobs are executed
+##   os_ver: OS Major version
 ##
 ## ----------------------------------------------------------------------
 {% set platform_gp_combinations = [
-    {'gp_ver': '5', 'execution_os': 'centos', 'os_ver': '7',  'build_os': 'centos'},
-    {'gp_ver': '6', 'execution_os': 'centos', 'os_ver': '7',  'build_os': 'centos'},
-    {'gp_ver': '6', 'execution_os': 'rocky',  'os_ver': '8',  'build_os': 'rocky'},
-    {'gp_ver': '6', 'execution_os': 'oel',    'os_ver': '7',  'build_os': 'centos'},
-    {'gp_ver': '6', 'execution_os': 'ubuntu', 'os_ver': '18', 'build_os': 'ubuntu'},
-    {'gp_ver': '7', 'execution_os': 'rocky',  'os_ver': '8',  'build_os': 'rocky'}] %}
+    {'gp_ver': '5', 'build_os': 'centos', 'test_os': 'centos', 'os_ver': '7'},
+    {'gp_ver': '6', 'build_os': 'centos', 'test_os': 'centos', 'os_ver': '7'},
+    {'gp_ver': '6', 'build_os': 'rocky', 'test_os': 'rocky', 'os_ver': '8'},
+    {'gp_ver': '6', 'build_os': 'centos', 'test_os': 'oel', 'os_ver': '7'},
+    {'gp_ver': '6', 'build_os': 'ubuntu', 'test_os': 'ubuntu', 'os_ver': '18'},
+    {'gp_ver': '7', 'build_os': 'rocky', 'test_os': 'rocky', 'os_ver': '8'}] %}
 
 {% for config in platform_gp_combinations %}
 
-    {% set gp_ver = config.gp_ver %}
-    {% set platform = config.execution_os %}
-    {% set os_ver = config.os_ver %}
-    {% set build_platform = config.build_os %}
+    {% set test_platform = config.test_os ~ config.os_ver %}
+    {% set build_platform = config.build_os ~ config.os_ver %}
 
-    {% set platform_ver = platform ~ os_ver %}
-    {% set build_platform_ver = build_platform ~ os_ver %}
-
-    {% if platform in ['ubuntu'] %}
+    {% if config.test_os in ['ubuntu'] %}
       {% set pkg_type = 'deb' %}
       {% set gpdb_os_platform = 'ubuntu' %}
-      {% set pxf_tarball_filename = 'dist/pxf-gp' ~ gp_ver ~ '-*-ubuntu' ~ os_ver ~ '.04' ~ '.tar.gz' %}
+      {% set pxf_tarball_filename = 'dist/pxf-gp' ~ config.gp_ver ~ '-*-ubuntu' ~ config.os_ver ~ '.04' ~ '.tar.gz' %}
       {% set pxf_fdw_tarball_filename = '' %}{# Doesn't apply for ubuntu platform #}
-    {% else %}
+    {% else %} {# Else section applies to centos, rocky and oel platforms #}
       {% set pkg_type = 'rpm' %}
       {% set gpdb_os_platform = 'rhel' %}
-      {% set pxf_tarball_filename = 'dist/pxf-gp' ~ gp_ver ~ '-*.el' ~ os_ver ~ '.tar.gz' %}
-      {% set pxf_fdw_tarball_filename = 'dist/pxf-fdw-gp' ~ gp_ver ~ '-*.el' ~ os_ver ~ '.tar.gz' %}
+      {% set pxf_tarball_filename = 'dist/pxf-gp' ~ config.gp_ver ~ '-*.el' ~ config.os_ver ~ '.tar.gz' %}
+      {% set pxf_fdw_tarball_filename = 'dist/pxf-fdw-gp' ~ config.gp_ver ~ '-*.el' ~ config.os_ver ~ '.tar.gz' %}
     {% endif %}
 
     {# OEL doesn't have a separate build job #}
-    {% if platform != 'oel' %}
+    {% if config.test_os != 'oel' %}
       {% include 'jobs/build-tpl.yml' %}
     {% endif %}
 
@@ -428,53 +423,51 @@ jobs:
 ## platform_gp_combinations dictionary definition:
 ##
 ##   gp_ver: GPDB Major Version
-##   execution_os: OS platform in which build and test jobs are executed
-##   os_ver: OS Major version
 ##   build_os: OS Platform in which the build was performed
+##   test_os: OS platform in which test jobs are executed
+##   os_ver: OS Major version
 ##
 ## ----------------------------------------------------------------------
 {% set platform_gp_combinations = [
-    {'gp_ver': '6', 'execution_os': 'rocky', 'os_ver': '8', 'build_os': 'rocky'},
-    {'gp_ver': '7', 'execution_os': 'rocky', 'os_ver': '8', 'build_os': 'rocky'}] %}
+    {'gp_ver': '6', 'build_os': 'rocky', 'test_os': 'rocky', 'os_ver': '8'},
+    {'gp_ver': '7', 'build_os': 'rocky', 'test_os': 'rocky', 'os_ver': '8'}] %}
 
 {% for config in platform_gp_combinations %}
-    {% set gp_ver = config.gp_ver %}
-    {% set platform = config.execution_os %}
-    {% set os_ver = config.os_ver %}
-    {% set build_platform = config.build_os %}
 
-    {% set platform_ver = platform ~ os_ver %}
+    {% set test_platform = config.test_os ~ config.os_ver %}
+    {% set build_platform = config.build_os ~ config.os_ver %}
+
     {% set gpdb_os_platform = 'rhel' %}{# This only supports RHEL platform #}
     {% set pkg_type = 'rpm' %}
 
-- name: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_[[platform_ver]]
+- name: test_pxf-fdw-gp[[config.gp_ver]]-hdp2_on_[[test_platform]]
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
+      passed: [build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]]
       trigger: true
     - get: pxf_tarball
-      resource: pxf_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
-      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
-{% if gp_ver == '6' %}
+      resource: pxf_gp[[config.gp_ver]]_tarball_[[gpdb_os_platform]][[config.os_ver]]
+      passed: [build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]]
+{% if config.gp_ver == '6' %}
     - get: pxf_fdw_tarball
-      resource: pxf_fdw_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
-      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
+      resource: pxf_fdw_gp[[config.gp_ver]]_tarball_[[gpdb_os_platform]][[config.os_ver]]
+      passed: [build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]]
 {% endif %}
     - get: gpdb_package
-      resource: gpdb[[gp_ver]]_[[gpdb_os_platform]][[os_ver]]_[[pkg_type]]_latest-0
-      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
-    - get: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
-      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
+      resource: gpdb[[config.gp_ver]]_[[gpdb_os_platform]][[config.os_ver]]_[[pkg_type]]_latest-0
+      passed: [build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]]
+    - get: gpdb[[config.gp_ver]]-pxf-dev-[[test_platform]]-image
+      passed: [build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]]
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_[[platform_ver]]
+  - task: test_pxf-fdw-gp[[config.gp_ver]]-hdp2_on_[[test_platform]]
     file: pxf_src/concourse/tasks/test.yml
-    image: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
+    image: gpdb[[config.gp_ver]]-pxf-dev-[[test_platform]]-image
     params:
       ACCESS_KEY_ID: ((tf-machine-access-key-id))
-      GP_VER: [[gp_ver]]
+      GP_VER: [[config.gp_ver]]
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
       USE_FDW: true

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -369,220 +369,109 @@ resources:
 ## ======================================================================
 jobs:
 
-## ---------- Centos 7 Swimlane ----------
-{% for gp_ver in range(5, 7) %}
-- name: build_pxf-gp[[gp_ver]]_on_rhel7
-  plan:
-  - in_parallel:
-    - get: pxf_src
-      trigger: true
-    - get: gpdb_package
-      resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-    - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
-    - get: pxf-build-dependencies
-  - task: build_pxf-gp[[gp_ver]]_on_rhel7
-    image: gpdb[[gp_ver]]-pxf-dev-centos7-image
-    file: pxf_src/concourse/tasks/build.yml
-    params:
-      LICENSE: ((ud/pxf/common/rpm-license))
-      VENDOR: ((ud/pxf/common/rpm-vendor))
-  - put: pxf_gp[[gp_ver]]_tarball_rhel7
-    params:
-      file: dist/pxf-gp[[gp_ver]]-*.el7.tar.gz
+## ======================================================================
+##                    Build and Sanity Test Swimlanes
+## ----------------------------------------------------------------------
+##
+## The creation of the PXF Build and Sanity test jobs are driven by
+## the following platform_gp_combinations dictionary definition:
+##
+##   gp_ver: GPDB Major Version
+##   execution_os: OS platform in which build and test jobs are executed
+##   os_ver: OS Major version
+##   build_os: OS Platform in which the build was performed
+##
+## ----------------------------------------------------------------------
+{% set platform_gp_combinations = [
+    {'gp_ver': '5', 'execution_os': 'centos', 'os_ver': '7',  'build_os': 'centos'},
+    {'gp_ver': '6', 'execution_os': 'centos', 'os_ver': '7',  'build_os': 'centos'},
+    {'gp_ver': '6', 'execution_os': 'rocky',  'os_ver': '8',  'build_os': 'rocky'},
+    {'gp_ver': '6', 'execution_os': 'oel',    'os_ver': '7',  'build_os': 'centos'},
+    {'gp_ver': '6', 'execution_os': 'ubuntu', 'os_ver': '18', 'build_os': 'ubuntu'},
+    {'gp_ver': '7', 'execution_os': 'rocky',  'os_ver': '8',  'build_os': 'rocky'}] %}
 
-- name: test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
-  plan:
-  - in_parallel:
-    - get: pxf_src
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
-      trigger: true
-    - get: pxf_tarball
-      resource: pxf_gp[[gp_ver]]_tarball_rhel7
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
-    - get: gpdb_package
-      resource: gpdb[[gp_ver]]_rhel7_rpm_latest-0
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
-    - get: gpdb[[gp_ver]]-pxf-dev-centos7-image
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel7]
-    - get: pxf-automation-dependencies
-    - get: singlecluster
-      resource: singlecluster-hdp2
-  - task: test_pxf-gp[[gp_ver]]-hdp2_on_rhel7
-    file: pxf_src/concourse/tasks/test.yml
-    image: gpdb[[gp_ver]]-pxf-dev-centos7-image
-    params:
-      ACCESS_KEY_ID: ((tf-machine-access-key-id))
-      GP_VER: [[gp_ver]]
-      GROUP: gpdb,proxy,profile
-      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-{% if slack_notification %}
-    <<: *slack_alert
-{% endif %}
+{% for config in platform_gp_combinations %}
+
+    {% set gp_ver = config.gp_ver %}
+    {% set platform = config.execution_os %}
+    {% set os_ver = config.os_ver %}
+    {% set build_platform = config.build_os %}
+
+    {% set platform_ver = platform ~ os_ver %}
+    {% set build_platform_ver = build_platform ~ os_ver %}
+
+    {% if platform in ['ubuntu'] %}
+      {% set pkg_type = 'deb' %}
+      {% set gpdb_os_platform = 'ubuntu' %}
+      {% set pxf_tarball_filename = 'dist/pxf-gp' ~ gp_ver ~ '-*-ubuntu' ~ os_ver ~ '.04' ~ '.tar.gz' %}
+      {% set pxf_fdw_tarball_filename = '' %}{# Doesn't apply for ubuntu platform #}
+    {% else %}
+      {% set pkg_type = 'rpm' %}
+      {% set gpdb_os_platform = 'rhel' %}
+      {% set pxf_tarball_filename = 'dist/pxf-gp' ~ gp_ver ~ '-*.el' ~ os_ver ~ '.tar.gz' %}
+      {% set pxf_fdw_tarball_filename = 'dist/pxf-fdw-gp' ~ gp_ver ~ '-*.el' ~ os_ver ~ '.tar.gz' %}
+    {% endif %}
+
+    {# OEL doesn't have a separate build job #}
+    {% if platform != 'oel' %}
+      {% include 'jobs/build-tpl.yml' %}
+    {% endif %}
+
+    {% include 'jobs/test-tpl.yml' %}
 {% endfor %}
 
-{% if oel7 %}
-- name: test_pxf-gp6-hdp2_on_oel7
+## ======================================================================
+##                             FDW Test Job
+## ----------------------------------------------------------------------
+##
+## The creation of the PXF FDW test jobs are driven by the following
+## platform_gp_combinations dictionary definition:
+##
+##   gp_ver: GPDB Major Version
+##   execution_os: OS platform in which build and test jobs are executed
+##   os_ver: OS Major version
+##   build_os: OS Platform in which the build was performed
+##
+## ----------------------------------------------------------------------
+{% set platform_gp_combinations = [
+    {'gp_ver': '6', 'execution_os': 'rocky', 'os_ver': '8', 'build_os': 'rocky'},
+    {'gp_ver': '7', 'execution_os': 'rocky', 'os_ver': '8', 'build_os': 'rocky'}] %}
+
+{% for config in platform_gp_combinations %}
+    {% set gp_ver = config.gp_ver %}
+    {% set platform = config.execution_os %}
+    {% set os_ver = config.os_ver %}
+    {% set build_platform = config.build_os %}
+
+    {% set platform_ver = platform ~ os_ver %}
+    {% set gpdb_os_platform = 'rhel' %}{# This only supports RHEL platform #}
+    {% set pkg_type = 'rpm' %}
+
+- name: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_[[platform_ver]]
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [build_pxf-gp6_on_rhel7]
+      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
       trigger: true
     - get: pxf_tarball
-      resource: pxf_gp6_tarball_rhel7
-      passed: [build_pxf-gp6_on_rhel7]
-    - get: gpdb_package
-      resource: gpdb6_rhel7_rpm_latest-0
-      passed: [build_pxf-gp6_on_rhel7]
-    - get: gpdb6-pxf-dev-oel7-image
-    - get: pxf-automation-dependencies
-    - get: singlecluster
-      resource: singlecluster-hdp2
-  - task: test_pxf-gp6-hdp2_on_oel7
-    file: pxf_src/concourse/tasks/test.yml
-    image: gpdb6-pxf-dev-oel7-image
-    params:
-      ACCESS_KEY_ID: ((tf-machine-access-key-id))
-      GP_VER: 6
-      GROUP: gpdb,proxy,profile
-      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-{% if slack_notification %}
-    <<: *slack_alert
-{% endif %}
-{% endif %}
-
-## ---------- Ubuntu 18 Swimlane ----------
-{% set gp_ver = 6 %}
-- name: build_pxf-gp[[gp_ver]]_on_ubuntu18
-  plan:
-  - in_parallel:
-    - get: pxf_src
-      trigger: true
-    - get: gpdb_package
-      resource: gpdb[[gp_ver]]_ubuntu18_deb_latest-0
-    - get: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
-    - get: pxf-build-dependencies
-  - task: build_pxf-gp[[gp_ver]]_on_ubuntu18
-    image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
-    file: pxf_src/concourse/tasks/build.yml
-    params:
-      LICENSE: ((ud/pxf/common/rpm-license))
-      VENDOR: ((ud/pxf/common/deb-maintainer))
-  - put: pxf_gp[[gp_ver]]_tarball_ubuntu18
-    params:
-      file: dist/pxf-gp[[gp_ver]]-*-ubuntu18.04.tar.gz
-
-- name: test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18
-  plan:
-  - in_parallel:
-    - get: pxf_src
-      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
-      trigger: true
-    - get: pxf_tarball
-      resource: pxf_gp[[gp_ver]]_tarball_ubuntu18
-      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
-    - get: gpdb_package
-      resource: gpdb[[gp_ver]]_ubuntu18_deb_latest-0
-      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
-    - get: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
-      passed: [build_pxf-gp[[gp_ver]]_on_ubuntu18]
-    - get: pxf-automation-dependencies
-    - get: singlecluster
-      resource: singlecluster-hdp2
-  - task: test_pxf-gp[[gp_ver]]-hdp2_on_ubuntu18
-    file: pxf_src/concourse/tasks/test.yml
-    image: gpdb[[gp_ver]]-pxf-dev-ubuntu18-image
-    params:
-      ACCESS_KEY_ID: ((tf-machine-access-key-id))
-      GP_VER: [[gp_ver]]
-      GROUP: gpdb,proxy,profile
-      PXF_BASE_DIR: /home/gpadmin/pxf
-      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-{% if slack_notification %}
-    <<: *slack_alert
-{% endif %}
-{% set gp_ver = None %}
-
-## ---------- RHEL 8 Swimlane (uses Rocky 8 images) ----------
-{% for gp_ver in range(6, 8) %}
-- name: build_pxf-gp[[gp_ver]]_on_rhel8
-  plan:
-  - in_parallel:
-    - get: pxf_src
-      trigger: true
-    - get: gpdb_package
-      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-    - get: pxf-build-dependencies
-  - task: build_pxf-gp[[gp_ver]]_on_rhel8
-    image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-    file: pxf_src/concourse/tasks/build.yml
-    params:
-      LICENSE: ((ud/pxf/common/rpm-license))
-      VENDOR: ((ud/pxf/common/rpm-vendor))
-  - put: pxf_gp[[gp_ver]]_tarball_rhel8
-    params:
-      file: dist/pxf-gp[[gp_ver]]-*.el8.tar.gz
-{% if gp_ver == 6 %}
-  - put: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
-    params:
-      file: dist/pxf-fdw-gp[[gp_ver]]-*.el8.tar.gz
-{% endif %}
-
-- name: test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
-  plan:
-  - in_parallel:
-    - get: pxf_src
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-      trigger: true
-    - get: pxf_tarball
-      resource: pxf_gp[[gp_ver]]_tarball_rhel8
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-    - get: gpdb_package
-      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-    - get: pxf-automation-dependencies
-    - get: singlecluster
-      resource: singlecluster-hdp2
-  - task: test_pxf-gp[[gp_ver]]-hdp2_on_rhel8
-    file: pxf_src/concourse/tasks/test.yml
-    image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-    params:
-      ACCESS_KEY_ID: ((tf-machine-access-key-id))
-      GP_VER: [[gp_ver]]
-      GROUP: gpdb,proxy,profile
-      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-{% endfor %}
-{% set gp_ver = None %}
-
-## ---------- FDW RHEL 8 Swimlane ----------
-{% for gp_ver in range(6, 8) %}
-- name: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_rhel8
-  plan:
-  - in_parallel:
-    - get: pxf_src
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-      trigger: true
-    - get: pxf_tarball
-      resource: pxf_gp[[gp_ver]]_tarball_rhel8
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-{% if gp_ver == 6 %}
+      resource: pxf_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
+      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
+{% if gp_ver == '6' %}
     - get: pxf_fdw_tarball
-      resource: pxf_fdw_gp[[gp_ver]]_tarball_rhel8
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+      resource: pxf_fdw_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
+      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
 {% endif %}
     - get: gpdb_package
-      resource: gpdb[[gp_ver]]_rhel8_rpm_latest-0
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
-    - get: gpdb[[gp_ver]]-pxf-dev-rocky8-image
-      passed: [build_pxf-gp[[gp_ver]]_on_rhel8]
+      resource: gpdb[[gp_ver]]_[[gpdb_os_platform]][[os_ver]]_[[pkg_type]]_latest-0
+      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
+    - get: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
+      passed: [build_pxf-gp[[gp_ver]]_on_[[platform_ver]]]
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_rhel8
+  - task: test_pxf-fdw-gp[[gp_ver]]-hdp2_on_[[platform_ver]]
     file: pxf_src/concourse/tasks/test.yml
-    image: gpdb[[gp_ver]]-pxf-dev-rocky8-image
+    image: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
     params:
       ACCESS_KEY_ID: ((tf-machine-access-key-id))
       GP_VER: [[gp_ver]]
@@ -590,7 +479,6 @@ jobs:
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
       USE_FDW: true
 {% endfor %}
-{% set gp_ver = None %}
 
 ## ---------- GP7 PXF CLI tests ----------
 

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -370,10 +370,10 @@ resources:
 jobs:
 
 ## ======================================================================
-##                    Build and Sanity Test Swimlanes
+##                    Build and Basic SingleNode Test Swimlanes
 ## ----------------------------------------------------------------------
 ##
-## The creation of the PXF Build and Sanity test jobs are driven by
+## The creation of the PXF Build and Basic SingleNode test jobs are driven by
 ## the following platform_gp_combinations dictionary definition:
 ##
 ##   gp_ver: GPDB Major Version

--- a/concourse/pipelines/templates/jobs/build-tpl.yml
+++ b/concourse/pipelines/templates/jobs/build-tpl.yml
@@ -1,25 +1,32 @@
 ## Template for generating build jobs in the dev and build pipeline
 
-- name: build_pxf-gp[[gp_ver]]_on_[[platform_ver]]
+## Following variables are expected to be passed to set the build job
+## config.gp_ver = GPDB Major version
+## config.os_ver = OS Major version
+## build_platform = build_os + os_ver
+## gpdb_os_platform = GPDB RPM OS ( rhel or ubuntu)
+## pkg_type = rpm or deb
+
+- name: build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]
   plan:
   - in_parallel:
     - get: pxf_src
       trigger: true
     - get: gpdb_package
-      resource: gpdb[[gp_ver]]_[[gpdb_os_platform]][[os_ver]]_[[pkg_type]]_latest-0
-    - get: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
+      resource: gpdb[[config.gp_ver]]_[[gpdb_os_platform]][[config.os_ver]]_[[pkg_type]]_latest-0
+    - get: gpdb[[config.gp_ver]]-pxf-dev-[[build_platform]]-image
     - get: pxf-build-dependencies
-  - task: build_pxf-gp[[gp_ver]]_on_[[platform_ver]]
-    image: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
+  - task: build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]
+    image: gpdb[[config.gp_ver]]-pxf-dev-[[build_platform]]-image
     file: pxf_src/concourse/tasks/build.yml
     params:
       LICENSE: ((ud/pxf/common/rpm-license))
       VENDOR: ((ud/pxf/common/[[pkg_type]]-vendor))
-  - put: pxf_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
+  - put: pxf_gp[[config.gp_ver]]_tarball_[[gpdb_os_platform]][[config.os_ver]]
     params:
       file: [[pxf_tarball_filename]]
-{% if gp_ver == '6'  and platform_ver == 'rocky8' %}
-  - put: pxf_fdw_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
+{% if config.gp_ver == '6'  and build_platform == 'rocky8' %}
+  - put: pxf_fdw_gp[[config.gp_ver]]_tarball_[[gpdb_os_platform]][[config.os_ver]]
     params:
       file: [[pxf_fdw_tarball_filename]]
 {% endif %}

--- a/concourse/pipelines/templates/jobs/build-tpl.yml
+++ b/concourse/pipelines/templates/jobs/build-tpl.yml
@@ -1,0 +1,25 @@
+## Template for generating build jobs in the dev and build pipeline
+
+- name: build_pxf-gp[[gp_ver]]_on_[[platform_ver]]
+  plan:
+  - in_parallel:
+    - get: pxf_src
+      trigger: true
+    - get: gpdb_package
+      resource: gpdb[[gp_ver]]_[[gpdb_os_platform]][[os_ver]]_[[pkg_type]]_latest-0
+    - get: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
+    - get: pxf-build-dependencies
+  - task: build_pxf-gp[[gp_ver]]_on_[[platform_ver]]
+    image: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
+    file: pxf_src/concourse/tasks/build.yml
+    params:
+      LICENSE: ((ud/pxf/common/rpm-license))
+      VENDOR: ((ud/pxf/common/[[pkg_type]]-vendor))
+  - put: pxf_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
+    params:
+      file: [[pxf_tarball_filename]]
+{% if gp_ver == '6'  and platform_ver == 'rocky8' %}
+  - put: pxf_fdw_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
+    params:
+      file: [[pxf_fdw_tarball_filename]]
+{% endif %}

--- a/concourse/pipelines/templates/jobs/test-tpl.yml
+++ b/concourse/pipelines/templates/jobs/test-tpl.yml
@@ -1,0 +1,36 @@
+## Template for generating test jobs in the dev and build pipeline
+
+- name: test_pxf-gp[[gp_ver]]-hdp2_on_[[platform_ver]]
+  plan:
+  - in_parallel:
+    - get: pxf_src
+      passed: [build_pxf-gp[[gp_ver]]_on_[[build_platform_ver]]]
+      trigger: true
+    - get: pxf_tarball
+      resource: pxf_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
+      passed: [build_pxf-gp[[gp_ver]]_on_[[build_platform_ver]]]
+    - get: gpdb_package
+      resource: gpdb[[gp_ver]]_[[gpdb_os_platform]][[os_ver]]_[[pkg_type]]_latest-0
+      passed: [build_pxf-gp[[gp_ver]]_on_[[build_platform_ver]]]
+    - get: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
+      {# If the platform_ver matches build_platform_ver then add the passed condition #}
+      {% if [[platform_ver]] == [[build_platform_ver]] %}
+      passed: [build_pxf-gp[[gp_ver]]_on_[[build_platform_ver]]]
+      {% endif %}
+    - get: pxf-automation-dependencies
+    - get: singlecluster
+      resource: singlecluster-hdp2
+  - task: test_pxf-gp[[gp_ver]]-hdp2_on_[[platform_ver]]
+    file: pxf_src/concourse/tasks/test.yml
+    image: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
+    params:
+      ACCESS_KEY_ID: ((tf-machine-access-key-id))
+      GP_VER: [[gp_ver]]
+      GROUP: gpdb,proxy,profile
+      SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+      {% if platform == 'ubuntu' %}
+      PXF_BASE_DIR: /home/gpadmin/pxf
+      {% endif %}
+{% if slack_notification %}
+    <<: *slack_alert
+{% endif %}

--- a/concourse/pipelines/templates/jobs/test-tpl.yml
+++ b/concourse/pipelines/templates/jobs/test-tpl.yml
@@ -1,34 +1,43 @@
 ## Template for generating test jobs in the dev and build pipeline
 
-- name: test_pxf-gp[[gp_ver]]-hdp2_on_[[platform_ver]]
+## Following variables are expected to be passed to set the test job
+## config.gp_ver = GPDB Major version
+## config.os_ver = OS Major version
+## config.test_os = OS platform in which test jobs are executed
+## build_platform = build_os + os_ver
+## test_platform = test_os + os_ver
+## gpdb_os_platform = GPDB RPM OS ( rhel or ubuntu)
+## pkg_type = rpm or deb
+
+- name: test_pxf-gp[[config.gp_ver]]-hdp2_on_[[test_platform]]
   plan:
   - in_parallel:
     - get: pxf_src
-      passed: [build_pxf-gp[[gp_ver]]_on_[[build_platform_ver]]]
+      passed: [build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]]
       trigger: true
     - get: pxf_tarball
-      resource: pxf_gp[[gp_ver]]_tarball_[[gpdb_os_platform]][[os_ver]]
-      passed: [build_pxf-gp[[gp_ver]]_on_[[build_platform_ver]]]
+      resource: pxf_gp[[config.gp_ver]]_tarball_[[gpdb_os_platform]][[config.os_ver]]
+      passed: [build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]]
     - get: gpdb_package
-      resource: gpdb[[gp_ver]]_[[gpdb_os_platform]][[os_ver]]_[[pkg_type]]_latest-0
-      passed: [build_pxf-gp[[gp_ver]]_on_[[build_platform_ver]]]
-    - get: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
-      {# If the platform_ver matches build_platform_ver then add the passed condition #}
-      {% if [[platform_ver]] == [[build_platform_ver]] %}
-      passed: [build_pxf-gp[[gp_ver]]_on_[[build_platform_ver]]]
+      resource: gpdb[[config.gp_ver]]_[[gpdb_os_platform]][[config.os_ver]]_[[pkg_type]]_latest-0
+      passed: [build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]]
+    - get: gpdb[[config.gp_ver]]-pxf-dev-[[test_platform]]-image
+      {# If the test_platform matches build_platform then add the passed condition #}
+      {% if [[test_platform]] == [[build_platform]] %}
+      passed: [build_pxf-gp[[config.gp_ver]]_on_[[build_platform]]]
       {% endif %}
     - get: pxf-automation-dependencies
     - get: singlecluster
       resource: singlecluster-hdp2
-  - task: test_pxf-gp[[gp_ver]]-hdp2_on_[[platform_ver]]
+  - task: test_pxf-gp[[config.gp_ver]]-hdp2_on_[[test_platform]]
     file: pxf_src/concourse/tasks/test.yml
-    image: gpdb[[gp_ver]]-pxf-dev-[[platform_ver]]-image
+    image: gpdb[[config.gp_ver]]-pxf-dev-[[test_platform]]-image
     params:
       ACCESS_KEY_ID: ((tf-machine-access-key-id))
-      GP_VER: [[gp_ver]]
+      GP_VER: [[config.gp_ver]]
       GROUP: gpdb,proxy,profile
       SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
-      {% if platform == 'ubuntu' %}
+      {% if config.test_os == 'ubuntu' %}
       PXF_BASE_DIR: /home/gpadmin/pxf
       {% endif %}
 {% if slack_notification %}


### PR DESCRIPTION
- Added build and test template files.
- Added a dictionary that contains the configuration to generate the jobs.
- Renamed jobs to reflect the platform.
- The build and test jobs ( sanity test) jobs are now generated through the templates.

Pipeline: https://ci.ud.gpdb.pivotal.io/teams/main/pipelines/dev-pandeyhi-job_templates
