### PR TITLE
Modify build pipeline to make it easier to set release pipelines

### DIFF
--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -77,13 +77,13 @@ set-release-pipeline: set-build-pipeline-base
 endif
 
 .PHONY: set-main-pipeline
+set-main-pipeline: SHIPIT_REGEX=noop
 set-main-pipeline: NOTIFY=true
 set-main-pipeline: PIPELINE_NAME=$(BUILD_PIPELINE_NAME)
 set-main-pipeline: RELEASE_BRANCH=main
 set-main-pipeline: ENVIRONMENT=prod
 set-main-pipeline: BUCKET_PREFIX=prod
 set-main-pipeline: IMAGE_TAG=latest
-set-main-pipeline: SHIPIT_REGEX=noop
 set-main-pipeline: set-build-pipeline-base
 
 .PHONY: set-dev-release-pipeline

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -69,7 +69,6 @@ set-release-pipeline:
 ifndef RELEASE_BRANCH
 	$(error RELEASE_BRANCH is not set, please set a release branch)
 else
-# substitute any / for - in the pipeline
 set-release-pipeline: SHIPIT_REGEX="$(RELEASE_BRANCH)/greenplum-pxf-(.*).txt"
 set-release-pipeline: NOTIFY=true
 set-release-pipeline: PIPELINE_NAME=$(BUILD_PIPELINE_NAME)-$(RELEASE_BRANCH)

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -111,7 +111,6 @@ set-build-pipeline-base:
 		environment=$(ENVIRONMENT) \
 		gchat_notification=$(NOTIFY) \
 		user=$(USER) \
-		git_branch=$(BRANCH) \
 		num_gpdb5_versions=$(NUM_GPDB5_VERSIONS) \
 		num_gpdb6_versions=$(NUM_GPDB6_VERSIONS) \
 		num_gpdb7_versions=$(NUM_GPDB7_VERSIONS) >"$${PIPELINE_FILE}" && \

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -66,22 +66,17 @@ longevity: set-longevity-pipeline
 # ============================= BUILD PIPELINE TARGETS =============================
 .PHONY: set-release-pipeline
 set-release-pipeline:
-ifndef RELEASE
-	$(error RELEASE is not set, please set a release version)
-else
-ifeq ($(shell echo ${RELEASE} | egrep "${release_regex}"),)
-	$(error RELEASE value $(RELEASE) is not in <major.minor.maintenance> format, please provide a valid release version)
+ifndef RELEASE_BRANCH
+	$(error RELEASE_BRANCH is not set, please set a release branch)
 else
 # substitute any / for - in the pipeline
-set-release-pipeline: RELEASE_BRANCH=branch-$(word 1, $(subst ., , $(RELEASE))).$(word 2, $(subst ., , $(RELEASE))).x
-set-release-pipeline: SHIPIT_REGEX="$(RELEASE)/greenplum-pxf-(.*).txt"
+set-release-pipeline: SHIPIT_REGEX="$(RELEASE_BRANCH)/greenplum-pxf-(.*).txt"
 set-release-pipeline: NOTIFY=true
-set-release-pipeline: PIPELINE_NAME=$(BUILD_PIPELINE_NAME)-$(RELEASE)
+set-release-pipeline: PIPELINE_NAME=$(BUILD_PIPELINE_NAME)-$(RELEASE_BRANCH)
 set-release-pipeline: ENVIRONMENT=prod
 set-release-pipeline: BUCKET_PREFIX=prod
 set-release-pipeline: IMAGE_TAG=latest
 set-release-pipeline: set-build-pipeline-base
-endif
 endif
 
 .PHONY: set-main-pipeline

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -50,8 +50,6 @@ ifeq ($(CHECK_CREDS), true)
 SET_PIPELINE += --check-creds
 endif
 
-release_regex := ^[0-9]+\.[0-9]+\.[0-9]+$
-
 .PHONY: build certification dev-release dev pr cloudbuild dev-cloudbuild longevity
 release: set-release-pipeline
 main: set-main-pipeline

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -42,7 +42,6 @@ MINIO                       ?= false
 OEL7                        ?= false
 FILE                        ?= false
 GP7_CLI                     ?= false
-RELEASE_BRANCH              ?= main
 # used to quickly modify the docker image tag being pulled ONLY in the dev_build_pipeline
 PXF_DEV_IMAGE_TAG           ?= latest
 
