### PR TITLE
Fix pxf register command

### DIFF
--- a/concourse/scripts/cli/test_reset_init.sh
+++ b/concourse/scripts/cli/test_reset_init.sh
@@ -27,6 +27,16 @@ remove_extension_files() {
 	"
 }
 
+make_gphome_extension_dir_readonly() {
+  local host=$1
+  ssh "${host}" "chmod u-w ${GPHOME}/share/postgresql/extension/"
+}
+
+make_gphome_extension_dir_readwrite() {
+  local host=$1
+  ssh "${host}" "chmod u+w ${GPHOME}/share/postgresql/extension/"
+}
+
 # === Test "pxf cluster reset" - does nothing on the remote nodes, PXF can be running, no state changes ======
 successful_reset_message=\
 "*****************************************************************************
@@ -117,6 +127,42 @@ test_init_extension_exists_succeeds() {
   done
 }
 run_test test_init_extension_exists_succeeds "pxf cluster init (extension exists) should succeed"
+# ============================================================================================================
+
+# === Test "pxf cluster register" - registers PXF extension into GPHOME, where extension already exist ======
+expected_register_error_message=\
+"Installing PXF extension on coordinator host and 2 segment hosts...
+ERROR: Failed to install PXF extension on 3 out of 3 hosts
+cdw ==> install: cannot create regular file '/usr/local/greenplum-db/share/postgresql/extension/pxf.control': Permission denied
+
+sdw1 ==> install: cannot create regular file '/usr/local/greenplum-db/share/postgresql/extension/pxf.control': Permission denied
+
+sdw2 ==> install: cannot create regular file '/usr/local/greenplum-db/share/postgresql/extension/pxf.control': Permission denied"
+
+test_register_gphome_not_writable() {
+  # given: extension files do not exist under GPHOME
+  for host in "${all_cluster_hosts[@]}"; do
+    remove_extension_files "${host}"
+    assert_empty "$(list_extension_files ${host})" "extension files should NOT exist on host ${host}"
+  done
+  # and: GPHOME is not writable
+  for host in "${all_cluster_hosts[@]}"; do
+    make_gphome_extension_dir_readonly "${host}"
+  done
+  # when : "pxf cluster register" command is run
+  local result status
+  result="$(pxf cluster register 2>&1)"
+  status=$?
+  # then : it fails
+  assert_not_equals "${status}" 0 "pxf cluster register (GPHOME/share/postgresql/extension not writable) should fail"
+  # and : prints an useful error message
+  assert_equals "${expected_register_error_message}" "${result}" "an error message should be printed when pxf cluster register fails"
+
+  for host in "${all_cluster_hosts[@]}"; do
+    make_gphome_extension_dir_readwrite "${host}"
+  done
+}
+run_test test_register_gphome_not_writable "pxf cluster register (GPHOME/share/postgresql/extension not writable) should not succeed"
 # ============================================================================================================
 
 #

--- a/server/pxf-service/src/scripts/pxf
+++ b/server/pxf-service/src/scripts/pxf
@@ -260,8 +260,7 @@ function installExtensions() {
             echoGreen "Installing Greenplum External Table PXF Extension into '${GPHOME}'"
 
             local target_control_file="${GPHOME}/share/postgresql/extension/pxf.control"
-            cp -Lv "${parent_script_dir}/gpextable/pxf.control" "${target_control_file}"
-            chmod 644 "${target_control_file}"
+            install --verbose --mode=0644 "${parent_script_dir}/gpextable/pxf.control" "${target_control_file}" || fail "cannot install pxf.control to '${target_control_file}'"
         fi
     fi
     if [[ -d ${parent_script_dir}/fdw ]]; then
@@ -273,8 +272,7 @@ function installExtensions() {
             echoGreen "Installing Greenplum Foreign Data Wrapper PXF Extension into '${GPHOME}'"
 
             local target_control_file="${GPHOME}/share/postgresql/extension/pxf_fdw.control"
-            cp -Lv "${parent_script_dir}/fdw/pxf_fdw.control" "${target_control_file}"
-            chmod 644 "${target_control_file}"
+            install --verbose --mode=0644 "${parent_script_dir}/fdw/pxf_fdw.control" "${target_control_file}" || fail "cannot install pxf_fdw.control to '${target_control_file}'"
         fi
     fi
 }


### PR DESCRIPTION
The pxf register command assumes that $GPHOME/share/postgresql/extension is writable by the user running the command (usually gpadmin). The GPDB installation docs include a step for changing the ownership of the GPDB installation directory but if this step is skipped, then pxf register will fail. As it is currently implemented, the step of copying the control file into $GPHOME fails but does not cause the pxf utility to exit with a non-zero value. This in turn causes the pxf cluster register command to not recognize the pxf register command failure and not print the stderr output of the command. This makes it seem like the register command has succeeded until the user attempts to call CREATE EXTENSION pxf in psql.

This commit replaces the usage of cp and chmod with install and explicitly adds a failure case if the install fails.

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>