### PR TITLE
Change to using vendored gcs-resource

### DIFF
--- a/concourse/pipelines/singlecluster-pipeline.yml
+++ b/concourse/pipelines/singlecluster-pipeline.yml
@@ -6,7 +6,8 @@ resource_types:
 - name: google-cloud-storage
   type: registry-image
   source:
-    repository: frodenas/gcs-resource
+    repository: gcr.io/data-gpdb-public-images/gcs-resource
+    tag: v0.6.0
 
 ## ======================================================================
 ## RESOURCES

--- a/concourse/pipelines/singlecluster-pipeline.yml
+++ b/concourse/pipelines/singlecluster-pipeline.yml
@@ -7,7 +7,6 @@ resource_types:
   type: registry-image
   source:
     repository: gcr.io/data-gpdb-public-images/gcs-resource
-    tag: v0.6.0
 
 ## ======================================================================
 ## RESOURCES

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -108,7 +108,7 @@ anchors:
 resource_types:
     [[macros.resource_type_registry_image('terraform', 'gcr.io/data-gpdb-ud/terraform-resource', '0.11.15')]]
     [[macros.resource_type_registry_image('terraform-0.14.10', 'ljfranklin/terraform-resource', '0.14.10')]]
-    [[macros.resource_type_registry_image('gcs', 'frodenas/gcs-resource', '')]]
+    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', 'v0.6.0')]]
     [[macros.resource_type_registry_image('google-chat-notify-resource', 'springio/google-chat-notify-resource', '0.0.1-SNAPSHOT')]]
 
 ## ======================================================================

--- a/concourse/pipelines/templates/build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/build_pipeline-tpl.yml
@@ -108,7 +108,7 @@ anchors:
 resource_types:
     [[macros.resource_type_registry_image('terraform', 'gcr.io/data-gpdb-ud/terraform-resource', '0.11.15')]]
     [[macros.resource_type_registry_image('terraform-0.14.10', 'ljfranklin/terraform-resource', '0.14.10')]]
-    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', 'v0.6.0')]]
+    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', '')]]
     [[macros.resource_type_registry_image('google-chat-notify-resource', 'springio/google-chat-notify-resource', '0.0.1-SNAPSHOT')]]
 
 ## ======================================================================

--- a/concourse/pipelines/templates/certification_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/certification_pipeline-tpl.yml
@@ -33,7 +33,7 @@ anchors:
 ## RESOURCE TYPES
 ## ======================================================================
 resource_types:
-    [[macros.resource_type_registry_image('gcs', 'frodenas/gcs-resource', '')]]
+    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', 'v0.6.0')]]
 {% if gchat_notification %}
     [[macros.resource_type_registry_image('google-chat-notify-resource', 'springio/google-chat-notify-resource', '0.0.1-SNAPSHOT')]]
 {% endif %}

--- a/concourse/pipelines/templates/certification_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/certification_pipeline-tpl.yml
@@ -33,7 +33,7 @@ anchors:
 ## RESOURCE TYPES
 ## ======================================================================
 resource_types:
-    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', 'v0.6.0')]]
+    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', '')]]
 {% if gchat_notification %}
     [[macros.resource_type_registry_image('google-chat-notify-resource', 'springio/google-chat-notify-resource', '0.0.1-SNAPSHOT')]]
 {% endif %}

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -84,7 +84,7 @@ resource_types:
     [[macros.resource_type_registry_image('terraform-0.14.10', 'ljfranklin/terraform-resource', '0.14.10')]]
 {% endif %}
 
-    [[macros.resource_type_registry_image('gcs', 'frodenas/gcs-resource', '')]]
+    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', 'v0.6.0')]]
 
 {% if gchat_notification %}
     [[macros.resource_type_registry_image('google-chat-notify-resource', 'springio/google-chat-notify-resource', '0.0.1-SNAPSHOT')]]

--- a/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
+++ b/concourse/pipelines/templates/dev_build_pipeline-tpl.yml
@@ -84,7 +84,7 @@ resource_types:
     [[macros.resource_type_registry_image('terraform-0.14.10', 'ljfranklin/terraform-resource', '0.14.10')]]
 {% endif %}
 
-    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', 'v0.6.0')]]
+    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', '')]]
 
 {% if gchat_notification %}
     [[macros.resource_type_registry_image('google-chat-notify-resource', 'springio/google-chat-notify-resource', '0.0.1-SNAPSHOT')]]

--- a/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
+++ b/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
@@ -2,7 +2,7 @@
 {% import "macros/macros.j2" as macros %}
 {% set attempts = 3 %}
 resource_types:
-    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', 'v0.6.0')]]
+    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', '')]]
 
 resources:
     [[macros.resource_timer('twice-a-day', '12h')]]

--- a/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
+++ b/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
@@ -2,7 +2,7 @@
 {% import "macros/macros.j2" as macros %}
 {% set attempts = 3 %}
 resource_types:
-    [[macros.resource_type_registry_image('gcs', 'frodenas/gcs-resource', '')]]
+    [[macros.resource_type_registry_image('gcs', 'gcr.io/data-gpdb-public-images/gcs-resource', 'v0.6.0')]]
 
 resources:
     [[macros.resource_timer('twice-a-day', '12h')]]


### PR DESCRIPTION
The concourse pipelines are getting rate-limited by docker when trying to pull down the gcs-resource image. 

```
ERRO[0000] checking origin frodenas/gcs-resource failed: initialize transport: GET https://index.docker.io/v2/: unexpected status code 429 Too Many Requests: Too Many Requests (HAP429)
```

Instead of pulling it from Dockerhub, pull it from our vendored copy to avoid getting rate-limited. 