@@ -53,15 +52,17 @@ endif
 
 ifneq "$(RELEASE_BRANCH)" "main"
 # substitute any / for - in the pipeline
-	RELEASE_NAME:=-$(shell echo $(subst /,-,$(RELEASE_BRANCH)) | tr A-Z a-z)
+	RELEASE_NAME:=$(shell echo $(subst /,-,$(RELEASE_BRANCH)) | tr A-Z a-z)
 else
 # if we're on the main branch, there should be no release name
 	RELEASE_NAME:=""
 endif
-SHIPIT_REGEX="pxf-build$(RELEASE_NAME)/greenplum-pxf-(.*).txt"
+
+SHIPIT_REGEX="$(RELEASE_NAME)/greenplum-pxf-(.*).txt"
 
 .PHONY: build certification dev-release dev pr cloudbuild dev-cloudbuild longevity
-build: set-build-pipeline
+release: set-release-pipeline
+main: set-main-pipeline
 certification: set-certification-pipeline
 dev-release: set-dev-release-pipeline
 dev: set-dev-build-pipeline
@@ -71,36 +72,43 @@ dev-cloudbuild: set-dev-cloudbuild-pipeline
 longevity: set-longevity-pipeline
 
 # ============================= BUILD PIPELINE TARGETS =============================
-.PHONY: set-build-pipeline
-set-build-pipeline: NOTIFY=true
-set-build-pipeline:
-	@PIPELINE_FILE=$$(mktemp) && \
-	$(TEMPLATE_CMD) --template build_pipeline-tpl.yml --vars \
-		environment=prod \
-		gchat_notification=$(NOTIFY) \
-		num_gpdb5_versions=$(NUM_GPDB5_VERSIONS) \
-		num_gpdb6_versions=$(NUM_GPDB6_VERSIONS) \
-		num_gpdb7_versions=$(NUM_GPDB7_VERSIONS) >"$${PIPELINE_FILE}" && \
-	$(FLY_CMD) --target=$(CONCOURSE) \
-		$(SET_PIPELINE) \
-		--pipeline=$(BUILD_PIPELINE_NAME)$(RELEASE_NAME) \
-		--config "$${PIPELINE_FILE}" \
-		--load-vars-from=$(HOME)/workspace/pxf/concourse/settings/pxf-multinode-params.yml \
-		--var=pxf-git-branch=$(RELEASE_BRANCH) \
-		--var=pxf-build-bucket-prefix=prod \
-		--var=gpdb-pxf-dev-image-tag=latest \
-		--var=shipit-regex=$(SHIPIT_REGEX) \
-		${FLY_OPTION_NON-INTERACTIVE} || echo "Generated yaml has errors: check $${PIPELINE_FILE}"
+.PHONY: set-release-pipeline
+set-release-pipeline:
+ifndef RELEASE_BRANCH
+	$(error RELEASE_BRANCH is not set, please set a release branch)
+endif
+set-release-pipeline: NOTIFY=true
+set-release-pipeline: PIPELINE_NAME=$(BUILD_PIPELINE_NAME)-$(RELEASE_NAME)
+set-release-pipeline: ENVIRONMENT=prod
+set-release-pipeline: BUCKET_PREFIX=prod
+set-release-pipeline: IMAGE_TAG=latest
+set-release-pipeline: set-build-pipeline-base
 
-	@echo using the following command to unpause the pipeline:
-	@echo -e "\t$(FLY_CMD) -t ${CONCOURSE} unpause-pipeline --pipeline ${BUILD_PIPELINE_NAME}"
+.PHONY: set-main-pipeline
+set-main-pipeline: NOTIFY=true
+set-main-pipeline: PIPELINE_NAME=$(BUILD_PIPELINE_NAME)
+set-main-pipeline: RELEASE_BRANCH=main
+set-main-pipeline: ENVIRONMENT=prod
+set-main-pipeline: BUCKET_PREFIX=prod
+set-main-pipeline: IMAGE_TAG=latest
+set-main-pipeline: set-build-pipeline-base
 
 .PHONY: set-dev-release-pipeline
 set-dev-release-pipeline: SHIPIT_REGEX="$(USER)-$(BRANCH)/greenplum-pxf-(.*).txt"
