### PR TITLE
Bumped Spring Framework version to 5.3.33

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>5.3.18</version>
+            <version>5.3.33</version>
             <scope>provided</scope>
         </dependency>
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,6 +29,10 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 
+// override Spring Framework version to pick the Spring MVC 5.3.33 with the async race condition fix
+// https://github.com/spring-projects/spring-framework/issues/32342
+ext['spring-framework.version'] = '5.3.33'
+
 def javaProjects = subprojects.findAll {
     it.name.startsWith("pxf-")
 }


### PR DESCRIPTION
This PR updates the Spring Framework (and the associated spring-mvc modules) to versions 5.3.33 to pick the fix for the async race condition (https://github.com/spring-projects/spring-framework/issues/32342). 

The race condition was manifesting itself in PXF with `partial file transfer error` that GPDB would receive from PXF when executing LIMIT queries or queries issued after LIMIT queries with hight load and concurrency. Tomcat would close the connections without writing a 0-length chunk even if there was no error reported in PXF.
