### PR TITLE
Add GP6 RHEL 9 artifacts to pivnet_artifacts pipeline

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -170,9 +170,9 @@ resources:
 ## ---------- Greenplum Packages ----------
 {% call(x) macros.for_each_config(build_test_pxf_combinations) %}
     {% do x.update({'gp_num_versions': gp_num_versions[x.gp_ver]}) %}
-    {% if x.os_ver == '9' %}
+    {% if x.gp_ver == '7' and x.os_ver == '9' %}
         {# define RPMs for rocky9 until they are released into standard locations #}
-        {% include 'resources/greenplum-rocky9-package-tpl.yml' %}
+        {% include 'resources/greenplum-7-rocky9-package-tpl.yml' %}
     {% else %}
         {% include 'resources/greenplum-package-tpl.yml' %}
     {% endif %}

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -133,9 +133,9 @@ resources:
 ## ---------- Greenplum Packages ----------
 {% call(x) macros.for_each_config(build_test_pxf_combinations) %}
     {% do x.update({'gp_num_versions': gp_num_versions[x.gp_ver]}) %}
-    {% if x.os_ver == '9' %}
+    {% if x.gp_ver == '7' and x.os_ver == '9' %}
         {# define RPMs for rocky9 until they are released into standard locations #}
-        {% include 'resources/greenplum-rocky9-package-tpl.yml' %}
+        {% include 'resources/greenplum-7-rocky9-package-tpl.yml' %}
     {% else %}
         {% include 'resources/greenplum-package-tpl.yml' %}
     {% endif %}

--- a/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
+++ b/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
@@ -14,6 +14,7 @@ resources:
     {'gp_ver': '5', 'build_os': 'centos', 'test_os': 'centos', 'os_ver': '7',     'test_fdw': false, 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': true},
     {'gp_ver': '6', 'build_os': 'centos', 'test_os': 'centos', 'os_ver': '7',     'test_fdw': false, 'test_file': true , 'test_cli': false, 'test_multi': true , 'test_features': supported_features, 'generate_release_tarball': true},
     {'gp_ver': '6', 'build_os': 'rocky' , 'test_os': 'rocky' , 'os_ver': '8',     'test_fdw': true , 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': false},
+    {'gp_ver': '6', 'build_os': 'rocky' , 'test_os': 'rocky' , 'os_ver': '9',     'test_fdw': true , 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': false},
     {'gp_ver': '6', 'build_os': 'ubuntu', 'test_os': 'ubuntu', 'os_ver': '18.04', 'test_fdw': false, 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': false}] %}
 
 {% set gp_num_versions = { '5': num_gpdb5_versions, '6': num_gpdb6_versions, '7': num_gpdb7_versions} %}

--- a/concourse/pipelines/templates/resources/greenplum-7-rocky9-package-tpl.yml
+++ b/concourse/pipelines/templates/resources/greenplum-7-rocky9-package-tpl.yml
@@ -4,16 +4,6 @@
  #}
 
 {# define RPMs for rocky9 until they are released into standard locations #}
-{% if x.os_ver == '9' and x.gp_ver == '6' %}
-- name: gpdb6-el9-rpm-latest-0
-  type: gcs
-  icon: google-drive
-  source:
-    bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: maintenance/release-candidates/gpdb6/greenplum-db-server-(6.*)-rhel9-x86_64.rpm
-
-{% elif x.os_ver == '9' and x.gp_ver == '7' %}
 - name: gpdb7-el9-rpm-latest-0
   type: gcs
   icon: google-drive
@@ -21,4 +11,3 @@
     bucket: ((ud/pxf/common/gpdb-concourse-resources-prod-bucket-name))
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/release-candidates/gpdb7/greenplum-db-server-(7.*)-el9-x86_64.rpm
-{% endif %}


### PR DESCRIPTION
Now that GP6 includes support for RHEL 9, PXF's CI pipelines should be updated to use released server installers. This requires updating the build and dev pipelines to retrieve server installers from the standard location. This also requires updating the pivnet_artifacts pipeline to download new versions of the server installer and save a copy in the standard cloud storage bucket location.