-set-dev-release-pipeline:
+set-dev-release-pipeline: PIPELINE_NAME=$(DEV_BUILD_PIPELINE_NAME)
+set-dev-release-pipeline: RELEASE_BRANCH=$(BRANCH)
+set-dev-release-pipeline: ENVIRONMENT=dev
+set-dev-release-pipeline: set-build-pipeline-base
+set-dev-release-pipeline: EXTRA_VARS=--var=ud/pxf/dev/git-remote-ssh-url=noop
+set-dev-release-pipeline: BUCKET_PREFIX=dev/$(USER)-$(BRANCH)
+set-dev-release-pipeline: IMAGE_TAG=$(PXF_DEV_IMAGE_TAG)
+set-dev-release-pipeline: set-build-pipeline-base
+
+.PHONY: set-build-pipeline-base
+set-build-pipeline-base:
 	@PIPELINE_FILE=$$(mktemp) && \
 	$(TEMPLATE_CMD) --template build_pipeline-tpl.yml --vars \
-		environment=dev \
+		environment=$(ENVIRONMENT) \
 		gchat_notification=$(NOTIFY) \
 		user=$(USER) \
 		git_branch=$(BRANCH) \
@@ -108,20 +116,19 @@ set-dev-release-pipeline:
 		num_gpdb6_versions=$(NUM_GPDB6_VERSIONS) \
 		num_gpdb7_versions=$(NUM_GPDB7_VERSIONS) >"$${PIPELINE_FILE}" && \
 	$(FLY_CMD) --target=$(CONCOURSE) \
-		$(SET_PIPELINE) \ \
-		--pipeline=$(DEV_BUILD_PIPELINE_NAME) \
+		$(SET_PIPELINE) \
+		--pipeline=$(PIPELINE_NAME) \
 		--config "$${PIPELINE_FILE}" \
 		--load-vars-from=$(HOME)/workspace/pxf/concourse/settings/pxf-multinode-params.yml \
-		--var=ud/pxf/dev/git-remote-ssh-url=noop \
-		--var=pxf-git-branch=${BRANCH} \
-		--var=pxf-build-bucket-prefix=dev/$(USER)-$(BRANCH) \
-		--var=pxf-releases-bucket-prefix=dev/$(USER)-$(BRANCH) \
-		--var=gpdb-pxf-dev-image-tag=$(PXF_DEV_IMAGE_TAG) \
+		--var=pxf-git-branch=$(RELEASE_BRANCH) \
+		--var=pxf-build-bucket-prefix=$(BUCKET_PREFIX) \
+		--var=gpdb-pxf-dev-image-tag=$(IMAGE_TAG) \
 		--var=shipit-regex=$(SHIPIT_REGEX) \
+		$(EXTRA_VARS) \
 		${FLY_OPTION_NON-INTERACTIVE} || echo "Generated yaml has errors: check $${PIPELINE_FILE}"
 
 	@echo using the following command to unpause the pipeline:
-	@echo -e "\t$(FLY_CMD) -t ${CONCOURSE} unpause-pipeline --pipeline ${DEV_BUILD_PIPELINE_NAME}"
+	@echo -e "\t$(FLY_CMD) -t ${CONCOURSE} unpause-pipeline --pipeline ${BUILD_PIPELINE_NAME}"
 
 .PHONY: set-dev-build-pipeline
 set-dev-build-pipeline:

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -42,6 +42,7 @@ MINIO                       ?= false
 OEL7                        ?= false
 FILE                        ?= false
 GP7_CLI                     ?= false
+RELEASE_BRANCH              ?= main
 # used to quickly modify the docker image tag being pulled ONLY in the dev_build_pipeline
 PXF_DEV_IMAGE_TAG           ?= latest
 
@@ -49,6 +50,15 @@ SET_PIPELINE := set-pipeline
 ifeq ($(CHECK_CREDS), true)
 SET_PIPELINE += --check-creds
 endif
+
+ifneq "$(RELEASE_BRANCH)" "main"
+# substitute any / for - in the pipeline
+	RELEASE_NAME:=-$(shell echo $(subst /,-,$(RELEASE_BRANCH)) | tr A-Z a-z)
+else
+# if we're on the main branch, there should be no release name
+	RELEASE_NAME:=""
+endif
+SHIPIT_REGEX="pxf-build$(RELEASE_NAME)/greenplum-pxf-(.*).txt"
 
 .PHONY: build certification dev-release dev pr cloudbuild dev-cloudbuild longevity
 build: set-build-pipeline
