### PR TITLE
Add RHEL9 Docker Images

### DIFF
--- a/concourse/docker/README.md
+++ b/concourse/docker/README.md
@@ -15,13 +15,13 @@ changes to `pxf-build-base` and is also in charge of tagging the images as
 
 ## Available docker images
 
-|                  | Greenplum 5              | Greenplum 6                   | Greenplum 7                  |
-|------------------|--------------------------|-------------------------------|------------------------------|
-| CentOS 7         | `gpdb5-centos7-test-pxf` | `gpdb6-centos7-test-pxf`      | N/A                          |
-| OEL 7            | N/A                      | `gpdb6-oel7-test-pxf`         | N/A                          |
-| Ubuntu 18.04     | N/A                      | `gpdb6-ubuntu18.04-test-pxf`  | N/A                          |
-| Rocky Linux 8    | N/A                      | `gpdb6-rocky8-test-pxf`       | `gpdb7-rocky8-test-pxf`      |
-| Rocky Linux 9    | N/A                      | `gpdb6-rocky9-test-pxf`       |                              |
+|                  | Greenplum 5              | Greenplum 6                   | Greenplum 7             |
+|------------------|--------------------------|-------------------------------|-------------------------|
+| CentOS 7         | `gpdb5-centos7-test-pxf` | `gpdb6-centos7-test-pxf`      | N/A                     |
+| OEL 7            | N/A                      | `gpdb6-oel7-test-pxf`         | N/A                     |
+| Ubuntu 18.04     | N/A                      | `gpdb6-ubuntu18.04-test-pxf`  | N/A                     |
+| Rocky Linux 8    | N/A                      | `gpdb6-rocky8-test-pxf`       | `gpdb7-rocky8-test-pxf` |
+| Rocky Linux 9    | N/A                      | `gpdb6-rocky9-test-pxf`       | `gpdb7-rocky9-test-pxf` |
 
 ## Development docker image
 
@@ -49,13 +49,14 @@ flowchart TD
   subgraph gcr_images ["GP RelEng Images (gcr.io/data-gpdb-public-images)"]
     gp5_centos7_latest[centos-gpdb-dev:7-gcc6.2-llvm3.7]
     gp6_centos7_latest[gpdb6-centos7-test:latest]
-    gp6_centos7_build[gpdb6-centos7-build:latest]
     gp6_ubuntu18_latest[gpdb6-ubuntu18.04-test:latest]
     gp6_oel7_latest[gpdb6-oel7-test:latest]
     gp6_rocky8_latest[gpdb6-rocky8-test:latest]
-    gp6_rocky8_build[gpdb6-rocky8-build:latest]
     gp6_rocky9_latest[gpdb6-rocky9-test:latest]
     gp7_rocky8_latest[gpdb7-rocky8-test:latest]
+    gp7_rocky9_latest[gpdb7-rocky9-test:latest]
+    gp6_centos7_build[gpdb6-centos7-build:latest]
+    gp6_rocky8_build[gpdb6-rocky8-build:latest]
 
     class gp5_centos7_latest gcrPublicStyle
     class gp6_centos7_latest gcrPublicStyle
@@ -64,6 +65,7 @@ flowchart TD
     class gp6_rocky8_latest gcrPublicStyle
     class gp6_rocky9_latest gcrPublicStyle
     class gp7_rocky8_latest gcrPublicStyle
+    class gp7_rocky9_latest gcrPublicStyle
   end
   class gcr_images subgraphStyle
 
@@ -75,6 +77,7 @@ flowchart TD
     gp6_ubuntu18_dockerfile[gpdb6/ubuntu18.04]
     gp6_oel7_dockerfile[gpdb6/oel7]
     gp7_rocky8_dockerfile[gpdb7/rocky8]
+    gp7_rocky9_dockerfile[gpdb7/rocky9]
 
     class gp5_centos7_dockerfile dockerfileStyle
     class gp6_centos7_dockerfile dockerfileStyle
@@ -83,6 +86,7 @@ flowchart TD
     class gp6_ubuntu18_dockerfile dockerfileStyle
     class gp6_oel7_dockerfile dockerfileStyle
     class gp7_rocky8_dockerfile dockerfileStyle
+    class gp7_rocky9_dockerfile dockerfileStyle
   end
   class pxf_dev_base subgraphStyle
 
@@ -104,6 +108,7 @@ flowchart TD
       gp6_ubuntu18_pxf_sha[gpdb6-ubuntu18.04-test-pxf:$COMMIT_SHA]
       gp6_oel7_pxf_sha[gpdb6-oel7-test-pxf:$COMMIT_SHA]
       gp7_rocky8_pxf_sha[gpdb7-rocky8-test-pxf:$COMMIT_SHA]
+      gp7_rocky9_pxf_sha[gpdb7-rocky9-test-pxf:$COMMIT_SHA]
 
       class gp5_centos7_pxf_sha plainStyle
       class gp6_centos7_pxf_sha plainStyle
@@ -112,6 +117,7 @@ flowchart TD
       class gp6_ubuntu18_pxf_sha plainStyle
       class gp6_oel7_pxf_sha plainStyle
       class gp7_rocky8_pxf_sha plainStyle
+      class gp7_rocky9_pxf_sha plainStyle
 
       gp5_centos7_pxf_latest[gpdb5-centos7-test-pxf:latest]
       gp6_centos7_pxf_latest[gpdb6-centos7-test-pxf:latest]
@@ -120,6 +126,7 @@ flowchart TD
       gp6_ubuntu18_pxf_latest[gpdb6-ubuntu18.04-test-pxf:latest]
       gp6_oel7_pxf_latest[gpdb6-oel7-test-pxf:latest]
       gp7_rocky8_pxf_latest[gpdb7-rocky8-test-pxf:latest]
+      gp7_rocky9_pxf_latest[gpdb7-rocky9-test-pxf:latest]
 
       class gp5_centos7_pxf_latest latestStyle
       class gp6_centos7_pxf_latest latestStyle
@@ -128,6 +135,7 @@ flowchart TD
       class gp6_ubuntu18_pxf_latest latestStyle
       class gp6_oel7_pxf_latest latestStyle
       class gp7_rocky8_pxf_latest latestStyle
