### PR TITLE
Add formatting when getting DATE values in JDBC profile 

### DIFF
--- a/automation/sqlrepo/features/jdbc/readable_date_wide_range/expected/query01.ans
+++ b/automation/sqlrepo/features/jdbc/readable_date_wide_range/expected/query01.ans
@@ -12,9 +12,6 @@
 -- m/ERROR:  invalid byte sequence for encoding.*/
 -- s/ERROR:  invalid byte sequence for encoding.*/ERROR:  invalid input syntax./
 --
--- m/ERROR:  invalid input syntax.*/
--- s/ERROR:  invalid input syntax.*/ERROR:  invalid input syntax./
---
 -- m/ERROR:  time zone displacement out of range.*/
 -- s/ERROR:  time zone displacement out of range.*/ERROR:  time zone displacement out of range/
 --
@@ -71,7 +68,7 @@ ERROR:  time zone displacement out of range
 CONTEXT:  External table pxf_jdbc_readable_date_wide_range_off
 
 SELECT dt FROM pxf_jdbc_readable_date_wide_range_off ORDER BY t1;
-ERROR:  invalid input syntax for type date
+ERROR:  time zone displacement out of range
 CONTEXT:  External table pxf_jdbc_readable_date_wide_range_off
 
 SELECT tmz FROM pxf_jdbc_readable_date_wide_range_off ORDER BY t1;

--- a/automation/sqlrepo/features/jdbc/readable_date_wide_range/sql/query01.sql
+++ b/automation/sqlrepo/features/jdbc/readable_date_wide_range/sql/query01.sql
@@ -10,9 +10,6 @@
 -- m/ERROR:  invalid byte sequence for encoding.*/
 -- s/ERROR:  invalid byte sequence for encoding.*/ERROR:  invalid input syntax./
 --
--- m/ERROR:  invalid input syntax.*/
--- s/ERROR:  invalid input syntax.*/ERROR:  invalid input syntax./
---
 -- m/ERROR:  time zone displacement out of range.*/
 -- s/ERROR:  time zone displacement out of range.*/ERROR:  time zone displacement out of range/
 --

--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
@@ -216,7 +216,8 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                         LocalDate localDate = result.getObject(colName, LocalDate.class);
                         value = localDate != null ? localDate.format(LOCAL_DATE_GET_FORMATTER) : null;
                     } else {
-                        value = result.getDate(colName);
+                        Date date = result.getDate(colName);
+                        value = date != null ? date.toLocalDate().format(GreenplumDateTime.DATE_FORMATTER) : null;
                     }
                     break;
                 case TIMESTAMP:

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
@@ -73,7 +73,8 @@ class JdbcResolverTest {
         isDateWideRange = false;
         Date date = Date.valueOf("1977-12-11");
         OneField oneField = getOneField(date, DataType.DATE.getOID(), "date");
-        assertEquals("1977-12-11", oneField.toString());
+        assertTrue(oneField.val instanceof String);
+        assertEquals("1977-12-11", oneField.val);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes a bug from commit [afa00d5](https://github.com/greenplum-db/pxf/commit/afa00d59f097ebc40c029c8a1a29cfc21fcd4133).

The bug causes an incorrect result when getting a DATE value with more than 4-digit year using JDBC with DATE_WIDE_RANGE disabled. We expect it to error out; however, it will take the last 4 digits of the year value and drop the leading digits. For example, the DATE value of `12345-02-23` becomes `2345-02-23`.