@@ -73,18 +83,20 @@ set-build-pipeline:
 		num_gpdb7_versions=$(NUM_GPDB7_VERSIONS) >"$${PIPELINE_FILE}" && \
 	$(FLY_CMD) --target=$(CONCOURSE) \
 		$(SET_PIPELINE) \
-		--pipeline=$(BUILD_PIPELINE_NAME) \
+		--pipeline=$(BUILD_PIPELINE_NAME)$(RELEASE_NAME) \
 		--config "$${PIPELINE_FILE}" \
 		--load-vars-from=$(HOME)/workspace/pxf/concourse/settings/pxf-multinode-params.yml \
-		--var=pxf-git-branch=main \
+		--var=pxf-git-branch=$(RELEASE_BRANCH) \
 		--var=pxf-build-bucket-prefix=prod \
 		--var=gpdb-pxf-dev-image-tag=latest \
+		--var=shipit-regex=$(SHIPIT_REGEX) \
 		${FLY_OPTION_NON-INTERACTIVE} || echo "Generated yaml has errors: check $${PIPELINE_FILE}"
 
 	@echo using the following command to unpause the pipeline:
 	@echo -e "\t$(FLY_CMD) -t ${CONCOURSE} unpause-pipeline --pipeline ${BUILD_PIPELINE_NAME}"
 
 .PHONY: set-dev-release-pipeline
+set-dev-release-pipeline: SHIPIT_REGEX="$(USER)-$(BRANCH)/greenplum-pxf-(.*).txt"
 set-dev-release-pipeline:
 	@PIPELINE_FILE=$$(mktemp) && \
 	$(TEMPLATE_CMD) --template build_pipeline-tpl.yml --vars \
@@ -105,6 +117,7 @@ set-dev-release-pipeline:
 		--var=pxf-build-bucket-prefix=dev/$(USER)-$(BRANCH) \
 		--var=pxf-releases-bucket-prefix=dev/$(USER)-$(BRANCH) \
 		--var=gpdb-pxf-dev-image-tag=$(PXF_DEV_IMAGE_TAG) \
+		--var=shipit-regex=$(SHIPIT_REGEX) \
 		${FLY_OPTION_NON-INTERACTIVE} || echo "Generated yaml has errors: check $${PIPELINE_FILE}"
 
 	@echo using the following command to unpause the pipeline:
@@ -145,6 +158,7 @@ set-dev-build-pipeline:
 		--var=pxf-git-branch=${BRANCH} \
 		--var=pxf-build-bucket-prefix=dev/$(USER)-$(BRANCH) \
 		--var=gpdb-pxf-dev-image-tag=$(PXF_DEV_IMAGE_TAG) \
+		--var=shipit-regex=$(SHIPIT_REGEX) \
 		${FLY_OPTION_NON-INTERACTIVE} || echo "Generated yaml has errors: check $${PIPELINE_FILE}"
 
 	@echo using the following command to unpause the pipeline:

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -50,15 +50,7 @@ ifeq ($(CHECK_CREDS), true)
 SET_PIPELINE += --check-creds
 endif
 
-ifneq "$(RELEASE_BRANCH)" "main"
-# substitute any / for - in the pipeline
-	RELEASE_NAME:=$(shell echo $(subst /,-,$(RELEASE_BRANCH)) | tr A-Z a-z)
-else
-# if we're on the main branch, there should be no release name
-	RELEASE_NAME:=""
-endif
-
-SHIPIT_REGEX="$(RELEASE_NAME)/greenplum-pxf-(.*).txt"
+release_regex := ^[0-9]+\.[0-9]+\.[0-9]+$
 
 .PHONY: build certification dev-release dev pr cloudbuild dev-cloudbuild longevity
 release: set-release-pipeline
@@ -74,15 +66,23 @@ longevity: set-longevity-pipeline
 # ============================= BUILD PIPELINE TARGETS =============================
 .PHONY: set-release-pipeline
 set-release-pipeline:
-ifndef RELEASE_BRANCH
-	$(error RELEASE_BRANCH is not set, please set a release branch)
-endif
+ifndef RELEASE
+	$(error RELEASE is not set, please set a release version)
+else
+ifeq ($(shell echo ${RELEASE} | egrep "${release_regex}"),)
+	$(error RELEASE value $(RELEASE) is not in <major.minor.maintenance> format, please provide a valid release version)
+else
+# substitute any / for - in the pipeline
+set-release-pipeline: RELEASE_BRANCH=branch-$(word 1, $(subst ., , $(RELEASE))).$(word 2, $(subst ., , $(RELEASE))).x
+set-release-pipeline: SHIPIT_REGEX="$(RELEASE)/greenplum-pxf-(.*).txt"
 set-release-pipeline: NOTIFY=true