+      class gp7_rocky9_pxf_latest latestStyle
     end
     class gpdb_pxf_dev subgraphStyle
 
@@ -200,6 +208,10 @@ flowchart TD
   gp7_rocky8_dockerfile -- CloudBuild --> gp7_rocky8_pxf_sha
   gp7_rocky8_pxf_sha -- "tag (concourse pipeline)" --> gp7_rocky8_pxf_latest
 
+  gp7_rocky9_latest --> gp7_rocky9_dockerfile
+  gp7_rocky9_dockerfile -- CloudBuild --> gp7_rocky9_pxf_sha
+  gp7_rocky9_pxf_sha -- "tag (concourse pipeline)" --> gp7_rocky9_pxf_latest
+
   gp6_centos7_build --> rpm_docker_centos7
   rpm_docker_centos7 --> rpm_centos7_latest
   gp6_rocky8_build --> rpm_docker_rocky8
@@ -236,6 +248,8 @@ flowchart TD
   gp7_rocky8_pxf_latest --> certification
   gp7_rocky8_pxf_latest --> build
   gp7_rocky8_pxf_latest --> pr
+
+  gp7_rocky9_pxf_latest --> build
 
   rpm_centos7_latest --> build
   rpm_rocky8_latest --> build

--- a/concourse/docker/README.md
+++ b/concourse/docker/README.md
@@ -21,6 +21,7 @@ changes to `pxf-build-base` and is also in charge of tagging the images as
 | OEL 7            | N/A                      | `gpdb6-oel7-test-pxf`         | N/A                          |
 | Ubuntu 18.04     | N/A                      | `gpdb6-ubuntu18.04-test-pxf`  | N/A                          |
 | Rocky Linux 8    | N/A                      | `gpdb6-rocky8-test-pxf`       | `gpdb7-rocky8-test-pxf`      |
+| Rocky Linux 9    | N/A                      | `gpdb6-rocky9-test-pxf`       |                              |
 
 ## Development docker image
 
@@ -53,6 +54,7 @@ flowchart TD
     gp6_oel7_latest[gpdb6-oel7-test:latest]
     gp6_rocky8_latest[gpdb6-rocky8-test:latest]
     gp6_rocky8_build[gpdb6-rocky8-build:latest]
+    gp6_rocky9_latest[gpdb6-rocky9-test:latest]
     gp7_rocky8_latest[gpdb7-rocky8-test:latest]
 
     class gp5_centos7_latest gcrPublicStyle
@@ -60,6 +62,7 @@ flowchart TD
     class gp6_ubuntu18_latest gcrPublicStyle
     class gp6_oel7_latest gcrPublicStyle
     class gp6_rocky8_latest gcrPublicStyle
+    class gp6_rocky9_latest gcrPublicStyle
     class gp7_rocky8_latest gcrPublicStyle
   end
   class gcr_images subgraphStyle
@@ -68,6 +71,7 @@ flowchart TD
     gp5_centos7_dockerfile[gpdb5/centos7]
     gp6_centos7_dockerfile[gpdb6/centos7]
     gp6_rocky8_dockerfile[gpdb6/rocky8]
+    gp6_rocky9_dockerfile[gpdb6/rocky9]
     gp6_ubuntu18_dockerfile[gpdb6/ubuntu18.04]
     gp6_oel7_dockerfile[gpdb6/oel7]
     gp7_rocky8_dockerfile[gpdb7/rocky8]
@@ -75,6 +79,7 @@ flowchart TD
     class gp5_centos7_dockerfile dockerfileStyle
     class gp6_centos7_dockerfile dockerfileStyle
     class gp6_rocky8_dockerfile dockerfileStyle
+    class gp6_rocky9_dockerfile dockerfileStyle
     class gp6_ubuntu18_dockerfile dockerfileStyle
     class gp6_oel7_dockerfile dockerfileStyle
     class gp7_rocky8_dockerfile dockerfileStyle
@@ -95,6 +100,7 @@ flowchart TD
       gp5_centos7_pxf_sha[gpdb5-centos7-test-pxf:$COMMIT_SHA]
       gp6_centos7_pxf_sha[gpdb6-centos7-test-pxf:$COMMIT_SHA]
       gp6_rocky8_pxf_sha[gpdb6-rocky8-test-pxf:$COMMIT_SHA]
+      gp6_rocky9_pxf_sha[gpdb6-rocky9-test-pxf:$COMMIT_SHA]
       gp6_ubuntu18_pxf_sha[gpdb6-ubuntu18.04-test-pxf:$COMMIT_SHA]
       gp6_oel7_pxf_sha[gpdb6-oel7-test-pxf:$COMMIT_SHA]
       gp7_rocky8_pxf_sha[gpdb7-rocky8-test-pxf:$COMMIT_SHA]
@@ -102,6 +108,7 @@ flowchart TD
       class gp5_centos7_pxf_sha plainStyle
       class gp6_centos7_pxf_sha plainStyle
       class gp6_rocky8_pxf_sha plainStyle
+      class gp6_rocky9_pxf_sha plainStyle
       class gp6_ubuntu18_pxf_sha plainStyle
       class gp6_oel7_pxf_sha plainStyle
       class gp7_rocky8_pxf_sha plainStyle
@@ -109,6 +116,7 @@ flowchart TD
       gp5_centos7_pxf_latest[gpdb5-centos7-test-pxf:latest]
       gp6_centos7_pxf_latest[gpdb6-centos7-test-pxf:latest]
       gp6_rocky8_pxf_latest[gpdb6-rocky8-test-pxf:latest]
+      gp6_rocky9_pxf_latest[gpdb6-rocky9-test-pxf:latest]
       gp6_ubuntu18_pxf_latest[gpdb6-ubuntu18.04-test-pxf:latest]
       gp6_oel7_pxf_latest[gpdb6-oel7-test-pxf:latest]
       gp7_rocky8_pxf_latest[gpdb7-rocky8-test-pxf:latest]
@@ -116,6 +124,7 @@ flowchart TD
       class gp5_centos7_pxf_latest latestStyle
       class gp6_centos7_pxf_latest latestStyle
       class gp6_rocky8_pxf_latest latestStyle
