### PR TITLE
ci: Fix fetching Greenplum installers from Tanzu Net

### DIFF
--- a/concourse/scripts/get_product_files.bash
+++ b/concourse/scripts/get_product_files.bash
@@ -72,6 +72,7 @@ for ((i = 0; i < ${#product_files[@]}; i++)); do
 		case "${file}" in
 			*rhel7*) existing_file="$(find ${product_dirs[$i]}/ -name *rhel7*.rpm)" ;;
 			*rhel8*) existing_file="$(find ${product_dirs[$i]}/ -name *rhel8*.rpm)" ;;
+			*rhel9*) existing_file="$(find ${product_dirs[$i]}/ -name *rhel9*.rpm)" ;;
 			*ubuntu18*) existing_file="$(find ${product_dirs[$i]}/ -name *ubuntu18*.deb)" ;;
 			*)
 				echo "Unexpected file: ${file}"


### PR DESCRIPTION
The CI script for downloading Greenplum installers from Tanzu network needed to be updated to handle RHEL9 not having releases for all of the N previous releases.

Authored-by: Bradford D. Boyle <bradford.boyle@broadcom.com>