### PR TITLE
Add GP7 to PivNet artifacts pipeline

### DIFF
--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -17,8 +17,8 @@ DEV_CLOUDBUILD_PIPELINE_NAME ?= dev-cloudbuild-$(USER)-$(BRANCH)
 PERF_PIPELINE_NAME          ?= pxf_perf-$(SCALE)g-RHEL$(REDHAT_MAJOR_VERSION)
 PIVNET_PIPELINE_NAME        ?= pivnet_artifacts
 NUM_GPDB5_VERSIONS          ?= 10
-NUM_GPDB6_VERSIONS          ?=  9
-NUM_GPDB7_VERSIONS          ?=  1
+NUM_GPDB6_VERSIONS          ?= 10
+NUM_GPDB7_VERSIONS          ?= 10
 REDHAT_MAJOR_VERSION        ?= 7
 FLY_CMD                     ?= fly
 CHECK_CREDS                 ?= true
@@ -245,7 +245,8 @@ generate-pivnet-pipeline:
 	mkdir -p generated
 	$(TEMPLATE_CMD) --template get_pivnet_artifacts-tpl.yml --vars \
 		num_gpdb5_versions=$(NUM_GPDB5_VERSIONS) \
-		num_gpdb6_versions=$(NUM_GPDB6_VERSIONS) >./generated/get_pivnet_artifacts.yml
+		num_gpdb6_versions=$(NUM_GPDB6_VERSIONS) \
+		num_gpdb7_versions=$(NUM_GPDB7_VERSIONS)>./generated/get_pivnet_artifacts.yml
 
 .PHONY: singlecluster
 singlecluster:

--- a/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
+++ b/concourse/pipelines/templates/get_pivnet_artifacts-tpl.yml
@@ -15,7 +15,10 @@ resources:
     {'gp_ver': '6', 'build_os': 'centos', 'test_os': 'centos', 'os_ver': '7',     'test_fdw': false, 'test_file': true , 'test_cli': false, 'test_multi': true , 'test_features': supported_features, 'generate_release_tarball': true},
     {'gp_ver': '6', 'build_os': 'rocky' , 'test_os': 'rocky' , 'os_ver': '8',     'test_fdw': true , 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': false},
     {'gp_ver': '6', 'build_os': 'rocky' , 'test_os': 'rocky' , 'os_ver': '9',     'test_fdw': true , 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': false},
-    {'gp_ver': '6', 'build_os': 'ubuntu', 'test_os': 'ubuntu', 'os_ver': '18.04', 'test_fdw': false, 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': false}] %}
+    {'gp_ver': '6', 'build_os': 'ubuntu', 'test_os': 'ubuntu', 'os_ver': '18.04', 'test_fdw': false, 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': false},
+    {'gp_ver': '7', 'build_os': 'rocky' , 'test_os': 'rocky' , 'os_ver': '8',     'test_fdw': true , 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': false},
+    {'gp_ver': '7', 'build_os': 'rocky' , 'test_os': 'rocky' , 'os_ver': '9',     'test_fdw': true , 'test_file': false, 'test_cli': false, 'test_multi': false, 'test_features': [], 'generate_release_tarball': false}] %}
+
 
 {% set gp_num_versions = { '5': num_gpdb5_versions, '6': num_gpdb6_versions, '7': num_gpdb7_versions} %}
 

--- a/concourse/pipelines/templates/macros/macros.j2
+++ b/concourse/pipelines/templates/macros/macros.j2
@@ -96,16 +96,22 @@
         {% for p in platforms %}
             {% set y = dict() %}
             {% if p.build_os in [ 'centos', 'rocky' ] %}
-                {% do y.update({'greenplum_platform': 'rhel' ~ p.os_ver}) %}
                 {% do y.update({'release_platform':   'el' ~ p.os_ver}) %}
                 {% do y.update({'pkg_type':           'rpm'}) %}
                 {% do y.update({'pkg_arch':           'x86_64'}) %}
             {% else %}
-                {% do y.update({'greenplum_platform': 'ubuntu' ~ p.os_ver}) %}
                 {% do y.update({'release_platform':   'ubuntu' ~ p.os_ver}) %}
                 {% do y.update({'pkg_type':           'deb'}) %}
                 {% do y.update({'pkg_arch':           'amd64'}) %}
             {% endif %}
+
+            {# adjust Greenplum release platform due to historical inconsistencies #}
+            {% if x.gp_ver in ['5', '6'] and y.release_platform.startswith('el') %}
+                {% do y.update({'greenplum_platform': 'rh' ~ y.release_platform}) %}
+            {% else %}
+                {% do y.update({'greenplum_platform': y.release_platform}) %}
+            {% endif %}
+
             {% do y.update({'gpdb_package_resource_name':   "gpdb" ~ x.gp_ver ~ "-" ~ y.release_platform ~ "-" ~ y.pkg_type ~ "-latest"}) %}
             {% do y.update({'gpdb_package_file_name':       "greenplum-db-GPDB_VERSION-" ~ y.greenplum_platform ~ "-" ~ y.pkg_arch ~ "." ~ y.pkg_type}) %}
             {% do y.update({'gpdb_package_file_glob':       y.gpdb_package_file_name | replace("GPDB_VERSION", x.gp_ver ~ ".*")}) %}


### PR DESCRIPTION
Download the latest N=10 releases of Greenplum 7 for EL8 and EL9 for use in build and certification pipelines.

Since Greenplum 7 only has two release currently, the script for downloading the last N release has been modified to check the number of available releases for a given GP major version. If the number of requested releases exceeds the number of available releases, then the last available release is used fo the additional requested versions.

Authored-by: Bradford D. Boyle <bradford.boyle@broadcom.com>