### PR TITLE
Adjusted PXF error handling and determining client disconnects

### DIFF
--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/Utilities.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/Utilities.java
@@ -389,8 +389,8 @@ public class Utilities {
     }
 
     /**
-     * Inspects the throwable and its causes to determine if the throwable due to the client disconnecting
-     * from the socket. Spring MVC since 5.3.33 is wrapping Tomcat's ClientAbortException during async processing into
+     * Inspects the throwable and its causes to determine if the throwable is due to the client disconnecting
+     * from the socket. Spring MVC 5.3.33+ wraps Tomcat's ClientAbortException during async processing into
      * AsyncRequestNotUsableException. To accommodate potential future changes in Spring MVC, the logic here
      * will traverse the exception chain to determine whether a ClientAbortException is in the chain.
      * @param e exception to analyze

--- a/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/Utilities.java
+++ b/server/pxf-api/src/main/java/org/greenplum/pxf/api/utilities/Utilities.java
@@ -19,7 +19,9 @@ package org.greenplum.pxf.api.utilities;
  * under the License.
  */
 
+import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -384,5 +386,17 @@ public class Utilities {
                     "Property %s has invalid value '%s'; value should be either 'true' or 'false'", propertyName, propertyValue
             ));
         }
+    }
+
+    /**
+     * Inspects the throwable and its causes to determine if the throwable due to the client disconnecting
+     * from the socket. Spring MVC since 5.3.33 is wrapping Tomcat's ClientAbortException during async processing into
+     * AsyncRequestNotUsableException. To accommodate potential future changes in Spring MVC, the logic here
+     * will traverse the exception chain to determine whether a ClientAbortException is in the chain.
+     * @param e exception to analyze
+     * @return true if ClientAbortException is in the exception chain, false otherwise
+     */
+    public static boolean isClientDisconnectException(Exception e) {
+        return ExceptionUtils.getThrowableList(e).stream().anyMatch(t -> t instanceof ClientAbortException);
     }
 }

--- a/server/pxf-api/src/test/java/org/greenplum/pxf/api/utilities/UtilitiesTest.java
+++ b/server/pxf-api/src/test/java/org/greenplum/pxf/api/utilities/UtilitiesTest.java
@@ -19,6 +19,7 @@ package org.greenplum.pxf.api.utilities;
  * under the License.
  */
 
+import org.apache.catalina.connector.ClientAbortException;
 import org.apache.hadoop.conf.Configuration;
 import org.greenplum.pxf.api.OneField;
 import org.greenplum.pxf.api.OneRow;
@@ -30,6 +31,7 @@ import org.greenplum.pxf.api.model.RequestContext;
 import org.greenplum.pxf.api.model.Resolver;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -423,5 +425,14 @@ public class UtilitiesTest {
         assertEquals("Property invalidProperty has invalid value 'foo'; value should be either 'true' or 'false'", e.getMessage());
 
         assertTrue(Utilities.parseBooleanProperty(configuration, "trueWithExtraWhitespace", false));
+    }
+
+    @Test
+    public void isClientDisconnectException() {
+        assertFalse(Utilities.isClientDisconnectException(new Exception()));
+        assertFalse(Utilities.isClientDisconnectException(new IOException("Broken pipe")));
+        assertTrue(Utilities.isClientDisconnectException(new ClientAbortException()));
+        assertTrue(Utilities.isClientDisconnectException(new Exception(new ClientAbortException())));
+        assertTrue(Utilities.isClientDisconnectException(new Exception(new Exception(new ClientAbortException()))));
     }
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/BaseServiceImpl.java
@@ -1,10 +1,10 @@
 package org.greenplum.pxf.service.controller;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.catalina.connector.ClientAbortException;
 import org.apache.hadoop.conf.Configuration;
 import org.greenplum.pxf.api.model.ConfigurationFactory;
 import org.greenplum.pxf.api.model.RequestContext;
+import org.greenplum.pxf.api.utilities.Utilities;
 import org.greenplum.pxf.service.MetricsReporter;
 import org.greenplum.pxf.service.bridge.Bridge;
 import org.greenplum.pxf.service.bridge.BridgeFactory;
@@ -77,7 +77,7 @@ public abstract class BaseServiceImpl<T> extends PxfErrorReporter<T> {
         OperationStats stats = result.getStats();
         Exception exception = result.getException();
         String status = (exception == null) ? "Completed" :
-                (exception instanceof ClientAbortException) ? "Aborted" : "Failed";
+                (Utilities.isClientDisconnectException(exception)) ? "Aborted" : "Failed";
 
         // log action status and stats
         long recordCount = stats.getRecordCount();

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
@@ -38,6 +38,9 @@ public abstract class PxfErrorReporter<T> {
                 } else {
                     log.warn("Remote connection closed by the client (enable debug for the stacktrace).");
                 }
+            } else {
+                // some other IO error, log it as usual
+                log.error(StringUtils.defaultIfBlank(e.getMessage(), e.getClass().getName()), e);
             }
             // wrap into PxfRuntimeException and throw back so that it can be handled by the PxfExceptionHandler
             throw new PxfRuntimeException(e);

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/controller/PxfErrorReporter.java
@@ -1,10 +1,12 @@
 package org.greenplum.pxf.service.controller;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.lang.StringUtils;
 import org.greenplum.pxf.api.error.PxfRuntimeException;