+      class gp6_rocky9_pxf_latest latestStyle
       class gp6_ubuntu18_pxf_latest latestStyle
       class gp6_oel7_pxf_latest latestStyle
       class gp7_rocky8_pxf_latest latestStyle
@@ -175,6 +184,10 @@ flowchart TD
   gp6_rocky8_dockerfile -- CloudBuild --> gp6_rocky8_pxf_sha
   gp6_rocky8_pxf_sha -- "tag (concourse pipeline)" --> gp6_rocky8_pxf_latest
 
+  gp6_rocky9_latest --> gp6_rocky9_dockerfile
+  gp6_rocky9_dockerfile -- CloudBuild --> gp6_rocky9_pxf_sha
+  gp6_rocky9_pxf_sha -- "tag (concourse pipeline)" --> gp6_rocky9_pxf_latest
+
   gp6_ubuntu18_latest --> gp6_ubuntu18_dockerfile
   gp6_ubuntu18_dockerfile -- CloudBuild --> gp6_ubuntu18_pxf_sha
   gp6_ubuntu18_pxf_sha -- "tag (concourse pipeline)" --> gp6_ubuntu18_pxf_latest
@@ -210,6 +223,8 @@ flowchart TD
   gp6_rocky8_pxf_latest --> perf
   gp6_rocky8_pxf_latest --> build
   gp6_rocky8_pxf_latest --> pr
+
+  gp6_rocky9_pxf_latest --> build
 
   gp6_ubuntu18_pxf_latest --> certification
   gp6_ubuntu18_pxf_latest --> build

--- a/concourse/docker/README.md
+++ b/concourse/docker/README.md
@@ -57,6 +57,7 @@ flowchart TD
     gp7_rocky9_latest[gpdb7-rocky9-test:latest]
     gp6_centos7_build[gpdb6-centos7-build:latest]
     gp6_rocky8_build[gpdb6-rocky8-build:latest]
+    gp6_rocky9_build[gpdb6-rocky9-build:latest]
 
     class gp5_centos7_latest gcrPublicStyle
     class gp6_centos7_latest gcrPublicStyle
@@ -93,9 +94,11 @@ flowchart TD
   subgraph rpmrebuild [rpmrebuild/cloudbuild.yaml]
     rpm_docker_centos7[centos/Dockerfile]
     rpm_docker_rocky8[rocky/Dockerfile]
+    rpm_docker_rocky9[rocky/Dockerfile]
 
     class rpm_docker_centos7 dockerfileStyle
     class rpm_docker_rocky8 dockerfileStyle
+    class rpm_docker_rocky9 dockerfileStyle
   end
   class rpmrebuild subgraphStyle
 
@@ -141,9 +144,11 @@ flowchart TD
 
     rpm_centos7_latest[rpmrebuild-centos7:latest]
     rpm_rocky8_latest[rpmrebuild-rocky8:latest]
+    rpm_rocky9_latest[rpmrebuild-rocky9:latest]
 
     class rpm_centos7_latest latestStyle
     class rpm_rocky8_latest latestStyle
+    class rpm_rocky9_latest latestStyle
   end
   class gcr_data_gpdb_ud subgraphStyle
 
@@ -216,6 +221,8 @@ flowchart TD
   rpm_docker_centos7 --> rpm_centos7_latest
   gp6_rocky8_build --> rpm_docker_rocky8
   rpm_docker_rocky8 --> rpm_rocky8_latest
+  gp6_rocky9_build --> rpm_docker_rocky9
+  rpm_docker_rocky9 --> rpm_rocky9_latest
 
   gp6_centos7_pxf_latest --> server_dockerfile
   server_dockerfile -- "CloudBuild (add singlecluster, build deps, & automation deps)" --> gp6_centos7_pxf_hdp2_sha
@@ -253,4 +260,5 @@ flowchart TD
 
   rpm_centos7_latest --> build
   rpm_rocky8_latest --> build
