### PR TITLE
Change dataproc script to use golang-petname

### DIFF
--- a/concourse/scripts/start_dataproc_cluster.bash
+++ b/concourse/scripts/start_dataproc_cluster.bash
@@ -22,9 +22,9 @@ SECRETS_BUCKET=${SECRETS_BUCKET:-data-gpdb-ud-pxf-secrets}
 SUBNETWORK=${SUBNETWORK:-dynamic}
 ZONE=${GOOGLE_ZONE:-us-central1-a}
 
-pip3 install petname
+apt install golang-petname
 
-CLUSTER_NAME=${CLUSTER_NAME:-ccp-$(petname)}
+CLUSTER_NAME=${CLUSTER_NAME:-ccp-$(golang-petname)}
 # remove any . in the value and lower case it as dataproc names can not contain dots or capital letters
 CLUSTER_NAME=${CLUSTER_NAME//./}
 CLUSTER_NAME=$(echo ${CLUSTER_NAME} | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
This PR updates the package used in the dataproc script that generates a random cluster name. 

This change is needed because the google/cloud-sdk:slim image used to spin up the dataproc clusters has been bumped to Debian 12 (Bookworm) and comes with Python3.11. Python 3.11 introduces a concept called externally managed environments (see PEP 668) which now distinguishes between user-installed packages and system packages. 

Instead of using a python package, we can directly download the `golang-petname` package, a Debian supported package with the same functionality. 