-set-release-pipeline: PIPELINE_NAME=$(BUILD_PIPELINE_NAME)-$(RELEASE_NAME)
+set-release-pipeline: PIPELINE_NAME=$(BUILD_PIPELINE_NAME)-$(RELEASE)
 set-release-pipeline: ENVIRONMENT=prod
 set-release-pipeline: BUCKET_PREFIX=prod
 set-release-pipeline: IMAGE_TAG=latest
 set-release-pipeline: set-build-pipeline-base
+endif
+endif
 
 .PHONY: set-main-pipeline
 set-main-pipeline: NOTIFY=true

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -91,6 +91,7 @@ set-main-pipeline: RELEASE_BRANCH=main
 set-main-pipeline: ENVIRONMENT=prod
 set-main-pipeline: BUCKET_PREFIX=prod
 set-main-pipeline: IMAGE_TAG=latest
+set-main-pipeline: SHIPIT_REGEX=noop
 set-main-pipeline: set-build-pipeline-base
 
 .PHONY: set-dev-release-pipeline

--- a/concourse/Makefile
+++ b/concourse/Makefile
@@ -50,7 +50,7 @@ ifeq ($(CHECK_CREDS), true)
 SET_PIPELINE += --check-creds
 endif
 
-.PHONY: build certification dev-release dev pr cloudbuild dev-cloudbuild longevity
+.PHONY: release main certification dev-release dev pr cloudbuild dev-cloudbuild longevity
 release: set-release-pipeline
 main: set-main-pipeline
 certification: set-certification-pipeline
@@ -91,7 +91,6 @@ set-dev-release-pipeline: SHIPIT_REGEX="$(USER)-$(BRANCH)/greenplum-pxf-(.*).txt
 set-dev-release-pipeline: PIPELINE_NAME=$(DEV_BUILD_PIPELINE_NAME)
 set-dev-release-pipeline: RELEASE_BRANCH=$(BRANCH)
 set-dev-release-pipeline: ENVIRONMENT=dev
-set-dev-release-pipeline: set-build-pipeline-base
 set-dev-release-pipeline: EXTRA_VARS=--var=ud/pxf/dev/git-remote-ssh-url=noop
 set-dev-release-pipeline: BUCKET_PREFIX=dev/$(USER)-$(BRANCH)
 set-dev-release-pipeline: IMAGE_TAG=$(PXF_DEV_IMAGE_TAG)

--- a/concourse/pipelines/templates/resources/gchat-notification-tpl.yml
+++ b/concourse/pipelines/templates/resources/gchat-notification-tpl.yml
@@ -7,4 +7,4 @@
 - name: [[alert_name]]
   type: google-chat-notify-resource
   source:
-    url: ((ud/pxf/secrets/[[url_key]]))
+    url: ((ud/secrets/[[url_key]]))

--- a/concourse/pipelines/templates/resources/release-shipit-tpl.yml
+++ b/concourse/pipelines/templates/resources/release-shipit-tpl.yml
@@ -8,4 +8,4 @@
   source:
     bucket: ((ud/pxf/common/releases-bucket-name))
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
-    regexp: [[environment]]/shipit/greenplum-pxf-(.*).txt
+    regexp: [[environment]]/shipit/((shipit-regex))


### PR DESCRIPTION
This commit removes the `build` make target in favor of 2 new make targets: `release` and `main`. 

As we no longer expect releases to be done off main, `make main` spins up the current `pxf-build` pipeline. However, shipit files for the main branch point to `${BUCKET}/shipit/noop` and should effectively be ignored.

The `release` make target is to be used for all releases going forward and expects the variable `RELEASE_BRANCH` to be set. Release branches are expected in the form `branch-<major.minor>.x`. We expect these release pipelines to be long standing and so a release for 6.10.99 would be expected to use the same pipeline as 6.10.4. 
 
Running `make release RELEASE_BRANCH=branch-6.10.x` would do the following: 
- create a pipeline with the name `pxf-build-branch-6.10.x` that points to the `branch-6.10.x` branch for deployment
- any shipit file would live in `${BUCKET}/shipit/branch-6.10.x`