+  rpm_rocky9_latest --> build
 ```

--- a/concourse/docker/pxf-dev-base/README.md
+++ b/concourse/docker/pxf-dev-base/README.md
@@ -144,3 +144,19 @@ command to build the image:
       -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb7/rocky8/Dockerfile \
       .
     popd
+
+
+### Docker gpdb7-rocky9-test-pxf-image image
+
+Build this image for Greenplum 7 running on Rocky 9. Run the following
+command to build the image:
+
+    pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
+    docker build \
+      --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb7-rocky9-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=MAVEN_VERSION=${MAVEN_VERSION} \
+      --tag=gpdb7-rocky9-test-pxf \
+      -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile \
+      .
+    popd

--- a/concourse/docker/pxf-dev-base/README.md
+++ b/concourse/docker/pxf-dev-base/README.md
@@ -83,6 +83,21 @@ command to build the image:
       .
     popd
 
+### Docker gpdb6-rocky9-test-pxf-image image
+
+Build this image for Greenplum 6 running on Rhel 9. Run the following
+command to build the image:
+
+    pushd ~/workspace/pxf/concourse/docker/pxf-dev-base/
+    docker build \
+      --build-arg=BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-rocky9-test:latest \
+      --build-arg=GO_VERSION=${GO_VERSION} \
+      --build-arg=MAVEN_VERSION=${MAVEN_VERSION} \
+      --tag=gpdb6-rocky9-test-pxf \
+      -f ~/workspace/pxf/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile \
+      .
+    popd
+
 ### Docker gpdb6-ubuntu18.04-test-pxf-image image
 
 Build this image for Greenplum 6 running on Ubuntu 18.04. Run the following

--- a/concourse/docker/pxf-dev-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-dev-base/cloudbuild.yaml
@@ -220,6 +220,34 @@ steps:
     - apache-maven-binaries
     - gpdb7-rocky8-test-pxf-image-cache
 
+  # Greenplum 7 Rocky 9 Image
+- name: 'gcr.io/cloud-builders/docker'
+  id: gpdb7-rocky9-test-pxf-image-cache
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      mkdir -p /workspace/build
+      docker pull gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:latest || exit 0
+  waitFor: ['-']
+
+- name: 'gcr.io/cloud-builders/docker'
+  id: gpdb7-rocky9-test-pxf-image
+  args:
+    - 'build'
+    - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb7-rocky9-test:latest'
+    - '--build-arg=GO_VERSION=${_GO_VERSION}'
+    - '--build-arg=GO_SHA256SUM=${_GO_SHA256SUM}'
+    - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:$COMMIT_SHA'
+    - '--cache-from'
+    - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:latest'
+    - '-f'
+    - 'concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile'
+    - '/workspace/build/'
+  waitFor:
+    - apache-maven-binaries
+    - gpdb7-rocky9-test-pxf-image-cache
+
 substitutions:
   _GO_VERSION: '1.21.3' # default values
   _GO_SHA256SUM: '1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8' # sha256 for 1.21.3
@@ -234,3 +262,4 @@ images:
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-ubuntu18.04-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-oel7-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:$COMMIT_SHA'
+- 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:$COMMIT_SHA'

--- a/concourse/docker/pxf-dev-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-dev-base/cloudbuild.yaml
@@ -107,6 +107,33 @@ steps:
     - gpdb6-rocky8-test-pxf-image-cache
 
 - name: 'gcr.io/cloud-builders/docker'
+  id: gpdb6-rocky9-test-pxf-image-cache
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    mkdir -p /workspace/build
+    docker pull gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-rocky9-test-pxf:latest || exit 0
+  waitFor: ['-']
+
+- name: 'gcr.io/cloud-builders/docker'
+  id: gpdb6-rocky9-test-pxf-image
+  args:
+  - 'build'
+  - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-rocky9-test:latest'
+  - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=GO_SHA256SUM=${_GO_SHA256SUM}'
+  - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-rocky9-test-pxf:$COMMIT_SHA'
+  - '--cache-from'
+  - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-rocky9-test-pxf:latest'
+  - '-f'
+  - 'concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile'
+  - '/workspace/build/'
+  waitFor:
+    - apache-maven-binaries
+    - gpdb6-rocky9-test-pxf-image-cache
+
+- name: 'gcr.io/cloud-builders/docker'
   id: gpdb6-ubuntu18.04-test-pxf-image-cache
   entrypoint: 'bash'
   args:
@@ -203,6 +230,7 @@ images:
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb5-centos7-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-centos7-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-rocky8-test-pxf:$COMMIT_SHA'
+- 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-rocky9-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-ubuntu18.04-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb6-oel7-test-pxf:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:$COMMIT_SHA'

--- a/concourse/docker/pxf-dev-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-dev-base/cloudbuild.yaml
@@ -1,7 +1,7 @@
 ---
 # In root pxf directory, run the following command to build this builder.
 # $ gcloud builds submit . --config=concourse/docker/pxf-dev-base/cloudbuild.yaml \
-#  --substitutions=_BASE_IMAGE_REPOSITORY=gcr.io/data-gpdb-public-images,COMMIT_SHA=<tagname>,_PXF_BUILD_BUCKET=<bucketname>
+#  --substitutions=_BASE_IMAGE_REPOSITORY=gcr.io/data-gpdb-public-images,COMMIT_SHA=<tag>,_PXF_BUILD_BUCKET=<bucket>
 
 # Increase timeout to 30 minutes
 timeout: 1800s
@@ -14,7 +14,10 @@ steps:
 
 - name: 'gcr.io/cloud-builders/gsutil'
   id: apache-maven-binaries
-  args: ['cp', 'gs://${_PXF_BUILD_BUCKET}/apache-maven/apache-maven-${_MAVEN_VERSION}-bin.tar.gz', 'build/apache-maven.tar.gz']
+  args:
+  - 'cp'
+  - 'gs://${_PXF_BUILD_BUCKET}/apache-maven/apache-maven-${_MAVEN_VERSION}-bin.tar.gz'
+  - 'build/apache-maven.tar.gz'
   waitFor: ['-']
 
 ##############################################################################
@@ -250,9 +253,9 @@ steps:
   - gpdb7-rocky9-test-pxf-image-cache
 
 substitutions:
-  _GO_VERSION: '1.21.3' # default values
-  _GO_SHA256SUM: '1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8' # sha256 for 1.21.3
-  _MAVEN_VERSION: '3.9.3' # default values
+  _GO_VERSION: '1.21.3'  # default values
+  _GO_SHA256SUM: '1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8'  # sha256 for 1.21.3
+  _MAVEN_VERSION: '3.9.3'  # default values
 
 # Push images to Cloud Build to Container Registry
 images:

--- a/concourse/docker/pxf-dev-base/cloudbuild.yaml
+++ b/concourse/docker/pxf-dev-base/cloudbuild.yaml
@@ -1,3 +1,4 @@
+---
 # In root pxf directory, run the following command to build this builder.
 # $ gcloud builds submit . --config=concourse/docker/pxf-dev-base/cloudbuild.yaml \
 #  --substitutions=_BASE_IMAGE_REPOSITORY=gcr.io/data-gpdb-public-images,COMMIT_SHA=<tagname>,_PXF_BUILD_BUCKET=<bucketname>
@@ -45,8 +46,8 @@ steps:
   - 'concourse/docker/pxf-dev-base/gpdb5/centos7/Dockerfile'
   - '/workspace/build/'
   waitFor:
-    - apache-maven-binaries
-    - gpdb5-centos7-test-pxf-image-cache
+  - apache-maven-binaries
+  - gpdb5-centos7-test-pxf-image-cache
 
 ##############################################################################
 # GPDB 6 Images
@@ -76,8 +77,8 @@ steps:
   - 'concourse/docker/pxf-dev-base/gpdb6/centos7/Dockerfile'
   - '/workspace/build/'
   waitFor:
-    - gpdb6-centos7-test-pxf-image-cache
-    - apache-maven-binaries
+  - gpdb6-centos7-test-pxf-image-cache
+  - apache-maven-binaries
 
 - name: 'gcr.io/cloud-builders/docker'
   id: gpdb6-rocky8-test-pxf-image-cache
@@ -103,8 +104,8 @@ steps:
   - 'concourse/docker/pxf-dev-base/gpdb6/rocky8/Dockerfile'
   - '/workspace/build/'
   waitFor:
-    - apache-maven-binaries
-    - gpdb6-rocky8-test-pxf-image-cache
+  - apache-maven-binaries
+  - gpdb6-rocky8-test-pxf-image-cache
 
 - name: 'gcr.io/cloud-builders/docker'
   id: gpdb6-rocky9-test-pxf-image-cache
@@ -130,8 +131,8 @@ steps:
   - 'concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile'
   - '/workspace/build/'
   waitFor:
-    - apache-maven-binaries
-    - gpdb6-rocky9-test-pxf-image-cache
+  - apache-maven-binaries
+  - gpdb6-rocky9-test-pxf-image-cache
 
 - name: 'gcr.io/cloud-builders/docker'
   id: gpdb6-ubuntu18.04-test-pxf-image-cache
@@ -157,8 +158,8 @@ steps:
   - 'concourse/docker/pxf-dev-base/gpdb6/ubuntu18.04/Dockerfile'
   - '/workspace/build/'
   waitFor:
-    - apache-maven-binaries
-    - gpdb6-ubuntu18.04-test-pxf-image-cache
+  - apache-maven-binaries
+  - gpdb6-ubuntu18.04-test-pxf-image-cache
 
 # An image for gpdb6 running on OEL7
 - name: 'gcr.io/cloud-builders/docker'
@@ -185,8 +186,8 @@ steps:
   - 'concourse/docker/pxf-dev-base/gpdb6/oel7/Dockerfile'
   - '/workspace/build/'
   waitFor:
-    - apache-maven-binaries
-    - gpdb6-oel7-test-pxf-image-cache
+  - apache-maven-binaries
+  - gpdb6-oel7-test-pxf-image-cache
 
 ##############################################################################
 # GPDB 7 Images
@@ -197,56 +198,56 @@ steps:
   id: gpdb7-rocky8-test-pxf-image-cache
   entrypoint: 'bash'
   args:
-    - '-c'
-    - |
-      mkdir -p /workspace/build
-      docker pull gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:latest || exit 0
+  - '-c'
+  - |
+    mkdir -p /workspace/build
+    docker pull gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:latest || exit 0
   waitFor: ['-']
 
 - name: 'gcr.io/cloud-builders/docker'
   id: gpdb7-rocky8-test-pxf-image
   args:
-    - 'build'
-    - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb7-rocky8-test:latest'
-    - '--build-arg=GO_VERSION=${_GO_VERSION}'
-    - '--build-arg=GO_SHA256SUM=${_GO_SHA256SUM}'
-    - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:$COMMIT_SHA'
-    - '--cache-from'
-    - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:latest'
-    - '-f'
-    - 'concourse/docker/pxf-dev-base/gpdb7/rocky8/Dockerfile'
-    - '/workspace/build/'
+  - 'build'
+  - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb7-rocky8-test:latest'
+  - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=GO_SHA256SUM=${_GO_SHA256SUM}'
+  - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:$COMMIT_SHA'
+  - '--cache-from'
+  - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky8-test-pxf:latest'
+  - '-f'
+  - 'concourse/docker/pxf-dev-base/gpdb7/rocky8/Dockerfile'
+  - '/workspace/build/'
   waitFor:
-    - apache-maven-binaries
-    - gpdb7-rocky8-test-pxf-image-cache
+  - apache-maven-binaries
+  - gpdb7-rocky8-test-pxf-image-cache
 
   # Greenplum 7 Rocky 9 Image
 - name: 'gcr.io/cloud-builders/docker'
   id: gpdb7-rocky9-test-pxf-image-cache
   entrypoint: 'bash'
   args:
-    - '-c'
-    - |
-      mkdir -p /workspace/build
-      docker pull gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:latest || exit 0
+  - '-c'
+  - |
+    mkdir -p /workspace/build
+    docker pull gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:latest || exit 0
   waitFor: ['-']
 
 - name: 'gcr.io/cloud-builders/docker'
   id: gpdb7-rocky9-test-pxf-image
   args:
-    - 'build'
-    - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb7-rocky9-test:latest'
-    - '--build-arg=GO_VERSION=${_GO_VERSION}'
-    - '--build-arg=GO_SHA256SUM=${_GO_SHA256SUM}'
-    - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:$COMMIT_SHA'
-    - '--cache-from'
-    - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:latest'
-    - '-f'
-    - 'concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile'
-    - '/workspace/build/'
+  - 'build'
+  - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb7-rocky9-test:latest'
+  - '--build-arg=GO_VERSION=${_GO_VERSION}'
+  - '--build-arg=GO_SHA256SUM=${_GO_SHA256SUM}'
+  - '--tag=gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:$COMMIT_SHA'
+  - '--cache-from'
+  - 'gcr.io/$PROJECT_ID/gpdb-pxf-dev/gpdb7-rocky9-test-pxf:latest'
+  - '-f'
+  - 'concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile'
+  - '/workspace/build/'
   waitFor:
-    - apache-maven-binaries
-    - gpdb7-rocky9-test-pxf-image-cache
+  - apache-maven-binaries
+  - gpdb7-rocky9-test-pxf-image-cache
 
 substitutions:
   _GO_VERSION: '1.21.3' # default values

--- a/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
@@ -28,8 +28,6 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
     && chmod +x /opt/minio/bin/minio \
     && chown -R minio:minio /opt/minio
 
-ARG USER_HOME_DIR="/root"
-
 # install dependencies that are missing on the base images
 RUN ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn
 

--- a/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
@@ -57,8 +57,6 @@ RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
     && echo -e "password\npassword" | passwd gpadmin 2> /dev/null \
     && awk '{print "localhost", $1, $2; print "127.0.0.1", $1, $2}' /etc/ssh/ssh_host_rsa_key.pub >> /home/gpadmin/.ssh/known_hosts \
     && chown -R gpadmin:gpadmin /home/gpadmin/.ssh \
-    # install dependencies as gpadmin \
-    && su gpadmin -c "pip install paramiko --no-cache-dir" \
     # configure gpadmin limits
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft core unlimited' \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nproc 131072' \

--- a/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
@@ -1,0 +1,77 @@
+ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb6-rocky9-test:latest
+
+FROM ${BASE_IMAGE}
+
+ARG GO_VERSION
+ARG GO_SHA256SUM
+
+ADD apache-maven.tar.gz /usr/share
+
+# install Go utilities
+RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
+    && wget -O go.tgz -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
+    && echo "${GO_SHA256SUM} /tmp/go.tgz" | sha256sum --check \
+    && rm -rf /usr/local/go && mkdir /opt/pxf && tar -C /opt/pxf -xzf go.tgz && rm go.tgz
+
+# add Java 11
+RUN wget -q https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz \
+    && mkdir -p /usr/lib/jvm \
+    && tar -C /usr/lib/jvm -xzf openjdk-11+28_linux-x64_bin.tar.gz \
+    && rm -f openjdk-11+28_linux-x64_bin.tar.gz
+
+# add minio software
+RUN useradd -s /sbin/nologin -d /opt/minio minio \
+    && mkdir -p /opt/minio/bin \
+    && chmod a+rx /opt/minio \
+    && mkdir /opt/minio/data \
+    && wget -q https://dl.minio.io/server/minio/release/linux-amd64/minio -O /opt/minio/bin/minio \
+    && chmod +x /opt/minio/bin/minio \
+    && chown -R minio:minio /opt/minio
+
+ARG USER_HOME_DIR="/root"
+
+# install dependencies that are missing on the base images
+RUN ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn \
+    && /usr/bin/pip3 install paramiko --no-cache-dir
+
+# create rsa key for the root user
+RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
+    && cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys \
+    && chmod 0600 /root/.ssh/authorized_keys \
+    && echo -e "password\npassword" | passwd 2> /dev/null \
+    # create rsa key for the server
+    && ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa \
+    && sed -i -e 's|Defaults    requiretty|#Defaults    requiretty|' /etc/sudoers \
+    && sed -ri 's/UsePAM yes/UsePAM no/g;s/PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config \
+    && sed -ri 's@^HostKey /etc/ssh/ssh_host_ecdsa_key$@#&@;s@^HostKey /etc/ssh/ssh_host_ed25519_key$@#&@' /etc/ssh/sshd_config \
+    # create user gpadmin since GPDB cannot run under root
+    && groupadd -g 6000 gpadmin && useradd -u 6000 -g 6000 gpadmin \
+    && echo "gpadmin  ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/gpadmin \
+    && groupadd supergroup && usermod -a -G supergroup gpadmin \
+    && mkdir /home/gpadmin/.ssh \
+    # create an rsa key for the gpadmin user
+    && ssh-keygen -m PEM -t rsa -f /home/gpadmin/.ssh/id_rsa \
+    && cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys \
+    && chmod 0600 /home/gpadmin/.ssh/authorized_keys \
+    && echo -e "password\npassword" | passwd gpadmin 2> /dev/null \
+    && awk '{print "localhost", $1, $2; print "127.0.0.1", $1, $2}' /etc/ssh/ssh_host_rsa_key.pub >> /home/gpadmin/.ssh/known_hosts \
+    && chown -R gpadmin:gpadmin /home/gpadmin/.ssh \
+    # configure gpadmin limits
+    && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft core unlimited' \
+    && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nproc 131072' \
+    && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nofile 65536' \
+    # add locale for testing
+    && localedef -c -i ru_RU -f CP1251 ru_RU.CP1251 \
+    # create .pxfrc
+    && echo >> ~gpadmin/.pxfrc 'export LANG=en_US.UTF-8' \
+    && echo >> ~gpadmin/.pxfrc 'export PGPORT=5432' \
+    && echo >> ~gpadmin/.pxfrc 'export GOPATH=/opt/go' \
+    && echo >> ~gpadmin/.pxfrc 'export GPHOME=$(find /usr/local/ -name greenplum-db* -type d | head -n1)' \
+    && echo >> ~gpadmin/.pxfrc 'export LD_LIBRARY_PATH=${GPHOME}/lib:${LD_LIBRARY_PATH-}' \
+    && echo >> ~gpadmin/.pxfrc 'export GPHD_ROOT=/singlecluster' \
+    && echo >> ~gpadmin/.pxfrc 'export PXF_HOME=/usr/local/pxf-gp6' \
+    && echo >> ~gpadmin/.pxfrc 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk' \
+    && echo >> ~gpadmin/.pxfrc 'export PATH=${GPHOME}/bin:${PXF_HOME}/bin:${GOPATH}/bin:/opt/pxf/go/bin:$PATH' \
+    && ln -s ~gpadmin/.pxfrc ~root \
+    && echo >> ~gpadmin/.bashrc 'source ~/.pxfrc' \
+    && chown -R gpadmin:gpadmin ~gpadmin

--- a/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
@@ -31,8 +31,9 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
 ARG USER_HOME_DIR="/root"
 
 # install dependencies that are missing on the base images
-RUN ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn \
-    && /usr/bin/pip3 install paramiko --no-cache-dir
+RUN ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn
+
+RUN update-crypto-policies --set DEFAULT:SHA1
 
 # create rsa key for the root user
 RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
@@ -56,6 +57,8 @@ RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
     && echo -e "password\npassword" | passwd gpadmin 2> /dev/null \
     && awk '{print "localhost", $1, $2; print "127.0.0.1", $1, $2}' /etc/ssh/ssh_host_rsa_key.pub >> /home/gpadmin/.ssh/known_hosts \
     && chown -R gpadmin:gpadmin /home/gpadmin/.ssh \
+    # install dependencies as gpadmin \
+    && su gpadmin -c "pip install paramiko --no-cache-dir" \
     # configure gpadmin limits
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft core unlimited' \
     && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nproc 131072' \

--- a/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb6/rocky9/Dockerfile
@@ -31,6 +31,7 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
 # install dependencies that are missing on the base images
 RUN ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn
 
+# automation tests use jsystem and requires the older SHA1 crypto policy, include it here
 RUN update-crypto-policies --set DEFAULT:SHA1
 
 # create rsa key for the root user

--- a/concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile
@@ -22,8 +22,6 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
     && chmod +x /opt/minio/bin/minio \
     && chown -R minio:minio /opt/minio
 
-ARG USER_HOME_DIR="/root"
-
 # install dependencies that are missing on the base images
 RUN ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn
 

--- a/concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile
@@ -27,6 +27,8 @@ ARG USER_HOME_DIR="/root"
 # install dependencies that are missing on the base images
 RUN ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn
 
+RUN update-crypto-policies --set DEFAULT:SHA1
+
 # create rsa key for the root user
 RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
     && cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys \

--- a/concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile
@@ -1,0 +1,70 @@
+ARG BASE_IMAGE=gcr.io/data-gpdb-public-images/gpdb7-rocky9-test:latest
+
+FROM ${BASE_IMAGE}
+
+ARG GO_VERSION
+ARG GO_SHA256SUM
+
+ADD apache-maven.tar.gz /usr/share
+
+# install Go utilities
+RUN mkdir -p /tmp/pxf_src/ && cd /tmp \
+    && wget -O go.tgz -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
+    && echo "${GO_SHA256SUM} /tmp/go.tgz" | sha256sum --check \
+    && rm -rf /usr/local/go && mkdir /opt/pxf && tar -C /opt/pxf -xzf go.tgz && rm go.tgz
+
+# add minio software
+RUN useradd -s /sbin/nologin -d /opt/minio minio \
+    && mkdir -p /opt/minio/bin \
+    && chmod a+rx /opt/minio \
+    && mkdir /opt/minio/data \
+    && wget -q https://dl.minio.io/server/minio/release/linux-amd64/minio -O /opt/minio/bin/minio \
+    && chmod +x /opt/minio/bin/minio \
+    && chown -R minio:minio /opt/minio
+
+ARG USER_HOME_DIR="/root"
+
+# install dependencies that are missing on the base images
+RUN ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn
+
+# create rsa key for the root user
+RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa \
+    && cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys \
+    && chmod 0600 /root/.ssh/authorized_keys \
+    && echo -e "password\npassword" | passwd 2> /dev/null \
+    # create rsa key for the server
+    && ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa \
+    && sed -i -e 's|Defaults    requiretty|#Defaults    requiretty|' /etc/sudoers \
+    && sed -ri 's/UsePAM yes/UsePAM no/g;s/PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config \
+    && sed -ri 's@^HostKey /etc/ssh/ssh_host_ecdsa_key$@#&@;s@^HostKey /etc/ssh/ssh_host_ed25519_key$@#&@' /etc/ssh/sshd_config \
+    # create user gpadmin since GPDB cannot run under root
+    && groupadd -g 6000 gpadmin && useradd -u 6000 -g 6000 gpadmin \
+    && echo "gpadmin  ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/gpadmin \
+    && groupadd supergroup && usermod -a -G supergroup gpadmin \
+    && mkdir /home/gpadmin/.ssh \
+    # create an rsa key for the gpadmin user
+    && ssh-keygen -m PEM -t rsa -f /home/gpadmin/.ssh/id_rsa \
+    && cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys \
+    && chmod 0600 /home/gpadmin/.ssh/authorized_keys \
+    && echo -e "password\npassword" | passwd gpadmin 2> /dev/null \
+    && awk '{print "localhost", $1, $2; print "127.0.0.1", $1, $2}' /etc/ssh/ssh_host_rsa_key.pub >> /home/gpadmin/.ssh/known_hosts \
+    && chown -R gpadmin:gpadmin /home/gpadmin/.ssh \
+    # configure gpadmin limits
+    && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft core unlimited' \
+    && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nproc 131072' \
+    && echo >> /etc/security/limits.d/gpadmin-limits.conf 'gpadmin soft nofile 65536' \
+    # add locale for testing
+    && localedef -c -i ru_RU -f CP1251 ru_RU.CP1251 \
+    # create .pxfrc
+    && echo >> ~gpadmin/.pxfrc 'export LANG=en_US.UTF-8' \
+    && echo >> ~gpadmin/.pxfrc 'export PGPORT=5432' \
+    && echo >> ~gpadmin/.pxfrc 'export GOPATH=/opt/go' \
+    && echo >> ~gpadmin/.pxfrc 'export GPHOME=$(find /usr/local/ -name greenplum-db* -type d | head -n1)' \
+    && echo >> ~gpadmin/.pxfrc 'export LD_LIBRARY_PATH=${GPHOME}/lib:${LD_LIBRARY_PATH-}' \
+    && echo >> ~gpadmin/.pxfrc 'export GPHD_ROOT=/singlecluster' \
+    && echo >> ~gpadmin/.pxfrc 'export PXF_HOME=/usr/local/pxf-gp7' \
+    && echo >> ~gpadmin/.pxfrc 'export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk' \
+    && echo >> ~gpadmin/.pxfrc 'export PATH=${GPHOME}/bin:${PXF_HOME}/bin:${GOPATH}/bin:/opt/pxf/go/bin:$JAVA_HOME/bin:$PATH' \
+    && ln -s ~gpadmin/.pxfrc ~root \
+    && echo >> ~gpadmin/.bashrc 'source ~/.pxfrc' \
+    && chown -R gpadmin:gpadmin ~gpadmin

--- a/concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile
+++ b/concourse/docker/pxf-dev-base/gpdb7/rocky9/Dockerfile
@@ -25,6 +25,7 @@ RUN useradd -s /sbin/nologin -d /opt/minio minio \
 # install dependencies that are missing on the base images
 RUN ln -s /usr/share/apache-maven-*/bin/mvn /usr/bin/mvn
 
+# automation tests use jsystem and requires the older SHA1 crypto policy, include it here
 RUN update-crypto-policies --set DEFAULT:SHA1
 
 # create rsa key for the root user

--- a/concourse/docker/rpmrebuild/cloudbuild.yaml
+++ b/concourse/docker/rpmrebuild/cloudbuild.yaml
@@ -27,7 +27,20 @@ steps:
     - 'concourse/docker/rpmrebuild/rocky'
   waitFor: ['-']
 
+# Builds the rpmrebuild-rocky9 image
+- name: 'gcr.io/cloud-builders/docker'
+  id: rpmrebuild-rocky8-image
+  args:
+    - 'build'
+    - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-rocky9-build:latest'
+    - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-rocky9:latest'
+    - '-f'
+    - 'concourse/docker/rpmrebuild/rocky/Dockerfile'
+    - 'concourse/docker/rpmrebuild/rocky'
+  waitFor: ['-']
+
 # Push images from Cloud Build to Container Registry
 images:
   - 'gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
   - 'gcr.io/$PROJECT_ID/rpmrebuild-rocky8:latest'
+  - 'gcr.io/$PROJECT_ID/rpmrebuild-rocky9:latest'

--- a/concourse/docker/rpmrebuild/cloudbuild.yaml
+++ b/concourse/docker/rpmrebuild/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
 
 # Builds the rpmrebuild-rocky9 image
 - name: 'gcr.io/cloud-builders/docker'
-  id: rpmrebuild-rocky8-image
+  id: rpmrebuild-rocky9-image
   args:
     - 'build'
     - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-rocky9-build:latest'

--- a/concourse/docker/rpmrebuild/cloudbuild.yaml
+++ b/concourse/docker/rpmrebuild/cloudbuild.yaml
@@ -1,3 +1,4 @@
+---
 # In this directory, run the following command to build this builder.
 # $ gcloud builds submit . --config=cloudbuild.yaml
 
@@ -7,40 +8,40 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   id: rpmrebuild-centos7-image
   args:
-    - 'build'
-    - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-centos7-build:latest'
-    - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
-    - '-f'
-    - 'concourse/docker/rpmrebuild/centos/Dockerfile'
-    - 'concourse/docker/rpmrebuild/centos'
+  - 'build'
+  - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-centos7-build:latest'
+  - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
+  - '-f'
+  - 'concourse/docker/rpmrebuild/centos/Dockerfile'
+  - 'concourse/docker/rpmrebuild/centos'
   waitFor: ['-']
 
 # Builds the rpmrebuild-rocky8 image
 - name: 'gcr.io/cloud-builders/docker'
   id: rpmrebuild-rocky8-image
   args:
-    - 'build'
-    - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-rocky8-build:latest'
-    - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-rocky8:latest'
-    - '-f'
-    - 'concourse/docker/rpmrebuild/rocky/Dockerfile'
-    - 'concourse/docker/rpmrebuild/rocky'
+  - 'build'
+  - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-rocky8-build:latest'
+  - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-rocky8:latest'
+  - '-f'
+  - 'concourse/docker/rpmrebuild/rocky/Dockerfile'
+  - 'concourse/docker/rpmrebuild/rocky'
   waitFor: ['-']
 
 # Builds the rpmrebuild-rocky9 image
 - name: 'gcr.io/cloud-builders/docker'
   id: rpmrebuild-rocky9-image
   args:
-    - 'build'
-    - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-rocky9-build:latest'
-    - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-rocky9:latest'
-    - '-f'
-    - 'concourse/docker/rpmrebuild/rocky/Dockerfile'
-    - 'concourse/docker/rpmrebuild/rocky'
+  - 'build'
+  - '--build-arg=BASE_IMAGE=${_BASE_IMAGE_REPOSITORY}/gpdb6-rocky9-build:latest'
+  - '--tag=gcr.io/$PROJECT_ID/rpmrebuild-rocky9:latest'
+  - '-f'
+  - 'concourse/docker/rpmrebuild/rocky/Dockerfile'
+  - 'concourse/docker/rpmrebuild/rocky'
   waitFor: ['-']
 
 # Push images from Cloud Build to Container Registry
 images:
-  - 'gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
-  - 'gcr.io/$PROJECT_ID/rpmrebuild-rocky8:latest'
-  - 'gcr.io/$PROJECT_ID/rpmrebuild-rocky9:latest'
+- 'gcr.io/$PROJECT_ID/rpmrebuild-centos7:latest'
+- 'gcr.io/$PROJECT_ID/rpmrebuild-rocky8:latest'
+- 'gcr.io/$PROJECT_ID/rpmrebuild-rocky9:latest'

--- a/concourse/pipelines/cloudbuild_pipeline.yml
+++ b/concourse/pipelines/cloudbuild_pipeline.yml
@@ -84,7 +84,7 @@ jobs:
       GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GOOGLE_ZONE: ((ud/pxf/common/google-zone))
       # yamllint disable rule:line-length
-      IMAGE_LIST: "gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-rocky8-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf gpdb7-rocky8-test-pxf"
+      IMAGE_LIST: "gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-rocky8-test-pxf gpdb6-rocky9-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf gpdb7-rocky8-test-pxf"
       IMAGE_TAG: ((gcp-image-tag))
     config:
       platform: linux

--- a/concourse/pipelines/cloudbuild_pipeline.yml
+++ b/concourse/pipelines/cloudbuild_pipeline.yml
@@ -84,7 +84,7 @@ jobs:
       GOOGLE_PROJECT_ID: ((ud/pxf/common/google-project-id))
       GOOGLE_ZONE: ((ud/pxf/common/google-zone))
       # yamllint disable rule:line-length
-      IMAGE_LIST: "gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-rocky8-test-pxf gpdb6-rocky9-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf gpdb7-rocky8-test-pxf"
+      IMAGE_LIST: "gpdb5-centos7-test-pxf gpdb6-centos7-test-pxf gpdb6-rocky8-test-pxf gpdb6-rocky9-test-pxf gpdb6-ubuntu18.04-test-pxf gpdb6-oel7-test-pxf gpdb7-rocky8-test-pxf gpdb7-rocky9-test-pxf"
       IMAGE_TAG: ((gcp-image-tag))
     config:
       platform: linux


### PR DESCRIPTION
This PR does the following: 
- adds in GP6 and GP7 Dockerfiles for RHEL9
- updates the cloudbuild.yaml file to include new dockerfiles
- addresses yamllint issues in cloudbuild.yaml
- updates the docker diagram to include the new images

This PR is only the image portion of https://github.com/greenplum-db/pxf/pull/1038 in anticipation of incoming pipeline changes. 