### PR TITLE
Minor fix: Add OEL test job only when the oel7 param set to true

### DIFF
--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -412,7 +412,11 @@ jobs:
       {% include 'jobs/build-tpl.yml' %}
     {% endif %}
 
-    {% include 'jobs/test-tpl.yml' %}
+    {# Add OEL test job only when oel7 is set to true #}
+    {% if config.test_os != 'oel' or oel7 %}
+      {% include 'jobs/test-tpl.yml' %}
+    {% endif %}
+
 {% endfor %}
 
 ## ======================================================================


### PR DESCRIPTION
Minor fix: Set the OEL test job only when `oel7` param set to true. 