### PR TITLE
ci: Update the ccp_reap_minutes to 180 min

### DIFF
--- a/concourse/pipelines/templates/jobs/test-multinode-tpl.yml
+++ b/concourse/pipelines/templates/jobs/test-multinode-tpl.yml
@@ -69,7 +69,7 @@
             extra_nodes: 1
             segments_per_host: 4
             instance_type: n1-standard-4
-            ccp_reap_minutes: 120
+            ccp_reap_minutes: 180
             standby_master: [[ccp_default_conf]]
       - task: generate-greenplum-cluster
         input_mapping:
@@ -116,7 +116,7 @@
         GOOGLE_ZONE: ((ud/pxf/common/google-zone))
         IMAGE_VERSION: ((dataproc-image-version))
         KERBEROS: ((kerberos-enabled))
-        ccp_reap_minutes: 120
+        ccp_reap_minutes: 180
     - task: generate-hadoop-cluster-2
       file: pxf_src/concourse/tasks/install_dataproc.yml
       output_mapping:
@@ -132,7 +132,7 @@
         KERBEROS: ((kerberos-enabled))
         KEY: dataproc-kerberos-key
         KEYRING: dataproc-kerberos
-        ccp_reap_minutes: 120
+        ccp_reap_minutes: 180
         NO_ADDRESS: false
         PROXY_USER: gpuser
         SECRETS_BUCKET: ((ud/pxf/secrets/kerberos-pxf-secrets-bucket-name))


### PR DESCRIPTION
This commit updates the ccp_reap_minutes for the GPDB cluster and the dataproc clusters to 180 minutes to allow more time for the second attempt of the automation test suite.

The multinode tests are configured to attempt the automation task twice. After the dataproc cluster is created, it takes about 30 minutes for the multinode-ipa cluster to be created and around 60 minutes for the first run of the automation tests.

This does not give us enough time to do a second run of automation before the clusters get reaped.

Unlike clusters created through terraform where the reap time starts after failure, dataproc clusters only have a concept of `max age`, for consistency, the team sets the value for `max age` to be `ccp_reap_minutes`. Let us bring this number up to 180 minutes so that the pipeline has enough time to do 2 full runs of the automation suite if necessary.

We update the ccp_reap_minutes for the GPDB cluster just for consistency.