### PR TITLE
Fix data path for non-HDFS protocols

### DIFF
--- a/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
@@ -53,6 +53,9 @@ import java.util.List;
 import java.util.UUID;
 
 import static java.lang.Thread.sleep;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.with;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -234,6 +237,13 @@ public class Hdfs extends BaseSystemObject implements IFSFunctionality {
         }
 
         return new Path(pathString);
+    }
+
+    public void waitForFile(String path) {
+        with().pollInterval(20, MILLISECONDS)
+                .and().with().pollDelay(20, MILLISECONDS)
+                .await().atMost(240, SECONDS)
+                .until(() -> doesFileExist(getDatapath(path).toString()));
     }
 
     @Override

--- a/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
+++ b/automation/src/main/java/org/greenplum/pxf/automation/components/hdfs/Hdfs.java
@@ -239,10 +239,10 @@ public class Hdfs extends BaseSystemObject implements IFSFunctionality {
         return new Path(pathString);
     }
 
-    public void waitForFile(String path) {
+    public void waitForFile(String path, int maxSecondsToWait) {
         with().pollInterval(20, MILLISECONDS)
                 .and().with().pollDelay(20, MILLISECONDS)
-                .await().atMost(240, SECONDS)
+                .await().atMost(maxSecondsToWait, SECONDS)
                 .until(() -> doesFileExist(getDatapath(path).toString()));
     }
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
@@ -133,7 +133,7 @@ public class HcfsGlobbingTest extends BaseFeature {
         List<String> datafiles = Arrays.asList(data1, data2, data3, data4);
         datafiles.parallelStream().forEach(datafile -> {
             if (datafile != null) {
-                hdfs.waitForFile(hdfs.getWorkingDirectory() + "/" + path + "/" + datafile);
+                hdfs.waitForFile(hdfs.getWorkingDirectory() + "/" + path + "/" + datafile, 240);
             }
         });
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/hcfs/HcfsGlobbingTest.java
@@ -12,10 +12,6 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.with;
-
 /**
  * Functional Globbing Tests. Tests are based on Hadoop Glob Tests
  * https://github.com/apache/hadoop/blob/rel/release-3.2.1/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/fs/TestGlobPaths.java
@@ -137,10 +133,7 @@ public class HcfsGlobbingTest extends BaseFeature {
         List<String> datafiles = Arrays.asList(data1, data2, data3, data4);
         datafiles.parallelStream().forEach(datafile -> {
             if (datafile != null) {
-                with().pollInterval(20, MILLISECONDS)
-                        .and().with().pollDelay(20, MILLISECONDS)
-                        .await().atMost(240, SECONDS)
-                        .until(() -> hdfs.doesFileExist("/" + hdfs.getWorkingDirectory() + "/" + path + "/" + datafile));
+                hdfs.waitForFile(hdfs.getWorkingDirectory() + "/" + path + "/" + datafile);
             }
         });
 

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -1,7 +1,5 @@
 package org.greenplum.pxf.automation.features.writable;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
 import annotations.SkipForFDW;
 import annotations.WorksWithFDW;
 import org.apache.commons.lang.StringUtils;
@@ -27,8 +25,6 @@ import java.util.Random;
 import java.util.TimeZone;
 
 import static java.lang.Thread.sleep;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.with;
 
 /**
  * Testing cases for PXF Writable feature for Text formats (Text, CSV) and compressions.
@@ -597,10 +593,7 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
 
         String localResultFile = dataTempFolder + "/" + hdfsPath.replaceAll("/", "_");
         // wait a bit for async write in previous steps to finish
-        with().pollInterval(20, MILLISECONDS)
-            .and().with().pollDelay(20, MILLISECONDS)
-            .await().atMost(120, SECONDS)
-            .until(() -> hdfs.doesFileExist("/" + hdfsPath));
+        hdfs.waitForFile(hdfsPath);
         List<String> files = hdfs.list(hdfsPath);
         Table resultTable = new Table("result_table", null);
         int index = 0;

--- a/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
+++ b/automation/src/test/java/org/greenplum/pxf/automation/features/writable/HdfsWritableTextTest.java
@@ -593,7 +593,7 @@ public class HdfsWritableTextTest extends BaseWritableFeature {
 
         String localResultFile = dataTempFolder + "/" + hdfsPath.replaceAll("/", "_");
         // wait a bit for async write in previous steps to finish
-        hdfs.waitForFile(hdfsPath);
+        hdfs.waitForFile(hdfsPath, 120);
         List<String> files = hdfs.list(hdfsPath);
         Table resultTable = new Table("result_table", null);
         int index = 0;


### PR DESCRIPTION
This PR is a follow up to https://github.com/greenplum-db/pxf/commit/3b625d77900196a46560da7d56815ac1025ed890. It fixes the location in the datapath for protocols that aren't HDFS. 