### PR TITLE
Update job trigger for certification pipeline

### DIFF
--- a/concourse/pipelines/templates/jobs/certify-gpdb-with-pxf-tpl.yml
+++ b/concourse/pipelines/templates/jobs/certify-gpdb-with-pxf-tpl.yml
@@ -11,12 +11,12 @@
   plan:
   - in_parallel:
     - get: pxf_src
+      trigger: true
     - get: bin_gpdb
       resource: [[x.gpdb_tarball_name]]
       trigger: true
     - get: pxf_package
       resource: [[x.pxf_package_name]]
-      trigger: true
     - get: gpdb[[x.gp_ver]]-pxf-dev-[[x.test_platform]]-image
     - get: ccp-7-image
     - get: pxf-automation-dependencies


### PR DESCRIPTION
The pxf-build pipeline pushes release tags to Github after the release artifacts have been successfully pushed to required buckets.

The certification pipeline's pxf_src resource updates when there is a new release tag on Github. As such, the trigger for the certification pipeline should be on the pxf_src and not on the pxf artifacts. Changing the trigger would ensure that the certification pipeline is being properly kicked off: when both the new release tag is present on Github and the artifacts are present in the required buckets. 