### PR TITLE
Fix pxf-build pipeline

### DIFF
--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -331,7 +331,7 @@ jobs:
 {% call(x) macros.for_each_config(build_test_pxf_combinations) %}
     {# rocky9 is a new platform and there are no previous versions of gpdb to test against.
      # this conditional can be removed once there are at least gp_num_versions of rocky9 gpdb builds #}
-    {% if x.os_ver == '9' %}
+    {% if x.gp_ver == '7' and x.os_ver == '9' %}
         {% do x.update({'gp_num_versions': 1}) %}
     {% else %}
         {% do x.update({'gp_num_versions': gp_num_versions[x.gp_ver]}) %}


### PR DESCRIPTION
Commit ae51cee updated the pxf-build pipeline to include resources for previous release of GPDB on EL9 but missed updating the certification job to consume theses resources. This causes an error when setting the pipeline because it is an invalid configuration to have unused resources.

Authored-by: Bradford D. Boyle <bradford.boyle@broadcom.com>