+import org.greenplum.pxf.api.utilities.Utilities;
 import org.greenplum.pxf.service.utilities.ThrowingSupplier;
+
+import java.io.IOException;
 
 /**
  * Base class that allows executing an action that returns a result or throws an exception. The exception
@@ -24,17 +26,20 @@ public abstract class PxfErrorReporter<T> {
         try {
             // call the action and return the value if there are no errors
             return action.get();
-        } catch (ClientAbortException e) {
-            // the ClientAbortException occurs whenever a client (GPDB) decides to end the connection
-            // which is common for LIMIT queries (ex: SELECT * FROM table LIMIT 1)
-            // so we want to log just a warning message, not an error with the full stacktrace (unless in debug mode)
-            if (log.isDebugEnabled()) {
-                // Stacktrace in debug
-                log.warn("Remote connection closed by the client.", e);
-            } else {
-                log.warn("Remote connection closed by the client (enable debug for the stacktrace).");
+        } catch (IOException e) {
+            // if the exception is due to client disconnecting prematurely, log the appropriate message
+            if (Utilities.isClientDisconnectException(e)) {
+                // this occurs when a client (GPDB) ends the connection which is common for LIMIT queries
+                // (ex: SELECT * FROM table LIMIT 1) so we want to log just a warning message,
+                // not an error with the full stacktrace (unless in debug mode)
+                if (log.isDebugEnabled()) {
+                    // Stacktrace in debug
+                    log.warn("Remote connection closed by the client.", e);
+                } else {
+                    log.warn("Remote connection closed by the client (enable debug for the stacktrace).");
+                }
             }
-            // wrap into PxfRuntimeException so that it can be handled by the PxfExceptionHandler
+            // wrap into PxfRuntimeException and throw back so that it can be handled by the PxfExceptionHandler
             throw new PxfRuntimeException(e);
         } catch (PxfRuntimeException | Error e) {
             // let PxfRuntimeException and Error propagate themselves
@@ -42,9 +47,8 @@ public abstract class PxfErrorReporter<T> {
             throw e;
         } catch (Exception e) {
             log.error(StringUtils.defaultIfBlank(e.getMessage(), e.getClass().getName()), e);
-            // wrap into PxfRuntimeException so that it can be handled by the PxfExceptionHandler
+            // wrap into PxfRuntimeException and throw back so that it can be handled by the PxfExceptionHandler
             throw new PxfRuntimeException(e);
         }
     }
 }
-

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfExceptionHandler.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfExceptionHandler.java
@@ -15,15 +15,34 @@ import java.io.IOException;
  * This handler prevents the PXF specific exception from being thrown to the container, where it would've gotten
  * logged without an MDC context, since by that time the MDC context is cleaned up.
  * <p>
- * Instead, it is assumed that the PXF specific exception has been seen by the the PXF resource
+ * Instead, it is assumed that the PXF specific exception has been seen by the PXF resource
  * or the processing logic and was logged there, where the MDC context is still available.
  */
 @ControllerAdvice
 public class PxfExceptionHandler {
 
+    /**
+     * Handles PxfRuntimeException that PXF controller methods can throw. If the response has already been committed,
+     * it re-throws the exception to signal Tomcat to abort the connection without properly terminating it
+     * with a 0-length chunk. If the response has not yet been committed, it sets the response status to 500 that will
+     * cause the exception to follow the error flow and be serialized as JSON by Spring Boot to the response message body.
+     * @param e exception to process
+     * @param response http response object
+     * @throws IOException if any operation fails
+     */
     @ExceptionHandler({PxfRuntimeException.class})
     public void handlePxfRuntimeException(PxfRuntimeException e, HttpServletResponse response) throws IOException {
-        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        if (response.isCommitted()) {
+            // streaming has already started, it's too late to send an error
+            // re-throw the exception so that Tomcat can write the error response and
+            // terminate the connection immediately without writing the end 0-length chunk
+            // causing the client to recognize an error occurred
+            // if the exception is not re-thrown, Tomcat thinks it has been handled and does not terminate the connection
+            // abnormally, which results in client not realizing there was an error in PXF server
+            throw e;
+        } else {
+            // do not re-throw the error, otherwise it will be logged 2 more times by Tomcat, just set the error status
+            response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        }
     }
-
 }

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfExceptionHandler.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/spring/PxfExceptionHandler.java
@@ -23,8 +23,8 @@ public class PxfExceptionHandler {
 
     /**
      * Handles PxfRuntimeException that PXF controller methods can throw. If the response has already been committed,
-     * it re-throws the exception to signal Tomcat to abort the connection without properly terminating it
-     * with a 0-length chunk. If the response has not yet been committed, it sets the response status to 500 that will
+     * it re-throws the exception to signal to Tomcat that it needs to abort the connection without properly terminating it
+     * with a 0-length chunk. If the response has not yet been committed, it sets the response status to 500 which will
      * cause the exception to follow the error flow and be serialized as JSON by Spring Boot to the response message body.
      * @param e exception to process
      * @param response http response object

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/PxfErrorReporterTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/controller/PxfErrorReporterTest.java
@@ -1,0 +1,74 @@
+package org.greenplum.pxf.service.controller;
+
+import org.apache.catalina.connector.ClientAbortException;
+import org.greenplum.pxf.api.error.PxfRuntimeException;
+import org.greenplum.pxf.service.utilities.ThrowingSupplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PxfErrorReporterTest {
+    class TestReporter extends PxfErrorReporter<String> {}
+    private TestReporter reporter = new TestReporter();
+
+    @Mock
+    private ThrowingSupplier<String, Exception> mockAction;
+
+    @Test
+    public void testNoException() throws Exception {
+        when(mockAction.get()).thenReturn("ok");
+        String result = reporter.invokeWithErrorHandling(mockAction);
+        assertEquals("ok", result);
+    }
+
+    @Test
+    public void testIOException_NotClientAbort() throws Exception {
+        assertWrapped(new IOException());
+    }
+
+    @Test
+    public void testIOException_ClientAbort() throws Exception {
+        assertWrapped(new ClientAbortException());
+    }
+
+    @Test
+    public void testIOException_ClientAbort_Chained() throws Exception {
+        assertWrapped(new IOException(new ClientAbortException()));
+    }
+
+    @Test
+    public void testOtherException() throws Exception {
+        assertWrapped(new Exception());
+    }
+
+    @Test
+    public void testError() throws Exception {
+        assertNotWrapped(new Error());
+    }
+
+    @Test
+    public void testPxfRuntimeException() throws Exception {
+        assertNotWrapped(new PxfRuntimeException());
+    }
+
+    private void assertWrapped(Throwable e) throws Exception {
+        when(mockAction.get()).thenThrow(e);
+        Exception thrownException = assertThrows(PxfRuntimeException.class, () -> reporter.invokeWithErrorHandling(mockAction));
+        assertSame(e, thrownException.getCause());
+    }
+
+    private void assertNotWrapped(Throwable e) throws Exception {
+        when(mockAction.get()).thenThrow(e);
+        Throwable thrown = assertThrows(e.getClass(), () -> reporter.invokeWithErrorHandling(mockAction));
+        assertSame(e, thrown);
+    }
+}

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/spring/PxfExceptionHandlerTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/spring/PxfExceptionHandlerTest.java
@@ -36,6 +36,7 @@ public class PxfExceptionHandlerTest {
         verify(mockResponse).sendError(500);
         verifyNoMoreInteractions(mockResponse);
     }
+
     @Test
     public void testHandlePxfRuntimeException_ResponseCommitted() {
         String originalMessage = "foo";

--- a/server/pxf-service/src/test/java/org/greenplum/pxf/service/spring/PxfExceptionHandlerTest.java
+++ b/server/pxf-service/src/test/java/org/greenplum/pxf/service/spring/PxfExceptionHandlerTest.java
@@ -10,8 +10,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class PxfExceptionHandlerTest {
@@ -26,9 +30,21 @@ public class PxfExceptionHandlerTest {
     }
 
     @Test
-    public void testHandlePxfRuntimeException() throws IOException {
+    public void testHandlePxfRuntimeException_ResponseNotCommitted() throws IOException {
+        when(mockResponse.isCommitted()).thenReturn(false);
         handler.handlePxfRuntimeException(new PxfRuntimeException("foo"), mockResponse);
         verify(mockResponse).sendError(500);
+        verifyNoMoreInteractions(mockResponse);
+    }
+    @Test
+    public void testHandlePxfRuntimeException_ResponseCommitted() {
+        String originalMessage = "foo";
+        PxfRuntimeException originalException = new PxfRuntimeException(originalMessage);
+        when(mockResponse.isCommitted()).thenReturn(true);
+        PxfRuntimeException thrownException = assertThrows(PxfRuntimeException.class,
+                () -> handler.handlePxfRuntimeException(originalException, mockResponse));
+        assertSame(originalException, thrownException);
+        assertEquals(originalMessage, thrownException.getMessage());
         verifyNoMoreInteractions(mockResponse);
     }
 }


### PR DESCRIPTION
Spring MVC 5.3.33 now wraps ClientAbortException into its own `AsyncRequestNotUsableException` when client disconnect happens on async thread, so we need to adjust how we determine this scenario.

This PR also changes exception handling when the response is committed. It used to set an error on the response, but this was causing an IllegalStateException from Tomcat. Now we just re-throw the original exception to make Tomcat terminate the client connection abnormally without sending the closing 0-length chunk, thus informing the client that there was a processing error.