### PR TITLE
Remove oslogin_trustedca.pub on IPA cluster

### DIFF
--- a/concourse/ansible/ipa-multinode-hadoop/tasks/common.yml
+++ b/concourse/ansible/ipa-multinode-hadoop/tasks/common.yml
@@ -18,3 +18,8 @@
     name: "*"
     state: latest
     lock_timeout: 300
+
+- name: remove oslogin_trustedca.pub
+  ansible.builtin.file:
+    path: /etc/ssh/oslogin_trustedca.pub
+    state: absent


### PR DESCRIPTION
VMs launched in GCP include a service called google-guest-agent [1] that enables GCE platform features. One of the platform features this service can enable is OS Login [2]. If OS Login is configured, the google-guest-agent creates a named pipe in /etc/ssh/ called oslogin_trustedca.pub and configures SSHD to use this pipe for TrustedUserCAKeys. We do not use OS Login but the named pipe is still present in the file system.

When we install IPA on a machine, one the steps it does it attempt to read all *.pub files under /etc/ssh [3] which includes oslogin_trustedca.pub. However, since OS Login is not configured, google-guest-agent has not opened the pipe for writing and this causes the call to open the pipe for reading in ipa-client-install to hang.

This commit updates the Ansible playbook for provisioning an IPA cluster to remove oslogin_trustedca.pub (if it exists) before running ipa-client-install.

[1]: https://github.com/GoogleCloudPlatform/guest-agent
[2]: https://cloud.google.com/compute/docs/oslogin
[3]: https://github.com/freeipa/freeipa/blob/release-4-6-8/ipaclient/install/client.py#L1502-L1530