### PR TITLE
Reduce flakiness by waiting for HDFS file to exist

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -231,6 +231,12 @@
             <version>1.10.11</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+        </dependency>
+
         <!-- AWS Dependencies -->
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
@@ -9,6 +9,10 @@ import org.greenplum.pxf.automation.utils.system.ProtocolEnum;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 import org.testng.annotations.Test;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.with;
+
 /**
  * Functional Globbing Tests. Tests are based on Hadoop Glob Tests
  * https://github.com/apache/hadoop/blob/rel/release-3.2.1/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/TestGlobPaths.java
@@ -125,6 +129,17 @@ public class HcfsGlobbingTest extends BaseFeature {
         prepareTableData(path, data2, "2b");
         prepareTableData(path, data3, "3c");
         prepareTableData(path, data4, "4d");
+        String datafile = data4 != null ? data4 :
+                          data3 != null ? data3 :
+                          data2 != null ? data2 :
+                          data1 != null ? data1 : null;
+
+        if (datafile != null) {
+            with().pollInterval(20, MILLISECONDS)
+                .and().with().pollDelay(20, MILLISECONDS)
+                .await().atMost(300, SECONDS)
+                .until(() -> hdfs.doesFileExist("/" + hdfs.getWorkingDirectory() + "/" + path + "/" + datafile));
+        }
 
         ProtocolEnum protocol = ProtocolUtils.getProtocol();
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
@@ -9,6 +9,9 @@ import org.greenplum.pxf.automation.utils.system.ProtocolEnum;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.with;
@@ -129,12 +132,12 @@ public class HcfsGlobbingTest extends BaseFeature {
         prepareTableData(path, data2, "2b");
         prepareTableData(path, data3, "3c");
         prepareTableData(path, data4, "4d");
-        String datafile = data4 != null ? data4 :
-                          data3 != null ? data3 :
-                          data2 != null ? data2 :
-                          data1 != null ? data1 : null;
 
-        if (datafile != null) {
+        // there is an assumption that if data3 has value, then data1, data2 will have values
+        // however, there is a possibility that these values could be null and if so, find the last non-null value
+        // so that we can watch and wait to make sure all of the files exist, before continuing the test
+        Optional<String> datafile = Stream.of(data4, data3, data2, data1).filter(data -> data != null).findFirst();
+        if (datafile.isPresent()) {
             with().pollInterval(20, MILLISECONDS)
                 .and().with().pollDelay(20, MILLISECONDS)
                 .await().atMost(300, SECONDS)

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
@@ -140,7 +140,7 @@ public class HcfsGlobbingTest extends BaseFeature {
         if (datafile.isPresent()) {
             with().pollInterval(20, MILLISECONDS)
                 .and().with().pollDelay(20, MILLISECONDS)
-                .await().atMost(300, SECONDS)
+                .await().atMost(120, SECONDS)
                 .until(() -> hdfs.doesFileExist("/" + hdfs.getWorkingDirectory() + "/" + path + "/" + datafile));
         }
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
@@ -136,10 +136,12 @@ public class HcfsGlobbingTest extends BaseFeature {
         // wait until all the files exist, before continuing the test
         List<String> datafiles = Arrays.asList(data1, data2, data3, data4);
         datafiles.parallelStream().forEach(datafile -> {
-            with().pollInterval(20, MILLISECONDS)
-                .and().with().pollDelay(20, MILLISECONDS)
-                .await().atMost(120, SECONDS)
-                .until(() -> hdfs.doesFileExist("/" + hdfs.getWorkingDirectory() + "/" + path + "/" + datafile));
+            if (datafile != null) {
+                with().pollInterval(20, MILLISECONDS)
+                        .and().with().pollDelay(20, MILLISECONDS)
+                        .await().atMost(240, SECONDS)
+                        .until(() -> hdfs.doesFileExist("/" + hdfs.getWorkingDirectory() + "/" + path + "/" + datafile));
+            }
         });
 
         ProtocolEnum protocol = ProtocolUtils.getProtocol();

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
@@ -9,12 +9,8 @@ import org.greenplum.pxf.automation.utils.system.ProtocolEnum;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -137,9 +133,8 @@ public class HcfsGlobbingTest extends BaseFeature {
         prepareTableData(path, data3, "3c");
         prepareTableData(path, data4, "4d");
 
-        // wait until all of the files exist, before continuing the test
-        List<String> datafiles = new ArrayList();
-        Collections.addAll(datafiles, data1, data2, data3, data4);
+        // wait until all the files exist, before continuing the test
+        List<String> datafiles = Arrays.asList(data1, data2, data3, data4);
         datafiles.parallelStream().forEach(datafile -> {
             with().pollInterval(20, MILLISECONDS)
                 .and().with().pollDelay(20, MILLISECONDS)

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
@@ -9,6 +9,7 @@ import org.greenplum.pxf.automation.utils.system.ProtocolEnum;
 import org.greenplum.pxf.automation.utils.system.ProtocolUtils;
 import org.testng.annotations.Test;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -136,12 +137,12 @@ public class HcfsGlobbingTest extends BaseFeature {
         // there is an assumption that if data3 has value, then data1, data2 will have values
         // however, there is a possibility that these values could be null and if so, find the last non-null value
         // so that we can watch and wait to make sure all of the files exist, before continuing the test
-        Optional<String> datafile = Stream.of(data4, data3, data2, data1).filter(data -> data != null).findFirst();
+        Optional<String> datafile = Stream.of(data4, data3, data2, data1).filter(Objects::nonNull).findFirst();
         if (datafile.isPresent()) {
             with().pollInterval(20, MILLISECONDS)
                 .and().with().pollDelay(20, MILLISECONDS)
                 .await().atMost(120, SECONDS)
-                .until(() -> hdfs.doesFileExist("/" + hdfs.getWorkingDirectory() + "/" + path + "/" + datafile));
+                .until(() -> hdfs.doesFileExist("/" + hdfs.getWorkingDirectory() + "/" + path + "/" + datafile.get()));
         }
 
         ProtocolEnum protocol = ProtocolUtils.getProtocol();

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -596,10 +596,7 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
             throws Exception {
 
         String localResultFile = dataTempFolder + "/" + hdfsPath.replaceAll("/", "_");
-        // for HCFS on Cloud, wait a bit for async write in previous steps to finish
-        if (protocol != ProtocolEnum.HDFS) {
-            sleep(10000);
-        }
+        // wait a bit for async write in previous steps to finish
         with().pollInterval(20, MILLISECONDS)
             .and().with().pollDelay(20, MILLISECONDS)
             .await().atMost(120, SECONDS)

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -1,7 +1,6 @@
 package org.greenplum.pxf.automation.features.writable;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 import annotations.SkipForFDW;
 import annotations.WorksWithFDW;
@@ -28,8 +27,8 @@ import java.util.Random;
 import java.util.TimeZone;
 
 import static java.lang.Thread.sleep;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.with;
-import static org.awaitility.Awaitility.await;
 
 /**
  * Testing cases for PXF Writable feature for Text formats (Text, CSV) and compressions.
@@ -603,7 +602,7 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
         }
         with().pollInterval(20, MILLISECONDS)
             .and().with().pollDelay(20, MILLISECONDS)
-            .await().atMost(300, SECONDS)
+            .await().atMost(120, SECONDS)
             .until(() -> hdfs.doesFileExist("/" + hdfsPath));
         List<String> files = hdfs.list(hdfsPath);
         Table resultTable = new Table("result_table", null);

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -1,7 +1,7 @@
 package org.greenplum.pxf.automation.features.writable;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 
 import annotations.SkipForFDW;
 import annotations.WorksWithFDW;
@@ -28,6 +28,8 @@ import java.util.Random;
 import java.util.TimeZone;
 
 import static java.lang.Thread.sleep;
+import static org.awaitility.Awaitility.with;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Testing cases for PXF Writable feature for Text formats (Text, CSV) and compressions.
@@ -599,8 +601,10 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
         if (protocol != ProtocolEnum.HDFS) {
             sleep(10000);
         }
-        short size = hdfs.getReplicationSize();
-        await().atMost(10, SECONDS).until(() -> hdfs.getCheckStatus() == 0);
+        with().pollInterval(20, MILLISECONDS)
+            .and().with().pollDelay(20, MILLISECONDS)
+            .await().atMost(300, SECONDS)
+            .until(() -> hdfs.doesFileExist("/" + hdfsPath));
         List<String> files = hdfs.list(hdfsPath);
         Table resultTable = new Table("result_table", null);
         int index = 0;

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -1,5 +1,8 @@
 package org.greenplum.pxf.automation.features.writable;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
 import annotations.SkipForFDW;
 import annotations.WorksWithFDW;
 import org.apache.commons.lang.StringUtils;
@@ -596,6 +599,8 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
         if (protocol != ProtocolEnum.HDFS) {
             sleep(10000);
         }
+        short size = hdfs.getReplicationSize();
+        await().atMost(10, SECONDS).until(() -> hdfs.getCheckStatus() == 0);
         List<String> files = hdfs.list(hdfsPath);
         Table resultTable = new Table("result_table", null);
         int index = 0;


### PR DESCRIPTION
This PR uses awaitility to wait for the HDFS file to exist before we run the SQL query. Metadata about a file is written to the Namenode after the file is written and closed. This is when the file is considered accessible, so waiting for the file to exist should ensure that we do not start reading while data is still being written to the files used by testing. 